### PR TITLE
docs: add migration entries for max_recycled feature

### DIFF
--- a/internal/commands/cmd_doc.go
+++ b/internal/commands/cmd_doc.go
@@ -72,6 +72,33 @@ type Migration struct {
 
 var migrations = []Migration{
 	{
+		Version:     "0.2.2",
+		Title:       "New max_recycled rule setting",
+		Description: "Rules can now set max_recycled to limit recycled sessions per repository. Oldest sessions beyond the limit are automatically deleted when recycling.",
+		Migration:   "No action required. Default is 5 sessions per repo. Configure via rules with empty pattern as catch-all.",
+		After: `# config.yaml
+rules:
+  # Catch-all sets the default (code default is 5 if not set)
+  - pattern: ""
+    max_recycled: 5
+
+  # Override for specific repos
+  - pattern: "github.com/my-org/large-repo"
+    max_recycled: 2  # keep fewer
+
+  # Unlimited for some repos
+  - pattern: "github.com/my-org/special-repo"
+    max_recycled: 0  # 0 = unlimited`,
+	},
+	{
+		Version:     "0.2.2",
+		Title:       "New prune --all flag",
+		Description: "The `hive prune` command now respects max_recycled limits by default. Use --all to delete all recycled sessions.",
+		Migration:   "If you want the old behavior (delete all recycled), use `hive prune --all`.",
+		Before:      `hive prune  # deleted all recycled sessions`,
+		After:       `hive prune --all  # same behavior as before`,
+	},
+	{
 		Version:     "0.2.1",
 		Title:       "New TUI auto-refresh feature",
 		Description: "The TUI sessions view now auto-refreshes every 15 seconds by default. This can be configured or disabled.",

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -36,7 +36,7 @@ var defaultKeybindings = map[string]Keybinding{
 
 // CurrentConfigVersion is the latest config schema version.
 // Increment this when making breaking changes to config format.
-const CurrentConfigVersion = "0.2.1"
+const CurrentConfigVersion = "0.2.2"
 
 // Config holds the application configuration.
 type Config struct {


### PR DESCRIPTION
## Summary

Follow-up to #43. Adds migration documentation for the max_recycled feature.

## Changes

- Bump config version to 0.2.2
- Add migration entry for `max_recycled` rule setting
- Add migration entry for `prune --all` flag (behavior change)

## Migration Guide Output

```
## Version 0.2.2 (Current)

### Breaking Changes

#### 1. New max_recycled rule setting

**What changed:** Rules can now set max_recycled to limit recycled sessions per repository.

**Migration:**
No action required. Default is 5 sessions per repo.

#### 2. New prune --all flag

**What changed:** The `hive prune` command now respects max_recycled limits by default.

**Migration:**
If you want the old behavior (delete all recycled), use `hive prune --all`.
```