### PR TITLE
feat: add hive claude plugin with messaging and config skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "hive",
+  "description": "plugin for hive cli",
+  "version": "v0.1.0",
+  "author": {
+    "name": "hay-kot"
+  }
+}

--- a/.claude-plugin/skills/config/SKILL.md
+++ b/.claude-plugin/skills/config/SKILL.md
@@ -1,0 +1,710 @@
+---
+name: hive:config
+description: Configure hive for your workflow - rules, spawn commands, keybindings, and terminal integration. Use when setting up new repos or customizing session behavior.
+compatibility: claude, opencode
+---
+
+# Config - Configure Hive for Your Workflow
+
+Set up and customize hive to match your development workflow with rules, spawn commands, keybindings, and terminal integration.
+
+## When to Use
+
+Use this skill when:
+- Setting up hive for the first time
+- Configuring repository-specific behavior
+- Customizing spawn commands for your terminal
+- Adding keybindings or user commands
+- Enabling tmux integration
+- Creating automation workflows
+
+**Common triggers:**
+- "configure hive"
+- "setup hive for my workflow"
+- "customize session spawn"
+- "add tmux integration"
+- "create custom keybindings"
+
+## Configuration File
+
+**Location:** `~/.config/hive/config.yaml`
+
+**Format:** YAML
+
+**Check current config:**
+```bash
+cat ~/.config/hive/config.yaml
+```
+
+**Edit config:**
+```bash
+$EDITOR ~/.config/hive/config.yaml
+```
+
+## Configuration Structure
+
+### Minimal Config
+
+```yaml
+version: 0.2.4
+
+rules:
+  - pattern: ""  # Matches all repos
+    spawn:
+      - 'wezterm cli spawn --cwd "{{ .Path }}" -- claude'
+```
+
+### Complete Config Example
+
+```yaml
+version: 0.2.4
+
+# Directories to scan for repos (enables 'n' key in TUI)
+repo_dirs:
+  - ~/code/repos
+  - ~/projects
+
+# Terminal integration
+integrations:
+  terminal:
+    enabled: [tmux]
+    poll_interval: 500ms
+
+# TUI settings
+tui:
+  refresh_interval: 10s
+  preview_enabled: true
+
+# Repository-specific rules
+rules:
+  # Default rule (empty pattern matches all)
+  - pattern: ""
+    max_recycled: 5
+    spawn:
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}"
+    commands:
+      - hive ctx init
+
+  # Work repos
+  - pattern: ".*github\\.com/my-org/.*"
+    spawn:
+      - 'wezterm cli spawn --cwd "{{ .Path }}" -- aider'
+    commands:
+      - npm install
+    copy:
+      - .envrc
+
+# User commands
+usercommands:
+  review:
+    sh: "send-claude {{ .Name }} /review"
+    help: "Send /review to Claude"
+    silent: true
+
+# Keybindings
+keybindings:
+  r:
+    cmd: Recycle
+    confirm: "Recycle session?"
+  d:
+    cmd: Delete
+```
+
+## Rules System
+
+Rules match repository URLs with regex patterns and define behavior for those repos.
+
+### Rule Structure
+
+```yaml
+rules:
+  - pattern: ".*github\\.com/org-name/.*"  # Regex pattern
+    max_recycled: 3                         # Max recycled sessions
+    spawn: []                               # Commands after creation
+    batch_spawn: []                         # Commands for batch creation
+    recycle: []                             # Commands when recycling
+    commands: []                            # Setup commands after clone
+    copy: []                                # Files to copy from original
+```
+
+### Pattern Matching
+
+Patterns are regex strings matched against the git remote URL.
+
+**Examples:**
+```yaml
+# Match all repos
+- pattern: ""
+
+# Match specific org
+- pattern: ".*github\\.com/my-org/.*"
+
+# Match specific repo
+- pattern: ".*github\\.com/my-org/my-repo"
+
+# Match by protocol
+- pattern: "git@github\\.com:.*"
+- pattern: "https://.*"
+
+# Match multiple orgs
+- pattern: ".*(my-org|other-org)/.*"
+```
+
+**Rule precedence:** First matching rule wins. Put specific patterns before general ones.
+
+### Spawn Commands
+
+Commands run after creating a new session.
+
+**spawn** - Interactive session creation (via TUI or `hive new`)
+**batch_spawn** - Background session creation (via `hive batch`)
+
+```yaml
+rules:
+  - pattern: ""
+    spawn:
+      # Open tmux session
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}"
+
+    batch_spawn:
+      # Background tmux with initial prompt
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" "claude '{{ .Prompt }}'"
+```
+
+### Recycle Commands
+
+Commands run when recycling a session (returning to clean state).
+
+**Default recycle behavior:**
+```yaml
+recycle:
+  - git fetch origin
+  - git checkout -f {{ .DefaultBranch }}
+  - git reset --hard origin/{{ .DefaultBranch }}
+  - git clean -fd
+```
+
+**Override for custom workflow:**
+```yaml
+rules:
+  - pattern: ".*monorepo.*"
+    recycle:
+      - git fetch origin
+      - git checkout -f main
+      - git reset --hard origin/main
+      - git clean -fd
+      - npm install  # Reinstall after clean
+```
+
+### Setup Commands
+
+Commands run after cloning the repository.
+
+```yaml
+rules:
+  - pattern: ".*my-project.*"
+    commands:
+      - hive ctx init           # Create .hive symlink
+      - npm install             # Install dependencies
+      - cp .env.example .env    # Setup environment
+      - make setup              # Run project setup
+```
+
+### Copy Files
+
+Copy files from original repo to session.
+
+```yaml
+rules:
+  - pattern: ""
+    copy:
+      - .envrc          # Direnv config
+      - .env.local      # Local environment
+      - config/*.yaml   # Config files (glob patterns supported)
+```
+
+## Template Variables
+
+Commands support Go templates with `{{ .Variable }}` syntax.
+
+### Available Variables
+
+| Context | Variables |
+|---------|-----------|
+| `spawn`, `batch_spawn` | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo` |
+| `batch_spawn` (additional) | `.Prompt` |
+| `recycle` | `.DefaultBranch` |
+| `usercommands.*.sh` | `.Path`, `.Name`, `.Remote`, `.ID`, `.Args` |
+
+### Variable Descriptions
+
+**`.Path`** - Absolute path to session directory
+- Example: `/Users/name/.local/share/hive/repos/myrepo-abc123`
+
+**`.Name`** - Session name (repo-sessionid format)
+- Example: `myrepo-abc123`
+
+**`.Slug`** - Repository slug (owner/repo)
+- Example: `my-org/myrepo`
+
+**`.ContextDir`** - Shared context directory path
+- Example: `/Users/name/.local/share/hive/context/my-org/myrepo`
+
+**`.Owner`** - Repository owner
+- Example: `my-org`
+
+**`.Repo`** - Repository name
+- Example: `myrepo`
+
+**`.Prompt`** - Initial prompt (batch_spawn only)
+- Example: `Implement user authentication`
+
+**`.DefaultBranch`** - Default branch name (recycle only)
+- Example: `main` or `master`
+
+**`.ID`** - Session ID (usercommands only)
+- Example: `abc123`
+
+**`.Remote`** - Git remote URL (usercommands only)
+- Example: `git@github.com:my-org/myrepo.git`
+
+**`.Args`** - Command arguments array (usercommands only)
+- Example: `["arg1", "arg2"]`
+
+### Shell Quoting
+
+Use `{{ .Variable | shq }}` to safely quote variables for shell commands:
+
+```yaml
+spawn:
+  - echo {{ .Name | shq }}          # Safe: handles spaces/quotes
+  - 'claude "{{ .Prompt | shq }}"'  # Safe: nested quotes
+```
+
+## Terminal Integration
+
+### Tmux Integration
+
+Enable real-time status monitoring of tmux panes:
+
+```yaml
+integrations:
+  terminal:
+    enabled: [tmux]
+    poll_interval: 500ms
+    preview_window_matcher: ["claude", "aider", "codex"]
+```
+
+**Status indicators:**
+- `[●]` Green - Agent actively working
+- `[!]` Yellow - Agent needs approval
+- `[>]` Cyan - Agent ready for input
+- `[?]` Dim - Terminal not found
+- `[○]` Gray - Session recycled
+
+**Preview sidebar:**
+Press `v` in TUI to toggle tmux pane preview.
+
+### Spawn Command Patterns
+
+#### WezTerm
+
+```yaml
+spawn:
+  - 'wezterm cli spawn --cwd "{{ .Path }}" -- claude'
+```
+
+#### Tmux (New Session)
+
+```yaml
+spawn:
+  - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" claude
+```
+
+#### Tmux (Create or Switch)
+
+```yaml
+spawn:
+  - tmux has-session -t "{{ .Name }}" 2>/dev/null && tmux switch-client -t "{{ .Name }}" || tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" claude
+```
+
+#### Kitty
+
+```yaml
+spawn:
+  - 'kitty @ launch --cwd "{{ .Path }}" --type tab claude'
+```
+
+#### Alacritty
+
+```yaml
+spawn:
+  - 'alacritty --working-directory "{{ .Path }}" -e claude &'
+```
+
+#### iTerm2 (macOS)
+
+```yaml
+spawn:
+  - osascript -e 'tell application "iTerm" to create window with default profile command "cd {{ .Path | shq }} && claude"'
+```
+
+## User Commands
+
+Define custom commands accessible via `:` command palette or keybindings.
+
+### Command Structure
+
+```yaml
+usercommands:
+  name:
+    sh: "command template"     # Shell command
+    help: "Description"        # Help text
+    confirm: "Are you sure?"   # Optional confirmation
+    silent: true               # Skip loading popup
+    exit: "true"               # Exit TUI after command
+```
+
+### System Default Commands
+
+Hive provides built-in commands you can reference:
+
+| Name | Description |
+|------|-------------|
+| `Recycle` | Reset session to clean state |
+| `Delete` | Delete session completely |
+
+### Example Commands
+
+```yaml
+usercommands:
+  # Send slash command to claude
+  tidy:
+    sh: "send-claude {{ .Name }} /tidy"
+    help: "Run /tidy in Claude session"
+    confirm: "Commit and push changes?"
+    silent: true
+
+  # Open in editor
+  vscode:
+    sh: "code {{ .Path }}"
+    help: "Open session in VS Code"
+    silent: true
+    exit: "true"
+
+  # Send message to inbox
+  msg:
+    sh: 'hive msg pub -t agent.{{ .ID }}.inbox "{{ range .Args }}{{ . }} {{ end }}"'
+    help: "Send message to session inbox"
+
+  # Run tests
+  test:
+    sh: "cd {{ .Path }} && npm test"
+    help: "Run test suite"
+
+  # Git worktree creation
+  worktree:
+    sh: 'cd {{ .Path }} && git worktree add ../{{ .Repo }}-{{ index .Args 0 }} {{ index .Args 0 }}'
+    help: "Create git worktree (usage: :worktree branch-name)"
+```
+
+### Arguments Support
+
+Access arguments via `.Args` template variable:
+
+```yaml
+usercommands:
+  checkout:
+    sh: "cd {{ .Path }} && git checkout {{ index .Args 0 }}"
+    help: "Checkout branch (usage: :checkout branch-name)"
+```
+
+**Usage:** `:checkout feature-x` → checks out `feature-x`
+
+### Exit Conditions
+
+Control when TUI exits after command:
+
+```yaml
+usercommands:
+  attach:
+    sh: "tmux attach -t {{ .Name }}"
+    exit: "$HIVE_POPUP"  # Exit if HIVE_POPUP env var is true
+```
+
+**Values:**
+- `"true"` - Always exit
+- `"false"` - Never exit
+- `"$ENV_VAR"` - Exit if environment variable is set to "true"
+
+## Keybindings
+
+Map keys to user commands in the TUI.
+
+### Keybinding Structure
+
+```yaml
+keybindings:
+  key:
+    cmd: command-name         # Command to execute
+    help: "Override help"     # Override command's help text
+    confirm: "Are you sure?"  # Override command's confirmation
+```
+
+### Example Keybindings
+
+```yaml
+keybindings:
+  # System defaults
+  r:
+    cmd: Recycle
+    confirm: "Recycle this session?"
+  d:
+    cmd: Delete
+
+  # Custom commands
+  o:
+    cmd: vscode
+  t:
+    cmd: tidy
+  enter:
+    cmd: attach
+  ctrl+t:
+    cmd: test
+```
+
+### Special Keys
+
+**Single keys:** `a-z`, `0-9`, `-`, `=`, `[`, `]`, etc.
+**Modified keys:** `ctrl+a`, `alt+x`, `shift+f1`
+**Function keys:** `f1`, `f2`, ..., `f12`
+**Special:** `enter`, `space`, `tab`, `esc`, `backspace`
+
+### Reserved Keys
+
+These keys are used by hive and cannot be bound:
+
+- `?` - Help screen
+- `:` - Command palette (if usercommands configured)
+- `v` - Toggle preview (if tmux enabled)
+- `j/k/↑/↓` - Navigation
+- `/` - Filter
+- `n` - New session (if repo_dirs configured)
+
+## Common Workflow Examples
+
+### Basic Setup (All Repos)
+
+```yaml
+rules:
+  - pattern: ""
+    spawn:
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" claude
+    commands:
+      - hive ctx init
+```
+
+### Organization-Specific Setup
+
+```yaml
+rules:
+  # Work repos with setup script
+  - pattern: ".*github\\.com/my-company/.*"
+    spawn:
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" claude
+    commands:
+      - hive ctx init
+      - make dev-setup
+      - npm install
+    copy:
+      - .envrc
+
+  # Personal repos (simple)
+  - pattern: ".*github\\.com/my-username/.*"
+    spawn:
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" claude
+    commands:
+      - hive ctx init
+```
+
+### Monorepo with Multiple Tools
+
+```yaml
+rules:
+  - pattern: ".*monorepo.*"
+    spawn:
+      # Create tmux session with multiple panes
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}"
+      - tmux split-window -h -t "{{ .Name }}" -c "{{ .Path }}"
+      - tmux send-keys -t "{{ .Name }}:0.0" "claude" Enter
+      - tmux send-keys -t "{{ .Name }}:0.1" "npm run dev" Enter
+    commands:
+      - npm install
+      - npm run build
+```
+
+### Git Worktree Pattern
+
+```yaml
+rules:
+  - pattern: ""
+    spawn:
+      - tmux new-session -d -s "{{ .Name }}" -c "{{ .Path }}" claude
+    commands:
+      - hive ctx init
+      - bd init --stealth || true  # Initialize beads tracking
+
+usercommands:
+  worktree:
+    sh: 'cd {{ .Path }} && git worktree add ../{{ .Repo }}-{{ index .Args 0 }} {{ index .Args 0 }}'
+    help: "Create worktree from branch"
+```
+
+### Terminal Emulator Matrix
+
+```yaml
+# WezTerm
+rules:
+  - pattern: ""
+    spawn:
+      - 'wezterm cli spawn --cwd "{{ .Path }}" -- claude'
+
+# Tmux with custom layout script
+rules:
+  - pattern: ""
+    spawn:
+      - ~/.config/tmux/layouts/hive.sh "{{ .Name }}" "{{ .Path }}"
+
+# Kitty with tab
+rules:
+  - pattern: ""
+    spawn:
+      - 'kitty @ launch --type tab --cwd "{{ .Path }}" claude'
+```
+
+## Best Practices
+
+### Rule Organization
+
+1. **Specific before general:** More specific patterns should come first
+2. **Test patterns:** Use `echo "url" | grep -E "pattern"` to test regex
+3. **Document patterns:** Add comments explaining complex regex
+
+```yaml
+rules:
+  # Critical production repos
+  - pattern: ".*github\\.com/company/prod-.*"
+    max_recycled: 1  # Keep clean
+
+  # Regular work repos
+  - pattern: ".*github\\.com/company/.*"
+    max_recycled: 3
+
+  # Catch-all
+  - pattern: ""
+    max_recycled: 5
+```
+
+### Command Safety
+
+1. **Quote variables:** Use `{{ .Variable | shq }}` for shell safety
+2. **Handle failures:** Use `|| true` for optional commands
+3. **Test commands:** Run manually before adding to config
+
+```yaml
+commands:
+  - npm install || echo "npm not found"  # Handle missing npm
+  - test -f .envrc && direnv allow       # Conditional execution
+```
+
+### Template Variables
+
+1. **Use `.Path` for working directory:** `cd {{ .Path }}`
+2. **Use `.Name` for session references:** `tmux attach -t {{ .Name }}`
+3. **Use `.Prompt` for batch initialization:** Only available in `batch_spawn`
+
+## Troubleshooting
+
+### Config Not Loading
+
+**Problem:** Changes to config.yaml not taking effect
+
+**Solutions:**
+- Check config location: `~/.config/hive/config.yaml`
+- Verify YAML syntax: Use `yamllint` or online validator
+- Check for error messages: Run `hive ls` and look for warnings
+- Restart hive TUI: Exit and relaunch
+
+### Pattern Not Matching
+
+**Problem:** Rule not applying to expected repos
+
+**Solutions:**
+- Test regex: `echo "git@github.com:org/repo" | grep -E "pattern"`
+- Check remote URL: `cd repo && git remote -v`
+- Escape special chars: Use `\\.` for literal dots
+- Check pattern order: More specific patterns must come first
+
+### Spawn Command Fails
+
+**Problem:** Terminal doesn't open or crashes
+
+**Solutions:**
+- Test command manually: Run with substituted variables
+- Check template syntax: Verify `{{ .Variable }}` format
+- Quote paths: Use `{{ .Path | shq }}` for spaces
+- Check executable exists: `which tmux`, `which wezterm`, etc.
+
+### Template Variable Empty
+
+**Problem:** Variable expands to empty string
+
+**Solutions:**
+- Check variable availability: Some only work in specific contexts
+- Verify spelling: Variable names are case-sensitive
+- Check session metadata: `hive ls` shows available data
+- Use default values: `{{ .Variable | default "fallback" }}`
+
+## Migration
+
+Check your config version and migrate if needed:
+
+```bash
+hive doc migrate
+```
+
+Current version: **0.2.4**
+
+### Key Changes in 0.2.4
+
+- **Keybindings:** Must reference commands via `cmd` field
+- **Built-in commands:** `Recycle` and `Delete` are now user commands
+- **Actions removed:** Use `cmd: Recycle` instead of `action: recycle`
+
+## Related Skills
+
+- `/hive:inbox` - Check inter-agent messages
+- `/hive:publish` - Send messages between sessions
+- `/hive:session-info` - Get current session details
+
+## Tips
+
+**Start Simple:**
+- Begin with minimal config
+- Add complexity as needed
+- Test each change before adding more
+
+**Use Version Control:**
+- Keep config in dotfiles repo
+- Document custom patterns
+- Share configs across machines
+
+**Leverage Templates:**
+- Create reusable command patterns
+- Use variables for flexibility
+- Quote safely with `| shq`
+
+**Optimize for Your Workflow:**
+- Map frequent actions to single keys
+- Create commands for common tasks
+- Use spawn commands to set up environment exactly how you want it

--- a/.claude-plugin/skills/inbox/SKILL.md
+++ b/.claude-plugin/skills/inbox/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: hive:inbox
+description: Check your inbox for inter-agent messages. Use when you need to read messages, check for unread messages, or review communication from other agents.
+compatibility: claude, opencode
+---
+
+# Inbox - Read Inter-Agent Messages
+
+Check and read messages sent to your session's inbox from other agents or sessions.
+
+## When to Use
+
+Use this skill when:
+- Another agent mentions sending you a message
+- You need to check for pending messages
+- You want to review recent inter-agent communications
+- Starting work on a task that may have been handed off to you
+- Coordinating with other Claude sessions
+
+**Common triggers:**
+- "check my inbox"
+- "read my messages"
+- "any unread messages?"
+- "check for new messages"
+- "see my inbox"
+
+## How It Works
+
+Each hive session has a unique inbox topic (`agent.<id>.inbox`). Other agents can publish messages to your inbox, and you can read them using this skill.
+
+Messages are automatically marked as read by default when you check your inbox. This prevents re-reading the same messages multiple times.
+
+## Commands
+
+### Read Unread Messages (Default)
+
+```bash
+hive msg inbox
+```
+
+Shows only unread messages and marks them as read. This is the most common usage.
+
+**Output format:**
+- Each message shows timestamp, sender, and content
+- Messages are displayed in chronological order
+- After reading, messages are marked with `read: true`
+
+### Peek Without Marking as Read
+
+```bash
+hive msg inbox --peek
+```
+
+View unread messages without marking them as read. Useful when you want to check messages but aren't ready to act on them yet.
+
+**Use cases:**
+- Quick check during another task
+- Previewing messages before committing to read them
+- Debugging message flow
+
+### Read All Messages
+
+```bash
+hive msg inbox --all
+```
+
+Shows all messages in your inbox, both read and unread. Does NOT mark messages as read.
+
+**Use cases:**
+- Reviewing conversation history
+- Finding a specific past message
+- Auditing communication timeline
+
+### JSON Output
+
+```bash
+hive msg inbox --json
+```
+
+Returns messages in JSON format for programmatic processing. Can be combined with other flags:
+- `hive msg inbox --json` - Unread messages, mark as read
+- `hive msg inbox --peek --json` - Unread messages, don't mark as read
+- `hive msg inbox --all --json` - All messages, don't mark as read
+
+## Message Format
+
+Messages contain:
+- `id`: Unique message identifier
+- `sender`: Who sent the message (agent ID or session name)
+- `timestamp`: When the message was sent
+- `content`: The message text
+- `read`: Whether you've read the message (boolean)
+- `topic`: The inbox topic (usually `agent.<id>.inbox`)
+
+## Auto-Acknowledgment System
+
+When you read messages from your inbox, the hive system automatically acknowledges receipt. This is built on four phases:
+
+1. **Foundation**: Messages store read/unread state
+2. **Read Tracking**: `hive msg inbox` updates read status
+3. **Acknowledgment Channels**: Senders can subscribe to ack topics
+4. **Confirmation Loop**: Acknowledgments are published when messages are read
+
+### How Acknowledgments Work
+
+When an agent sends you a message with `hive msg pub agent.123.inbox "message"`, they can optionally wait for acknowledgment:
+
+```bash
+# Sender subscribes to acknowledgment topic
+hive msg sub agent.123.inbox.ack
+```
+
+When you read the message with `hive msg inbox`, the system automatically:
+1. Marks the message as read
+2. Publishes an acknowledgment to `<topic>.ack`
+3. Includes the message ID and read timestamp
+
+The sender receives confirmation that you've read their message.
+
+## Common Workflows
+
+### Basic Message Check
+
+```bash
+# Check for new messages
+hive msg inbox
+
+# If there are messages, read and respond if needed
+# Messages are automatically marked as read
+```
+
+### Coordinated Handoff
+
+When another agent hands off work to you:
+
+```bash
+# Agent A publishes to your inbox:
+# "Task X is ready. See issue hive-123."
+
+# You check your inbox
+hive msg inbox
+
+# Read the task details
+bd show hive-123
+
+# Start working on the task
+```
+
+### Review Past Communication
+
+```bash
+# See all messages (read and unread)
+hive msg inbox --all
+
+# Find specific conversation
+hive msg inbox --all | grep "handoff"
+```
+
+## Troubleshooting
+
+### No Messages Showing
+
+**Problem:** Running `hive msg inbox` shows no messages
+
+**Solutions:**
+- Check if you're in the correct session: `hive session ls`
+- Verify your inbox topic: Your inbox is `agent.<session-id>.inbox`
+- Check if messages exist: `hive msg inbox --all`
+
+### Messages Not Marked as Read
+
+**Problem:** Messages keep showing as unread
+
+**Solutions:**
+- Ensure you're NOT using `--peek` or `--all` flags
+- Use default command: `hive msg inbox`
+- Check message file permissions in `$XDG_DATA_HOME/hive/messages/topics/`
+
+### Can't Find Specific Message
+
+**Problem:** Looking for a message that was sent earlier
+
+**Solutions:**
+- Use `--all` to see full history: `hive msg inbox --all`
+- Search with grep: `hive msg inbox --all | grep "keyword"`
+- Check with JSON: `hive msg inbox --all --json | jq '.[] | select(.sender == "agent-123")'`
+
+## Related Skills
+
+- `/hive:publish` - Send messages to other agents
+- `/hive:wait` - Wait for specific messages with timeout
+- `/hive:session-info` - Get your current session details
+
+## Tips
+
+**Be Proactive:**
+- Check inbox at start of new work sessions
+- Review messages when context switching between tasks
+
+**Stay Organized:**
+- Read messages when you can act on them
+- Use `--peek` only for quick checks
+- Use `--all` to review conversation threads
+
+**Coordinate Effectively:**
+- Acknowledge handoffs by starting the referenced work
+- Send responses using `/hive:publish` when appropriate
+- Keep message history for context on long-running work

--- a/.claude-plugin/skills/msg-publish/SKILL.md
+++ b/.claude-plugin/skills/msg-publish/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: hive:publish
+description: Send messages to other agents or broadcast to multiple sessions. Use when coordinating work, sending notifications, or communicating with other Claude sessions.
+compatibility: claude, opencode
+---
+
+# Publish - Send Inter-Agent Messages
+
+Send messages to other agents, broadcast to multiple sessions, or publish notifications to topic-based channels.
+
+## When to Use
+
+Use this skill when:
+- Handing off work to another agent
+- Notifying other sessions of events
+- Broadcasting status updates
+- Sending results or data to waiting agents
+- Coordinating distributed work
+
+**Common triggers:**
+- "send message to agent X"
+- "publish to topic"
+- "broadcast to all agents"
+- "notify other sessions"
+- "tell agent Y that..."
+
+## How It Works
+
+Messages are published to named topics stored as JSON files at `$XDG_DATA_HOME/hive/messages/topics/`. Other agents can subscribe to these topics to receive messages.
+
+The sender is auto-detected from your current hive session context. Each message includes:
+- Sender ID (your session)
+- Timestamp
+- Content
+- Topic(s)
+
+## Commands
+
+### Publish Direct Message
+
+Send a message as a command-line argument:
+
+```bash
+hive msg pub --topic <topic> "message content"
+```
+
+**Examples:**
+```bash
+# Send to specific agent's inbox
+hive msg pub --topic agent.abc123.inbox "Task completed, ready for review"
+
+# Publish to custom topic
+hive msg pub --topic build.status "Build #42 completed successfully"
+
+# Send to multiple topics
+hive msg pub -t agent.123.inbox -t agent.456.inbox "Important update"
+```
+
+### Publish from Stdin
+
+Pipe content directly to publish:
+
+```bash
+echo "Status update" | hive msg pub --topic notifications
+cat report.txt | hive msg pub --topic reports
+```
+
+**Use cases:**
+- Publishing command output
+- Sending file contents
+- Piping structured data
+
+### Publish from File
+
+Read message content from a file:
+
+```bash
+hive msg pub --topic logs -f build.log
+hive msg pub -t agent.abc.inbox --file handoff-context.md
+```
+
+**Use cases:**
+- Sending large messages
+- Publishing log files
+- Sharing structured data or reports
+
+### Broadcast with Wildcards
+
+Use wildcards to publish to multiple matching topics:
+
+```bash
+# Broadcast to all agent inboxes
+hive msg pub -t "agent.*.inbox" "System maintenance in 5 minutes"
+
+# Notify all build watchers
+hive msg pub -t "build.*.status" "Build server online"
+```
+
+**Wildcard patterns:**
+- `*` matches any characters within a segment
+- Topics are expanded at publish time
+- Messages are sent to all matching topics
+
+## Topic Patterns
+
+### Standard Inbox Format
+
+Agent inboxes follow the pattern: `agent.<session-id>.inbox`
+
+```bash
+# Find your session ID
+hive session ls
+
+# Send to specific agent
+hive msg pub --topic agent.abc123.inbox "Message"
+```
+
+### Custom Topics
+
+Create any topic name for specific use cases:
+
+```bash
+# Event notifications
+hive msg pub --topic deploy.started "Deployment initiated"
+hive msg pub --topic deploy.completed "Deployment finished"
+
+# Coordination channels
+hive msg pub --topic coordinator.requests "Need help with task X"
+hive msg pub --topic build.events "Test suite running"
+```
+
+### Topic Naming Conventions
+
+**Good topic names:**
+- `agent.<id>.inbox` - Direct messages to agents
+- `<domain>.<event>` - Event notifications (build.started, test.failed)
+- `<feature>.<channel>` - Feature-specific channels (auth.status, cache.updates)
+
+**Avoid:**
+- Generic names (messages, data, updates)
+- Special characters besides `.`, `-`, `_`
+- Very long topic names
+
+## Examples
+
+### Direct Handoff to Another Agent
+
+```bash
+# You: Complete work and notify next agent
+hive msg pub --topic agent.xyz789.inbox "Auth implementation complete. See PR #123. Tests passing."
+
+# Agent XYZ receives in their inbox
+hive msg inbox
+# > [2026-02-04 10:30] agent.abc123: Auth implementation complete. See PR #123. Tests passing.
+```
+
+### Broadcast Status Update
+
+```bash
+# Notify all agents monitoring build status
+hive msg pub -t "build.*.status" "Build server restarting for maintenance"
+
+# Any agent subscribed to build.main.status, build.dev.status, etc. receives the message
+```
+
+### Multi-Topic Notification
+
+```bash
+# Send to multiple specific recipients
+hive msg pub \
+  -t agent.abc.inbox \
+  -t agent.xyz.inbox \
+  -t coordinator.updates \
+  "Feature X ready for review"
+```
+
+### Send Command Output
+
+```bash
+# Publish test results
+go test -v ./... | hive msg pub --topic test.results
+
+# Share file list
+ls -la | hive msg pub --topic inventory
+
+# Send structured data
+jq '.' report.json | hive msg pub --topic reports.daily
+```
+
+### File-Based Message
+
+```bash
+# Send detailed context from file
+hive msg pub --topic agent.abc.inbox -f handoff-notes.md
+
+# Publish entire log file
+hive msg pub --topic logs.deployment --file deploy.log
+```
+
+## Coordinated Workflows
+
+### Work Handoff Pattern
+
+**Agent A (completing work):**
+```bash
+# Complete task
+git commit -m "feat: implement feature X"
+
+# Notify next agent with context
+hive msg pub --topic agent.bob.inbox "Feature X implementation complete.
+Branch: feat/feature-x
+Tests: All passing
+Next: Need integration testing with component Y
+See issue: hive-123"
+```
+
+**Agent B (receiving work):**
+```bash
+# Check inbox
+hive msg inbox
+# > Message from agent.alice: Feature X implementation complete...
+
+# Start work on next step
+bd show hive-123
+```
+
+### Event Broadcasting Pattern
+
+**Build Agent:**
+```bash
+# Start build
+hive msg pub --topic build.main.status "Build started: commit abc123"
+
+# Complete build
+hive msg pub --topic build.main.status "Build completed: all tests passed"
+```
+
+**Monitoring Agent:**
+```bash
+# Subscribe to build events
+hive msg sub build.main.status
+
+# Receives all build status updates
+```
+
+### Acknowledgment Pattern
+
+**Sender (waiting for confirmation):**
+```bash
+# Send message
+hive msg pub --topic agent.bob.inbox "Task ready for you"
+
+# Subscribe to acknowledgment topic
+hive msg sub agent.bob.inbox.ack
+
+# Wait for Bob to read the message
+```
+
+**Receiver (Bob):**
+```bash
+# Read message (automatically sends acknowledgment)
+hive msg inbox
+# Acknowledgment is automatically published to sender
+```
+
+## Advanced Usage
+
+### Override Sender ID
+
+Useful for testing or special coordination scenarios:
+
+```bash
+hive msg pub --topic test.channel --sender "custom-agent-id" "Test message"
+```
+
+**Use cases:**
+- Testing message workflows
+- Proxy messages from external systems
+- Debugging topic communication
+
+### Multiple Topic Publishing
+
+Send same message to multiple distinct topics:
+
+```bash
+hive msg pub \
+  -t notifications \
+  -t agent.alice.inbox \
+  -t agent.bob.inbox \
+  -t coordinator.events \
+  "Critical: Database migration starting"
+```
+
+## Troubleshooting
+
+### Message Not Received
+
+**Problem:** Published message doesn't appear in recipient's inbox
+
+**Solutions:**
+- Verify topic name: Check recipient's session ID with `hive session ls`
+- Correct format: Use `agent.<session-id>.inbox` for direct messages
+- Check message file: Look in `$XDG_DATA_HOME/hive/messages/topics/<topic>.json`
+
+### Wildcard Not Expanding
+
+**Problem:** Wildcard pattern doesn't match expected topics
+
+**Solutions:**
+- Check existing topics: `hive msg list`
+- Verify pattern syntax: Wildcards only work within segments
+- Create topics first: Topics must exist to be matched
+
+### Sender ID Incorrect
+
+**Problem:** Messages show wrong sender
+
+**Solutions:**
+- Verify session context: Run from correct hive session directory
+- Check session: `hive session ls` to see active sessions
+- Override if needed: Use `--sender` flag explicitly
+
+## Related Skills
+
+- `/hive:inbox` - Check your inbox for messages
+- `/hive:wait` - Wait for messages with timeout
+- `/hive:session-info` - Get your session details and inbox topic
+
+## Tips
+
+**Be Clear:**
+- Include context in messages (what, why, next steps)
+- Reference issues, PRs, or branches when relevant
+- Use structured format for complex messages
+
+**Be Efficient:**
+- Use stdin for command output
+- Use files for large or structured data
+- Use wildcards for broadcasts
+
+**Be Coordinated:**
+- Follow up on handoffs by checking acknowledgments
+- Subscribe to relevant topics for updates
+- Document coordination patterns in team workflows

--- a/.claude-plugin/skills/msg-wait/SKILL.md
+++ b/.claude-plugin/skills/msg-wait/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: hive:wait
+description: Wait for messages from other agents with timeout. Use for synchronization points, agent handoff coordination, or blocking until responses arrive.
+compatibility: claude, opencode
+---
+
+# Wait - Block Until Messages Arrive
+
+Wait for messages on specific topics, enabling synchronization between agents and coordinated handoff workflows.
+
+## When to Use
+
+Use this skill when:
+- Waiting for another agent to complete their work
+- Coordinating handoff between agents
+- Blocking until a response or acknowledgment arrives
+- Synchronizing at specific points in distributed workflows
+- Polling for status updates or events
+
+**Common triggers:**
+- "wait for message from agent X"
+- "block until response"
+- "wait for handoff"
+- "synchronize with other agents"
+- "wait for acknowledgment"
+
+## How It Works
+
+The `hive msg sub --wait` command polls the specified topic every 500ms until:
+- A message arrives (success)
+- The timeout is reached (failure)
+
+By default, the timeout is 30 seconds, but can be adjusted with `--timeout` flag.
+
+When a message arrives, it's automatically acknowledged (marked as read) unless `--peek` is used.
+
+## Commands
+
+### Wait for Single Message
+
+Block until one message arrives on a topic:
+
+```bash
+hive msg sub --wait --topic <topic>
+```
+
+**Examples:**
+```bash
+# Wait for handoff message (30s timeout)
+hive msg sub --wait --topic agent.abc.inbox
+
+# Wait for build completion
+hive msg sub --wait --topic build.main.status
+
+# Wait for acknowledgment
+hive msg sub --wait --topic agent.xyz.inbox.ack
+```
+
+**Behavior:**
+- Polls topic every 500ms
+- Returns immediately when message arrives
+- Exits with error if timeout reached
+- Marks message as read (acknowledged)
+
+### Wait with Custom Timeout
+
+Adjust timeout for longer or shorter waits:
+
+```bash
+hive msg sub --wait --topic <topic> --timeout <duration>
+```
+
+**Examples:**
+```bash
+# Short timeout for quick checks
+hive msg sub --wait --topic notifications --timeout 5s
+
+# Moderate timeout for typical handoffs
+hive msg sub --wait --topic agent.abc.inbox --timeout 2m
+
+# Long timeout for slow operations
+hive msg sub --wait --topic build.production --timeout 10m
+
+# Very long timeout for background work
+hive msg sub --wait --topic overnight.jobs --timeout 24h
+```
+
+**Timeout format:**
+- `s` - seconds (5s, 30s, 90s)
+- `m` - minutes (1m, 5m, 30m)
+- `h` - hours (1h, 12h, 24h)
+
+### Wait Without Acknowledging
+
+Peek at messages without marking them as read:
+
+```bash
+hive msg sub --wait --topic <topic> --peek
+```
+
+**Use cases:**
+- Monitoring without consuming messages
+- Checking for messages while another agent is primary handler
+- Debugging message flow
+
+### Wait with Wildcard Topics
+
+Wait for messages on any matching topic:
+
+```bash
+hive msg sub --wait --topic "pattern.*"
+```
+
+**Examples:**
+```bash
+# Wait for any agent to respond
+hive msg sub --wait --topic "agent.*.response"
+
+# Wait for any build event
+hive msg sub --wait --topic "build.*.status"
+```
+
+## Polling Behavior
+
+The wait command uses polling with these characteristics:
+
+**Polling interval:** 500ms (0.5 seconds)
+- Checks topic for new messages every half second
+- Low overhead for typical coordination scenarios
+- Balance between responsiveness and system load
+
+**Default timeout:** 30s
+- Suitable for most agent coordination
+- Override with `--timeout` for specific needs
+
+**Exit conditions:**
+- **Success (exit 0):** Message received before timeout
+- **Failure (exit 1):** Timeout reached with no message
+
+## Use Cases
+
+### Agent Handoff Coordination
+
+**Agent A (completing work):**
+```bash
+# Complete work
+git commit -m "feat: implement feature X"
+
+# Notify agent B
+hive msg pub --topic agent.bob.inbox "Feature X ready. Branch: feat/x"
+
+# Wait for acknowledgment
+hive msg sub --wait --topic agent.bob.inbox.ack --timeout 2m
+```
+
+**Agent B (receiving work):**
+```bash
+# Check inbox (auto-acknowledges)
+hive msg inbox
+# > Message from agent.alice: Feature X ready...
+
+# Start work immediately
+```
+
+### Long-Running Task Synchronization
+
+Wait for background task to complete:
+
+```bash
+# Agent starts long task
+hive msg pub --topic build.production "Starting production build" &
+
+# Other agents wait for completion
+hive msg sub --wait --topic build.production.complete --timeout 1h
+```
+
+### Multi-Agent Coordination
+
+Coordinate multiple agents at synchronization point:
+
+```bash
+# Agent 1: Complete phase 1
+hive msg pub --topic phase1.complete "Agent 1 done"
+
+# Agent 2: Complete phase 1
+hive msg pub --topic phase1.complete "Agent 2 done"
+
+# Coordinator: Wait for both (listen mode, wait for 2 messages)
+hive msg sub --listen --topic phase1.complete --timeout 5m
+```
+
+### Request-Response Pattern
+
+**Requester:**
+```bash
+# Send request
+hive msg pub --topic coordinator.requests "Need assignment: task-type-X"
+
+# Wait for response
+hive msg sub --wait --topic agent.myself.inbox --timeout 1m
+```
+
+**Responder:**
+```bash
+# Monitor requests
+hive msg sub --listen --topic coordinator.requests
+
+# Send response
+hive msg pub --topic agent.requester.inbox "Assigned: task-123"
+```
+
+## Timeout Handling
+
+### Choosing Appropriate Timeouts
+
+**Short timeouts (5-30s):**
+- Quick handoffs between active agents
+- Real-time coordination
+- Fast-fail scenarios
+
+**Medium timeouts (1-5m):**
+- Normal agent handoffs
+- Wait for human review
+- Moderate-speed operations
+
+**Long timeouts (10m-1h):**
+- Build and test operations
+- Code review wait times
+- Background processing
+
+**Very long timeouts (1-24h):**
+- Overnight jobs
+- Multi-day workflows
+- Asynchronous collaboration
+
+### Handling Timeout Failures
+
+The wait command exits with status 1 when timeout is reached:
+
+```bash
+# Wait with timeout handling
+if hive msg sub --wait --topic agent.bob.inbox --timeout 30s; then
+    echo "Message received"
+else
+    echo "Timeout: no message received"
+    # Handle timeout scenario
+fi
+```
+
+**Timeout strategies:**
+- **Retry:** Try waiting again with longer timeout
+- **Fallback:** Proceed without waiting for message
+- **Alert:** Notify user or coordinator of timeout
+- **Abort:** Stop workflow and require manual intervention
+
+## Advanced Patterns
+
+### Continuous Polling
+
+Use `--listen` mode for continuous message monitoring:
+
+```bash
+# Poll indefinitely (until timeout)
+hive msg sub --listen --topic notifications --timeout 1h
+
+# Process each message as it arrives
+```
+
+**Differences from `--wait`:**
+- `--wait`: Returns after ONE message
+- `--listen`: Continues polling, outputs ALL messages until timeout
+
+### Conditional Wait
+
+Wait for specific message content:
+
+```bash
+# Wait and filter with jq
+hive msg sub --wait --topic status | jq 'select(.content | contains("success"))'
+```
+
+### Multi-Topic Wait
+
+Wait for message on any of several topics (using wildcards):
+
+```bash
+# Wait for response from any agent
+hive msg sub --wait --topic "response.*"
+
+# Wait for any build status update
+hive msg sub --wait --topic "build.*.complete"
+```
+
+## Troubleshooting
+
+### Timeout Reached Without Message
+
+**Problem:** Wait command times out before message arrives
+
+**Solutions:**
+- Increase timeout: Use longer `--timeout` duration
+- Check topic name: Verify exact topic spelling and format
+- Verify sender: Ensure other agent is publishing to correct topic
+- Check timing: Other agent may need more time to complete work
+
+### Message Missed
+
+**Problem:** Message was sent but wait didn't receive it
+
+**Solutions:**
+- Check timing: Was message sent BEFORE wait started?
+- Verify topic: Ensure exact topic match (case-sensitive)
+- Review message log: Check `$XDG_DATA_HOME/hive/messages/topics/<topic>.json`
+- Use `--peek` first: Preview existing messages before waiting
+
+### Wait Blocks Forever
+
+**Problem:** Wait command never returns and never times out
+
+**Solutions:**
+- Check default timeout: Default is 30s, may need explicit `--timeout`
+- Verify topic exists: Use `hive msg list` to check topics
+- Test with short timeout: Use `--timeout 5s` to debug
+- Check polling: Verify no errors in polling loop
+
+### Wrong Message Received
+
+**Problem:** Wait returns unexpected message
+
+**Solutions:**
+- Use specific topics: Avoid overly broad wildcards
+- Check message history: Review with `hive msg sub --topic <topic>`
+- Filter results: Use `jq` or other tools to filter messages
+- Peek first: Use `--peek` to review messages before acknowledging
+
+## Related Skills
+
+- `/hive:inbox` - Check your inbox for messages
+- `/hive:publish` - Send messages to other agents
+- `/hive:session-info` - Get your session details and inbox topic
+
+## Tips
+
+**Choose Appropriate Timeouts:**
+- Start with default 30s for typical coordination
+- Use longer timeouts for known slow operations
+- Use shorter timeouts for fast-fail scenarios
+
+**Be Explicit:**
+- Use specific topic names, not wildcards, when possible
+- Document expected wait times in workflow docs
+- Log timeout events for debugging
+
+**Handle Failures:**
+- Always handle timeout scenarios gracefully
+- Provide fallback behavior when waits fail
+- Alert users or coordinators when critical waits time out
+
+**Test Wait Logic:**
+- Test with short timeouts during development
+- Simulate delays to verify timeout handling
+- Document expected wait patterns in code comments

--- a/.claude-plugin/skills/session-info/SKILL.md
+++ b/.claude-plugin/skills/session-info/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: hive:session-info
+description: Get your current session ID, inbox topic, and session information. Use when you need to know your agent identity for messaging coordination.
+compatibility: claude, opencode
+---
+
+# Session Info - Get Your Session Details
+
+Display information about your current hive session, including session ID, inbox topic, and state.
+
+## When to Use
+
+Use this skill when:
+- You need to know your session ID
+- Another agent asks for your inbox topic
+- Debugging messaging issues
+- Setting up inter-agent coordination
+- Verifying you're in the correct session
+
+**Common triggers:**
+- "what's my session ID?"
+- "show my inbox topic"
+- "get session info"
+- "what session am I in?"
+- "my agent ID"
+
+## How It Works
+
+The `hive session info` command detects your current session based on your working directory and displays relevant information including:
+
+- **Session ID**: Unique identifier for this agent session
+- **Name**: Human-readable session name
+- **Repository**: Git repository name
+- **Inbox**: Your inbox topic for receiving messages
+- **Path**: Full path to session directory
+- **State**: Current session state (active, recycled, corrupted)
+
+## Commands
+
+### Get Session Info (Human-Readable)
+
+```bash
+hive session info
+```
+
+**Example output:**
+```
+Session ID:  26kj0c
+Name:        claude-plugin
+Repository:  hive
+Inbox:       agent.26kj0c.inbox
+Path:        /Users/hayden/.local/share/hive/repos/hive-claude-plugin-26kj0c
+State:       active
+```
+
+### Get Session Info (JSON)
+
+For programmatic access or LLM parsing:
+
+```bash
+hive session info --json
+```
+
+**Example output:**
+```json
+{
+  "id": "26kj0c",
+  "name": "claude-plugin",
+  "repository": "hive",
+  "inbox": "agent.26kj0c.inbox",
+  "path": "/Users/hayden/.local/share/hive/repos/hive-claude-plugin-26kj0c",
+  "state": "active"
+}
+```
+
+## Session Detection
+
+The command automatically detects your session from the current working directory. Sessions are identified by:
+
+1. **Working directory path**: Must be within a hive session directory
+2. **Session directory pattern**: `$XDG_DATA_HOME/hive/repos/<repo>-<session-id>`
+3. **Session file**: `.hive-session` file in the directory
+
+If you're not in a hive session directory, the command will fail with an error.
+
+## Session States
+
+### Active
+Normal, working session. The session is ready for use.
+
+**Characteristics:**
+- Session directory exists
+- All required files present
+- Ready for commands and messaging
+
+### Recycled
+Session has been recycled (stopped and cleared).
+
+**Characteristics:**
+- Session may still exist on disk
+- Not actively running
+- Can be restarted or removed
+
+### Corrupted
+Session directory or files are damaged or incomplete.
+
+**Characteristics:**
+- Missing required files
+- Inconsistent state
+- May need manual cleanup or recreation
+
+## Inbox Topic Format
+
+Your inbox topic follows the pattern: `agent.<session-id>.inbox`
+
+**Example:**
+- Session ID: `26kj0c`
+- Inbox: `agent.26kj0c.inbox`
+
+Other agents use this topic to send you direct messages:
+
+```bash
+# Another agent sends to you
+hive msg pub --topic agent.26kj0c.inbox "Message for you"
+
+# You receive it
+hive msg inbox
+```
+
+## Use Cases
+
+### Share Your Inbox with Another Agent
+
+```bash
+# Get your inbox topic
+hive session info --json | jq -r '.inbox'
+# Output: agent.26kj0c.inbox
+
+# Tell another agent
+"Send messages to agent.26kj0c.inbox"
+```
+
+### Verify Session Before Messaging
+
+```bash
+# Check you're in the right session
+hive session info
+
+# Then check inbox
+hive msg inbox
+```
+
+### Debug Messaging Issues
+
+```bash
+# Get full session details
+hive session info
+
+# Verify inbox topic matches expectations
+# Check state is "active"
+```
+
+### Script Session Information
+
+```bash
+# Extract specific fields
+SESSION_ID=$(hive session info --json | jq -r '.id')
+INBOX=$(hive session info --json | jq -r '.inbox')
+
+echo "My session: $SESSION_ID"
+echo "Send messages to: $INBOX"
+```
+
+## Output Fields
+
+### id
+Short unique identifier for this session (e.g., `26kj0c`).
+
+Used in:
+- Inbox topic construction
+- Session directory naming
+- Message sender identification
+
+### name
+Human-readable name describing the session purpose (e.g., `claude-plugin`, `fix-auth-bug`).
+
+Helps identify what work this session is doing.
+
+### repository
+Git repository name this session is working on (e.g., `hive`, `myproject`).
+
+### inbox
+Full inbox topic for receiving messages: `agent.<session-id>.inbox`.
+
+Other agents publish to this topic to send you messages.
+
+### path
+Absolute path to the session directory on disk.
+
+Useful for:
+- Verifying session location
+- Debugging path issues
+- Scripting file operations
+
+### state
+Current session state: `active`, `recycled`, or `corrupted`.
+
+Indicates session health and readiness.
+
+## Examples
+
+### Basic Session Info
+
+```bash
+$ hive session info
+Session ID:  abc123
+Name:        implement-auth
+Repository:  backend
+Inbox:       agent.abc123.inbox
+Path:        /home/user/.local/share/hive/repos/backend-abc123
+State:       active
+```
+
+### JSON Output for Parsing
+
+```bash
+$ hive session info --json
+{
+  "id": "abc123",
+  "name": "implement-auth",
+  "repository": "backend",
+  "inbox": "agent.abc123.inbox",
+  "path": "/home/user/.local/share/hive/repos/backend-abc123",
+  "state": "active"
+}
+```
+
+### Extract Inbox Topic
+
+```bash
+$ hive session info --json | jq -r '.inbox'
+agent.abc123.inbox
+```
+
+### Share Your Info with Another Agent
+
+```bash
+# Agent A (you)
+$ hive session info --json
+{
+  "id": "abc123",
+  "inbox": "agent.abc123.inbox",
+  ...
+}
+
+# Send to Agent B
+$ hive msg pub --topic agent.xyz789.inbox "My inbox is agent.abc123.inbox. Send results there."
+
+# Agent B receives and replies
+$ hive msg pub --topic agent.abc123.inbox "Got it, will send results to you"
+```
+
+## Troubleshooting
+
+### Not in a Hive Session
+
+**Problem:** Command fails with "not in a hive session" error
+
+**Solutions:**
+- Verify working directory: `pwd`
+- Check if in hive session: Look for `.hive-session` file
+- List sessions: `hive session ls` (if available)
+- Change to correct directory
+
+### Session State is "corrupted"
+
+**Problem:** Session info shows state as "corrupted"
+
+**Solutions:**
+- Check session directory exists: Verify path from output
+- Look for missing files: `.hive-session`, tmux socket, etc.
+- Consider recreating session
+- Check disk space and permissions
+
+### Inbox Topic Not Working
+
+**Problem:** Messages sent to inbox don't appear
+
+**Solutions:**
+- Verify exact inbox topic: Copy from `hive session info` output
+- Check for typos: Topics are case-sensitive
+- Confirm messages exist: `hive msg sub --topic <your-inbox>`
+- Test with known-good message: Send to yourself
+
+## Related Skills
+
+- `/hive:inbox` - Check your inbox for messages
+- `/hive:publish` - Send messages to other agents' inboxes
+- `/hive:wait` - Wait for messages on your inbox
+
+## Tips
+
+**Be Explicit:**
+- Share exact inbox topic (don't paraphrase)
+- Use JSON output for programmatic access
+- Include session ID in coordination messages
+
+**Verify First:**
+- Check session info before setting up coordination
+- Confirm state is "active" before messaging
+- Validate inbox topic format matches pattern
+
+**Script Safely:**
+- Use JSON output for reliable parsing
+- Handle missing fields gracefully
+- Check exit codes for errors


### PR DESCRIPTION
Implements Claude Code plugin structure with five comprehensive skills:
- inbox: Check and manage inter-agent messages
- msg-publish: Send messages to other agents/topics
- msg-wait: Wait for messages with timeout (coordination)
- session-info: Get current session ID and inbox topic
- config: Configure hive workflow (rules, spawn, keybindings)

Each skill includes:
- YAML frontmatter with name, description, compatibility
- Comprehensive documentation with examples
- Common workflows and troubleshooting guides
- Related skills cross-references

Plugin structure follows .claude-plugin/ pattern with plugin.json metadata and skills/ subdirectories.
