### PR TITLE
refactor: unify hooks and copy into rules config

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,18 @@ commands:
 # Git executable (optional, defaults to "git")
 git_path: git
 
-# Repository-specific setup hooks
-# Pattern uses glob syntax (supports ** for path matching)
-hooks:
-  - pattern: "**/my-org/**"
+# Rules for repository-specific setup
+# Each rule can have commands (hooks) and/or copy patterns
+# Pattern uses regex syntax matched against the remote URL
+rules:
+  - pattern: ".*/my-org/.*"
     commands:
       - npm install
       - npm run build
-  - pattern: "**github.com/hay-kot/**"
+    copy:
+      - .envrc
+      - configs/*.yaml
+  - pattern: ".*/hay-kot/.*"
     commands:
       - go mod download
 
@@ -176,15 +180,16 @@ keybindings:
 | `commands.spawn`   | `[]string`              | `[]`                                                    | Commands to run after session creation (Go templates supported) |
 | `commands.recycle` | `[]string`              | `["git reset --hard", "git checkout main", "git pull"]` | Commands to run when recycling a session                        |
 | `git_path`         | `string`                | `git`                                                   | Path to git executable                                          |
-| `hooks`            | `[]Hook`                | `[]`                                                    | Repository-specific setup commands                              |
+| `rules`            | `[]Rule`                | `[]`                                                    | Repository-specific setup rules                                 |
 | `keybindings`      | `map[string]Keybinding` | see below                                               | TUI keybinding configuration                                    |
 
-### Hooks
+### Rules
 
-Hooks run after cloning or recycling a session. Each hook has:
+Rules run after cloning or recycling a session. Each rule has:
 
-- `pattern`: Glob pattern matched against the remote URL (supports `**` for path matching)
+- `pattern`: Regex pattern matched against the remote URL (empty matches all)
 - `commands`: Shell commands to execute in the session directory
+- `copy`: Glob patterns for files to copy from the source directory
 
 ### Keybindings
 

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -11,7 +11,7 @@ commands:
     - git checkout main
     - git pull
 
-hooks:
+rules:
   - pattern: ".*/hay-kot/recipinned"
     commands:
       - mise trust

--- a/config.invalid.yaml
+++ b/config.invalid.yaml
@@ -7,11 +7,11 @@ commands:
     - "echo {{.InvalidField}}" # Invalid template - unknown field
   recycle: []                  # Empty - triggers warning
 
-hooks:
+rules:
   - pattern: "[invalid-regex"  # Invalid regex - unclosed bracket
-    commands: []               # Empty commands - triggers warning
+    # No commands or copy - triggers warning
   - pattern: "^https://github.com/.*"
-    commands: []               # Empty commands - triggers warning
+    # No commands or copy - triggers warning
 
 keybindings:
   w:

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -37,8 +37,7 @@ type Config struct {
 	Git                 GitConfig             `yaml:"git"`
 	GitPath             string                `yaml:"git_path"`
 	Keybindings         map[string]Keybinding `yaml:"keybindings"`
-	Hooks               []Hook                `yaml:"hooks"`
-	Copy                []CopyRule            `yaml:"copy"`
+	Rules               []Rule                `yaml:"rules"`
 	AutoDeleteCorrupted bool                  `yaml:"auto_delete_corrupted"`
 	History             HistoryConfig         `yaml:"history"`
 	Context             ContextConfig         `yaml:"context"`
@@ -60,20 +59,14 @@ type GitConfig struct {
 	StatusWorkers int `yaml:"status_workers"`
 }
 
-// Hook defines setup commands for specific repositories.
-type Hook struct {
-	// Pattern matches against remote URL (regex pattern).
-	Pattern string `yaml:"pattern"`
-	// Commands to run in the session directory after clone/recycle.
-	Commands []string `yaml:"commands"`
-}
-
-// CopyRule defines files to copy for matching repositories.
-type CopyRule struct {
+// Rule defines actions to take for matching repositories.
+type Rule struct {
 	// Pattern matches against remote URL (regex). Empty = matches all.
 	Pattern string `yaml:"pattern"`
-	// Files are glob patterns to copy from source directory.
-	Files []string `yaml:"files"`
+	// Commands to run in the session directory after clone/recycle.
+	Commands []string `yaml:"commands,omitempty"`
+	// Copy are glob patterns to copy from source directory.
+	Copy []string `yaml:"copy,omitempty"`
 }
 
 // Commands defines the shell commands used by hive.


### PR DESCRIPTION
## Summary

- Replace separate `hooks` and `copy` top-level config arrays with a unified `rules` array
- Each rule can now have both `commands` and `copy` patterns with a single `pattern` matcher
- Move pattern matching logic from copier/hooks to the service layer
- Update validation, tests, config files, and documentation

## Test plan

- [x] All existing tests pass
- [x] `go build ./...` succeeds
- [x] `hive doctor --config config.dev.yaml` validates successfully
- [x] `hive doctor --config config.invalid.yaml` correctly reports errors