### PR TITLE
Feat/tui testing coverage

### DIFF
--- a/internal/tui/gitstatus_test.go
+++ b/internal/tui/gitstatus_test.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitStatusMock implements git.Git with configurable errors for testing fetchGitStatusForPath.
+type gitStatusMock struct {
+	branch    string
+	branchErr error
+	additions int
+	deletions int
+	diffErr   error
+	isClean   bool
+	cleanErr  error
+}
+
+func (m *gitStatusMock) Clone(context.Context, string, string) error           { return nil }
+func (m *gitStatusMock) Checkout(context.Context, string, string) error        { return nil }
+func (m *gitStatusMock) Pull(context.Context, string) error                    { return nil }
+func (m *gitStatusMock) ResetHard(context.Context, string) error               { return nil }
+func (m *gitStatusMock) RemoteURL(context.Context, string) (string, error)     { return "", nil }
+func (m *gitStatusMock) DefaultBranch(context.Context, string) (string, error) { return "main", nil }
+func (m *gitStatusMock) IsValidRepo(context.Context, string) error             { return nil }
+
+func (m *gitStatusMock) Branch(context.Context, string) (string, error) {
+	return m.branch, m.branchErr
+}
+
+func (m *gitStatusMock) DiffStats(context.Context, string) (int, int, error) {
+	return m.additions, m.deletions, m.diffErr
+}
+
+func (m *gitStatusMock) IsClean(context.Context, string) (bool, error) {
+	return m.isClean, m.cleanErr
+}
+
+func TestFetchGitStatusForPath(t *testing.T) {
+	ctx := context.Background()
+	errFail := errors.New("fail")
+
+	t.Run("branch error", func(t *testing.T) {
+		g := &gitStatusMock{branchErr: errFail}
+		status := fetchGitStatusForPath(ctx, g, "/repo")
+		assert.ErrorIs(t, status.Error, errFail)
+	})
+
+	t.Run("diff stats error", func(t *testing.T) {
+		g := &gitStatusMock{branch: "main", diffErr: errFail}
+		status := fetchGitStatusForPath(ctx, g, "/repo")
+		assert.Equal(t, "main", status.Branch)
+		assert.ErrorIs(t, status.Error, errFail)
+	})
+
+	t.Run("is clean error preserves prior fields", func(t *testing.T) {
+		g := &gitStatusMock{branch: "main", additions: 1, deletions: 2, cleanErr: errFail}
+		status := fetchGitStatusForPath(ctx, g, "/repo")
+		require.ErrorIs(t, status.Error, errFail)
+		assert.Equal(t, "main", status.Branch)
+		assert.Equal(t, 1, status.Additions)
+		assert.Equal(t, 2, status.Deletions)
+	})
+
+	t.Run("happy path clean repo", func(t *testing.T) {
+		g := &gitStatusMock{branch: "feat/x", additions: 10, deletions: 3, isClean: true}
+		status := fetchGitStatusForPath(ctx, g, "/repo")
+		require.NoError(t, status.Error)
+		assert.Equal(t, "feat/x", status.Branch)
+		assert.Equal(t, 10, status.Additions)
+		assert.Equal(t, 3, status.Deletions)
+		assert.False(t, status.HasChanges)
+	})
+
+	t.Run("happy path dirty repo", func(t *testing.T) {
+		g := &gitStatusMock{branch: "main", isClean: false}
+		status := fetchGitStatusForPath(ctx, g, "/repo")
+		require.NoError(t, status.Error)
+		assert.True(t, status.HasChanges)
+	})
+}

--- a/internal/tui/message_preview_modal_test.go
+++ b/internal/tui/message_preview_modal_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsDecorativeLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty string", "", true},
+		{"only spaces", "   ", true},
+		{"horizontal rule dashes", "────────", true},
+		{"horizontal rule hyphens", "-------", true},
+		{"horizontal rule equals", "=======", true},
+		{"mixed rule chars", "─━-=", true},
+		{"text content", "hello world", false},
+		{"rule with text", "── hello ──", false},
+		{"ansi codes around rule", "\x1b[0m────\x1b[0m", true},
+		{"ansi codes around text", "\x1b[31mhello\x1b[0m", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDecorativeLine(tt.input))
+		})
+	}
+}
+
+func TestStripLeadingDecorative(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no decorative lines", "hello\nworld", "hello\nworld"},
+		{"leading empty and rule", "\n────\nhello", "hello"},
+		{"all decorative", "────\n───", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripLeadingDecorative(tt.input))
+		})
+	}
+}
+
+func TestStripTrailingDecorative(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no trailing decorative", "hello\nworld", "hello\nworld"},
+		{"trailing empty and rule", "hello\n────\n", "hello"},
+		{"all decorative", "────\n───", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripTrailingDecorative(tt.input))
+		})
+	}
+}

--- a/internal/tui/messages_view_test.go
+++ b/internal/tui/messages_view_test.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hay-kot/hive/internal/core/messaging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMessages(n int) []messaging.Message {
+	msgs := make([]messaging.Message, n)
+	for i := range n {
+		msgs[i] = messaging.Message{
+			Topic:     "test.topic",
+			Sender:    "agent-" + itoa(i),
+			Payload:   "payload " + itoa(i),
+			CreatedAt: time.Now(),
+		}
+	}
+	return msgs
+}
+
+func TestMessagesView_Navigation(t *testing.T) {
+	v := NewMessagesView()
+	v.SetSize(120, 40)
+	v.SetMessages(newTestMessages(5))
+
+	// Starts at top
+	assert.Equal(t, 0, v.cursor)
+
+	// Move down
+	v.MoveDown()
+	assert.Equal(t, 1, v.cursor)
+
+	// Move up back to 0
+	v.MoveUp()
+	assert.Equal(t, 0, v.cursor)
+
+	// Move up at top stays at 0
+	v.MoveUp()
+	assert.Equal(t, 0, v.cursor)
+
+	// Move to end
+	for range 10 {
+		v.MoveDown()
+	}
+	assert.Equal(t, 4, v.cursor) // clamped to last
+}
+
+func TestMessagesView_Filtering(t *testing.T) {
+	v := NewMessagesView()
+	v.SetSize(120, 40)
+	v.SetMessages([]messaging.Message{
+		{Topic: "build.status", Sender: "ci", Payload: "passed"},
+		{Topic: "deploy.prod", Sender: "cd", Payload: "deployed"},
+		{Topic: "build.logs", Sender: "ci", Payload: "compiling"},
+	})
+
+	// All visible initially
+	assert.Len(t, v.filteredAt, 3)
+
+	// Start filter and type "deploy"
+	v.StartFilter()
+	assert.True(t, v.IsFiltering())
+	for _, r := range "deploy" {
+		v.AddFilterRune(r)
+	}
+	assert.Len(t, v.filteredAt, 1)
+
+	// Confirm filter
+	v.ConfirmFilter()
+	assert.False(t, v.IsFiltering())
+	assert.Len(t, v.filteredAt, 1)
+
+	// Cancel clears filter
+	v.StartFilter()
+	v.CancelFilter()
+	assert.Len(t, v.filteredAt, 3)
+}
+
+func TestMessagesView_DeleteFilterRune(t *testing.T) {
+	v := NewMessagesView()
+	v.SetSize(120, 40)
+	v.SetMessages(newTestMessages(3))
+
+	v.StartFilter()
+	v.AddFilterRune('a')
+	v.AddFilterRune('b')
+	assert.Equal(t, "ab", v.filter)
+
+	v.DeleteFilterRune()
+	assert.Equal(t, "a", v.filter)
+
+	v.DeleteFilterRune()
+	assert.Empty(t, v.filter)
+
+	// Delete on empty is safe
+	v.DeleteFilterRune()
+	assert.Empty(t, v.filter)
+}
+
+func TestMessagesView_SelectedMessage(t *testing.T) {
+	v := NewMessagesView()
+	v.SetSize(120, 40)
+
+	// No messages → nil
+	assert.Nil(t, v.SelectedMessage())
+
+	msgs := newTestMessages(3)
+	v.SetMessages(msgs)
+
+	// First message selected
+	selected := v.SelectedMessage()
+	require.NotNil(t, selected)
+	assert.Equal(t, "agent-0", selected.Sender)
+
+	// Navigate to second
+	v.MoveDown()
+	selected = v.SelectedMessage()
+	require.NotNil(t, selected)
+	assert.Equal(t, "agent-1", selected.Sender)
+}
+
+func TestMessagesView_MatchesFilter(t *testing.T) {
+	v := NewMessagesView()
+
+	tests := []struct {
+		name   string
+		msg    messaging.Message
+		filter string
+		want   bool
+	}{
+		{
+			name:   "matches topic",
+			msg:    messaging.Message{Topic: "build.status"},
+			filter: "build",
+			want:   true,
+		},
+		{
+			name:   "matches sender",
+			msg:    messaging.Message{Sender: "agent-1"},
+			filter: "agent",
+			want:   true,
+		},
+		{
+			name:   "matches payload",
+			msg:    messaging.Message{Payload: "hello world"},
+			filter: "world",
+			want:   true,
+		},
+		{
+			name:   "case insensitive",
+			msg:    messaging.Message{Topic: "Build.Status"},
+			filter: "build",
+			want:   true,
+		},
+		{
+			name:   "no match",
+			msg:    messaging.Message{Topic: "x", Sender: "y", Payload: "z"},
+			filter: "nope",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, v.matchesFilter(&tt.msg, tt.filter))
+		})
+	}
+}

--- a/internal/tui/modal_test.go
+++ b/internal/tui/modal_test.go
@@ -1,0 +1,32 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModal_NewDefaults(t *testing.T) {
+	m := NewModal("Title", "Are you sure?")
+	assert.True(t, m.Visible())
+	assert.True(t, m.ConfirmSelected()) // defaults to confirm
+	assert.Equal(t, "Title", m.title)
+	assert.Equal(t, "Are you sure?", m.message)
+}
+
+func TestModal_Overlay_NotVisible(t *testing.T) {
+	m := Modal{} // visible defaults to false
+	bg := "background content"
+	assert.Equal(t, bg, m.Overlay(bg, 80, 24))
+}
+
+func TestModal_ToggleSelection(t *testing.T) {
+	m := NewModal("", "")
+	assert.True(t, m.ConfirmSelected())
+
+	m.ToggleSelection()
+	assert.False(t, m.ConfirmSelected())
+
+	m.ToggleSelection()
+	assert.True(t, m.ConfirmSelected())
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -79,7 +79,7 @@ type PendingCreate struct {
 // Model is the main Bubble Tea model for the TUI.
 type Model struct {
 	cfg            *config.Config
-	service        *hive.Service
+	service        SessionLister
 	cmdService     *command.Service
 	list           list.Model
 	handler        *KeybindingResolver

--- a/internal/tui/model_sessions_test.go
+++ b/internal/tui/model_sessions_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hay-kot/hive/internal/core/git"
+	"github.com/hay-kot/hive/internal/core/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSessionLister struct {
+	sessions []session.Session
+	err      error
+	git      git.Git
+}
+
+func (m *mockSessionLister) ListSessions(context.Context) ([]session.Session, error) {
+	return m.sessions, m.err
+}
+
+func (m *mockSessionLister) Git() git.Git {
+	return m.git
+}
+
+func TestLoadSessions_Success(t *testing.T) {
+	sessions := []session.Session{
+		{ID: "1", Name: "s1", Path: "/tmp/s1"},
+		{ID: "2", Name: "s2", Path: "/tmp/s2"},
+	}
+	mock := &mockSessionLister{sessions: sessions}
+	m := Model{service: mock}
+
+	cmd := m.loadSessions()
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	loaded, ok := msg.(sessionsLoadedMsg)
+	require.True(t, ok)
+	require.NoError(t, loaded.err)
+	assert.Len(t, loaded.sessions, 2)
+	assert.Equal(t, "s1", loaded.sessions[0].Name)
+}
+
+func TestLoadSessions_Error(t *testing.T) {
+	mock := &mockSessionLister{err: errors.New("db error")}
+	m := Model{service: mock}
+
+	cmd := m.loadSessions()
+	msg := cmd()
+	loaded, ok := msg.(sessionsLoadedMsg)
+	require.True(t, ok)
+	assert.Error(t, loaded.err)
+}

--- a/internal/tui/model_state_test.go
+++ b/internal/tui/model_state_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/hay-kot/hive/internal/core/session"
+	"github.com/hay-kot/hive/internal/integration/terminal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleFilterAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionType ActionType
+		want       bool
+		wantFilter terminal.Status
+	}{
+		{"filter all clears filter", ActionTypeFilterAll, true, ""},
+		{"filter active", ActionTypeFilterActive, true, terminal.StatusActive},
+		{"filter approval", ActionTypeFilterApproval, true, terminal.StatusApproval},
+		{"filter ready", ActionTypeFilterReady, true, terminal.StatusReady},
+		{"none is not filter", ActionTypeNone, false, ""},
+		{"recycle is not filter", ActionTypeRecycle, false, ""},
+		{"delete is not filter", ActionTypeDelete, false, ""},
+		{"shell is not filter", ActionTypeShell, false, ""},
+		{"doc review is not filter", ActionTypeDocReview, false, ""},
+		{"delete batch is not filter", ActionTypeDeleteRecycledBatch, false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{}
+			got := m.handleFilterAction(tt.actionType)
+			assert.Equal(t, tt.want, got)
+			if tt.want {
+				assert.Equal(t, tt.wantFilter, m.statusFilter)
+			}
+		})
+	}
+}
+
+func TestIsModalActive(t *testing.T) {
+	tests := []struct {
+		name  string
+		state UIState
+		want  bool
+	}{
+		{"normal is not modal", stateNormal, false},
+		{"confirming is modal", stateConfirming, true},
+		{"loading is modal", stateLoading, true},
+		{"running recycle is modal", stateRunningRecycle, true},
+		{"previewing message is modal", statePreviewingMessage, true},
+		{"creating session is modal", stateCreatingSession, true},
+		{"command palette is modal", stateCommandPalette, true},
+		{"showing help is modal", stateShowingHelp, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{state: tt.state}
+			assert.Equal(t, tt.want, m.isModalActive())
+		})
+	}
+}
+
+func TestIsSessionsFocused(t *testing.T) {
+	tests := []struct {
+		name string
+		view ViewType
+		want bool
+	}{
+		{"sessions focused", ViewSessions, true},
+		{"messages not focused", ViewMessages, false},
+		{"review not focused", ViewReview, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{activeView: tt.view}
+			assert.Equal(t, tt.want, m.isSessionsFocused())
+		})
+	}
+}
+
+func TestIsCurrentTmuxSession(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentTmux string
+		sess        session.Session
+		want        bool
+	}{
+		{
+			name:        "empty current returns false",
+			currentTmux: "",
+			sess:        session.Session{Slug: "my-session"},
+			want:        false,
+		},
+		{
+			name:        "exact slug match",
+			currentTmux: "my-session",
+			sess:        session.Session{Slug: "my-session"},
+			want:        true,
+		},
+		{
+			name:        "prefix with underscore",
+			currentTmux: "my-session_123",
+			sess:        session.Session{Slug: "my-session"},
+			want:        true,
+		},
+		{
+			name:        "prefix with dash",
+			currentTmux: "my-session-extra",
+			sess:        session.Session{Slug: "my-session"},
+			want:        true,
+		},
+		{
+			name:        "metadata tmux session match",
+			currentTmux: "custom-name",
+			sess: session.Session{
+				Slug:     "other-slug",
+				Metadata: map[string]string{session.MetaTmuxSession: "custom-name"},
+			},
+			want: true,
+		},
+		{
+			name:        "no match",
+			currentTmux: "different",
+			sess:        session.Session{Slug: "my-session"},
+			want:        false,
+		},
+		{
+			name:        "partial slug without separator no match",
+			currentTmux: "my-sessionextra",
+			sess:        session.Session{Slug: "my-session"},
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{currentTmuxSession: tt.currentTmux}
+			assert.Equal(t, tt.want, m.isCurrentTmuxSession(&tt.sess))
+		})
+	}
+}

--- a/internal/tui/model_utils_test.go
+++ b/internal/tui/model_utils_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTailLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		n     int
+		want  string
+	}{
+		{"zero returns empty", "a\nb\nc", 0, ""},
+		{"all lines fit", "a\nb", 5, "a\nb"},
+		{"returns last n", "a\nb\nc\nd", 2, "c\nd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tailLines(tt.input, tt.n))
+		})
+	}
+}
+
+func TestTruncateLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxWidth int
+		want     string
+	}{
+		{"zero width returns input", "hello", 0, "hello"},
+		{"short lines unchanged", "hi\nok", 10, "hi\nok"},
+		{"long line truncated", "abcdefghij", 5, "abcde"},
+		{"multiline truncates only long", "hi\nabcdefghij\nok", 5, "hi\nabcde\nok"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, truncateLines(tt.input, tt.maxWidth))
+		})
+	}
+}
+
+func TestEnsureExactWidth(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		width int
+	}{
+		{"zero width returns input", "hello", 0},
+		{"short line padded", "hi", 6},
+		{"long line truncated", "abcdefghij", 5},
+		{"exact width unchanged", "abcde", 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ensureExactWidth(tt.input, tt.width)
+			if tt.width <= 0 {
+				assert.Equal(t, tt.input, got)
+				return
+			}
+			for _, line := range strings.Split(got, "\n") {
+				assert.Len(t, line, tt.width)
+			}
+		})
+	}
+}
+
+func TestEnsureExactHeight(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		n         int
+		wantLines int
+		wantExact string
+	}{
+		{"zero returns empty", "a\nb", 0, 0, ""},
+		{"truncates preserving first", "first\nsecond\nthird", 2, 2, "first\nsecond"},
+		{"pads short content", "a", 3, 3, "a\n\n"},
+		{"exact height unchanged", "a\nb\nc", 3, 3, "a\nb\nc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ensureExactHeight(tt.input, tt.n)
+			assert.Equal(t, tt.wantExact, got)
+		})
+	}
+}
+
+func TestItoa(t *testing.T) {
+	tests := []struct {
+		input int
+		want  string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{-7, "-7"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, itoa(tt.input))
+		})
+	}
+}
+
+func TestIsFilterAction(t *testing.T) {
+	tests := []struct {
+		action string
+		want   bool
+	}{
+		{"filter-all", true},
+		{"filter-active", true},
+		{"filter-approval", true},
+		{"filter-ready", true},
+		{"delete", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			assert.Equal(t, tt.want, isFilterAction(tt.action))
+		})
+	}
+}

--- a/internal/tui/previewtemplate_test.go
+++ b/internal/tui/previewtemplate_test.go
@@ -1,0 +1,147 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/hay-kot/hive/internal/core/session"
+	"github.com/hay-kot/hive/internal/integration/terminal"
+	"github.com/hay-kot/hive/internal/plugins"
+	"github.com/hay-kot/hive/pkg/kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShortID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"abcdefgh", "efgh"},
+		{"abcd", "abcd"},
+		{"ab", "ab"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, shortID(tt.input))
+		})
+	}
+}
+
+func TestBuildPreviewTemplateData(t *testing.T) {
+	sess := &session.Session{
+		ID:   "abc12345",
+		Name: "test-session",
+		Path: "/tmp/test",
+	}
+
+	t.Run("nil stores populate basic fields", func(t *testing.T) {
+		data := BuildPreviewTemplateData(sess, nil, nil, nil, true)
+		assert.Equal(t, "test-session", data.Name)
+		assert.Equal(t, "abc12345", data.ID)
+		assert.Equal(t, "2345", data.ShortID)
+		assert.Equal(t, "/tmp/test", data.Path)
+		assert.Empty(t, data.Branch)
+	})
+
+	t.Run("git status populates branch and stats", func(t *testing.T) {
+		gitStatuses := kv.New[string, GitStatus]()
+		gitStatuses.Set("/tmp/test", GitStatus{
+			Branch:     "main",
+			Additions:  5,
+			Deletions:  3,
+			HasChanges: true,
+		})
+
+		data := BuildPreviewTemplateData(sess, gitStatuses, nil, nil, true)
+		assert.Equal(t, "main", data.Branch)
+		assert.Equal(t, 5, data.GitStatus.Additions)
+		assert.Equal(t, 3, data.GitStatus.Deletions)
+		assert.True(t, data.GitStatus.HasChanges)
+	})
+
+	t.Run("loading git status skipped", func(t *testing.T) {
+		gitStatuses := kv.New[string, GitStatus]()
+		gitStatuses.Set("/tmp/test", GitStatus{IsLoading: true, Branch: "main"})
+
+		data := BuildPreviewTemplateData(sess, gitStatuses, nil, nil, true)
+		assert.Empty(t, data.Branch)
+	})
+
+	t.Run("plugin statuses populated", func(t *testing.T) {
+		pluginStatuses := map[string]*kv.Store[string, plugins.Status]{
+			"github": kv.New[string, plugins.Status](),
+			"beads":  kv.New[string, plugins.Status](),
+			"claude": kv.New[string, plugins.Status](),
+		}
+		pluginStatuses["github"].Set("abc12345", plugins.Status{Label: "open"})
+		pluginStatuses["beads"].Set("abc12345", plugins.Status{Label: "2/5"})
+		pluginStatuses["claude"].Set("abc12345", plugins.Status{Label: "45%"})
+
+		data := BuildPreviewTemplateData(sess, nil, pluginStatuses, nil, true)
+		assert.Equal(t, "open", data.Plugin.Github)
+		assert.Equal(t, "2/5", data.Plugin.Beads)
+		assert.Equal(t, "45%", data.Plugin.Claude)
+	})
+
+	t.Run("git status with error skipped", func(t *testing.T) {
+		gitStatuses := kv.New[string, GitStatus]()
+		gitStatuses.Set("/tmp/test", GitStatus{
+			Error:  assert.AnError,
+			Branch: "main",
+		})
+
+		data := BuildPreviewTemplateData(sess, gitStatuses, nil, nil, true)
+		assert.Empty(t, data.Branch)
+	})
+
+	t.Run("terminal status populated", func(t *testing.T) {
+		termStatuses := kv.New[string, TerminalStatus]()
+		termStatuses.Set("abc12345", TerminalStatus{Status: terminal.StatusActive})
+
+		data := BuildPreviewTemplateData(sess, nil, nil, termStatuses, true)
+		assert.Equal(t, "active", data.TerminalStatus)
+	})
+
+	t.Run("icons disabled returns empty icons", func(t *testing.T) {
+		data := BuildPreviewTemplateData(sess, nil, nil, nil, false)
+		assert.Empty(t, data.Icon.Git)
+		assert.Empty(t, data.Icon.GitBranch)
+	})
+}
+
+func TestParsePreviewTemplates(t *testing.T) {
+	t.Run("empty strings use defaults", func(t *testing.T) {
+		pt := ParsePreviewTemplates("", "")
+		require.NotNil(t, pt.title)
+		require.NotNil(t, pt.status)
+	})
+
+	t.Run("valid custom templates render correctly", func(t *testing.T) {
+		pt := ParsePreviewTemplates("{{ .Name }}", "{{ .Branch }}")
+		data := PreviewTemplateData{Name: "foo", Branch: "main"}
+		assert.Equal(t, "foo", pt.RenderTitle(data))
+		assert.Equal(t, "main", pt.RenderStatus(data))
+	})
+
+	t.Run("invalid template falls back to default", func(t *testing.T) {
+		pt := ParsePreviewTemplates("{{ .Invalid", "{{ .Invalid")
+		require.NotNil(t, pt.title)
+
+		data := PreviewTemplateData{Name: "test", ShortID: "abcd"}
+		assert.Contains(t, pt.RenderTitle(data), "test")
+	})
+
+	t.Run("nil template returns empty", func(t *testing.T) {
+		pt := &PreviewTemplates{}
+		assert.Empty(t, pt.RenderTitle(PreviewTemplateData{}))
+		assert.Empty(t, pt.RenderStatus(PreviewTemplateData{}))
+	})
+}
+
+func TestRenderStatus_EmptyData(t *testing.T) {
+	pt := ParsePreviewTemplates("", "")
+	result := pt.RenderStatus(PreviewTemplateData{})
+	assert.Empty(t, result)
+}

--- a/internal/tui/service.go
+++ b/internal/tui/service.go
@@ -1,0 +1,18 @@
+package tui
+
+import (
+	"context"
+
+	"github.com/hay-kot/hive/internal/core/git"
+	"github.com/hay-kot/hive/internal/core/session"
+	"github.com/hay-kot/hive/internal/hive"
+)
+
+// SessionLister provides the session listing and git access needed by the TUI Model.
+type SessionLister interface {
+	ListSessions(ctx context.Context) ([]session.Session, error)
+	Git() git.Git
+}
+
+// Compile-time check that *hive.Service satisfies SessionLister.
+var _ SessionLister = (*hive.Service)(nil)

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColorForString_Deterministic(t *testing.T) {
+	// Same input always returns same color
+	c1 := ColorForString("agent.abc123")
+	c2 := ColorForString("agent.abc123")
+	assert.Equal(t, c1, c2)
+}
+
+func TestColorForString_DifferentInputs(t *testing.T) {
+	// Verify the function doesn't panic on varied inputs and stays within pool
+	inputs := []string{"", "a", "agent.abc", "very.long.topic.name.here"}
+	for _, input := range inputs {
+		c := ColorForString(input)
+		assert.NotNil(t, c)
+	}
+}
+
+func TestViewType_String(t *testing.T) {
+	tests := []struct {
+		view ViewType
+		want string
+	}{
+		{ViewSessions, "sessions"},
+		{ViewMessages, "messages"},
+		{ViewReview, "review"},
+		{ViewType(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.view.String())
+		})
+	}
+}


### PR DESCRIPTION
  ## Summary

  - Add 10 new test files covering pure functions in the `internal/tui/` package (22.9% → 33.2% coverage)
  - Extract `SessionLister` interface from `*hive.Service` to enable mock-based testing of session loading
  - Tests cover: model utilities, state helpers, preview templates, messages view navigation/filtering, modal state machine, decorative line stripping, color hashing,
  ViewType.String, git status fetching, and session loading

  ## Test plan

  - [x] `task check` passes (lint + tests)
  - [x] Test review agent validated no critical gaps, no redundancy
  - [x] All new tests use table-driven patterns and testify assertions
