### PR TITLE
refactor: consolidate TreeItem type assertions

### DIFF
--- a/internal/tui/tree_items.go
+++ b/internal/tui/tree_items.go
@@ -1,0 +1,39 @@
+package tui
+
+import (
+	"iter"
+
+	"charm.land/bubbles/v2/list"
+)
+
+// TreeItemsAll yields every TreeItem in items together with its index.
+// Non-TreeItem elements are silently skipped.
+func TreeItemsAll(items []list.Item) iter.Seq2[int, TreeItem] {
+	return func(yield func(int, TreeItem) bool) {
+		for i, item := range items {
+			ti, ok := item.(TreeItem)
+			if !ok {
+				continue
+			}
+			if !yield(i, ti) {
+				return
+			}
+		}
+	}
+}
+
+// TreeItemsSessions yields only regular session items (not headers, recycled
+// placeholders, or window sub-items) together with their index.
+func TreeItemsSessions(items []list.Item) iter.Seq2[int, TreeItem] {
+	return func(yield func(int, TreeItem) bool) {
+		for i, item := range items {
+			ti, ok := item.(TreeItem)
+			if !ok || !ti.IsSession() {
+				continue
+			}
+			if !yield(i, ti) {
+				return
+			}
+		}
+	}
+}

--- a/internal/tui/tree_items_test.go
+++ b/internal/tui/tree_items_test.go
@@ -1,0 +1,81 @@
+package tui
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/list"
+	"github.com/colonyops/hive/internal/core/session"
+)
+
+func TestIsSession(t *testing.T) {
+	tests := []struct {
+		name string
+		item TreeItem
+		want bool
+	}{
+		{name: "header", item: TreeItem{IsHeader: true}, want: false},
+		{name: "recycled", item: TreeItem{IsRecycledPlaceholder: true}, want: false},
+		{name: "window", item: TreeItem{IsWindowItem: true}, want: false},
+		{name: "session", item: TreeItem{Session: session.Session{ID: "a"}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.IsSession(); got != tt.want {
+				t.Errorf("IsSession() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTreeItemsAll(t *testing.T) {
+	items := []list.Item{
+		TreeItem{IsHeader: true, RepoName: "repo1"},
+		TreeItem{Session: session.Session{ID: "s1"}},
+		TreeItem{IsRecycledPlaceholder: true},
+	}
+
+	var got []TreeItem
+	for _, ti := range TreeItemsAll(items) {
+		got = append(got, ti)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("TreeItemsAll yielded %d items, want 3", len(got))
+	}
+	if !got[0].IsHeader {
+		t.Error("first item should be header")
+	}
+	if got[1].Session.ID != "s1" {
+		t.Error("second item should be session s1")
+	}
+	if !got[2].IsRecycledPlaceholder {
+		t.Error("third item should be recycled placeholder")
+	}
+}
+
+func TestTreeItemsSessions(t *testing.T) {
+	items := []list.Item{
+		TreeItem{IsHeader: true, RepoName: "repo1"},
+		TreeItem{Session: session.Session{ID: "s1"}},
+		TreeItem{IsRecycledPlaceholder: true},
+		TreeItem{Session: session.Session{ID: "s2"}},
+		TreeItem{IsWindowItem: true},
+	}
+
+	var indices []int
+	var ids []string
+	for i, ti := range TreeItemsSessions(items) {
+		indices = append(indices, i)
+		ids = append(ids, ti.Session.ID)
+	}
+
+	if len(ids) != 2 {
+		t.Fatalf("TreeItemsSessions yielded %d items, want 2", len(ids))
+	}
+	if ids[0] != "s1" || ids[1] != "s2" {
+		t.Errorf("got IDs %v, want [s1 s2]", ids)
+	}
+	if indices[0] != 1 || indices[1] != 3 {
+		t.Errorf("got indices %v, want [1 3]", indices)
+	}
+}

--- a/internal/tui/tree_selection.go
+++ b/internal/tui/tree_selection.go
@@ -73,8 +73,7 @@ func (s treeSelection) restore(items []TreeItem) int {
 	// 4. Session by ID
 	if s.sessionID != "" {
 		for i, ti := range items {
-			if !ti.IsHeader && !ti.IsRecycledPlaceholder && !ti.IsWindowItem &&
-				ti.Session.ID == s.sessionID {
+			if ti.IsSession() && ti.Session.ID == s.sessionID {
 				return i
 			}
 		}

--- a/internal/tui/tree_view.go
+++ b/internal/tui/tree_view.go
@@ -151,6 +151,12 @@ type TreeItem struct {
 	IsLastWindow  bool            // For └─ vs ├─ rendering within the window group
 }
 
+// IsSession returns true when this item represents a regular session (not a
+// header, recycled placeholder, or window sub-item).
+func (i TreeItem) IsSession() bool {
+	return !i.IsHeader && !i.IsRecycledPlaceholder && !i.IsWindowItem
+}
+
 // FilterValue returns the value used for filtering.
 // Headers are not filterable (return empty).
 // Sessions return "repoName sessionName" to allow searching by either.

--- a/internal/tui/views/review/picker_view.go
+++ b/internal/tui/views/review/picker_view.go
@@ -135,8 +135,8 @@ func (v PickerView) Update(msg tea.Msg) (PickerView, tea.Cmd) {
 	case keyEnter:
 		// Select current item (skip headers)
 		if item := v.list.SelectedItem(); item != nil {
-			if treeItem, ok := item.(TreeItem); ok && !treeItem.IsHeader {
-				v.selectedDoc = &treeItem.Document
+			if ti, ok := item.(TreeItem); ok && ti.IsDocument() {
+				v.selectedDoc = &ti.Document
 			}
 		}
 		return v, nil
@@ -172,16 +172,8 @@ func (v *PickerView) updateFilter() {
 
 // selectFirstDocument selects the first non-header item in the list.
 func (v *PickerView) selectFirstDocument() {
-	items := v.list.Items()
-	if len(items) == 0 {
-		return
-	}
-
-	for i, item := range items {
-		if treeItem, ok := item.(TreeItem); ok && !treeItem.IsHeader {
-			v.list.Select(i)
-			break
-		}
+	if i := TreeItemsFirstDocument(v.list.Items()); i >= 0 {
+		v.list.Select(i)
 	}
 }
 

--- a/internal/tui/views/review/tree_items.go
+++ b/internal/tui/views/review/tree_items.go
@@ -1,0 +1,49 @@
+package review
+
+import (
+	"iter"
+
+	"charm.land/bubbles/v2/list"
+)
+
+// TreeItemsAll yields every TreeItem in items together with its index.
+// Non-TreeItem elements are silently skipped.
+func TreeItemsAll(items []list.Item) iter.Seq2[int, TreeItem] {
+	return func(yield func(int, TreeItem) bool) {
+		for i, item := range items {
+			ti, ok := item.(TreeItem)
+			if !ok {
+				continue
+			}
+			if !yield(i, ti) {
+				return
+			}
+		}
+	}
+}
+
+// TreeItemsDocuments yields only document items (not headers) together with
+// their index.
+func TreeItemsDocuments(items []list.Item) iter.Seq2[int, TreeItem] {
+	return func(yield func(int, TreeItem) bool) {
+		for i, item := range items {
+			ti, ok := item.(TreeItem)
+			if !ok || !ti.IsDocument() {
+				continue
+			}
+			if !yield(i, ti) {
+				return
+			}
+		}
+	}
+}
+
+// TreeItemsFirstDocument returns the index of the first document item, or -1
+// if the list contains no documents.
+func TreeItemsFirstDocument(items []list.Item) int {
+	for i, ti := range TreeItemsDocuments(items) {
+		_ = ti
+		return i
+	}
+	return -1
+}

--- a/internal/tui/views/review/tree_items_test.go
+++ b/internal/tui/views/review/tree_items_test.go
@@ -1,0 +1,98 @@
+package review
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/list"
+)
+
+func TestIsDocument(t *testing.T) {
+	tests := []struct {
+		name string
+		item TreeItem
+		want bool
+	}{
+		{name: "header", item: TreeItem{IsHeader: true}, want: false},
+		{name: "document", item: TreeItem{Document: Document{RelPath: "a.md"}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.IsDocument(); got != tt.want {
+				t.Errorf("IsDocument() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTreeItemsAll(t *testing.T) {
+	items := []list.Item{
+		TreeItem{IsHeader: true, HeaderName: "Plans"},
+		TreeItem{Document: Document{RelPath: "a.md"}},
+		TreeItem{Document: Document{RelPath: "b.md"}},
+	}
+
+	var got []TreeItem
+	for _, ti := range TreeItemsAll(items) {
+		got = append(got, ti)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("TreeItemsAll yielded %d items, want 3", len(got))
+	}
+	if !got[0].IsHeader {
+		t.Error("first item should be header")
+	}
+}
+
+func TestTreeItemsDocuments(t *testing.T) {
+	items := []list.Item{
+		TreeItem{IsHeader: true, HeaderName: "Plans"},
+		TreeItem{Document: Document{RelPath: "a.md"}},
+		TreeItem{IsHeader: true, HeaderName: "Research"},
+		TreeItem{Document: Document{RelPath: "b.md"}},
+	}
+
+	var paths []string
+	var indices []int
+	for i, ti := range TreeItemsDocuments(items) {
+		indices = append(indices, i)
+		paths = append(paths, ti.Document.RelPath)
+	}
+
+	if len(paths) != 2 {
+		t.Fatalf("TreeItemsDocuments yielded %d items, want 2", len(paths))
+	}
+	if paths[0] != "a.md" || paths[1] != "b.md" {
+		t.Errorf("got paths %v, want [a.md b.md]", paths)
+	}
+	if indices[0] != 1 || indices[1] != 3 {
+		t.Errorf("got indices %v, want [1 3]", indices)
+	}
+}
+
+func TestTreeItemsFirstDocument(t *testing.T) {
+	t.Run("with documents", func(t *testing.T) {
+		items := []list.Item{
+			TreeItem{IsHeader: true},
+			TreeItem{Document: Document{RelPath: "a.md"}},
+		}
+		if got := TreeItemsFirstDocument(items); got != 1 {
+			t.Errorf("TreeItemsFirstDocument() = %d, want 1", got)
+		}
+	})
+
+	t.Run("only headers", func(t *testing.T) {
+		items := []list.Item{
+			TreeItem{IsHeader: true},
+		}
+		if got := TreeItemsFirstDocument(items); got != -1 {
+			t.Errorf("TreeItemsFirstDocument() = %d, want -1", got)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		if got := TreeItemsFirstDocument(nil); got != -1 {
+			t.Errorf("TreeItemsFirstDocument() = %d, want -1", got)
+		}
+	})
+}


### PR DESCRIPTION
## Purpose

The TUI stores TreeItems as `[]list.Item` (an interface), requiring `item.(TreeItem)` type assertions at every access. ~15 sites repeated the same cast-and-filter boilerplate with compound boolean checks like `!ti.IsHeader && !ti.IsRecycledPlaceholder && !ti.IsWindowItem`.

## Proposed Changes

- Add `IsSession()` / `IsDocument()` variant query methods to replace compound boolean checks
- Add `iter.Seq2` iterator helpers (`TreeItemsAll`, `TreeItemsSessions`, `TreeItemsDocuments`, `TreeItemsFirstDocument`) to centralize the cast-and-filter pattern
- Refactor ~15 call sites across `model.go`, `tree_selection.go`, `review_view.go`, `picker_view.go`, and `review_picker_modal.go`
- Leave 8 single-item cast sites unchanged (render delegates, `selectedSession`, navigation) where an iterator adds no value

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)