### PR TITLE
Rename :Messages command to :Notifications

### DIFF
--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -138,7 +138,7 @@ var defaultUserCommands = map[string]UserCommand{
 		Help:   "preview theme (" + strings.Join(styles.ThemeNames(), ", ") + ")",
 		Silent: true,
 	},
-	"Messages": {
+	"Notifications": {
 		Action: ActionMessages,
 		Help:   "show notification history",
 		Silent: true,


### PR DESCRIPTION
Fixes #143 

Renames the `:Messages` command to `:Notifications` in the TUI to differentiate it from the message bus tab. This makes it clearer that the command shows notification history rather than message bus content.

**Changes:**
- Renamed command key from "Messages" to "Notifications" in `internal/core/config/config.go`
- Help text remains "show notification history" (unchanged)

This is a simple one-line change to improve UX clarity.
