### PR TITLE
fix:openNewSession checks if item is a header

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1830,9 +1830,18 @@ func (m Model) executeRename(sessionID, newName string) tea.Cmd {
 // openNewSessionForm initializes the new session form and transitions to the creating state.
 func (m Model) openNewSessionForm() (tea.Model, tea.Cmd) {
 	preselectedRemote := m.localRemote
-	if selected := m.selectedSession(); selected != nil {
-		preselectedRemote = selected.Remote
+
+	item := m.list.SelectedItem()
+	if item != nil {
+		if treeItem, ok := item.(TreeItem); ok {
+			if treeItem.IsHeader && treeItem.RepoRemote != "" {
+				preselectedRemote = treeItem.RepoRemote
+			} else if selected := m.selectedSession(); selected != nil {
+				preselectedRemote = selected.Remote
+			}
+		}
 	}
+
 	existingNames := make(map[string]bool, len(m.allSessions))
 	for _, s := range m.allSessions {
 		existingNames[s.Name] = true


### PR DESCRIPTION
Fixes #

## Purpose

If a user is selecting the name of a project in Sessions and they create a new project with N, the selected project header will be the selected project in the new session form.

## Proposed Changes

  - Change the openSessionForm handler handle this logic correctly

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)