### PR TITLE
feat: improve new command UI with banner, themed form, and styled hooks

### DIFF
--- a/internal/commands/cmd_new.go
+++ b/internal/commands/cmd_new.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/hay-kot/hive/internal/hive"
 	"github.com/hay-kot/hive/internal/printer"
+	"github.com/hay-kot/hive/internal/styles"
 	"github.com/urfave/cli/v3"
 )
 
@@ -91,12 +92,16 @@ func (cmd *NewCmd) run(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("create session: %w", err)
 	}
 
-	p.Successf("Created session %s at %s", sess.ID, sess.Path)
+	p.Success("Session created", sess.Path)
 
 	return nil
 }
 
 func (cmd *NewCmd) runForm() error {
+	// Print banner header
+	fmt.Println(styles.BannerStyle.Render(styles.Banner))
+	fmt.Println()
+
 	return huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
@@ -109,7 +114,7 @@ func (cmd *NewCmd) runForm() error {
 				Description("AI prompt to pass to spawn command").
 				Value(&cmd.prompt),
 		),
-	).Run()
+	).WithTheme(styles.FormTheme()).Run()
 }
 
 func validateName(s string) error {

--- a/internal/hive/hooks.go
+++ b/internal/hive/hooks.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	"github.com/hay-kot/hive/internal/core/config"
+	"github.com/hay-kot/hive/internal/styles"
 	"github.com/hay-kot/hive/pkg/executil"
 	"github.com/rs/zerolog"
 )
@@ -36,6 +38,7 @@ func (h *HookRunner) RunHooks(ctx context.Context, hooks []config.Hook, remote, 
 		Int("hook_count", len(hooks)).
 		Msg("evaluating hooks")
 
+	hookNum := 0
 	for _, hook := range hooks {
 		matched, err := matchPattern(hook.Pattern, remote)
 		if err != nil {
@@ -52,19 +55,38 @@ func (h *HookRunner) RunHooks(ctx context.Context, hooks []config.Hook, remote, 
 			continue
 		}
 
+		hookNum++
+
 		h.log.Debug().
 			Str("pattern", hook.Pattern).
 			Strs("commands", hook.Commands).
 			Msg("running hook")
 
-		for _, cmd := range hook.Commands {
+		for i, cmd := range hook.Commands {
+			h.printCommandHeader(hookNum, i+1, len(hook.Commands), cmd)
+
 			if err := h.executor.RunDirStream(ctx, path, h.stdout, h.stderr, "sh", "-c", cmd); err != nil {
 				return fmt.Errorf("run hook %q command %q: %w", hook.Pattern, cmd, err)
 			}
+
+			_, _ = fmt.Fprintln(h.stdout)
 		}
 	}
 
 	return nil
+}
+
+// printCommandHeader prints a styled header for a hook command.
+func (h *HookRunner) printCommandHeader(hookNum, cmdNum, totalCmds int, cmd string) {
+	divider := styles.DividerStyle.Render(strings.Repeat("─", 50))
+	header := styles.CommandHeaderStyle.Render(fmt.Sprintf("hook %d", hookNum))
+	cmdLabel := styles.DividerStyle.Render(fmt.Sprintf("[%d/%d]", cmdNum, totalCmds))
+	command := styles.CommandStyle.Render(cmd)
+
+	_, _ = fmt.Fprintln(h.stdout)
+	_, _ = fmt.Fprintln(h.stdout, divider)
+	_, _ = fmt.Fprintf(h.stdout, "%s %s %s\n", header, cmdLabel, command)
+	_, _ = fmt.Fprintln(h.stdout, divider)
 }
 
 // matchPattern checks if remote matches the regex pattern.

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 )
 
-// ANSI color codes
+// ANSI color codes (Tokyo Night palette)
 const (
 	ColorReset = "\033[0m"
 	ColorRed   = "\033[38;2;215;95;107m"  // #d75f6b
-	ColorGreen = "\033[38;2;34;197;94m"   // #22c55e
-	ColorGray  = "\033[38;2;163;163;163m" // #a3a3a3
+	ColorGreen = "\033[38;2;158;206;106m" // #9ece6a (Tokyo Night green)
+	ColorGray  = "\033[38;2;86;95;137m"   // #565f89 (Tokyo Night comment)
 	ColorBold  = "\033[1m"
 )
 
@@ -79,6 +79,14 @@ func (p *Printer) Errorf(format string, args ...interface{}) {
 func (p *Printer) Successf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	_, _ = p.writer.Write([]byte(p.colorize(ColorGreen, Check+" "+msg) + "\n"))
+}
+
+// Success prints a success message with details on a separate line
+func (p *Printer) Success(message string, details string) {
+	_, _ = p.writer.Write([]byte(p.colorize(ColorGreen, Check+" "+message) + "\n"))
+	if details != "" {
+		_, _ = p.writer.Write([]byte("  " + p.colorize(ColorGray, details) + "\n"))
+	}
 }
 
 // Infof prints an info message in gray

--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -1,0 +1,83 @@
+// Package styles provides shared lipgloss styles for CLI and TUI components.
+package styles
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Tokyo Night color palette.
+var (
+	ColorGreen  = lipgloss.Color("#9ece6a")
+	ColorYellow = lipgloss.Color("#e0af68")
+	ColorBlue   = lipgloss.Color("#7aa2f7")
+	ColorGray   = lipgloss.Color("#565f89")
+	ColorWhite  = lipgloss.Color("#c0caf5")
+)
+
+// Banner ASCII art for the header.
+const Banner = `
+ ╦ ╦╦╦  ╦╔═╗
+ ╠═╣║╚╗╔╝║╣
+ ╩ ╩╩ ╚╝ ╚═╝`
+
+// BannerStyle styles the ASCII art banner.
+var BannerStyle = lipgloss.NewStyle().
+	Foreground(ColorBlue).
+	Bold(true)
+
+// CommandHeaderStyle styles the hook command headers.
+var CommandHeaderStyle = lipgloss.NewStyle().
+	Foreground(ColorBlue).
+	Bold(true)
+
+// CommandStyle styles the command text.
+var CommandStyle = lipgloss.NewStyle().
+	Foreground(ColorWhite)
+
+// DividerStyle styles horizontal dividers.
+var DividerStyle = lipgloss.NewStyle().
+	Foreground(ColorGray)
+
+// FormTheme returns a huh form theme using Tokyo Night colors.
+func FormTheme() *huh.Theme {
+	t := huh.ThemeBase()
+
+	t.Focused.Title = lipgloss.NewStyle().
+		Foreground(ColorBlue).
+		Bold(true)
+
+	t.Focused.Description = lipgloss.NewStyle().
+		Foreground(ColorGray)
+
+	t.Focused.TextInput.Cursor = lipgloss.NewStyle().
+		Foreground(ColorBlue)
+
+	t.Focused.TextInput.Placeholder = lipgloss.NewStyle().
+		Foreground(ColorGray)
+
+	t.Focused.TextInput.Prompt = lipgloss.NewStyle().
+		Foreground(ColorBlue)
+
+	t.Focused.FocusedButton = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#1a1b26")).
+		Background(ColorBlue).
+		Bold(true).
+		Padding(0, 1)
+
+	t.Focused.BlurredButton = lipgloss.NewStyle().
+		Foreground(ColorWhite).
+		Background(lipgloss.Color("#3b4261")).
+		Padding(0, 1)
+
+	t.Blurred.Title = lipgloss.NewStyle().
+		Foreground(ColorGray)
+
+	t.Blurred.Description = lipgloss.NewStyle().
+		Foreground(ColorGray)
+
+	t.Blurred.TextInput.Placeholder = lipgloss.NewStyle().
+		Foreground(ColorGray)
+
+	return t
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -4,15 +4,16 @@ package tui
 import (
 	"github.com/charmbracelet/lipgloss"
 	lipglossv2 "github.com/charmbracelet/lipgloss/v2"
+	"github.com/hay-kot/hive/internal/styles"
 )
 
-// Tokyo Night color palette.
+// Re-export colors for local use.
 var (
-	colorGreen  = lipgloss.Color("#9ece6a") // green
-	colorYellow = lipgloss.Color("#e0af68") // yellow
-	colorBlue   = lipgloss.Color("#7aa2f7") // blue
-	colorGray   = lipgloss.Color("#565f89") // comment
-	colorWhite  = lipgloss.Color("#c0caf5") // foreground
+	colorGreen  = styles.ColorGreen
+	colorYellow = styles.ColorYellow
+	colorBlue   = styles.ColorBlue
+	colorGray   = styles.ColorGray
+	colorWhite  = styles.ColorWhite
 )
 
 // Styles used for rendering the TUI (lipgloss v1 for bubbles compatibility).
@@ -58,18 +59,11 @@ const (
 	iconDot = "•"      // Unicode bullet separator
 )
 
-// Banner ASCII art for the header.
-const banner = `
- ╦ ╦╦╦  ╦╔═╗
- ╠═╣║╚╗╔╝║╣
- ╩ ╩╩ ╚╝ ╚═╝`
-
-// bannerStyle styles the ASCII art banner.
-var bannerStyle = lipgloss.NewStyle().
-	Foreground(colorBlue).
-	Bold(true).
-	PaddingLeft(1).
-	PaddingBottom(1)
+// Use shared banner and style.
+var (
+	banner      = styles.Banner
+	bannerStyle = styles.BannerStyle.PaddingLeft(1).PaddingBottom(1)
+)
 
 // Modal styles using lipgloss v2 for canvas/layer support.
 var (


### PR DESCRIPTION
## Summary
- Add shared `internal/styles` package with Tokyo Night colors and huh form theme
- Display HIVE banner header when running `hive new` interactively
- Style hook command output with dividers, labels (`hook N [x/y]`), and spacing
- Improve success message with structured output (green message, gray path on separate line)
- Update printer colors to use Tokyo Night palette for consistency

## Test plan
- [ ] Run `hive new` interactively and verify banner displays with themed form
- [ ] Create a session with hooks configured and verify styled command output
- [ ] Verify success message shows green checkmark with path in gray below