### PR TITLE
feat(config): add conditional exit for keybindings via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,40 @@ Each keybinding can have:
 - `sh`: Shell command template (mutually exclusive with `action`)
 - `help`: Help text shown in TUI status bar
 - `confirm`: Confirmation prompt (optional, shows dialog before executing)
+- `exit`: Exit hive after command completes (see below)
 
 Default keybindings (`r` for recycle, `d` for delete) are provided and can be overridden.
+
+#### Conditional Exit
+
+The `exit` field controls whether hive exits after executing a keybinding. This is useful for popup/ephemeral terminal scenarios (e.g., tmux popup).
+
+```yaml
+keybindings:
+  # Static exit - always exit after this command
+  enter:
+    sh: "wezterm cli spawn --cwd {{ .Path }}"
+    exit: true
+
+  # Conditional exit - exit only when HIVE_POPUP=true
+  enter:
+    sh: "wezterm cli spawn --cwd {{ .Path }}"
+    exit: $HIVE_POPUP
+```
+
+The `exit` field accepts:
+- Boolean values: `true`, `false`, `1`, `0`
+- Environment variable reference: `$VAR_NAME` - exits if the var is set to a truthy value
+
+This allows the same config to work in both persistent and popup modes:
+
+```bash
+# Persistent session - select project, stay in hive
+hive
+
+# Popup mode - select project, exit so popup closes
+HIVE_POPUP=true hive
+```
 
 ## Data Storage
 

--- a/internal/core/config/exit_condition_test.go
+++ b/internal/core/config/exit_condition_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseExitCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		envName  string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "empty string returns false",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "true string returns true",
+			input:    "true",
+			expected: true,
+		},
+		{
+			name:     "false string returns false",
+			input:    "false",
+			expected: false,
+		},
+		{
+			name:     "1 returns true",
+			input:    "1",
+			expected: true,
+		},
+		{
+			name:     "0 returns false",
+			input:    "0",
+			expected: false,
+		},
+		{
+			name:     "TRUE returns true",
+			input:    "TRUE",
+			expected: true,
+		},
+		{
+			name:     "invalid string returns false",
+			input:    "invalid",
+			expected: false,
+		},
+		{
+			name:     "env var set to true",
+			input:    "$TEST_EXIT_VAR",
+			envName:  "TEST_EXIT_VAR",
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var set to 1",
+			input:    "$TEST_EXIT_VAR",
+			envName:  "TEST_EXIT_VAR",
+			envValue: "1",
+			expected: true,
+		},
+		{
+			name:     "env var set to false",
+			input:    "$TEST_EXIT_VAR",
+			envName:  "TEST_EXIT_VAR",
+			envValue: "false",
+			expected: false,
+		},
+		{
+			name:     "env var unset returns false",
+			input:    "$TEST_EXIT_VAR_UNSET",
+			expected: false,
+		},
+		{
+			name:     "env var set to empty string returns false",
+			input:    "$TEST_EXIT_VAR",
+			envName:  "TEST_EXIT_VAR",
+			envValue: "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envName != "" {
+				t.Setenv(tt.envName, tt.envValue)
+			}
+
+			result := ParseExitCondition(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestKeybinding_ShouldExit(t *testing.T) {
+	tests := []struct {
+		name     string
+		exit     string
+		envName  string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "static true",
+			exit:     "true",
+			expected: true,
+		},
+		{
+			name:     "static false",
+			exit:     "false",
+			expected: false,
+		},
+		{
+			name:     "env var true",
+			exit:     "$HIVE_POPUP",
+			envName:  "HIVE_POPUP",
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var false",
+			exit:     "$HIVE_POPUP",
+			envName:  "HIVE_POPUP",
+			envValue: "false",
+			expected: false,
+		},
+		{
+			name:     "env var unset",
+			exit:     "$HIVE_POPUP_UNSET",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envName != "" {
+				t.Setenv(tt.envName, tt.envValue)
+			}
+
+			kb := Keybinding{Exit: tt.exit}
+			assert.Equal(t, tt.expected, kb.ShouldExit())
+		})
+	}
+}

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -71,7 +71,7 @@ func (h *KeybindingHandler) Resolve(key string, sess session.Session) (Action, b
 		SessionID:   sess.ID,
 		SessionPath: sess.Path,
 		Silent:      kb.Silent,
-		Exit:        kb.Exit,
+		Exit:        kb.ShouldExit(),
 	}
 
 	// Built-in actions


### PR DESCRIPTION
## Summary

- Add support for environment variable checks in keybinding `exit` field
- The `exit` field now accepts either a boolean (`true`/`false`) or an env var reference (`$VAR_NAME`)
- When using an env var, hive exits only if the var is set to a truthy value (uses Go's `strconv.ParseBool`)

## Use Case

This enables the same config to work in both persistent and popup modes:

```yaml
keybindings:
  enter:
    sh: "wezterm cli spawn --cwd {{ .Path }}"
    exit: $HIVE_POPUP
```

```bash
# Persistent session - select project, stay in hive
hive

# Popup mode - select project, exit so popup closes
HIVE_POPUP=true hive
```

## Test plan

- [x] Added unit tests for `ParseExitCondition` function
- [x] Added unit tests for `Keybinding.ShouldExit()` method
- [x] All existing tests pass
- [x] Updated README with documentation