### PR TITLE
fix: kill tmux session when recycling

### DIFF
--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -224,6 +224,11 @@ func (s *SessionService) RecycleSession(ctx context.Context, id string, w io.Wri
 		return fmt.Errorf("recycle session %s: %w", id, err)
 	}
 
+	// Kill associated tmux session (best-effort)
+	if _, err := s.executor.Run(ctx, "tmux", "kill-session", "-t", sess.Name); err != nil {
+		s.log.Debug().Err(err).Str("session", sess.Name).Msg("no tmux session to kill")
+	}
+
 	// Rename directory to recycled pattern immediately
 	repoName := git.ExtractRepoName(sess.Remote)
 	newPath := filepath.Join(s.config.ReposDir(), fmt.Sprintf("%s-recycle-%s", repoName, generateID()))


### PR DESCRIPTION
## Summary
- Recycling a hive session now kills the associated tmux session as part of the recycle flow
- Runs `tmux kill-session -t <name>` after git cleanup succeeds, before directory rename
- Best-effort: errors are logged at debug level (tmux may not be installed or session may not exist)

## Test plan
- [x] Recycle a session that has an active tmux session — verify tmux session is killed
- [x] Recycle a session with no tmux session — verify recycle completes without error
- [x] Recycle on a system without tmux installed — verify recycle completes without error