### PR TITLE
feat: add TUI search filtering and hide recycled sessions

### DIFF
--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -11,8 +11,9 @@ import (
 )
 
 type TuiCmd struct {
-	flags   *Flags
-	showAll bool
+	flags        *Flags
+	showAll      bool
+	hideRecycled bool
 }
 
 // NewTuiCmd creates a new tui command
@@ -42,6 +43,12 @@ Use --all to show all sessions, or press 'a' to toggle in the TUI.`,
 				Value:       false,
 				Destination: &cmd.showAll,
 			},
+			&cli.BoolFlag{
+				Name:        "hide-recycled",
+				Usage:       "Hide recycled sessions (toggle with 'x' in TUI)",
+				Value:       true,
+				Destination: &cmd.hideRecycled,
+			},
 		},
 		Action: cmd.run,
 	})
@@ -66,8 +73,9 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 	}
 
 	opts := tui.Options{
-		ShowAll:     cmd.showAll,
-		LocalRemote: localRemote,
+		ShowAll:      cmd.showAll,
+		LocalRemote:  localRemote,
+		HideRecycled: cmd.hideRecycled,
 	}
 
 	m := tui.New(cmd.flags.Service, cmd.flags.Config, opts)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -20,7 +20,8 @@ var (
 	// Title style for the list header.
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(colorBlue).PaddingLeft(1).PaddingBottom(1)
+			Foreground(colorBlue).
+			PaddingLeft(1)
 
 	// Active session state style.
 	activeStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
- Enable bubbles built-in list filtering (press `/` to search)
- Search across repo name and session name with fuzzy matching
- Underline matched characters in search results
- Add `--hide-recycled` flag (default true) to hide recycled sessions
- Add `x` keybinding to toggle recycled session visibility
- Update title to show filter state (e.g. "Sessions (local, active)")
- Style filter prompt with blue color and proper spacing

## Test plan
- [ ] Run `hive tui` and press `/` to activate search
- [ ] Type to filter by repo name or session name
- [ ] Verify matched characters are underlined
- [ ] Press `esc` to cancel filter, `enter` to apply
- [ ] Verify recycled sessions are hidden by default
- [ ] Press `x` to toggle recycled session visibility
- [ ] Run `hive tui --hide-recycled=false` to show recycled by default