### PR TITLE
fix: hide recycled sessions by default when TUI launched without subcommand

### DIFF
--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -18,7 +18,10 @@ type TuiCmd struct {
 
 // NewTuiCmd creates a new tui command
 func NewTuiCmd(flags *Flags) *TuiCmd {
-	return &TuiCmd{flags: flags}
+	return &TuiCmd{
+		flags:        flags,
+		hideRecycled: true,
+	}
 }
 
 // Register adds the tui command to the application


### PR DESCRIPTION
## Summary
- Initialize `hideRecycled` to `true` in `NewTuiCmd` constructor
- Fixes issue where recycled sessions were shown when running `hive` directly (without the `tui` subcommand)

## Test plan
- [x] Run `hive` directly and verify recycled sessions are hidden
- [x] Run `hive tui` and verify recycled sessions are hidden
- [x] Run `hive tui --hide-recycled=false` and verify recycled sessions are shown
- [x] Press `x` in TUI to toggle recycled visibility