### PR TITLE
feat: move spawn commands from global config to rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,6 @@ integrations:
     enabled: [tmux]
     poll_interval: 500ms
 
-# Commands executed by hive
-commands:
-  recycle:
-    - git fetch origin
-    - git checkout {{ .DefaultBranch }}
-    - git reset --hard origin/{{ .DefaultBranch }}
-    - git clean -fd
-
 # Rules for repository-specific setup
 rules:
   # Default rule (empty pattern matches all)
@@ -136,6 +128,12 @@ rules:
       - 'wezterm cli spawn --cwd "{{ .Path }}" -- claude'
     batch_spawn:
       - 'wezterm cli spawn --cwd "{{ .Path }}" -- claude "{{ .Prompt }}"'
+    # recycle commands have sensible defaults; override if needed:
+    # recycle:
+    #   - git fetch origin
+    #   - git checkout -f {{ .DefaultBranch }}
+    #   - git reset --hard origin/{{ .DefaultBranch }}
+    #   - git clean -fd
     commands:
       - hive ctx init
 
@@ -184,7 +182,7 @@ Commands support Go templates with `{{ .Variable }}` syntax and `{{ .Variable | 
 | ---------------------- | ----------------------------------------------------------- |
 | `rules[].spawn`        | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo` |
 | `rules[].batch_spawn`  | Same as spawn, plus `.Prompt`                               |
-| `commands.recycle`     | `.DefaultBranch`                                            |
+| `rules[].recycle`      | `.DefaultBranch`                                            |
 | `usercommands.*.sh`    | `.Path`, `.Name`, `.Remote`, `.ID`, `.Args`                 |
 
 ### User Commands & Command Palette
@@ -278,11 +276,12 @@ keybindings:
 | Option                                | Type                    | Default                        | Description                              |
 | ------------------------------------- | ----------------------- | ------------------------------ | ---------------------------------------- |
 | `repo_dirs`                           | `[]string`              | `[]`                           | Directories to scan for repositories     |
-| `commands.recycle`                    | `[]string`              | git fetch/checkout/reset/clean | Commands when recycling                  |
+| `copy_command`                        | `string`                | `pbcopy` (macOS)               | Command to copy to clipboard             |
 | `rules`                               | `[]Rule`                | `[]`                           | Repository-specific setup rules          |
 | `rules[].pattern`                     | `string`                | `""`                           | Regex pattern to match remote URL        |
 | `rules[].spawn`                       | `[]string`              | `[]`                           | Commands after session creation          |
 | `rules[].batch_spawn`                 | `[]string`              | `[]`                           | Commands after batch session creation    |
+| `rules[].recycle`                     | `[]string`              | git fetch/checkout/reset/clean | Commands when recycling a session        |
 | `rules[].commands`                    | `[]string`              | `[]`                           | Setup commands to run after clone        |
 | `rules[].copy`                        | `[]string`              | `[]`                           | Glob patterns for files to copy          |
 | `rules[].max_recycled`                | `*int`                  | `5`                            | Max recycled sessions (0 = unlimited)    |

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -216,7 +216,7 @@ func (s *Service) RecycleSession(ctx context.Context, id string, w io.Writer) er
 		DefaultBranch: defaultBranch,
 	}
 
-	if err := s.recycler.Recycle(ctx, sess.Path, s.config.Commands.Recycle, data, w); err != nil {
+	if err := s.recycler.Recycle(ctx, sess.Path, s.config.GetRecycleCommands(sess.Remote), data, w); err != nil {
 		return fmt.Errorf("recycle session %s: %w", id, err)
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -256,7 +256,7 @@ func New(service *hive.Service, cfg *config.Config, opts Options) Model {
 		msgView:            msgView,
 		topicFilter:        "*",
 		activeView:         ViewSessions,
-		copyCommand:        cfg.Commands.CopyCommand,
+		copyCommand:        cfg.CopyCommand,
 		repoDirs:           cfg.RepoDirs,
 	}
 }


### PR DESCRIPTION
## Summary

- Move `spawn` and `batch_spawn` from `Commands` struct to `Rule` struct
- Enable per-repository spawn configuration based on pattern matching
- Add `GetSpawnCommands` method for rule-based resolution

## Changes

| File | Changes |
|------|---------|
| `internal/core/config/config.go` | Add Spawn/BatchSpawn to Rule, remove from Commands, add GetSpawnCommands method |
| `internal/core/config/validate.go` | Validate rule spawn templates, add warning for missing spawn |
| `internal/core/config/validate_test.go` | Add tests for GetSpawnCommands and warnings |
| `internal/hive/service.go` | Use GetSpawnCommands instead of Commands.Spawn |

## New Config Format

```yaml
rules:
  - pattern: ""  # Default (matches all)
    spawn: ["wezterm cli spawn --cwd {{.Path}}"]
    batch_spawn: ["wezterm cli spawn --cwd {{.Path}} -- claude --prompt '{{.Prompt}}'"]

  - pattern: "github.com/work/.*"  # Override for work repos
    spawn: ["wezterm cli spawn --cwd {{.Path}} -- aider"]
```

## Test plan

- [x] All existing tests pass
- [x] New tests for `GetSpawnCommands` (8 cases)
- [x] New tests for spawn warnings
- [x] Linter passes

## Breaking Change

Users must move `commands.spawn` and `commands.batch_spawn` to a rule with empty pattern.