### PR TITLE
fix: detect default branch dynamically in recycle command

### DIFF
--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -71,7 +71,7 @@ func DefaultConfig() Config {
 	return Config{
 		Commands: Commands{
 			Spawn:   []string{},
-			Recycle: []string{"git reset --hard", "git checkout main", "git pull"},
+			Recycle: []string{"git reset --hard", "git checkout $(git rev-parse --abbrev-ref origin/HEAD | sed 's|origin/||')", "git pull"},
 		},
 		Git: GitConfig{
 			StatusWorkers: 3,


### PR DESCRIPTION
## Summary
- Replace hardcoded `git checkout main` with dynamic branch detection
- Uses `git rev-parse --abbrev-ref origin/HEAD` to determine the remote's default branch
- Works with any default branch name (main, master, develop, etc.)

## Test plan
- [x] Verified command works via `sh -c` on macOS
- [x] All existing tests pass
- [x] Linter passes