### PR TITLE
Add :HiveInfo and :HiveDoctor command palette dialogs

### DIFF
--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -94,10 +94,17 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 			DB:              cmd.app.DB,
 			KVStore:         cmd.app.KV,
 			Renderer:        cmd.app.Renderer,
+			BuildInfo: tui.BuildInfo{
+				Version: cmd.app.Build.Version,
+				Commit:  cmd.app.Build.Commit,
+				Date:    cmd.app.Build.Date,
+			},
+			DoctorService: cmd.app.Doctor,
 		}
 		opts := tui.Opts{
 			LocalRemote: localRemote,
 			Warnings:    warnings,
+			ConfigPath:  cmd.flags.ConfigPath,
 		}
 
 		restoreOutput := cmd.app.Sessions.SilenceOutput()

--- a/internal/core/action/action.go
+++ b/internal/core/action/action.go
@@ -80,6 +80,8 @@ var configActions = map[Type]bool{
 	TypeRenameSession:  true,
 	TypeNextActive:     true,
 	TypePrevActive:     true,
+	TypeHiveInfo:       true,
+	TypeHiveDoctor:     true,
 }
 
 // IsConfigAction reports whether t is a valid action for use in YAML config.

--- a/internal/core/action/type.go
+++ b/internal/core/action/type.go
@@ -23,6 +23,8 @@ package action
 //	PrevActive
 //	DeleteRecycledBatch
 //	SpawnWindows
+//	HiveInfo
+//	HiveDoctor
 //
 // )
 type Type string

--- a/internal/core/action/type_enum.go
+++ b/internal/core/action/type_enum.go
@@ -49,6 +49,10 @@ const (
 	TypeDeleteRecycledBatch Type = "DeleteRecycledBatch"
 	// TypeSpawnWindows is a Type of type SpawnWindows.
 	TypeSpawnWindows Type = "SpawnWindows"
+	// TypeHiveInfo is a Type of type HiveInfo.
+	TypeHiveInfo Type = "HiveInfo"
+	// TypeHiveDoctor is a Type of type HiveDoctor.
+	TypeHiveDoctor Type = "HiveDoctor"
 )
 
 var ErrInvalidType = fmt.Errorf("not a valid Type, try [%s]", strings.Join(_TypeNames, ", "))
@@ -73,6 +77,8 @@ var _TypeNames = []string{
 	string(TypePrevActive),
 	string(TypeDeleteRecycledBatch),
 	string(TypeSpawnWindows),
+	string(TypeHiveInfo),
+	string(TypeHiveDoctor),
 }
 
 // TypeNames returns a list of possible string values of Type.
@@ -133,6 +139,10 @@ var _TypeValue = map[string]Type{
 	"deleterecycledbatch": TypeDeleteRecycledBatch,
 	"SpawnWindows":        TypeSpawnWindows,
 	"spawnwindows":        TypeSpawnWindows,
+	"HiveInfo":            TypeHiveInfo,
+	"hiveinfo":            TypeHiveInfo,
+	"HiveDoctor":          TypeHiveDoctor,
+	"hivedoctor":          TypeHiveDoctor,
 }
 
 // ParseType attempts to convert a string to a Type.

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -142,6 +142,16 @@ var defaultUserCommands = map[string]UserCommand{
 		Help:   "prev active session",
 		Silent: true,
 	},
+	"HiveInfo": {
+		Action: action.TypeHiveInfo,
+		Help:   "show build and config info",
+		Silent: true,
+	},
+	"HiveDoctor": {
+		Action: action.TypeHiveDoctor,
+		Help:   "run health checks",
+		Silent: true,
+	},
 	"SendBatch": {
 		Sh: `{{ range .Form.targets }}
 {{ agentSend }} {{ .Name | shq }}:claude {{ $.Form.message | shq }}

--- a/internal/hive/app.go
+++ b/internal/hive/app.go
@@ -12,6 +12,13 @@ import (
 	"github.com/colonyops/hive/pkg/tmpl"
 )
 
+// BuildInfo holds build-time metadata set by the main package.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
 // App is the central entry point for all hive operations.
 // Commands and TUI consume App instead of cherry-picking raw dependencies.
 type App struct {
@@ -27,6 +34,7 @@ type App struct {
 	DB       *db.DB
 	KV       kv.KV
 	Renderer *tmpl.Renderer
+	Build    BuildInfo
 }
 
 // NewApp constructs an App from explicit dependencies.

--- a/internal/tui/buildinfo.go
+++ b/internal/tui/buildinfo.go
@@ -1,0 +1,8 @@
+package tui
+
+// BuildInfo holds build-time metadata for display in the TUI.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}

--- a/internal/tui/components/info_dialog.go
+++ b/internal/tui/components/info_dialog.go
@@ -1,0 +1,168 @@
+// Package components provides reusable TUI components.
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/colonyops/hive/internal/core/styles"
+)
+
+const (
+	infoModalMaxHeight = 30
+	infoModalMargin    = 4
+	infoModalChrome    = 6 // title + divider + help + spacing
+	infoModalMinWidth  = 50
+)
+
+// InfoStatus represents the status of an info item.
+type InfoStatus int
+
+const (
+	InfoStatusNone InfoStatus = iota
+	InfoStatusPass
+	InfoStatusWarn
+	InfoStatusFail
+)
+
+// InfoItem is a single labeled row in an info section.
+type InfoItem struct {
+	Label  string
+	Value  string
+	Status InfoStatus
+}
+
+// InfoSection groups related info items under a section title.
+type InfoSection struct {
+	Title string
+	Items []InfoItem
+}
+
+// InfoDialog displays structured, optionally status-annotated information.
+type InfoDialog struct {
+	title    string
+	sections []InfoSection
+	footer   string
+	helpText string
+	viewport viewport.Model
+}
+
+// NewInfoDialog creates a new info dialog.
+func NewInfoDialog(title string, sections []InfoSection, footer, helpText string, width, height int) *InfoDialog {
+	modalWidth := min(max(int(float64(width)*0.65), infoModalMinWidth), width-infoModalMargin)
+	modalHeight := min(height-infoModalMargin, infoModalMaxHeight)
+	contentHeight := modalHeight - infoModalChrome
+
+	vp := viewport.New(
+		viewport.WithWidth(modalWidth-4),
+		viewport.WithHeight(contentHeight),
+	)
+
+	d := &InfoDialog{
+		title:    title,
+		sections: sections,
+		footer:   footer,
+		helpText: helpText,
+		viewport: vp,
+	}
+	d.viewport.SetContent(d.renderContent(modalWidth))
+	return d
+}
+
+func (d *InfoDialog) renderContent(modalWidth int) string {
+	separator := styles.TextSurfaceStyle.Render(strings.Repeat("─", max(modalWidth-6, 1)))
+	lines := make([]string, 0)
+
+	for i, section := range d.sections {
+		if i > 0 {
+			lines = append(lines, "")
+		}
+		if section.Title != "" {
+			lines = append(lines, styles.HelpDialogSectionStyle.Render(section.Title))
+			lines = append(lines, separator)
+		}
+		for _, item := range section.Items {
+			lines = append(lines, formatInfoItem(item))
+		}
+	}
+
+	if d.footer != "" {
+		lines = append(lines, "", d.footer)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func formatInfoItem(item InfoItem) string {
+	label := styles.TextForegroundBoldStyle.Render(item.Label)
+	value := styles.TextMutedStyle.Render(item.Value)
+
+	if icon := statusIcon(item.Status); icon != "" {
+		return fmt.Sprintf("%s %s  %s", icon, label, value)
+	}
+	return fmt.Sprintf("%s  %s", label, value)
+}
+
+func statusIcon(s InfoStatus) string {
+	switch s {
+	case InfoStatusPass:
+		return styles.TextSuccessStyle.Render("✔")
+	case InfoStatusWarn:
+		return styles.TextWarningStyle.Render("●")
+	case InfoStatusFail:
+		return styles.TextErrorStyle.Render("✘")
+	default:
+		return ""
+	}
+}
+
+// ScrollUp scrolls the viewport up.
+func (d *InfoDialog) ScrollUp() {
+	d.viewport.ScrollUp(1)
+}
+
+// ScrollDown scrolls the viewport down.
+func (d *InfoDialog) ScrollDown() {
+	d.viewport.ScrollDown(1)
+}
+
+// Overlay renders the dialog centered over the provided background.
+func (d *InfoDialog) Overlay(background string, width, height int) string {
+	modalWidth := min(max(int(float64(width)*0.65), infoModalMinWidth), width-infoModalMargin)
+	modalHeight := min(height-infoModalMargin, infoModalMaxHeight)
+
+	scrollInfo := ""
+	if d.viewport.TotalLineCount() > d.viewport.VisibleLineCount() {
+		scrollInfo = styles.TextMutedStyle.Render(
+			fmt.Sprintf(" (%.0f%%)", d.viewport.ScrollPercent()*100),
+		)
+	}
+
+	divider := styles.TextSurfaceStyle.Render(strings.Repeat("─", max(modalWidth-6, 1)))
+	modalContent := lipgloss.JoinVertical(
+		lipgloss.Left,
+		styles.ModalTitleStyle.Render(d.title+scrollInfo),
+		divider,
+		d.viewport.View(),
+		styles.ModalHelpStyle.Render(d.helpText),
+	)
+
+	modal := styles.ModalStyle.
+		Width(modalWidth).
+		Height(modalHeight).
+		Render(modalContent)
+
+	bgLayer := lipgloss.NewLayer(background)
+	modalLayer := lipgloss.NewLayer(modal)
+
+	modalW := lipgloss.Width(modal)
+	modalH := lipgloss.Height(modal)
+	centerX := max((width-modalW)/2, 0)
+	centerY := max((height-modalH)/2, 0)
+	modalLayer.X(centerX).Y(centerY).Z(1)
+
+	return lipgloss.NewCompositor(bgLayer, modalLayer).Render()
+}

--- a/internal/tui/components/info_dialog_test.go
+++ b/internal/tui/components/info_dialog_test.go
@@ -1,0 +1,71 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfoDialog_RendersSectionsItemsFooter(t *testing.T) {
+	d := NewInfoDialog(
+		"Hive Info",
+		[]InfoSection{
+			{
+				Title: "Build",
+				Items: []InfoItem{
+					{Label: "Version", Value: "dev"},
+					{Label: "Commit", Value: "abc1234"},
+				},
+			},
+			{
+				Title: "Checks",
+				Items: []InfoItem{
+					{Label: "git", Value: "ok", Status: InfoStatusPass},
+					{Label: "tmux", Value: "warn", Status: InfoStatusWarn},
+					{Label: "cfg", Value: "bad", Status: InfoStatusFail},
+				},
+			},
+		},
+		"footer summary",
+		"[j/k] scroll  [esc] close",
+		120,
+		40,
+	)
+
+	out := d.Overlay("bg", 120, 40)
+	assert.Contains(t, out, "Hive Info")
+	assert.Contains(t, out, "Build")
+	assert.Contains(t, out, "Version")
+	assert.Contains(t, out, "abc1234")
+	assert.Contains(t, out, "footer summary")
+	assert.Contains(t, out, "✔")
+	assert.Contains(t, out, "●")
+	assert.Contains(t, out, "✘")
+}
+
+func TestInfoDialog_ScrollAndEmptySections(t *testing.T) {
+	items := make([]InfoItem, 0, 50)
+	for i := 0; i < 50; i++ {
+		items = append(items, InfoItem{Label: "item", Value: "value"})
+	}
+
+	d := NewInfoDialog(
+		"Hive Doctor",
+		[]InfoSection{
+			{Title: "Many", Items: items},
+			{Title: "Empty", Items: nil},
+		},
+		"",
+		"help",
+		70,
+		18,
+	)
+
+	before := d.Overlay("bg", 70, 18)
+	d.ScrollDown()
+	after := d.Overlay("bg", 70, 18)
+
+	assert.Contains(t, before, "Hive Doctor")
+	assert.Contains(t, after, "Hive Doctor")
+	assert.NotEqual(t, before, after)
+}

--- a/internal/tui/doctor_results_test.go
+++ b/internal/tui/doctor_results_test.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/colonyops/hive/internal/core/doctor"
+	"github.com/colonyops/hive/internal/tui/components"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDoctorDialogContent_StatusMappingAndSummary(t *testing.T) {
+	results := []doctor.Result{
+		{
+			Name: "tools",
+			Items: []doctor.CheckItem{
+				{Label: "git", Detail: "available", Status: doctor.StatusPass},
+				{Label: "tmux", Detail: "missing", Status: doctor.StatusFail},
+			},
+		},
+		{
+			Name: "config",
+			Items: []doctor.CheckItem{
+				{Label: "repo_dirs", Detail: "empty", Status: doctor.StatusWarn},
+			},
+		},
+	}
+
+	sections, footer := buildDoctorDialogContent(results)
+
+	if assert.Len(t, sections, 2) {
+		assert.Equal(t, "tools", sections[0].Title)
+		if assert.Len(t, sections[0].Items, 2) {
+			assert.Equal(t, components.InfoStatusPass, sections[0].Items[0].Status)
+			assert.Equal(t, components.InfoStatusFail, sections[0].Items[1].Status)
+		}
+
+		assert.Equal(t, "config", sections[1].Title)
+		if assert.Len(t, sections[1].Items, 1) {
+			assert.Equal(t, components.InfoStatusWarn, sections[1].Items[0].Status)
+		}
+	}
+
+	assert.Contains(t, footer, "1 passed", "footer should include pass count")
+	assert.Contains(t, footer, "1 warnings", "footer should include warning count")
+	assert.Contains(t, footer, "1 failed", "footer should include fail count")
+}

--- a/internal/tui/modal_coordinator.go
+++ b/internal/tui/modal_coordinator.go
@@ -26,6 +26,7 @@ type ModalCoordinator struct {
 	CommandPalette  *CommandPalette
 	Help            *components.HelpDialog
 	Notification    *NotificationModal
+	InfoDialog      *components.InfoDialog
 	FormDialog      *form.Dialog
 	DocPicker       *review.DocumentPickerModal
 	RenameInput     textinput.Model
@@ -119,6 +120,9 @@ func (mc *ModalCoordinator) Overlay(state UIState, bg string, s spinner.Model, l
 	case state == stateShowingNotifications && mc.Notification != nil:
 		return mc.Notification.Overlay(bg, w, h)
 
+	case state == stateShowingInfo && mc.InfoDialog != nil:
+		return mc.InfoDialog.Overlay(bg, w, h)
+
 	case state == stateRenaming:
 		renameContent := lipgloss.JoinVertical(
 			lipgloss.Left,
@@ -166,6 +170,16 @@ func (mc *ModalCoordinator) DismissHelp() {
 // DismissNotifications closes the notification modal.
 func (mc *ModalCoordinator) DismissNotifications() {
 	mc.Notification = nil
+}
+
+// ShowInfo creates and displays the info dialog.
+func (mc *ModalCoordinator) ShowInfo(title string, sections []components.InfoSection, footer, helpText string) {
+	mc.InfoDialog = components.NewInfoDialog(title, sections, footer, helpText, mc.width, mc.height)
+}
+
+// DismissInfo closes the info dialog.
+func (mc *ModalCoordinator) DismissInfo() {
+	mc.InfoDialog = nil
 }
 
 // DismissConfirm resets the confirm modal to zero value.

--- a/main.go
+++ b/main.go
@@ -269,6 +269,11 @@ Run 'hive new' to create a new session from the current repository.`,
 				renderer,
 				pluginInfos,
 			)
+			hiveApp.Build = hive.BuildInfo{
+				Version: version,
+				Commit:  commit,
+				Date:    date,
+			}
 
 			return ctx, nil
 		},


### PR DESCRIPTION
## Summary
- add HiveInfo and HiveDoctor action types and default command-palette commands
- plumb build metadata and doctor service into TUI deps/options
- add reusable InfoDialog component with scrolling, status icons, and centered overlay
- integrate :HiveInfo modal with build/runtime/config/session details
- integrate :HiveDoctor async health-check execution with loading state and summary counts
- tune info dialog width to about 65% of terminal width and left-align section items
- add tests for info dialog rendering/scrolling and doctor-result mapping

## Verification
- mise run check
- go test ./internal/tui/... ./internal/tui/components/...
