### PR TITLE
feat: warn on launch when no repositories are found

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -844,6 +844,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case reposDiscoveredMsg:
 		m.discoveredRepos = msg.repos
+		// Warn if no repositories were found but directories were configured
+		if len(msg.repos) == 0 && len(m.repoDirs) > 0 {
+			return m, m.notifyWarn("No repositories found in configured directories")
+		}
 		// Help keybindings remain minimal - full list shown via ? dialog
 		return m, nil
 
@@ -3223,6 +3227,11 @@ func (m *Model) ensureToastTick() tea.Cmd {
 // to start the toast tick timer if needed.
 func (m *Model) notifyError(format string, args ...any) tea.Cmd {
 	m.notifyBus.Errorf(format, args...)
+	return m.ensureToastTick()
+}
+
+func (m *Model) notifyWarn(format string, args ...any) tea.Cmd {
+	m.notifyBus.Warnf(format, args...)
 	return m.ensureToastTick()
 }
 


### PR DESCRIPTION
## Summary
This PR adds a warning notification when hive launches without finding any git repositories in the configured search directories.

## Changes
- Added `notifyWarn` helper method to display warning-level toast notifications
- Check for empty repository list after scanning configured directories
- Display warning toast when no repositories found but directories are configured
- Helps users quickly identify misconfigured repository directories

## Behavior
When hive starts and scans the configured `repo_dirs`, if no git repositories are found but directories were configured, a warning toast appears:
```
⚠️  No repositories found in configured directories
```

This provides immediate feedback to users about potential configuration issues, preventing confusion about why the repository list is empty.

## Testing
- Built successfully with `go build`
- Code follows existing notification patterns (`notifyError`, `notifySuccess`)
- Warning only shows when directories are configured but no repos found (not on first run)

Closes #149