### PR TITLE
feat: improve modal confirmation UX with button navigation

### DIFF
--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -6,18 +6,30 @@ import (
 
 // Modal represents a confirmation dialog.
 type Modal struct {
-	title   string
-	message string
-	visible bool
+	title           string
+	message         string
+	visible         bool
+	confirmSelected bool // true = confirm button selected, false = cancel button selected
 }
 
 // NewModal creates a new modal with the given title and message.
 func NewModal(title, message string) Modal {
 	return Modal{
-		title:   title,
-		message: message,
-		visible: true,
+		title:           title,
+		message:         message,
+		visible:         true,
+		confirmSelected: true, // default to confirm button
 	}
+}
+
+// ToggleSelection switches the selected button.
+func (m *Modal) ToggleSelection() {
+	m.confirmSelected = !m.confirmSelected
+}
+
+// ConfirmSelected returns true if the confirm button is selected.
+func (m Modal) ConfirmSelected() bool {
+	return m.confirmSelected
 }
 
 // Visible returns whether the modal should be displayed.
@@ -31,13 +43,27 @@ func (m Modal) Overlay(background string, width, height int) string {
 		return background
 	}
 
+	// Render buttons with selection state
+	var confirmBtn, cancelBtn string
+	if m.confirmSelected {
+		confirmBtn = modalButtonSelectedStyle.Render("Confirm")
+		cancelBtn = modalButtonStyle.Render("Cancel")
+	} else {
+		confirmBtn = modalButtonStyle.Render("Confirm")
+		cancelBtn = modalButtonSelectedStyle.Render("Cancel")
+	}
+
+	buttons := lipgloss.JoinHorizontal(lipgloss.Center, confirmBtn, "  ", cancelBtn)
+	buttonRow := lipgloss.NewStyle().MarginTop(1).Render(buttons)
+
 	// Build the modal content
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
 		modalTitleStyle.Render(m.title),
 		"",
 		m.message,
-		modalHelpStyle.Render("[y] confirm  [n/esc] cancel"),
+		buttonRow,
+		modalHelpStyle.Render("←/→ select  enter confirm  esc cancel"),
 	)
 
 	modal := modalStyle.Render(content)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -198,12 +198,19 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Handle modal state
 	if m.state == stateConfirming {
 		switch key {
-		case "y", "Y":
+		case "enter":
 			m.state = stateNormal
-			return m, m.executeAction(m.pending)
-		case "n", "N", "esc":
+			if m.modal.ConfirmSelected() {
+				return m, m.executeAction(m.pending)
+			}
+			m.pending = Action{}
+			return m, nil
+		case "esc":
 			m.state = stateNormal
 			m.pending = Action{}
+			return m, nil
+		case "left", "right", "h", "l", "tab":
+			m.modal.ToggleSelection()
 			return m, nil
 		}
 		return m, nil

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -80,6 +80,17 @@ var (
 			Foreground(lipglossv2.Color("#565f89")).
 			MarginTop(1)
 
+	modalButtonStyle = lipglossv2.NewStyle().
+				Padding(0, 1).
+				Background(lipglossv2.Color("#3b4261")).
+				Foreground(lipglossv2.Color("#a9b1d6"))
+
+	modalButtonSelectedStyle = lipglossv2.NewStyle().
+					Padding(0, 1).
+					Background(lipglossv2.Color("#7aa2f7")).
+					Foreground(lipglossv2.Color("#1a1b26")).
+					Bold(true)
+
 	// Spinner style.
 	spinnerStyle = lipgloss.NewStyle().
 			Foreground(colorBlue)


### PR DESCRIPTION
Replace y/n key bindings with enter/escape and add arrow key navigation between confirm and cancel buttons. Buttons now render as solid-colored elements with visual selection highlighting.

