### PR TITLE
Add global vars and vars_files support for templates

### DIFF
--- a/internal/core/config/vars.go
+++ b/internal/core/config/vars.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// loadVarsFiles reads YAML vars files and merges them in declaration order.
+// Later files override earlier files for the same keys.
+func loadVarsFiles(configDir string, files []string) (map[string]any, error) {
+	merged := make(map[string]any)
+
+	for _, file := range files {
+		path := file
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(configDir, path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read vars file %q: %w", file, err)
+		}
+
+		var vars map[string]any
+		if err := yaml.Unmarshal(data, &vars); err != nil {
+			return nil, fmt.Errorf("parse vars file %q: %w", file, err)
+		}
+
+		mergeMaps(merged, vars)
+	}
+
+	return merged, nil
+}
+
+// mergeMaps recursively merges src into dst.
+// Nested maps are merged, while scalar and non-map values are replaced.
+func mergeMaps(dst, src map[string]any) {
+	if src == nil {
+		return
+	}
+
+	for key, srcVal := range src {
+		srcMap, srcIsMap := srcVal.(map[string]any)
+		if !srcIsMap {
+			dst[key] = srcVal
+			continue
+		}
+
+		dstMap, dstIsMap := dst[key].(map[string]any)
+		if !dstIsMap {
+			dst[key] = srcMap
+			continue
+		}
+
+		mergeMaps(dstMap, srcMap)
+	}
+}

--- a/internal/core/config/vars_test.go
+++ b/internal/core/config/vars_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadVarsFiles_Single(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, writeTestFile(filepath.Join(dir, "vars.yaml"), "editor: nvim\norg: colonyops\n"))
+
+	got, err := loadVarsFiles(dir, []string{"vars.yaml"})
+	require.NoError(t, err)
+	assert.Equal(t, "nvim", got["editor"])
+	assert.Equal(t, "colonyops", got["org"])
+}
+
+func TestLoadVarsFiles_Multiple_MergeOrder(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, writeTestFile(filepath.Join(dir, "base.yaml"), "editor: vim\norg: old\n"))
+	require.NoError(t, writeTestFile(filepath.Join(dir, "override.yaml"), "editor: nvim\n"))
+
+	got, err := loadVarsFiles(dir, []string{"base.yaml", "override.yaml"})
+	require.NoError(t, err)
+	assert.Equal(t, "nvim", got["editor"])
+	assert.Equal(t, "old", got["org"])
+}
+
+func TestLoadVarsFiles_NestedMerge(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, writeTestFile(filepath.Join(dir, "a.yaml"), "github:\n  org: colonyops\n  team: platform\n"))
+	require.NoError(t, writeTestFile(filepath.Join(dir, "b.yaml"), "github:\n  team: infra\n"))
+
+	got, err := loadVarsFiles(dir, []string{"a.yaml", "b.yaml"})
+	require.NoError(t, err)
+
+	github := got["github"].(map[string]any)
+	assert.Equal(t, "colonyops", github["org"])
+	assert.Equal(t, "infra", github["team"])
+}
+
+func TestLoadVarsFiles_AbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "vars.yaml")
+	require.NoError(t, writeTestFile(file, "editor: nvim\n"))
+
+	got, err := loadVarsFiles("ignored", []string{file})
+	require.NoError(t, err)
+	assert.Equal(t, "nvim", got["editor"])
+}
+
+func TestLoadVarsFiles_NotFound(t *testing.T) {
+	_, err := loadVarsFiles(t.TempDir(), []string{"missing.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read vars file")
+}
+
+func TestLoadVarsFiles_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, writeTestFile(filepath.Join(dir, "bad.yaml"), "editor: [\n"))
+
+	_, err := loadVarsFiles(dir, []string{"bad.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse vars file")
+}
+
+func TestMergeMaps_InlineOverridesFiles(t *testing.T) {
+	fileVars := map[string]any{
+		"editor": "vim",
+		"github": map[string]any{
+			"org":  "colonyops",
+			"team": "platform",
+		},
+	}
+	inlineVars := map[string]any{
+		"editor": "nvim",
+		"github": map[string]any{
+			"team": "infra",
+		},
+	}
+
+	mergeMaps(fileVars, inlineVars)
+
+	assert.Equal(t, "nvim", fileVars["editor"])
+	github := fileVars["github"].(map[string]any)
+	assert.Equal(t, "colonyops", github["org"])
+	assert.Equal(t, "infra", github["team"])
+}
+
+func writeTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/hive/recycler.go
+++ b/internal/hive/recycler.go
@@ -13,6 +13,7 @@ import (
 // RecycleData contains template data for recycle commands.
 type RecycleData struct {
 	DefaultBranch string
+	Vars          map[string]any
 }
 
 // Recycler handles resetting a session environment for reuse.

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -212,6 +212,7 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 		ContextDir: s.config.RepoContextDir(owner, repoName),
 		Owner:      owner,
 		Repo:       repoName,
+		Vars:       s.config.Vars,
 	}
 
 	if !opts.SkipSpawn {
@@ -276,6 +277,7 @@ func (s *SessionService) RecycleSession(ctx context.Context, id string, w io.Wri
 
 	data := RecycleData{
 		DefaultBranch: defaultBranch,
+		Vars:          s.config.Vars,
 	}
 
 	if err := s.recycler.Recycle(ctx, sess.Path, s.config.GetRecycleCommands(sess.Remote), data, w); err != nil {
@@ -473,6 +475,7 @@ func (s *SessionService) OpenTmuxSession(ctx context.Context, name, path, remote
 		ContextDir: s.config.RepoContextDir(owner, repo),
 		Owner:      owner,
 		Repo:       repo,
+		Vars:       s.config.Vars,
 	}
 
 	return s.spawner.OpenWindows(ctx, strategy.Windows, data, background, targetWindow)

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -24,13 +24,14 @@ type SessionClient interface {
 
 // SpawnData is the template context for spawn commands.
 type SpawnData struct {
-	Path       string // Absolute path to session directory
-	Name       string // Session name (display name)
-	Prompt     string // User-provided prompt (batch only)
-	Slug       string // Session slug (URL-safe version of name)
-	ContextDir string // Path to context directory
-	Owner      string // Repository owner
-	Repo       string // Repository name
+	Path       string         // Absolute path to session directory
+	Name       string         // Session name (display name)
+	Prompt     string         // User-provided prompt (batch only)
+	Slug       string         // Session slug (URL-safe version of name)
+	ContextDir string         // Path to context directory
+	Owner      string         // Repository owner
+	Repo       string         // Repository name
+	Vars       map[string]any // User-defined template variables
 }
 
 // Spawner handles terminal spawning with template rendering.

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -201,6 +201,22 @@ func TestKeybindingHandler_ResolveUserCommand(t *testing.T) {
 	}
 }
 
+func TestKeybindingHandler_ResolveUserCommand_WithVars(t *testing.T) {
+	handler := NewKeybindingResolver(nil, nil, testRenderer, map[string]any{"editor": "nvim"})
+	sess := session.Session{
+		ID:   "test-id",
+		Path: "/test/path",
+		Name: "test-name",
+	}
+
+	cmd := config.UserCommand{Sh: "echo {{ .Vars.editor }} {{ .Name }}"}
+	action := handler.ResolveUserCommand("vars", cmd, sess, nil)
+
+	require.NoError(t, action.Err)
+	assert.Equal(t, act.TypeShell, action.Type)
+	assert.Equal(t, "echo nvim test-name", action.ShellCmd)
+}
+
 func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 	commands := map[string]config.UserCommand{
 		"Recycle": {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -174,7 +174,7 @@ func New(deps Deps, opts Opts) Model {
 	// Compute merged commands: system → plugins → user
 	mergedCommands := deps.PluginManager.MergedCommands(config.DefaultUserCommands(), cfg.UserCommands)
 
-	handler := NewKeybindingResolver(cfg.Keybindings, mergedCommands, deps.Renderer)
+	handler := NewKeybindingResolver(cfg.Keybindings, mergedCommands, deps.Renderer, cfg.Vars)
 	cmdService := command.NewService(service, service, service, service)
 
 	sessionsView := sessions.New(sessions.ViewOpts{

--- a/pkg/tmpl/tmpl_test.go
+++ b/pkg/tmpl/tmpl_test.go
@@ -192,6 +192,22 @@ func TestRenderer_SpawnCommand(t *testing.T) {
 	assert.Equal(t, "HIVE_AGENT_COMMAND='aider' HIVE_AGENT_WINDOW='aider' HIVE_AGENT_FLAGS='--model sonnet' /bin/hive-tmux 'test-session' '/tmp/work'", got)
 }
 
+func TestRender_WithVars(t *testing.T) {
+	r := New(Config{})
+
+	data := struct {
+		Name string
+		Vars map[string]any
+	}{
+		Name: "test-session",
+		Vars: map[string]any{"editor": "nvim"},
+	}
+
+	got, err := r.Render("{{ .Name }} {{ .Vars.editor }}", data)
+	require.NoError(t, err)
+	assert.Equal(t, "test-session nvim", got)
+}
+
 func TestNewValidation(t *testing.T) {
 	r := NewValidation()
 


### PR DESCRIPTION
## Summary
- add config-level vars and vars_files support with deterministic merge order
- load vars files relative to config path and merge inline vars as highest precedence
- expose .Vars in runtime template contexts (spawn, recycle, keybindings/user commands/windows)
- extend deep validation to validate vars_files existence and validate templates against configured vars
- add tests for vars loading/merge, validation behavior, keybinding rendering, and template rendering

## Testing
- mise run check

Fixes #173