### PR TITLE
feat: add --all flag and local session filtering to TUI

### DIFF
--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -11,7 +11,8 @@ import (
 )
 
 type TuiCmd struct {
-	flags *Flags
+	flags   *Flags
+	showAll bool
 }
 
 // NewTuiCmd creates a new tui command
@@ -24,13 +25,24 @@ func (cmd *TuiCmd) Register(app *cli.Command) *cli.Command {
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:      "tui",
 		Usage:     "Launch the interactive session manager",
-		UsageText: "hive tui",
+		UsageText: "hive tui [--all]",
 		Description: `Opens a terminal UI for managing sessions.
 
 Navigate with arrow keys or j/k. Press r to recycle, d to delete.
 Custom keybindings can be configured in the config file.
 
-This is the default command when hive is run without arguments.`,
+This is the default command when hive is run without arguments.
+
+By default, only sessions for the current repository are shown.
+Use --all to show all sessions, or press 'a' to toggle in the TUI.`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "all",
+				Usage:       "Show all sessions instead of only local repository sessions",
+				Value:       false,
+				Destination: &cmd.showAll,
+			},
+		},
 		Action: cmd.run,
 	})
 
@@ -42,8 +54,23 @@ func (cmd *TuiCmd) Run(ctx context.Context, c *cli.Command) error {
 	return cmd.run(ctx, c)
 }
 
-func (cmd *TuiCmd) run(_ context.Context, _ *cli.Command) error {
-	m := tui.New(cmd.flags.Service, cmd.flags.Config)
+func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
+	// Detect current repository remote for filtering
+	var localRemote string
+	if !cmd.showAll {
+		remote, err := cmd.flags.Service.DetectRemote(ctx, ".")
+		if err == nil {
+			localRemote = remote
+		}
+		// If detection fails (not in a git repo), show all sessions
+	}
+
+	opts := tui.Options{
+		ShowAll:     cmd.showAll,
+		LocalRemote: localRemote,
+	}
+
+	m := tui.New(cmd.flags.Service, cmd.flags.Config, opts)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
By default, the TUI now only shows sessions for the current repository. Press 'a' to toggle between local and all sessions view.
