### PR TITLE
feat: operator TODO list for agent output review

### DIFF
--- a/claude-plugin/hive/skills/todo/SKILL.md
+++ b/claude-plugin/hive/skills/todo/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: todo
+description: This skill should be used when the agent writes files to the .hive/ context directory (plans, research docs) and wants the operator to review them, or when the agent needs to create a TODO item for the operator. Also use when the agent asks "how do I request review?", "how do I notify the operator?", or "how do I use hive todo?".
+compatibility: claude, opencode
+---
+
+# TODO - Request Operator Review
+
+Notify the operator to review your work by including frontmatter in context directory files and using `hive todo create` for explicit review requests.
+
+## How It Works
+
+Hive watches the `.hive/` context directory for file changes. When you write plans, research, or other documents, the operator's TUI automatically detects new files and shows them as TODO items for review. Including frontmatter with your `session_id` enables the operator to send feedback directly to your inbox.
+
+## Frontmatter Format
+
+When writing files to `.hive/` (plans, research, notes), include a frontmatter block:
+
+```markdown
+---
+session_id: <your-session-id>
+title: <descriptive title>
+---
+
+# Your Document Content
+```
+
+### Getting Your Session ID
+
+```bash
+SESSION_ID=$(hive session info --json | jq -r '.id')
+```
+
+Or use `hive session info` for the human-readable version.
+
+### Example
+
+```bash
+SESSION_ID=$(hive session info --json | jq -r '.id')
+cat > .hive/plans/my-feature-plan.md << EOF
+---
+session_id: $SESSION_ID
+title: Feature X Implementation Plan
+---
+
+# Feature X Plan
+
+## Overview
+...
+EOF
+```
+
+The operator will see "Feature X Implementation Plan" in their TODO panel and can review, comment, and send feedback to your inbox.
+
+## Explicit TODO Items
+
+For actionable items that need operator attention beyond file reviews:
+
+```bash
+hive todo create "Please review the API design in .hive/plans/api-design.md"
+```
+
+### Guidelines
+
+- Use sparingly -- only for items that genuinely need human attention
+- Be specific about what you need reviewed
+- File changes in `.hive/` are auto-detected, so `hive todo create` is for supplementary requests
+- Rate limited to prevent abuse (default: 20 per session per hour)
+
+## What Happens Next
+
+1. Operator sees a `[N todo]` indicator in their TUI tab bar
+2. Pressing `t` opens the TODO action panel listing your item
+3. Operator selects the item to open it in the Review tab
+4. After reviewing, operator can send feedback to your inbox (if `session_id` was provided)
+5. Check your inbox: `hive msg inbox`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `hive todo create "<title>"` | Create a TODO item for the operator |
+| `hive todo list` | List pending TODO items (JSON) |
+| `hive todo dismiss <id>` | Dismiss a TODO item |
+
+## Related Skills
+
+- `/hive:inbox` - Check inbox for operator feedback
+- `/hive:session-info` - Get your session ID
+- `/hive:publish` - Send messages to other agents

--- a/internal/commands/cmd_todo.go
+++ b/internal/commands/cmd_todo.go
@@ -1,0 +1,226 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/colonyops/hive/internal/core/todo"
+	"github.com/colonyops/hive/internal/hive"
+	"github.com/colonyops/hive/pkg/iojson"
+	"github.com/urfave/cli/v3"
+)
+
+func (cmd *TodoCmd) todos() *hive.TodoService {
+	return cmd.app.Todos
+}
+
+// TodoCmd implements the hive todo command group.
+type TodoCmd struct {
+	flags *Flags
+	app   *hive.App
+
+	// create flags
+	createTitle       string
+	createDescription string
+	createRepo        string
+
+	// list flags
+	listStatus string
+
+	// dismiss flags (none, uses positional arg)
+}
+
+// NewTodoCmd creates a new todo command.
+func NewTodoCmd(flags *Flags, app *hive.App) *TodoCmd {
+	return &TodoCmd{flags: flags, app: app}
+}
+
+// Register adds the todo command to the application.
+func (cmd *TodoCmd) Register(app *cli.Command) *cli.Command {
+	app.Commands = append(app.Commands, &cli.Command{
+		Name:  "todo",
+		Usage: "Manage operator TODO items",
+		Description: `TODO commands for managing operator action items.
+
+Items are auto-created when files change in context directories,
+or created manually by agents via "hive todo create".
+
+Examples:
+  hive todo list                              # list pending items
+  hive todo list --status completed           # list completed items
+  hive todo create --title "Review PR #42"    # create a custom TODO
+  hive todo dismiss <id>                      # dismiss an item`,
+		Commands: []*cli.Command{
+			cmd.listCmd(),
+			cmd.createCmd(),
+			cmd.dismissCmd(),
+			cmd.completeCmd(),
+		},
+	})
+
+	return app
+}
+
+func (cmd *TodoCmd) listCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "list",
+		Aliases:   []string{"ls"},
+		Usage:     "List TODO items",
+		UsageText: "hive todo list [--status <status>]",
+		Description: `Lists TODO items as JSON lines.
+
+Defaults to pending items. Use --status to filter by status.
+
+Examples:
+  hive todo list
+  hive todo list --status completed
+  hive todo list --status dismissed`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "status",
+				Aliases:     []string{"s"},
+				Usage:       "filter by status (pending, completed, dismissed)",
+				Destination: &cmd.listStatus,
+			},
+		},
+		Action: cmd.runList,
+	}
+}
+
+func (cmd *TodoCmd) createCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "create",
+		Usage:     "Create a custom TODO item",
+		UsageText: "hive todo create --title <title> [--description <desc>] [--repo <remote>]",
+		Description: `Creates a custom TODO item for the operator.
+
+The session ID is auto-detected from the current working directory.
+Rate limited to prevent abuse (default: 20 per session per hour).
+
+Examples:
+  hive todo create --title "Review PR #42"
+  hive todo create --title "Check test results" --description "CI failed on main"`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "title",
+				Aliases:     []string{"t"},
+				Usage:       "title for the TODO item",
+				Required:    true,
+				Destination: &cmd.createTitle,
+			},
+			&cli.StringFlag{
+				Name:        "description",
+				Aliases:     []string{"d"},
+				Usage:       "optional description",
+				Destination: &cmd.createDescription,
+			},
+			&cli.StringFlag{
+				Name:        "repo",
+				Aliases:     []string{"r"},
+				Usage:       "repository remote URL (auto-detected if omitted)",
+				Destination: &cmd.createRepo,
+			},
+		},
+		Action: cmd.runCreate,
+	}
+}
+
+func (cmd *TodoCmd) dismissCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "dismiss",
+		Usage:     "Dismiss a TODO item",
+		UsageText: "hive todo dismiss <id>",
+		Description: `Dismisses a TODO item without completing it.
+
+Examples:
+  hive todo dismiss abc123`,
+		Action: cmd.runDismiss,
+	}
+}
+
+func (cmd *TodoCmd) completeCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "complete",
+		Usage:     "Complete a TODO item",
+		UsageText: "hive todo complete <id>",
+		Description: `Marks a TODO item as completed.
+
+Examples:
+  hive todo complete abc123`,
+		Action: cmd.runComplete,
+	}
+}
+
+func (cmd *TodoCmd) runList(ctx context.Context, c *cli.Command) error {
+	filter := todo.ListFilter{}
+
+	if cmd.listStatus != "" {
+		filter.Status = todo.Status(cmd.listStatus)
+	} else {
+		filter.Status = todo.StatusPending
+	}
+
+	items, err := cmd.todos().List(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("list todo items: %w", err)
+	}
+
+	for _, item := range items {
+		if err := iojson.WriteLine(c.Root().Writer, item); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *TodoCmd) runCreate(ctx context.Context, c *cli.Command) error {
+	sessionID, _ := cmd.app.Sessions.DetectSession(ctx)
+
+	repoRemote := cmd.createRepo
+	if repoRemote == "" {
+		repoRemote = "unknown"
+	}
+
+	item := todo.Item{
+		Title:       cmd.createTitle,
+		Description: cmd.createDescription,
+		SessionID:   sessionID,
+		RepoRemote:  repoRemote,
+	}
+
+	if err := cmd.todos().CreateCustom(ctx, item); err != nil {
+		return fmt.Errorf("create todo: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(c.Root().Writer, "created")
+	return nil
+}
+
+func (cmd *TodoCmd) runDismiss(ctx context.Context, c *cli.Command) error {
+	if c.NArg() < 1 {
+		return fmt.Errorf("usage: hive todo dismiss <id>")
+	}
+
+	id := c.Args().Get(0)
+	if err := cmd.todos().Dismiss(ctx, id); err != nil {
+		return fmt.Errorf("dismiss todo: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(c.Root().Writer, "dismissed")
+	return nil
+}
+
+func (cmd *TodoCmd) runComplete(ctx context.Context, c *cli.Command) error {
+	if c.NArg() < 1 {
+		return fmt.Errorf("usage: hive todo complete <id>")
+	}
+
+	id := c.Args().Get(0)
+	if err := cmd.todos().Complete(ctx, id); err != nil {
+		return fmt.Errorf("complete todo: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(c.Root().Writer, "completed")
+	return nil
+}

--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -88,6 +88,7 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 			Config:          cmd.app.Config,
 			Service:         cmd.app.Sessions,
 			MsgStore:        cmd.app.Messages,
+			TodoService:     cmd.app.Todos,
 			Bus:             cmd.app.Bus,
 			TerminalManager: termMgr,
 			PluginManager:   cmd.app.Plugins,

--- a/internal/core/action/action.go
+++ b/internal/core/action/action.go
@@ -80,6 +80,7 @@ var configActions = map[Type]bool{
 	TypeRenameSession:  true,
 	TypeNextActive:     true,
 	TypePrevActive:     true,
+	TypeTodoPanel:      true,
 }
 
 // IsConfigAction reports whether t is a valid action for use in YAML config.

--- a/internal/core/action/type.go
+++ b/internal/core/action/type.go
@@ -23,6 +23,7 @@ package action
 //	PrevActive
 //	DeleteRecycledBatch
 //	SpawnWindows
+//	TodoPanel
 //
 // )
 type Type string

--- a/internal/core/action/type_enum.go
+++ b/internal/core/action/type_enum.go
@@ -6,8 +6,8 @@
 package action
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 )
 
 const (
@@ -49,38 +49,11 @@ const (
 	TypeDeleteRecycledBatch Type = "DeleteRecycledBatch"
 	// TypeSpawnWindows is a Type of type SpawnWindows.
 	TypeSpawnWindows Type = "SpawnWindows"
+	// TypeTodoPanel is a Type of type TodoPanel.
+	TypeTodoPanel Type = "TodoPanel"
 )
 
-var ErrInvalidType = fmt.Errorf("not a valid Type, try [%s]", strings.Join(_TypeNames, ", "))
-
-var _TypeNames = []string{
-	string(TypeNone),
-	string(TypeRecycle),
-	string(TypeDelete),
-	string(TypeShell),
-	string(TypeTmuxOpen),
-	string(TypeTmuxStart),
-	string(TypeFilterAll),
-	string(TypeFilterActive),
-	string(TypeFilterApproval),
-	string(TypeFilterReady),
-	string(TypeDocReview),
-	string(TypeNewSession),
-	string(TypeSetTheme),
-	string(TypeMessages),
-	string(TypeRenameSession),
-	string(TypeNextActive),
-	string(TypePrevActive),
-	string(TypeDeleteRecycledBatch),
-	string(TypeSpawnWindows),
-}
-
-// TypeNames returns a list of possible string values of Type.
-func TypeNames() []string {
-	tmp := make([]string, len(_TypeNames))
-	copy(tmp, _TypeNames)
-	return tmp
-}
+var ErrInvalidType = errors.New("not a valid Type")
 
 // String implements the Stringer interface.
 func (x Type) String() string {
@@ -96,43 +69,25 @@ func (x Type) IsValid() bool {
 
 var _TypeValue = map[string]Type{
 	"None":                TypeNone,
-	"none":                TypeNone,
 	"Recycle":             TypeRecycle,
-	"recycle":             TypeRecycle,
 	"Delete":              TypeDelete,
-	"delete":              TypeDelete,
 	"Shell":               TypeShell,
-	"shell":               TypeShell,
 	"TmuxOpen":            TypeTmuxOpen,
-	"tmuxopen":            TypeTmuxOpen,
 	"TmuxStart":           TypeTmuxStart,
-	"tmuxstart":           TypeTmuxStart,
 	"FilterAll":           TypeFilterAll,
-	"filterall":           TypeFilterAll,
 	"FilterActive":        TypeFilterActive,
-	"filteractive":        TypeFilterActive,
 	"FilterApproval":      TypeFilterApproval,
-	"filterapproval":      TypeFilterApproval,
 	"FilterReady":         TypeFilterReady,
-	"filterready":         TypeFilterReady,
 	"DocReview":           TypeDocReview,
-	"docreview":           TypeDocReview,
 	"NewSession":          TypeNewSession,
-	"newsession":          TypeNewSession,
 	"SetTheme":            TypeSetTheme,
-	"settheme":            TypeSetTheme,
 	"Messages":            TypeMessages,
-	"messages":            TypeMessages,
 	"RenameSession":       TypeRenameSession,
-	"renamesession":       TypeRenameSession,
 	"NextActive":          TypeNextActive,
-	"nextactive":          TypeNextActive,
 	"PrevActive":          TypePrevActive,
-	"prevactive":          TypePrevActive,
 	"DeleteRecycledBatch": TypeDeleteRecycledBatch,
-	"deleterecycledbatch": TypeDeleteRecycledBatch,
 	"SpawnWindows":        TypeSpawnWindows,
-	"spawnwindows":        TypeSpawnWindows,
+	"TodoPanel":           TypeTodoPanel,
 }
 
 // ParseType attempts to convert a string to a Type.
@@ -140,32 +95,5 @@ func ParseType(name string) (Type, error) {
 	if x, ok := _TypeValue[name]; ok {
 		return x, nil
 	}
-	// Case insensitive parse, do a separate lookup to prevent unnecessary cost of lowercasing a string if we don't need to.
-	if x, ok := _TypeValue[strings.ToLower(name)]; ok {
-		return x, nil
-	}
 	return Type(""), fmt.Errorf("%s is %w", name, ErrInvalidType)
-}
-
-// MarshalText implements the text marshaller method.
-func (x Type) MarshalText() ([]byte, error) {
-	return []byte(string(x)), nil
-}
-
-// UnmarshalText implements the text unmarshaller method.
-func (x *Type) UnmarshalText(text []byte) error {
-	tmp, err := ParseType(string(text))
-	if err != nil {
-		return err
-	}
-	*x = tmp
-	return nil
-}
-
-// AppendText appends the textual representation of itself to the end of b
-// (allocating a larger slice if necessary) and returns the updated slice.
-//
-// Implementations must not retain b, nor mutate any bytes within b[:len(b)].
-func (x *Type) AppendText(b []byte) ([]byte, error) {
-	return append(b, x.String()...), nil
 }

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -198,6 +198,7 @@ type Config struct {
 	Context             ContextConfig          `yaml:"context"`
 	TUI                 TUIConfig              `yaml:"tui"`
 	Review              ReviewConfig           `yaml:"review"`
+	Todo                TodoConfig             `yaml:"todo"`
 	Messaging           MessagingConfig        `yaml:"messaging"`
 	Tmux                TmuxConfig             `yaml:"tmux"`
 	Database            DatabaseConfig         `yaml:"database"`
@@ -323,6 +324,42 @@ func (t TUIConfig) IconsEnabled() bool {
 type PreviewConfig struct {
 	TitleTemplate  string `yaml:"title_template"`  // Go template for panel title (e.g., "{{ .Name }} • #{{ .ShortID }}")
 	StatusTemplate string `yaml:"status_template"` // Go template for status line (e.g., "{{ .Icon.GitBranch }} {{ .Branch }}")
+}
+
+// TodoConfig holds TODO item configuration.
+type TodoConfig struct {
+	Enabled       *bool            `yaml:"enabled"`    // nil = true by default
+	RateLimit     int              `yaml:"rate_limit"` // max custom items per session per hour (default: 20, 0 = unlimited)
+	Notifications TodoNotifyConfig `yaml:"notifications"`
+}
+
+// IsEnabled returns true if TODO tracking is enabled (default: true).
+func (t TodoConfig) IsEnabled() bool {
+	return t.Enabled == nil || *t.Enabled
+}
+
+// RateLimitOrDefault returns the configured rate limit or 20 if not set.
+func (t TodoConfig) RateLimitOrDefault() int {
+	if t.RateLimit <= 0 {
+		return 20
+	}
+	return t.RateLimit
+}
+
+// TodoNotifyConfig controls TODO notification delivery.
+type TodoNotifyConfig struct {
+	Toast    *bool `yaml:"toast"`    // nil = true by default
+	Terminal *bool `yaml:"terminal"` // nil = true by default (OSC 9/777)
+}
+
+// ToastEnabled returns true if toast notifications are enabled (default: true).
+func (n TodoNotifyConfig) ToastEnabled() bool {
+	return n.Toast == nil || *n.Toast
+}
+
+// TerminalEnabled returns true if terminal notifications are enabled (default: true).
+func (n TodoNotifyConfig) TerminalEnabled() bool {
+	return n.Terminal == nil || *n.Terminal
 }
 
 // MessagingConfig holds messaging-related configuration.

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -142,6 +142,11 @@ var defaultUserCommands = map[string]UserCommand{
 		Help:   "prev active session",
 		Silent: true,
 	},
+	"TodoPanel": {
+		Action: action.TypeTodoPanel,
+		Help:   "TODO items",
+		Silent: true,
+	},
 	"SendBatch": {
 		Sh: `{{ range .Form.targets }}
 {{ agentSend }} {{ .Name | shq }}:claude {{ $.Form.message | shq }}
@@ -177,6 +182,7 @@ var defaultKeybindings = map[string]Keybinding{
 	"R":      {Cmd: "RenameSession"},
 	"J":      {Cmd: "NextActive"},
 	"K":      {Cmd: "PrevActive"},
+	"t":      {Cmd: "TodoPanel"},
 }
 
 // CurrentConfigVersion is the latest config schema version.
@@ -329,7 +335,7 @@ type PreviewConfig struct {
 // TodoConfig holds TODO item configuration.
 type TodoConfig struct {
 	Enabled       *bool            `yaml:"enabled"`    // nil = true by default
-	RateLimit     int              `yaml:"rate_limit"` // max custom items per session per hour (default: 20, 0 = unlimited)
+	RateLimit     *int             `yaml:"rate_limit"` // max custom items per session per hour (nil = 20, 0 = unlimited)
 	Notifications TodoNotifyConfig `yaml:"notifications"`
 }
 
@@ -338,12 +344,13 @@ func (t TodoConfig) IsEnabled() bool {
 	return t.Enabled == nil || *t.Enabled
 }
 
-// RateLimitOrDefault returns the configured rate limit or 20 if not set.
+// RateLimitOrDefault returns the configured rate limit.
+// Nil defaults to 20. Zero means unlimited (no rate limiting).
 func (t TodoConfig) RateLimitOrDefault() int {
-	if t.RateLimit <= 0 {
+	if t.RateLimit == nil {
 		return 20
 	}
-	return t.RateLimit
+	return *t.RateLimit
 }
 
 // TodoNotifyConfig controls TODO notification delivery.

--- a/internal/core/config/validate.go
+++ b/internal/core/config/validate.go
@@ -12,6 +12,7 @@ import (
 
 // SpawnTemplateData defines available fields for spawn command templates (hive new).
 type SpawnTemplateData struct {
+	ID         string // Session ID (unique 6-character identifier)
 	Path       string // Absolute path to the session directory
 	Name       string // Session name (directory basename)
 	Slug       string // Session slug (URL-safe version of name)
@@ -22,6 +23,7 @@ type SpawnTemplateData struct {
 
 // BatchSpawnTemplateData defines available fields for batch_spawn command templates (hive batch).
 type BatchSpawnTemplateData struct {
+	ID         string // Session ID (unique 6-character identifier)
 	Path       string // Absolute path to the session directory
 	Name       string // Session name (directory basename)
 	Prompt     string // User-provided prompt (batch only)

--- a/internal/core/eventbus/events.go
+++ b/internal/core/eventbus/events.go
@@ -7,6 +7,7 @@ import (
 	"github.com/colonyops/hive/internal/core/messaging"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/internal/core/todo"
 )
 
 //go:generate gobusgen generate -p .Events
@@ -22,6 +23,8 @@ var Events = map[string]any{
 	"session.deleted":      SessionDeletedPayload{},
 	"session.recycled":     SessionRecycledPayload{},
 	"session.renamed":      SessionRenamedPayload{},
+	"todo.created":         TodoCreatedPayload{},
+	"todo.dismissed":       TodoDismissedPayload{},
 	"tui.started":          TUIStartedPayload{},
 	"tui.stopped":          TUIStoppedPayload{},
 }
@@ -74,4 +77,14 @@ type TUIStoppedPayload struct{}
 // ConfigReloadedPayload is emitted when configuration is reloaded.
 type ConfigReloadedPayload struct {
 	Config *config.Config
+}
+
+// TodoCreatedPayload is emitted when a new TODO item is created.
+type TodoCreatedPayload struct {
+	Item *todo.Item
+}
+
+// TodoDismissedPayload is emitted when a TODO item is dismissed.
+type TodoDismissedPayload struct {
+	Item *todo.Item
 }

--- a/internal/core/todo/frontmatter.go
+++ b/internal/core/todo/frontmatter.go
@@ -1,0 +1,45 @@
+package todo
+
+import (
+	"bufio"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Frontmatter holds metadata parsed from a document's YAML front matter.
+// All fields are best-effort: missing or malformed frontmatter produces zero values.
+type Frontmatter struct {
+	SessionID string `yaml:"session_id"`
+	Title     string `yaml:"title"`
+}
+
+// ParseFrontmatter extracts YAML front matter from document content.
+// Front matter must be delimited by "---" on its own line at the start of the file.
+// Returns zero-value Frontmatter if no valid front matter is found.
+func ParseFrontmatter(content string) Frontmatter {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	// First line must be "---"
+	if !scanner.Scan() || strings.TrimSpace(scanner.Text()) != "---" {
+		return Frontmatter{}
+	}
+
+	var lines []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		lines = append(lines, line)
+	}
+
+	if len(lines) == 0 {
+		return Frontmatter{}
+	}
+
+	var fm Frontmatter
+	_ = yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &fm)
+
+	return fm
+}

--- a/internal/core/todo/frontmatter_test.go
+++ b/internal/core/todo/frontmatter_test.go
@@ -1,0 +1,93 @@
+package todo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    Frontmatter
+	}{
+		{
+			name: "valid frontmatter with all fields",
+			content: `---
+session_id: abc123
+title: My Plan
+---
+# Document body
+`,
+			want: Frontmatter{SessionID: "abc123", Title: "My Plan"},
+		},
+		{
+			name: "valid frontmatter with session_id only",
+			content: `---
+session_id: sess-xyz
+---
+content here
+`,
+			want: Frontmatter{SessionID: "sess-xyz"},
+		},
+		{
+			name:    "no frontmatter",
+			content: "# Just a heading\nSome content\n",
+			want:    Frontmatter{},
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    Frontmatter{},
+		},
+		{
+			name: "frontmatter without closing delimiter",
+			content: `---
+session_id: orphaned
+`,
+			want: Frontmatter{SessionID: "orphaned"},
+		},
+		{
+			name: "frontmatter with extra fields ignored",
+			content: `---
+session_id: s1
+title: Title
+author: someone
+priority: high
+---
+body
+`,
+			want: Frontmatter{SessionID: "s1", Title: "Title"},
+		},
+		{
+			name:    "delimiter not on first line",
+			content: "\n---\nsession_id: nope\n---\n",
+			want:    Frontmatter{},
+		},
+		{
+			name: "empty frontmatter block",
+			content: `---
+---
+content
+`,
+			want: Frontmatter{},
+		},
+		{
+			name: "frontmatter with whitespace around delimiters",
+			content: `  ---
+session_id: ws
+  ---
+body
+`,
+			want: Frontmatter{SessionID: "ws"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseFrontmatter(tt.content)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/core/todo/store.go
+++ b/internal/core/todo/store.go
@@ -1,0 +1,54 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrNotFound is returned when a TODO item does not exist.
+	ErrNotFound = errors.New("todo item not found")
+	// ErrDuplicate is returned when a duplicate pending item already exists for a file path.
+	ErrDuplicate = errors.New("duplicate pending todo item")
+	// ErrRateLimited is returned when a session exceeds the custom item creation rate limit.
+	ErrRateLimited = errors.New("rate limit exceeded for custom todo items")
+)
+
+// ListFilter controls which items are returned by List.
+type ListFilter struct {
+	Status     Status // empty means all statuses
+	SessionID  string // empty means all sessions
+	RepoRemote string // empty means all repos
+}
+
+// Store defines the interface for TODO item persistence.
+type Store interface {
+	// Create persists a new TODO item.
+	// Returns ErrDuplicate if a pending item already exists for the same file path.
+	Create(ctx context.Context, item Item) error
+
+	// Get returns a single TODO item by ID.
+	// Returns ErrNotFound if the item does not exist.
+	Get(ctx context.Context, id string) (Item, error)
+
+	// List returns TODO items matching the filter, ordered by created_at DESC.
+	List(ctx context.Context, filter ListFilter) ([]Item, error)
+
+	// UpdateStatus changes the status of a TODO item.
+	// Returns ErrNotFound if the item does not exist.
+	UpdateStatus(ctx context.Context, id string, status Status) error
+
+	// DismissByPath dismisses all pending items matching the given file path.
+	DismissByPath(ctx context.Context, filePath string) error
+
+	// CountPending returns the total number of pending items.
+	CountPending(ctx context.Context) (int64, error)
+
+	// CountPendingBySession returns pending item count for a specific session.
+	CountPendingBySession(ctx context.Context, sessionID string) (int64, error)
+
+	// CountCustomBySessionSince counts custom items created by a session since a given time.
+	// Used for rate limiting.
+	CountCustomBySessionSince(ctx context.Context, sessionID string, since time.Time) (int64, error)
+}

--- a/internal/core/todo/store.go
+++ b/internal/core/todo/store.go
@@ -25,8 +25,9 @@ type ListFilter struct {
 // Store defines the interface for TODO item persistence.
 type Store interface {
 	// Create persists a new TODO item.
+	// The store populates ID, Status, CreatedAt, and UpdatedAt if not already set.
 	// Returns ErrDuplicate if a pending item already exists for the same file path.
-	Create(ctx context.Context, item Item) error
+	Create(ctx context.Context, item *Item) error
 
 	// Get returns a single TODO item by ID.
 	// Returns ErrNotFound if the item does not exist.
@@ -41,6 +42,9 @@ type Store interface {
 
 	// DismissByPath dismisses all pending items matching the given file path.
 	DismissByPath(ctx context.Context, filePath string) error
+
+	// CompleteByPath completes all pending items matching the given file path.
+	CompleteByPath(ctx context.Context, filePath string) error
 
 	// CountPending returns the total number of pending items.
 	CountPending(ctx context.Context) (int64, error)

--- a/internal/core/todo/todo.go
+++ b/internal/core/todo/todo.go
@@ -1,0 +1,37 @@
+// Package todo defines the TODO item domain model for operator action tracking.
+package todo
+
+import "time"
+
+// ItemType classifies how a TODO item was created.
+type ItemType string
+
+const (
+	// ItemTypeFileChange is auto-generated when a file changes in a context directory.
+	ItemTypeFileChange ItemType = "file_change"
+	// ItemTypeCustom is created via CLI by agents or operators.
+	ItemTypeCustom ItemType = "custom"
+)
+
+// Status represents the lifecycle state of a TODO item.
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusCompleted Status = "completed"
+	StatusDismissed Status = "dismissed"
+)
+
+// Item represents a single actionable TODO for the operator.
+type Item struct {
+	ID          string    `json:"id"`
+	Type        ItemType  `json:"type"`
+	Status      Status    `json:"status"`
+	Title       string    `json:"title"`
+	Description string    `json:"description,omitempty"`
+	FilePath    string    `json:"file_path,omitempty"`
+	SessionID   string    `json:"session_id,omitempty"`
+	RepoRemote  string    `json:"repo_remote"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}

--- a/internal/core/todo/todo.go
+++ b/internal/core/todo/todo.go
@@ -22,6 +22,16 @@ const (
 	StatusDismissed Status = "dismissed"
 )
 
+// IsValid returns true if the status is a known value.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusCompleted, StatusDismissed:
+		return true
+	default:
+		return false
+	}
+}
+
 // Item represents a single actionable TODO for the operator.
 type Item struct {
 	ID          string    `json:"id"`

--- a/internal/data/db/models.go
+++ b/internal/data/db/models.go
@@ -72,6 +72,19 @@ type Session struct {
 	UpdatedAt int64          `json:"updated_at"`
 }
 
+type TodoItem struct {
+	ID          string         `json:"id"`
+	Type        string         `json:"type"`
+	Status      string         `json:"status"`
+	Title       string         `json:"title"`
+	Description sql.NullString `json:"description"`
+	FilePath    sql.NullString `json:"file_path"`
+	SessionID   sql.NullString `json:"session_id"`
+	RepoRemote  string         `json:"repo_remote"`
+	CreatedAt   int64          `json:"created_at"`
+	UpdatedAt   int64          `json:"updated_at"`
+}
+
 type Topic struct {
 	Name      string      `json:"name"`
 	UpdatedAt interface{} `json:"updated_at"`

--- a/internal/data/db/queries.sql.go
+++ b/internal/data/db/queries.sql.go
@@ -28,6 +28,22 @@ func (q *Queries) AcknowledgeMessages(ctx context.Context, arg AcknowledgeMessag
 	return err
 }
 
+const completeTodoItemsByPath = `-- name: CompleteTodoItemsByPath :exec
+UPDATE todo_items
+SET status = 'completed', updated_at = ?
+WHERE file_path = ? AND status = 'pending'
+`
+
+type CompleteTodoItemsByPathParams struct {
+	UpdatedAt int64          `json:"updated_at"`
+	FilePath  sql.NullString `json:"file_path"`
+}
+
+func (q *Queries) CompleteTodoItemsByPath(ctx context.Context, arg CompleteTodoItemsByPathParams) error {
+	_, err := q.db.ExecContext(ctx, completeTodoItemsByPath, arg.UpdatedAt, arg.FilePath)
+	return err
+}
+
 const countCustomTodoItemsBySessionSince = `-- name: CountCustomTodoItemsBySessionSince :one
 SELECT COUNT(*) FROM todo_items
 WHERE type = 'custom' AND session_id = ? AND created_at >= ?

--- a/internal/data/db/queries/queries.sql
+++ b/internal/data/db/queries/queries.sql
@@ -180,3 +180,64 @@ SELECT key, value, expires_at, created_at, updated_at FROM kv_store WHERE key = 
 
 -- name: KVSweepExpired :exec
 DELETE FROM kv_store WHERE expires_at IS NOT NULL AND expires_at < ?;
+
+-- name: CreateTodoItem :exec
+INSERT INTO todo_items (
+    id, type, status, title, description, file_path, session_id, repo_remote,
+    created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+-- name: GetTodoItem :one
+SELECT * FROM todo_items
+WHERE id = ?;
+
+-- name: ListTodoItems :many
+SELECT * FROM todo_items
+ORDER BY created_at DESC;
+
+-- name: ListTodoItemsByStatus :many
+SELECT * FROM todo_items
+WHERE status = ?
+ORDER BY created_at DESC;
+
+-- name: ListTodoItemsBySession :many
+SELECT * FROM todo_items
+WHERE session_id = ?
+ORDER BY created_at DESC;
+
+-- name: ListTodoItemsByStatusAndSession :many
+SELECT * FROM todo_items
+WHERE status = ? AND session_id = ?
+ORDER BY created_at DESC;
+
+-- name: ListTodoItemsByRepo :many
+SELECT * FROM todo_items
+WHERE repo_remote = ?
+ORDER BY created_at DESC;
+
+-- name: ListTodoItemsByStatusAndRepo :many
+SELECT * FROM todo_items
+WHERE status = ? AND repo_remote = ?
+ORDER BY created_at DESC;
+
+-- name: UpdateTodoItemStatus :exec
+UPDATE todo_items
+SET status = ?, updated_at = ?
+WHERE id = ?;
+
+-- name: DismissTodoItemsByPath :exec
+UPDATE todo_items
+SET status = 'dismissed', updated_at = ?
+WHERE file_path = ? AND status = 'pending';
+
+-- name: CountPendingTodoItems :one
+SELECT COUNT(*) FROM todo_items
+WHERE status = 'pending';
+
+-- name: CountPendingTodoItemsBySession :one
+SELECT COUNT(*) FROM todo_items
+WHERE status = 'pending' AND session_id = ?;
+
+-- name: CountCustomTodoItemsBySessionSince :one
+SELECT COUNT(*) FROM todo_items
+WHERE type = 'custom' AND session_id = ? AND created_at >= ?;

--- a/internal/data/db/queries/queries.sql
+++ b/internal/data/db/queries/queries.sql
@@ -230,6 +230,11 @@ UPDATE todo_items
 SET status = 'dismissed', updated_at = ?
 WHERE file_path = ? AND status = 'pending';
 
+-- name: CompleteTodoItemsByPath :exec
+UPDATE todo_items
+SET status = 'completed', updated_at = ?
+WHERE file_path = ? AND status = 'pending';
+
 -- name: CountPendingTodoItems :one
 SELECT COUNT(*) FROM todo_items
 WHERE status = 'pending';

--- a/internal/data/stores/todostore.go
+++ b/internal/data/stores/todostore.go
@@ -1,0 +1,206 @@
+package stores
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/colonyops/hive/internal/core/todo"
+	"github.com/colonyops/hive/internal/data/db"
+	"github.com/colonyops/hive/pkg/randid"
+)
+
+// TodoStore implements todo.Store using SQLite.
+type TodoStore struct {
+	db *db.DB
+}
+
+var _ todo.Store = (*TodoStore)(nil)
+
+// NewTodoStore creates a new SQLite-backed TODO store.
+func NewTodoStore(db *db.DB) *TodoStore {
+	return &TodoStore{db: db}
+}
+
+// Create persists a new TODO item.
+// Generates an ID if not set. Returns ErrDuplicate if a pending item already
+// exists for the same file path (enforced by partial unique index).
+func (s *TodoStore) Create(ctx context.Context, item todo.Item) error {
+	if item.ID == "" {
+		item.ID = randid.Generate(8)
+	}
+
+	now := time.Now()
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = now
+	}
+	if item.UpdatedAt.IsZero() {
+		item.UpdatedAt = now
+	}
+	if item.Status == "" {
+		item.Status = todo.StatusPending
+	}
+
+	err := s.db.Queries().CreateTodoItem(ctx, db.CreateTodoItemParams{
+		ID:          item.ID,
+		Type:        string(item.Type),
+		Status:      string(item.Status),
+		Title:       item.Title,
+		Description: toNullString(item.Description),
+		FilePath:    toNullString(item.FilePath),
+		SessionID:   toNullString(item.SessionID),
+		RepoRemote:  item.RepoRemote,
+		CreatedAt:   item.CreatedAt.UnixNano(),
+		UpdatedAt:   item.UpdatedAt.UnixNano(),
+	})
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return todo.ErrDuplicate
+		}
+		return fmt.Errorf("create todo item: %w", err)
+	}
+
+	return nil
+}
+
+// Get returns a single TODO item by ID.
+func (s *TodoStore) Get(ctx context.Context, id string) (todo.Item, error) {
+	row, err := s.db.Queries().GetTodoItem(ctx, id)
+	if err != nil {
+		if IsNotFoundError(err) {
+			return todo.Item{}, todo.ErrNotFound
+		}
+		return todo.Item{}, fmt.Errorf("get todo item: %w", err)
+	}
+
+	return rowToTodoItem(row), nil
+}
+
+// List returns TODO items matching the filter, ordered by created_at DESC.
+func (s *TodoStore) List(ctx context.Context, filter todo.ListFilter) ([]todo.Item, error) {
+	var rows []db.TodoItem
+	var err error
+
+	hasStatus := filter.Status != ""
+	hasSession := filter.SessionID != ""
+	hasRepo := filter.RepoRemote != ""
+
+	switch {
+	case hasStatus && hasSession:
+		rows, err = s.db.Queries().ListTodoItemsByStatusAndSession(ctx, db.ListTodoItemsByStatusAndSessionParams{
+			Status:    string(filter.Status),
+			SessionID: toNullString(filter.SessionID),
+		})
+	case hasStatus && hasRepo:
+		rows, err = s.db.Queries().ListTodoItemsByStatusAndRepo(ctx, db.ListTodoItemsByStatusAndRepoParams{
+			Status:     string(filter.Status),
+			RepoRemote: filter.RepoRemote,
+		})
+	case hasStatus:
+		rows, err = s.db.Queries().ListTodoItemsByStatus(ctx, string(filter.Status))
+	case hasSession:
+		rows, err = s.db.Queries().ListTodoItemsBySession(ctx, toNullString(filter.SessionID))
+	case hasRepo:
+		rows, err = s.db.Queries().ListTodoItemsByRepo(ctx, filter.RepoRemote)
+	default:
+		rows, err = s.db.Queries().ListTodoItems(ctx)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("list todo items: %w", err)
+	}
+
+	items := make([]todo.Item, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, rowToTodoItem(row))
+	}
+
+	return items, nil
+}
+
+// UpdateStatus changes the status of a TODO item.
+func (s *TodoStore) UpdateStatus(ctx context.Context, id string, status todo.Status) error {
+	// Verify the item exists first
+	_, err := s.db.Queries().GetTodoItem(ctx, id)
+	if err != nil {
+		if IsNotFoundError(err) {
+			return todo.ErrNotFound
+		}
+		return fmt.Errorf("get todo item for update: %w", err)
+	}
+
+	err = s.db.Queries().UpdateTodoItemStatus(ctx, db.UpdateTodoItemStatusParams{
+		Status:    string(status),
+		UpdatedAt: time.Now().UnixNano(),
+		ID:        id,
+	})
+	if err != nil {
+		return fmt.Errorf("update todo item status: %w", err)
+	}
+
+	return nil
+}
+
+// DismissByPath dismisses all pending items matching the given file path.
+func (s *TodoStore) DismissByPath(ctx context.Context, filePath string) error {
+	err := s.db.Queries().DismissTodoItemsByPath(ctx, db.DismissTodoItemsByPathParams{
+		UpdatedAt: time.Now().UnixNano(),
+		FilePath:  toNullString(filePath),
+	})
+	if err != nil {
+		return fmt.Errorf("dismiss todo items by path: %w", err)
+	}
+
+	return nil
+}
+
+// CountPending returns the total number of pending items.
+func (s *TodoStore) CountPending(ctx context.Context) (int64, error) {
+	count, err := s.db.Queries().CountPendingTodoItems(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count pending todo items: %w", err)
+	}
+	return count, nil
+}
+
+// CountPendingBySession returns pending item count for a specific session.
+func (s *TodoStore) CountPendingBySession(ctx context.Context, sessionID string) (int64, error) {
+	count, err := s.db.Queries().CountPendingTodoItemsBySession(ctx, toNullString(sessionID))
+	if err != nil {
+		return 0, fmt.Errorf("count pending todo items by session: %w", err)
+	}
+	return count, nil
+}
+
+// CountCustomBySessionSince counts custom items created by a session since a given time.
+func (s *TodoStore) CountCustomBySessionSince(ctx context.Context, sessionID string, since time.Time) (int64, error) {
+	count, err := s.db.Queries().CountCustomTodoItemsBySessionSince(ctx, db.CountCustomTodoItemsBySessionSinceParams{
+		SessionID: toNullString(sessionID),
+		CreatedAt: since.UnixNano(),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count custom todo items by session since: %w", err)
+	}
+	return count, nil
+}
+
+func rowToTodoItem(row db.TodoItem) todo.Item {
+	return todo.Item{
+		ID:          row.ID,
+		Type:        todo.ItemType(row.Type),
+		Status:      todo.Status(row.Status),
+		Title:       row.Title,
+		Description: fromNullString(row.Description),
+		FilePath:    fromNullString(row.FilePath),
+		SessionID:   fromNullString(row.SessionID),
+		RepoRemote:  row.RepoRemote,
+		CreatedAt:   time.Unix(0, row.CreatedAt),
+		UpdatedAt:   time.Unix(0, row.UpdatedAt),
+	}
+}
+
+// isUniqueConstraintError checks if the error is a SQLite UNIQUE constraint violation.
+func isUniqueConstraintError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/internal/data/stores/todostore_test.go
+++ b/internal/data/stores/todostore_test.go
@@ -36,7 +36,7 @@ func TestTodoStore(t *testing.T) {
 			UpdatedAt:   now,
 		}
 
-		require.NoError(t, store.Create(ctx, item))
+		require.NoError(t, store.Create(ctx, &item))
 
 		got, err := store.Get(ctx, "test-id-1")
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestTodoStore(t *testing.T) {
 			RepoRemote: "https://github.com/org/repo",
 		}
 
-		require.NoError(t, store.Create(ctx, item))
+		require.NoError(t, store.Create(ctx, &item))
 
 		// Verify by listing all
 		items, err := store.List(ctx, todo.ListFilter{})
@@ -106,7 +106,7 @@ func TestTodoStore(t *testing.T) {
 
 		base := time.Now()
 		for i, status := range []todo.Status{todo.StatusPending, todo.StatusCompleted, todo.StatusPending} {
-			require.NoError(t, store.Create(ctx, todo.Item{
+			require.NoError(t, store.Create(ctx, &todo.Item{
 				ID:         fmt.Sprintf("item-%d", i),
 				Type:       todo.ItemTypeCustom,
 				Status:     status,
@@ -134,12 +134,12 @@ func TestTodoStore(t *testing.T) {
 		store := NewTodoStore(database)
 
 		now := time.Now()
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "s1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "From session A", SessionID: "sess-a", RepoRemote: "repo",
 			CreatedAt: now, UpdatedAt: now,
 		}))
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "s2", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "From session B", SessionID: "sess-b", RepoRemote: "repo",
 			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
@@ -159,12 +159,12 @@ func TestTodoStore(t *testing.T) {
 		store := NewTodoStore(database)
 
 		now := time.Now()
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "r1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "Repo A item", RepoRemote: "repo-a",
 			CreatedAt: now, UpdatedAt: now,
 		}))
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "r2", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "Repo B item", RepoRemote: "repo-b",
 			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
@@ -184,7 +184,7 @@ func TestTodoStore(t *testing.T) {
 		store := NewTodoStore(database)
 
 		now := time.Now()
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "upd-1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "Pending task", RepoRemote: "repo",
 			CreatedAt: now, UpdatedAt: now,
@@ -217,12 +217,12 @@ func TestTodoStore(t *testing.T) {
 		store := NewTodoStore(database)
 
 		now := time.Now()
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "d1", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
 			Title: "File changed", FilePath: "/repo/plan.md", RepoRemote: "repo",
 			CreatedAt: now, UpdatedAt: now,
 		}))
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "d2", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
 			Title: "Other file", FilePath: "/repo/other.md", RepoRemote: "repo",
 			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
@@ -248,14 +248,14 @@ func TestTodoStore(t *testing.T) {
 		store := NewTodoStore(database)
 
 		now := time.Now()
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "dup1", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
 			Title: "First", FilePath: "/repo/plan.md", RepoRemote: "repo",
 			CreatedAt: now, UpdatedAt: now,
 		}))
 
 		// Second pending item for same path should fail
-		err = store.Create(ctx, todo.Item{
+		err = store.Create(ctx, &todo.Item{
 			ID: "dup2", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
 			Title: "Second", FilePath: "/repo/plan.md", RepoRemote: "repo",
 			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
@@ -265,7 +265,7 @@ func TestTodoStore(t *testing.T) {
 		// After dismissing, a new pending item for the same path should succeed
 		require.NoError(t, store.DismissByPath(ctx, "/repo/plan.md"))
 
-		err = store.Create(ctx, todo.Item{
+		err = store.Create(ctx, &todo.Item{
 			ID: "dup3", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
 			Title: "Third", FilePath: "/repo/plan.md", RepoRemote: "repo",
 			CreatedAt: now.Add(2 * time.Second), UpdatedAt: now.Add(2 * time.Second),
@@ -286,7 +286,7 @@ func TestTodoStore(t *testing.T) {
 
 		now := time.Now()
 		for i := range 3 {
-			require.NoError(t, store.Create(ctx, todo.Item{
+			require.NoError(t, store.Create(ctx, &todo.Item{
 				ID: fmt.Sprintf("cp-%d", i), Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 				Title: "Task", RepoRemote: "repo",
 				CreatedAt: now.Add(time.Duration(i) * time.Millisecond),
@@ -314,17 +314,17 @@ func TestTodoStore(t *testing.T) {
 		store := NewTodoStore(database)
 
 		now := time.Now()
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "cps1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "A", SessionID: "sess-x", RepoRemote: "repo",
 			CreatedAt: now, UpdatedAt: now,
 		}))
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "cps2", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "B", SessionID: "sess-x", RepoRemote: "repo",
 			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
 		}))
-		require.NoError(t, store.Create(ctx, todo.Item{
+		require.NoError(t, store.Create(ctx, &todo.Item{
 			ID: "cps3", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 			Title: "C", SessionID: "sess-y", RepoRemote: "repo",
 			CreatedAt: now.Add(2 * time.Second), UpdatedAt: now.Add(2 * time.Second),
@@ -349,7 +349,7 @@ func TestTodoStore(t *testing.T) {
 		base := time.Now()
 		// Create 3 custom items at base, base+1h, base+2h
 		for i := range 3 {
-			require.NoError(t, store.Create(ctx, todo.Item{
+			require.NoError(t, store.Create(ctx, &todo.Item{
 				ID: fmt.Sprintf("rate-%d", i), Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 				Title: "Rate limited", SessionID: "agent-1", RepoRemote: "repo",
 				CreatedAt: base.Add(time.Duration(i) * time.Hour),
@@ -377,7 +377,7 @@ func TestTodoStore(t *testing.T) {
 
 		base := time.Now()
 		for i, title := range []string{"first", "second", "third"} {
-			require.NoError(t, store.Create(ctx, todo.Item{
+			require.NoError(t, store.Create(ctx, &todo.Item{
 				ID: fmt.Sprintf("ord-%d", i), Type: todo.ItemTypeCustom, Status: todo.StatusPending,
 				Title: title, RepoRemote: "repo",
 				CreatedAt: base.Add(time.Duration(i) * time.Second),

--- a/internal/data/stores/todostore_test.go
+++ b/internal/data/stores/todostore_test.go
@@ -1,0 +1,395 @@
+package stores
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/colonyops/hive/internal/core/todo"
+	"github.com/colonyops/hive/internal/data/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTodoStore(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create and get", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		item := todo.Item{
+			ID:          "test-id-1",
+			Type:        todo.ItemTypeFileChange,
+			Status:      todo.StatusPending,
+			Title:       "Review plan.md",
+			Description: "New plan file detected",
+			FilePath:    "/repo/.hive/plans/plan.md",
+			SessionID:   "session-abc",
+			RepoRemote:  "https://github.com/org/repo",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		require.NoError(t, store.Create(ctx, item))
+
+		got, err := store.Get(ctx, "test-id-1")
+		require.NoError(t, err)
+		assert.Equal(t, item.ID, got.ID)
+		assert.Equal(t, todo.ItemTypeFileChange, got.Type)
+		assert.Equal(t, todo.StatusPending, got.Status)
+		assert.Equal(t, "Review plan.md", got.Title)
+		assert.Equal(t, "New plan file detected", got.Description)
+		assert.Equal(t, "/repo/.hive/plans/plan.md", got.FilePath)
+		assert.Equal(t, "session-abc", got.SessionID)
+		assert.Equal(t, "https://github.com/org/repo", got.RepoRemote)
+	})
+
+	t.Run("create generates ID when empty", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		item := todo.Item{
+			Type:       todo.ItemTypeCustom,
+			Title:      "Custom task",
+			RepoRemote: "https://github.com/org/repo",
+		}
+
+		require.NoError(t, store.Create(ctx, item))
+
+		// Verify by listing all
+		items, err := store.List(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.NotEmpty(t, items[0].ID)
+		assert.Equal(t, todo.StatusPending, items[0].Status)
+	})
+
+	t.Run("get not found", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		_, err = store.Get(ctx, "nonexistent")
+		assert.ErrorIs(t, err, todo.ErrNotFound)
+	})
+
+	t.Run("list returns empty slice", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		items, err := store.List(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		assert.Empty(t, items)
+		assert.NotNil(t, items)
+	})
+
+	t.Run("list filters by status", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		base := time.Now()
+		for i, status := range []todo.Status{todo.StatusPending, todo.StatusCompleted, todo.StatusPending} {
+			require.NoError(t, store.Create(ctx, todo.Item{
+				ID:         fmt.Sprintf("item-%d", i),
+				Type:       todo.ItemTypeCustom,
+				Status:     status,
+				Title:      fmt.Sprintf("Task %d", i),
+				RepoRemote: "https://github.com/org/repo",
+				CreatedAt:  base.Add(time.Duration(i) * time.Second),
+				UpdatedAt:  base.Add(time.Duration(i) * time.Second),
+			}))
+		}
+
+		pending, err := store.List(ctx, todo.ListFilter{Status: todo.StatusPending})
+		require.NoError(t, err)
+		assert.Len(t, pending, 2)
+
+		completed, err := store.List(ctx, todo.ListFilter{Status: todo.StatusCompleted})
+		require.NoError(t, err)
+		assert.Len(t, completed, 1)
+	})
+
+	t.Run("list filters by session", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "s1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "From session A", SessionID: "sess-a", RepoRemote: "repo",
+			CreatedAt: now, UpdatedAt: now,
+		}))
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "s2", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "From session B", SessionID: "sess-b", RepoRemote: "repo",
+			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		}))
+
+		items, err := store.List(ctx, todo.ListFilter{SessionID: "sess-a"})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "From session A", items[0].Title)
+	})
+
+	t.Run("list filters by repo", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "r1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "Repo A item", RepoRemote: "repo-a",
+			CreatedAt: now, UpdatedAt: now,
+		}))
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "r2", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "Repo B item", RepoRemote: "repo-b",
+			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		}))
+
+		items, err := store.List(ctx, todo.ListFilter{RepoRemote: "repo-a"})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "Repo A item", items[0].Title)
+	})
+
+	t.Run("update status", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "upd-1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "Pending task", RepoRemote: "repo",
+			CreatedAt: now, UpdatedAt: now,
+		}))
+
+		require.NoError(t, store.UpdateStatus(ctx, "upd-1", todo.StatusCompleted))
+
+		got, err := store.Get(ctx, "upd-1")
+		require.NoError(t, err)
+		assert.Equal(t, todo.StatusCompleted, got.Status)
+		assert.True(t, got.UpdatedAt.After(now))
+	})
+
+	t.Run("update status not found", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		err = store.UpdateStatus(ctx, "nonexistent", todo.StatusCompleted)
+		assert.ErrorIs(t, err, todo.ErrNotFound)
+	})
+
+	t.Run("dismiss by path", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "d1", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
+			Title: "File changed", FilePath: "/repo/plan.md", RepoRemote: "repo",
+			CreatedAt: now, UpdatedAt: now,
+		}))
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "d2", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
+			Title: "Other file", FilePath: "/repo/other.md", RepoRemote: "repo",
+			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		}))
+
+		require.NoError(t, store.DismissByPath(ctx, "/repo/plan.md"))
+
+		got, err := store.Get(ctx, "d1")
+		require.NoError(t, err)
+		assert.Equal(t, todo.StatusDismissed, got.Status)
+
+		// Other item unaffected
+		got2, err := store.Get(ctx, "d2")
+		require.NoError(t, err)
+		assert.Equal(t, todo.StatusPending, got2.Status)
+	})
+
+	t.Run("deduplication by file path", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "dup1", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
+			Title: "First", FilePath: "/repo/plan.md", RepoRemote: "repo",
+			CreatedAt: now, UpdatedAt: now,
+		}))
+
+		// Second pending item for same path should fail
+		err = store.Create(ctx, todo.Item{
+			ID: "dup2", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
+			Title: "Second", FilePath: "/repo/plan.md", RepoRemote: "repo",
+			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		})
+		require.ErrorIs(t, err, todo.ErrDuplicate)
+
+		// After dismissing, a new pending item for the same path should succeed
+		require.NoError(t, store.DismissByPath(ctx, "/repo/plan.md"))
+
+		err = store.Create(ctx, todo.Item{
+			ID: "dup3", Type: todo.ItemTypeFileChange, Status: todo.StatusPending,
+			Title: "Third", FilePath: "/repo/plan.md", RepoRemote: "repo",
+			CreatedAt: now.Add(2 * time.Second), UpdatedAt: now.Add(2 * time.Second),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("count pending", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		count, err := store.CountPending(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+
+		now := time.Now()
+		for i := range 3 {
+			require.NoError(t, store.Create(ctx, todo.Item{
+				ID: fmt.Sprintf("cp-%d", i), Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+				Title: "Task", RepoRemote: "repo",
+				CreatedAt: now.Add(time.Duration(i) * time.Millisecond),
+				UpdatedAt: now.Add(time.Duration(i) * time.Millisecond),
+			}))
+		}
+
+		count, err = store.CountPending(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), count)
+
+		// Complete one, count should decrease
+		require.NoError(t, store.UpdateStatus(ctx, "cp-0", todo.StatusCompleted))
+
+		count, err = store.CountPending(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), count)
+	})
+
+	t.Run("count pending by session", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		now := time.Now()
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "cps1", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "A", SessionID: "sess-x", RepoRemote: "repo",
+			CreatedAt: now, UpdatedAt: now,
+		}))
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "cps2", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "B", SessionID: "sess-x", RepoRemote: "repo",
+			CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		}))
+		require.NoError(t, store.Create(ctx, todo.Item{
+			ID: "cps3", Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+			Title: "C", SessionID: "sess-y", RepoRemote: "repo",
+			CreatedAt: now.Add(2 * time.Second), UpdatedAt: now.Add(2 * time.Second),
+		}))
+
+		count, err := store.CountPendingBySession(ctx, "sess-x")
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), count)
+
+		count, err = store.CountPendingBySession(ctx, "sess-y")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("count custom by session since", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		base := time.Now()
+		// Create 3 custom items at base, base+1h, base+2h
+		for i := range 3 {
+			require.NoError(t, store.Create(ctx, todo.Item{
+				ID: fmt.Sprintf("rate-%d", i), Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+				Title: "Rate limited", SessionID: "agent-1", RepoRemote: "repo",
+				CreatedAt: base.Add(time.Duration(i) * time.Hour),
+				UpdatedAt: base.Add(time.Duration(i) * time.Hour),
+			}))
+		}
+
+		// Count since base+30min should return 2 (items at 1h and 2h)
+		count, err := store.CountCustomBySessionSince(ctx, "agent-1", base.Add(30*time.Minute))
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), count)
+
+		// Count since base should return 3
+		count, err = store.CountCustomBySessionSince(ctx, "agent-1", base)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), count)
+	})
+
+	t.Run("list ordered by created_at desc", func(t *testing.T) {
+		database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+		require.NoError(t, err)
+		defer func() { _ = database.Close() }()
+
+		store := NewTodoStore(database)
+
+		base := time.Now()
+		for i, title := range []string{"first", "second", "third"} {
+			require.NoError(t, store.Create(ctx, todo.Item{
+				ID: fmt.Sprintf("ord-%d", i), Type: todo.ItemTypeCustom, Status: todo.StatusPending,
+				Title: title, RepoRemote: "repo",
+				CreatedAt: base.Add(time.Duration(i) * time.Second),
+				UpdatedAt: base.Add(time.Duration(i) * time.Second),
+			}))
+		}
+
+		items, err := store.List(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		require.Len(t, items, 3)
+		assert.Equal(t, "third", items[0].Title)
+		assert.Equal(t, "second", items[1].Title)
+		assert.Equal(t, "first", items[2].Title)
+	})
+}

--- a/internal/hive/app.go
+++ b/internal/hive/app.go
@@ -51,7 +51,7 @@ func NewApp(
 		Messages: NewMessageService(msgStore, cfg, bus),
 		Context:  NewContextService(cfg, sessions.git),
 		Doctor:   NewDoctorService(sessions.sessions, cfg, pluginInfos),
-		Todos:    NewTodoService(todoStore, bus, log.Logger),
+		Todos:    NewTodoService(todoStore, cfg.Todo, bus, log.Logger),
 		Bus:      bus,
 		Terminal: termMgr,
 		Plugins:  pluginMgr,

--- a/internal/hive/app.go
+++ b/internal/hive/app.go
@@ -7,9 +7,11 @@ import (
 	"github.com/colonyops/hive/internal/core/kv"
 	"github.com/colonyops/hive/internal/core/messaging"
 	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/internal/core/todo"
 	"github.com/colonyops/hive/internal/data/db"
 	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/pkg/tmpl"
+	"github.com/rs/zerolog/log"
 )
 
 // App is the central entry point for all hive operations.
@@ -19,6 +21,7 @@ type App struct {
 	Messages *MessageService
 	Context  *ContextService
 	Doctor   *DoctorService
+	Todos    *TodoService
 
 	Bus      *eventbus.EventBus
 	Terminal *terminal.Manager
@@ -33,6 +36,7 @@ type App struct {
 func NewApp(
 	sessions *SessionService,
 	msgStore messaging.Store,
+	todoStore todo.Store,
 	cfg *config.Config,
 	bus *eventbus.EventBus,
 	termMgr *terminal.Manager,
@@ -47,6 +51,7 @@ func NewApp(
 		Messages: NewMessageService(msgStore, cfg, bus),
 		Context:  NewContextService(cfg, sessions.git),
 		Doctor:   NewDoctorService(sessions.sessions, cfg, pluginInfos),
+		Todos:    NewTodoService(todoStore, bus, log.Logger),
 		Bus:      bus,
 		Terminal: termMgr,
 		Plugins:  pluginMgr,

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -205,6 +205,7 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	// Spawn terminal
 	owner, repoName := git.ExtractOwnerRepo(remote)
 	data := SpawnData{
+		ID:         sess.ID,
 		Path:       sess.Path,
 		Name:       sess.Name,
 		Prompt:     opts.Prompt,

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -24,6 +24,7 @@ type SessionClient interface {
 
 // SpawnData is the template context for spawn commands.
 type SpawnData struct {
+	ID         string // Session ID (unique 6-character identifier)
 	Path       string // Absolute path to session directory
 	Name       string // Session name (display name)
 	Prompt     string // User-provided prompt (batch only)

--- a/internal/hive/todo_service.go
+++ b/internal/hive/todo_service.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/eventbus"
 	"github.com/colonyops/hive/internal/core/todo"
 	"github.com/rs/zerolog"
@@ -24,12 +25,12 @@ type TodoService struct {
 }
 
 // NewTodoService creates a new TodoService.
-func NewTodoService(store todo.Store, bus *eventbus.EventBus, log zerolog.Logger) *TodoService {
+func NewTodoService(store todo.Store, cfg config.TodoConfig, bus *eventbus.EventBus, log zerolog.Logger) *TodoService {
 	return &TodoService{
 		store:        store,
 		bus:          bus,
 		log:          log.With().Str("component", "todo-service").Logger(),
-		rateLimit:    20,
+		rateLimit:    cfg.RateLimitOrDefault(),
 		rateDuration: time.Hour,
 	}
 }

--- a/internal/hive/todo_service.go
+++ b/internal/hive/todo_service.go
@@ -1,0 +1,175 @@
+package hive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/colonyops/hive/internal/core/eventbus"
+	"github.com/colonyops/hive/internal/core/todo"
+	"github.com/rs/zerolog"
+)
+
+// TodoService wraps todo.Store with domain logic for file-change detection,
+// frontmatter parsing, deduplication, and event publishing.
+type TodoService struct {
+	store        todo.Store
+	bus          *eventbus.EventBus
+	log          zerolog.Logger
+	rateLimit    int // max custom items per session per hour (0 = unlimited)
+	rateDuration time.Duration
+}
+
+// NewTodoService creates a new TodoService.
+func NewTodoService(store todo.Store, bus *eventbus.EventBus, log zerolog.Logger) *TodoService {
+	return &TodoService{
+		store:        store,
+		bus:          bus,
+		log:          log.With().Str("component", "todo-service").Logger(),
+		rateLimit:    20,
+		rateDuration: time.Hour,
+	}
+}
+
+// HandleFileEvent processes a file change event from a context directory.
+// It reads the file's frontmatter for session attribution and creates a TODO item.
+// Duplicate pending items for the same file path are silently ignored.
+func (s *TodoService) HandleFileEvent(ctx context.Context, filePath string, repoRemote string) error {
+	fm := s.readFrontmatter(filePath)
+
+	title := fm.Title
+	if title == "" {
+		title = filepath.Base(filePath)
+	}
+
+	item := todo.Item{
+		Type:       todo.ItemTypeFileChange,
+		Title:      title,
+		FilePath:   filePath,
+		SessionID:  fm.SessionID,
+		RepoRemote: repoRemote,
+	}
+
+	if err := s.store.Create(ctx, item); err != nil {
+		if errors.Is(err, todo.ErrDuplicate) {
+			s.log.Debug().Str("path", filePath).Msg("duplicate pending todo, skipping")
+			return nil
+		}
+		return fmt.Errorf("create todo for file event: %w", err)
+	}
+
+	s.bus.PublishTodoCreated(eventbus.TodoCreatedPayload{Item: &item})
+
+	return nil
+}
+
+// HandleFileDelete dismisses all pending TODO items for a deleted file.
+func (s *TodoService) HandleFileDelete(ctx context.Context, filePath string) error {
+	if err := s.store.DismissByPath(ctx, filePath); err != nil {
+		return fmt.Errorf("dismiss todo for deleted file: %w", err)
+	}
+	return nil
+}
+
+// CreateCustom creates a custom TODO item, subject to rate limiting per session.
+func (s *TodoService) CreateCustom(ctx context.Context, item todo.Item) error {
+	item.Type = todo.ItemTypeCustom
+
+	if s.rateLimit > 0 && item.SessionID != "" {
+		since := time.Now().Add(-s.rateDuration)
+		count, err := s.store.CountCustomBySessionSince(ctx, item.SessionID, since)
+		if err != nil {
+			return fmt.Errorf("check rate limit: %w", err)
+		}
+		if count >= int64(s.rateLimit) {
+			return todo.ErrRateLimited
+		}
+	}
+
+	if err := s.store.Create(ctx, item); err != nil {
+		return fmt.Errorf("create custom todo: %w", err)
+	}
+
+	s.bus.PublishTodoCreated(eventbus.TodoCreatedPayload{Item: &item})
+
+	return nil
+}
+
+// Dismiss marks a TODO item as dismissed.
+func (s *TodoService) Dismiss(ctx context.Context, id string) error {
+	if err := s.store.UpdateStatus(ctx, id, todo.StatusDismissed); err != nil {
+		return fmt.Errorf("dismiss todo: %w", err)
+	}
+	return nil
+}
+
+// DismissByPath dismisses all pending items for a given file path.
+func (s *TodoService) DismissByPath(ctx context.Context, filePath string) error {
+	return s.store.DismissByPath(ctx, filePath)
+}
+
+// Complete marks a TODO item as completed.
+func (s *TodoService) Complete(ctx context.Context, id string) error {
+	if err := s.store.UpdateStatus(ctx, id, todo.StatusCompleted); err != nil {
+		return fmt.Errorf("complete todo: %w", err)
+	}
+	return nil
+}
+
+// CompleteByPath completes all pending items matching the given file path.
+// This is used when a review is finalized for a specific document.
+func (s *TodoService) CompleteByPath(ctx context.Context, filePath string) error {
+	items, err := s.store.List(ctx, todo.ListFilter{Status: todo.StatusPending})
+	if err != nil {
+		return fmt.Errorf("list pending for complete by path: %w", err)
+	}
+
+	for _, item := range items {
+		if item.FilePath == filePath {
+			if err := s.store.UpdateStatus(ctx, item.ID, todo.StatusCompleted); err != nil {
+				return fmt.Errorf("complete todo %s: %w", item.ID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ListPending returns all pending TODO items, optionally filtered.
+func (s *TodoService) ListPending(ctx context.Context, filter todo.ListFilter) ([]todo.Item, error) {
+	filter.Status = todo.StatusPending
+	return s.store.List(ctx, filter)
+}
+
+// CountPending returns the total number of pending items.
+func (s *TodoService) CountPending(ctx context.Context) (int64, error) {
+	return s.store.CountPending(ctx)
+}
+
+// CountPendingBySession returns the pending item count for a specific session.
+func (s *TodoService) CountPendingBySession(ctx context.Context, sessionID string) (int64, error) {
+	return s.store.CountPendingBySession(ctx, sessionID)
+}
+
+// Get returns a single TODO item by ID.
+func (s *TodoService) Get(ctx context.Context, id string) (todo.Item, error) {
+	return s.store.Get(ctx, id)
+}
+
+// List returns TODO items matching the filter.
+func (s *TodoService) List(ctx context.Context, filter todo.ListFilter) ([]todo.Item, error) {
+	return s.store.List(ctx, filter)
+}
+
+// readFrontmatter reads and parses frontmatter from a file. Best-effort.
+func (s *TodoService) readFrontmatter(filePath string) todo.Frontmatter {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		s.log.Debug().Err(err).Str("path", filePath).Msg("could not read file for frontmatter")
+		return todo.Frontmatter{}
+	}
+	return todo.ParseFrontmatter(string(data))
+}

--- a/internal/hive/todo_service_test.go
+++ b/internal/hive/todo_service_test.go
@@ -1,0 +1,264 @@
+package hive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/colonyops/hive/internal/core/eventbus"
+	"github.com/colonyops/hive/internal/core/eventbus/testbus"
+	"github.com/colonyops/hive/internal/core/todo"
+	"github.com/colonyops/hive/internal/data/db"
+	"github.com/colonyops/hive/internal/data/stores"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTodoService(t *testing.T) (*TodoService, *testbus.Bus) {
+	t.Helper()
+
+	database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+
+	store := stores.NewTodoStore(database)
+	tb := testbus.New(t)
+	log := zerolog.Nop()
+
+	svc := NewTodoService(store, tb.EventBus, log)
+	return svc, tb
+}
+
+func TestTodoService_HandleFileEvent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates item from file with frontmatter", func(t *testing.T) {
+		svc, tb := newTestTodoService(t)
+
+		// Create a temp file with frontmatter
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "plan.md")
+		err := os.WriteFile(filePath, []byte("---\nsession_id: sess-1\ntitle: My Plan\n---\n# Content\n"), 0o644)
+		require.NoError(t, err)
+
+		require.NoError(t, svc.HandleFileEvent(ctx, filePath, "https://github.com/org/repo"))
+
+		items, err := svc.ListPending(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "My Plan", items[0].Title)
+		assert.Equal(t, "sess-1", items[0].SessionID)
+		assert.Equal(t, todo.ItemTypeFileChange, items[0].Type)
+		assert.Equal(t, filePath, items[0].FilePath)
+
+		tb.AssertPublished(t, eventbus.EventTodoCreated)
+	})
+
+	t.Run("creates item from file without frontmatter", func(t *testing.T) {
+		svc, _ := newTestTodoService(t)
+
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "notes.md")
+		err := os.WriteFile(filePath, []byte("# Just notes\n"), 0o644)
+		require.NoError(t, err)
+
+		require.NoError(t, svc.HandleFileEvent(ctx, filePath, "repo"))
+
+		items, err := svc.ListPending(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "notes.md", items[0].Title)
+		assert.Empty(t, items[0].SessionID)
+	})
+
+	t.Run("deduplicates pending items for same path", func(t *testing.T) {
+		svc, _ := newTestTodoService(t)
+
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "plan.md")
+		require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+		require.NoError(t, svc.HandleFileEvent(ctx, filePath, "repo"))
+		require.NoError(t, svc.HandleFileEvent(ctx, filePath, "repo"))
+
+		items, err := svc.ListPending(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		assert.Len(t, items, 1)
+	})
+
+	t.Run("handles missing file gracefully", func(t *testing.T) {
+		svc, _ := newTestTodoService(t)
+
+		require.NoError(t, svc.HandleFileEvent(ctx, "/nonexistent/file.md", "repo"))
+
+		items, err := svc.ListPending(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "file.md", items[0].Title)
+	})
+}
+
+func TestTodoService_HandleFileDelete(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestTodoService(t)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+	require.NoError(t, svc.HandleFileEvent(ctx, filePath, "repo"))
+
+	require.NoError(t, svc.HandleFileDelete(ctx, filePath))
+
+	items, err := svc.ListPending(ctx, todo.ListFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestTodoService_CreateCustom(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates custom item", func(t *testing.T) {
+		svc, tb := newTestTodoService(t)
+
+		err := svc.CreateCustom(ctx, todo.Item{
+			Title:      "Please review PR #42",
+			SessionID:  "sess-1",
+			RepoRemote: "repo",
+		})
+		require.NoError(t, err)
+
+		items, err := svc.ListPending(ctx, todo.ListFilter{})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, todo.ItemTypeCustom, items[0].Type)
+		assert.Equal(t, "Please review PR #42", items[0].Title)
+
+		tb.AssertPublished(t, eventbus.EventTodoCreated)
+	})
+
+	t.Run("rate limits custom items per session", func(t *testing.T) {
+		svc, _ := newTestTodoService(t)
+		svc.rateLimit = 3
+		svc.rateDuration = time.Hour
+
+		for i := range 3 {
+			err := svc.CreateCustom(ctx, todo.Item{
+				Title:      "Task",
+				SessionID:  "sess-1",
+				RepoRemote: "repo",
+				CreatedAt:  time.Now().Add(time.Duration(i) * time.Millisecond),
+			})
+			require.NoError(t, err)
+		}
+
+		// 4th should fail
+		err := svc.CreateCustom(ctx, todo.Item{
+			Title:      "Too many",
+			SessionID:  "sess-1",
+			RepoRemote: "repo",
+		})
+		require.ErrorIs(t, err, todo.ErrRateLimited)
+	})
+
+	t.Run("rate limit does not apply without session ID", func(t *testing.T) {
+		svc, _ := newTestTodoService(t)
+		svc.rateLimit = 1
+
+		for i := range 3 {
+			err := svc.CreateCustom(ctx, todo.Item{
+				Title:      "Task",
+				RepoRemote: "repo",
+				CreatedAt:  time.Now().Add(time.Duration(i) * time.Millisecond),
+			})
+			require.NoError(t, err)
+		}
+	})
+}
+
+func TestTodoService_DismissAndComplete(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestTodoService(t)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "plan.md")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+	require.NoError(t, svc.HandleFileEvent(ctx, filePath, "repo"))
+
+	items, err := svc.ListPending(ctx, todo.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	// Dismiss
+	require.NoError(t, svc.Dismiss(ctx, items[0].ID))
+
+	pending, err := svc.ListPending(ctx, todo.ListFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+
+	// Create another and complete it
+	filePath2 := filepath.Join(dir, "plan2.md")
+	require.NoError(t, os.WriteFile(filePath2, []byte("content"), 0o644))
+	require.NoError(t, svc.HandleFileEvent(ctx, filePath2, "repo"))
+
+	items, err = svc.ListPending(ctx, todo.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	require.NoError(t, svc.Complete(ctx, items[0].ID))
+
+	pending, err = svc.ListPending(ctx, todo.ListFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+func TestTodoService_CompleteByPath(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestTodoService(t)
+
+	dir := t.TempDir()
+	path1 := filepath.Join(dir, "a.md")
+	path2 := filepath.Join(dir, "b.md")
+	require.NoError(t, os.WriteFile(path1, []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(path2, []byte("b"), 0o644))
+
+	require.NoError(t, svc.HandleFileEvent(ctx, path1, "repo"))
+	require.NoError(t, svc.HandleFileEvent(ctx, path2, "repo"))
+
+	require.NoError(t, svc.CompleteByPath(ctx, path1))
+
+	items, err := svc.ListPending(ctx, todo.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, path2, items[0].FilePath)
+}
+
+func TestTodoService_CountPending(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestTodoService(t)
+
+	count, err := svc.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+
+	dir := t.TempDir()
+	for _, name := range []string{"a.md", "b.md"} {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("---\nsession_id: s1\n---\n"), 0o644))
+		require.NoError(t, svc.HandleFileEvent(ctx, p, "repo"))
+	}
+
+	count, err = svc.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	count, err = svc.CountPendingBySession(ctx, "s1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	count, err = svc.CountPendingBySession(ctx, "s2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}

--- a/internal/hive/todo_service_test.go
+++ b/internal/hive/todo_service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/eventbus"
 	"github.com/colonyops/hive/internal/core/eventbus/testbus"
 	"github.com/colonyops/hive/internal/core/todo"
@@ -28,7 +29,7 @@ func newTestTodoService(t *testing.T) (*TodoService, *testbus.Bus) {
 	tb := testbus.New(t)
 	log := zerolog.Nop()
 
-	svc := NewTodoService(store, tb.EventBus, log)
+	svc := NewTodoService(store, config.TodoConfig{}, tb.EventBus, log)
 	return svc, tb
 }
 

--- a/internal/hive/todo_watcher.go
+++ b/internal/hive/todo_watcher.go
@@ -1,0 +1,197 @@
+package hive
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/fsnotify/fsnotify"
+	"github.com/rs/zerolog"
+)
+
+// TodoFileChangeMsg is sent when files change in watched context directories.
+type TodoFileChangeMsg struct {
+	Changed []string // file paths that were created or modified
+	Deleted []string // file paths that were deleted
+}
+
+// TodoWatcher watches context directories for file changes and emits
+// TodoFileChangeMsg via tea.Cmd. Follows the same fsnotify + debounce + re-subscribe
+// pattern as DocumentWatcher.
+type TodoWatcher struct {
+	watcher     *fsnotify.Watcher
+	dirs        []string
+	debounceDur time.Duration
+	log         zerolog.Logger
+}
+
+// NewTodoWatcher creates a watcher for the given context directories.
+// Returns nil if no directories exist or fsnotify fails.
+func NewTodoWatcher(dirs []string, log zerolog.Logger) *TodoWatcher {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Warn().Err(err).Msg("todo: failed to create fsnotify watcher")
+		return nil
+	}
+
+	w := &TodoWatcher{
+		watcher:     watcher,
+		dirs:        dirs,
+		debounceDur: 200 * time.Millisecond,
+		log:         log.With().Str("component", "todo-watcher").Logger(),
+	}
+
+	added := 0
+	for _, dir := range dirs {
+		if err := w.addRecursive(dir); err != nil {
+			w.log.Debug().Err(err).Str("dir", dir).Msg("skipping context directory")
+			continue
+		}
+		added++
+	}
+
+	if added == 0 {
+		_ = watcher.Close()
+		return nil
+	}
+
+	return w
+}
+
+// Start returns a tea.Cmd that blocks until file changes occur, then returns
+// a TodoFileChangeMsg. The caller must re-invoke Start() after processing
+// the message to continue watching.
+func (w *TodoWatcher) Start() tea.Cmd {
+	return func() tea.Msg {
+		for {
+			select {
+			case event, ok := <-w.watcher.Events:
+				if !ok {
+					return nil
+				}
+
+				if w.shouldIgnore(event.Name) {
+					continue
+				}
+
+				w.log.Debug().
+					Str("path", event.Name).
+					Str("op", event.Op.String()).
+					Msg("file system event")
+
+				// Track new directories for recursive watching
+				if event.Has(fsnotify.Create) {
+					if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+						_ = w.addRecursive(event.Name)
+					}
+				}
+
+				// Debounce: wait for changes to settle
+				time.Sleep(w.debounceDur)
+
+				// Collect all events during debounce window
+				changed := map[string]bool{}
+				deleted := map[string]bool{}
+
+				w.classifyEvent(event, changed, deleted)
+
+				// Drain queued events
+				draining := true
+				for draining {
+					select {
+					case e := <-w.watcher.Events:
+						if !w.shouldIgnore(e.Name) {
+							w.classifyEvent(e, changed, deleted)
+						}
+					default:
+						draining = false
+					}
+				}
+
+				// Remove deleted paths from changed set
+				for p := range deleted {
+					delete(changed, p)
+				}
+
+				msg := TodoFileChangeMsg{
+					Changed: mapKeys(changed),
+					Deleted: mapKeys(deleted),
+				}
+
+				if len(msg.Changed) == 0 && len(msg.Deleted) == 0 {
+					continue
+				}
+
+				return msg
+
+			case err, ok := <-w.watcher.Errors:
+				if !ok {
+					return nil
+				}
+				w.log.Error().Err(err).Msg("watcher error")
+			}
+		}
+	}
+}
+
+// Close stops the watcher.
+func (w *TodoWatcher) Close() error {
+	return w.watcher.Close()
+}
+
+func (w *TodoWatcher) classifyEvent(event fsnotify.Event, changed, deleted map[string]bool) {
+	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+		deleted[event.Name] = true
+	} else {
+		changed[event.Name] = true
+	}
+}
+
+func (w *TodoWatcher) addRecursive(path string) error {
+	return filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") && d.Name() != ".hive" {
+				return filepath.SkipDir
+			}
+			return w.watcher.Add(p)
+		}
+		return nil
+	})
+}
+
+func (w *TodoWatcher) shouldIgnore(path string) bool {
+	base := filepath.Base(path)
+
+	if strings.HasPrefix(base, ".") && base != ".hive" {
+		return true
+	}
+
+	for _, ext := range []string{".tmp", ".lock", ".swp", ".swx", "~"} {
+		if strings.HasSuffix(base, ext) {
+			return true
+		}
+	}
+
+	ext := filepath.Ext(path)
+	if ext != ".md" && ext != ".txt" && ext != "" {
+		return true
+	}
+
+	return false
+}
+
+func mapKeys(m map[string]bool) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/tui/modal_coordinator.go
+++ b/internal/tui/modal_coordinator.go
@@ -132,7 +132,7 @@ func (mc *ModalCoordinator) Overlay(state UIState, bg string, s spinner.Model, l
 		)
 		return centeredOverlay(bg, styles.ModalStyle.Width(50).Render(renameContent), w, h)
 
-	case mc.TodoPanel != nil:
+	case state == stateShowingTodoPanel && mc.TodoPanel != nil:
 		return mc.TodoPanel.Overlay(bg, w, h)
 
 	case mc.DocPicker != nil:

--- a/internal/tui/modal_coordinator.go
+++ b/internal/tui/modal_coordinator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
+	"github.com/colonyops/hive/internal/core/todo"
 	"github.com/colonyops/hive/internal/tui/components"
 	"github.com/colonyops/hive/internal/tui/components/form"
 	tuinotify "github.com/colonyops/hive/internal/tui/notify"
@@ -28,6 +29,7 @@ type ModalCoordinator struct {
 	Notification    *NotificationModal
 	FormDialog      *form.Dialog
 	DocPicker       *review.DocumentPickerModal
+	TodoPanel       *TodoActionPanel
 	RenameInput     textinput.Model
 	RenameSessionID string
 
@@ -130,6 +132,9 @@ func (mc *ModalCoordinator) Overlay(state UIState, bg string, s spinner.Model, l
 		)
 		return centeredOverlay(bg, styles.ModalStyle.Width(50).Render(renameContent), w, h)
 
+	case mc.TodoPanel != nil:
+		return mc.TodoPanel.Overlay(bg, w, h)
+
 	case mc.DocPicker != nil:
 		return mc.DocPicker.Overlay(bg, w, h)
 
@@ -180,6 +185,16 @@ func (mc *ModalCoordinator) ClearFormState() {
 	mc.PendingFormName = ""
 	mc.PendingFormSess = nil
 	mc.PendingFormArgs = nil
+}
+
+// ShowTodoPanel creates and displays the TODO action panel.
+func (mc *ModalCoordinator) ShowTodoPanel(items []todo.Item) {
+	mc.TodoPanel = NewTodoActionPanel(items, mc.width, mc.height)
+}
+
+// DismissTodoPanel closes the TODO action panel.
+func (mc *ModalCoordinator) DismissTodoPanel() {
+	mc.TodoPanel = nil
 }
 
 // HasEditorFocus returns true if a modal with text input is active.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -130,6 +130,9 @@ type Model struct {
 
 	renderer *tmpl.Renderer
 
+	// Messaging
+	msgService *hive.MessageService
+
 	// TODO tracking
 	todoWatcher      *hive.TodoWatcher
 	todoService      *hive.TodoService
@@ -294,6 +297,7 @@ func New(deps Deps, opts Opts) Model {
 		toastView:       toastView,
 		bus:             deps.Bus,
 		renderer:        deps.Renderer,
+		msgService:      deps.MsgStore,
 		todoWatcher:     todoWatcher,
 		todoService:     deps.TodoService,
 		todoContextDir:  contextDir,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -632,6 +632,14 @@ func (m Model) dispatchAction(action Action) (Model, tea.Cmd) {
 		return m, m.startRecycle(action.SessionID)
 	}
 
+	// UI-only actions handled inline — no executor needed.
+	if action.Type == act.TypeTodoPanel {
+		if m.todoService != nil && m.cfg.Todo.IsEnabled() {
+			return m, m.loadTodosAndShowPanel()
+		}
+		return m, nil
+	}
+
 	if action.Exit {
 		exec, err := m.cmdService.CreateExecutor(action)
 		if err != nil {

--- a/internal/tui/model_render.go
+++ b/internal/tui/model_render.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -81,6 +82,12 @@ func (m Model) renderTabView() string {
 	if statusFilter := m.sessionsView.StatusFilter(); statusFilter != "" {
 		filterLabel := string(statusFilter)
 		tabsLeft = lipgloss.JoinHorizontal(lipgloss.Left, tabsLeft, "  ", styles.TextPrimaryBoldStyle.Render("["+filterLabel+"]"))
+	}
+
+	// Add TODO count indicator
+	if m.todoPendingCount > 0 {
+		label := fmt.Sprintf("[%d todo]", m.todoPendingCount)
+		tabsLeft = lipgloss.JoinHorizontal(lipgloss.Left, tabsLeft, "  ", styles.TextWarningStyle.Render(label))
 	}
 
 	// Branding on right with background

--- a/internal/tui/todo_notify.go
+++ b/internal/tui/todo_notify.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/colonyops/hive/internal/core/todo"
+)
+
+// sendTerminalNotification emits OSC 9 + OSC 777 escape sequences to trigger
+// a desktop notification from the terminal emulator. Supports iTerm2/Kitty
+// (OSC 9) and Ghostty/WezTerm/Foot (OSC 777). When running inside tmux,
+// sequences are wrapped in DCS passthrough.
+func sendTerminalNotification(item todo.Item) tea.Cmd {
+	title := "Hive"
+	body := fmt.Sprintf("New todo: %s", item.Title)
+
+	// OSC 9 (iTerm2, Kitty)
+	osc9 := fmt.Sprintf("\x1b]9;%s: %s\x07", title, body)
+	// OSC 777 (Ghostty, WezTerm, Foot)
+	osc777 := fmt.Sprintf("\x1b]777;notify;%s;%s\x07", title, body)
+
+	seq := osc9 + osc777
+
+	if os.Getenv("TMUX") != "" {
+		seq = tmuxPassthrough(seq)
+	}
+
+	return tea.Raw(seq)
+}
+
+// tmuxPassthrough wraps escape sequences in DCS passthrough for tmux.
+// Each ESC byte in the original sequence is doubled for tmux.
+func tmuxPassthrough(seq string) string {
+	// Double all ESC bytes for tmux passthrough
+	doubled := strings.ReplaceAll(seq, "\x1b", "\x1b\x1b")
+	return "\x1bPtmux;" + doubled + "\x1b\\"
+}

--- a/internal/tui/todo_notify_test.go
+++ b/internal/tui/todo_notify_test.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTmuxPassthrough(t *testing.T) {
+	t.Run("wraps sequence in DCS passthrough", func(t *testing.T) {
+		seq := "\x1b]9;test\x07"
+		result := tmuxPassthrough(seq)
+
+		assert.Contains(t, result, "\x1bPtmux;")
+		assert.Equal(t, "\x1b\\", result[len(result)-2:], "should end with ST")
+	})
+
+	t.Run("doubles ESC bytes", func(t *testing.T) {
+		seq := "\x1b]9;Hello\x07\x1b]777;notify;Title;Body\x07"
+		result := tmuxPassthrough(seq)
+
+		// Each \x1b in original becomes \x1b\x1b inside the DCS body
+		assert.Contains(t, result, "\x1b\x1b]9;Hello\x07")
+		assert.Contains(t, result, "\x1b\x1b]777;notify;Title;Body\x07")
+	})
+}

--- a/internal/tui/todo_panel.go
+++ b/internal/tui/todo_panel.go
@@ -1,0 +1,321 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/colonyops/hive/internal/core/styles"
+	"github.com/colonyops/hive/internal/core/todo"
+)
+
+// TodoPanelAction represents the action taken on a TODO item.
+type TodoPanelAction int
+
+const (
+	TodoPanelNone     TodoPanelAction = iota
+	TodoPanelSelect                   // enter — user wants to open/act on the item
+	TodoPanelDismiss                  // d — dismiss the item
+	TodoPanelComplete                 // c — complete the item
+)
+
+// TodoPanelResult holds the outcome of a user interaction with the panel.
+type TodoPanelResult struct {
+	Action TodoPanelAction
+	Item   todo.Item
+}
+
+// TodoActionPanel is a modal overlay listing pending TODO items.
+// Items are grouped by repository remote with headers.
+type TodoActionPanel struct {
+	items     []todo.Item
+	cursor    int
+	cancelled bool
+	result    *TodoPanelResult
+	width     int
+	height    int
+	scroll    int // first visible row index
+}
+
+// NewTodoActionPanel creates a new TODO action panel.
+func NewTodoActionPanel(items []todo.Item, width, height int) *TodoActionPanel {
+	p := &TodoActionPanel{
+		items:  items,
+		width:  width,
+		height: height,
+	}
+	return p
+}
+
+// Update handles key events for the panel.
+func (p *TodoActionPanel) Update(msg tea.Msg) (*TodoActionPanel, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return p, nil
+	}
+
+	switch keyMsg.String() {
+	case "esc", "q":
+		p.cancelled = true
+	case "enter":
+		if len(p.items) > 0 {
+			p.result = &TodoPanelResult{Action: TodoPanelSelect, Item: p.items[p.cursor]}
+		}
+	case "d":
+		if len(p.items) > 0 {
+			p.result = &TodoPanelResult{Action: TodoPanelDismiss, Item: p.items[p.cursor]}
+		}
+	case "c":
+		if len(p.items) > 0 {
+			p.result = &TodoPanelResult{Action: TodoPanelComplete, Item: p.items[p.cursor]}
+		}
+	case "up", "k":
+		if p.cursor > 0 {
+			p.cursor--
+			p.ensureVisible()
+		}
+	case "down", "j":
+		if p.cursor < len(p.items)-1 {
+			p.cursor++
+			p.ensureVisible()
+		}
+	}
+
+	return p, nil
+}
+
+// View renders the panel content.
+func (p *TodoActionPanel) View() string {
+	modalWidth := max(int(float64(p.width)*0.8), 40)
+	modalHeight := max(int(float64(p.height)*0.8), 10)
+	listHeight := max(modalHeight-6, 3)
+
+	title := styles.ModalTitleStyle.Render("TODO Items")
+
+	if len(p.items) == 0 {
+		empty := styles.TextMutedStyle.Render("No pending TODO items")
+		help := styles.ModalHelpStyle.Render("esc close")
+		content := lipgloss.JoinVertical(lipgloss.Left, title, "", empty, "", help)
+		return styles.ModalStyle.Width(modalWidth).Render(content)
+	}
+
+	// Build grouped rows
+	rows := p.buildRows(modalWidth - 6) // account for border + padding
+
+	// Apply scrolling
+	visible := rows
+	if len(rows) > listHeight {
+		end := p.scroll + listHeight
+		if end > len(rows) {
+			end = len(rows)
+		}
+		visible = rows[p.scroll:end]
+	}
+
+	list := strings.Join(visible, "\n")
+
+	help := styles.ModalHelpStyle.Render("↑/↓ navigate  enter select  d dismiss  c complete  esc close")
+
+	content := lipgloss.JoinVertical(lipgloss.Left, title, "", list, "", help)
+	return styles.ModalStyle.Width(modalWidth).Render(content)
+}
+
+// Overlay renders the panel centered over the background.
+func (p *TodoActionPanel) Overlay(background string, width, height int) string {
+	modal := p.View()
+
+	bgLayer := lipgloss.NewLayer(background)
+	modalLayer := lipgloss.NewLayer(modal)
+
+	modalW := lipgloss.Width(modal)
+	modalH := lipgloss.Height(modal)
+	centerX := max((width-modalW)/2, 0)
+	centerY := max((height-modalH)/2, 0)
+	modalLayer.X(centerX).Y(centerY).Z(1)
+
+	return lipgloss.NewCompositor(bgLayer, modalLayer).Render()
+}
+
+// Cancelled returns true if the user dismissed the panel.
+func (p *TodoActionPanel) Cancelled() bool {
+	return p.cancelled
+}
+
+// Result returns the action result, or nil if none yet.
+func (p *TodoActionPanel) Result() *TodoPanelResult {
+	return p.result
+}
+
+// buildRows renders TODO items grouped by repo remote.
+func (p *TodoActionPanel) buildRows(maxWidth int) []string {
+	type group struct {
+		remote string
+		items  []int // indices into p.items
+	}
+
+	// Group items by repo remote, preserving order
+	var groups []group
+	seen := map[string]int{} // remote -> index in groups
+
+	for i, item := range p.items {
+		key := item.RepoRemote
+		if key == "" {
+			key = "unknown"
+		}
+		if idx, ok := seen[key]; ok {
+			groups[idx].items = append(groups[idx].items, i)
+		} else {
+			seen[key] = len(groups)
+			groups = append(groups, group{remote: key, items: []int{i}})
+		}
+	}
+
+	var rows []string
+	for gi, g := range groups {
+		if gi > 0 {
+			rows = append(rows, "") // spacer between groups
+		}
+
+		// Header
+		header := styles.TextPrimaryBoldStyle.Render(shortRemote(g.remote))
+		rows = append(rows, header)
+
+		// Items
+		for ii, idx := range g.items {
+			item := p.items[idx]
+			selected := idx == p.cursor
+
+			// Tree branch character
+			branch := "├─"
+			if ii == len(g.items)-1 {
+				branch = "└─"
+			}
+
+			// Type indicator
+			var typeIcon string
+			if item.Type == todo.ItemTypeFileChange {
+				typeIcon = "file"
+			} else {
+				typeIcon = "task"
+			}
+
+			// Session label
+			sessionLabel := ""
+			if item.SessionID != "" {
+				sessionLabel = fmt.Sprintf(" [%s]", truncate(item.SessionID, 12))
+			}
+
+			// Age
+			age := todoFormatAge(item.CreatedAt)
+
+			// Build the row content
+			titleStr := truncate(item.Title, max(maxWidth-30, 20))
+			meta := styles.TextMutedStyle.Render(fmt.Sprintf(" %s%s %s", typeIcon, sessionLabel, age))
+			rowContent := branch + " " + titleStr + meta
+
+			if selected {
+				rowContent = styles.TextPrimaryStyle.Render("┃ ") + rowContent
+			} else {
+				rowContent = "  " + rowContent
+			}
+
+			rows = append(rows, rowContent)
+		}
+	}
+
+	return rows
+}
+
+// ensureVisible adjusts scroll so the cursor is visible.
+func (p *TodoActionPanel) ensureVisible() {
+	modalHeight := max(int(float64(p.height)*0.8), 10)
+	listHeight := max(modalHeight-6, 3)
+
+	// Map cursor index to row index (accounting for headers and spacers).
+	// This is approximate but sufficient: scroll to keep cursor in view.
+	row := p.cursorToRow()
+
+	if row < p.scroll {
+		p.scroll = row
+	}
+	if row >= p.scroll+listHeight {
+		p.scroll = row - listHeight + 1
+	}
+}
+
+// cursorToRow estimates the row index for the current cursor position.
+func (p *TodoActionPanel) cursorToRow() int {
+	if len(p.items) == 0 {
+		return 0
+	}
+
+	row := 0
+	prevRemote := ""
+	for i, item := range p.items {
+		remote := item.RepoRemote
+		if remote == "" {
+			remote = "unknown"
+		}
+		if remote != prevRemote {
+			if prevRemote != "" {
+				row++ // spacer
+			}
+			row++ // header
+			prevRemote = remote
+		}
+		if i == p.cursor {
+			return row
+		}
+		row++ // item row
+	}
+
+	return row
+}
+
+// shortRemote extracts the owner/repo from a git remote URL.
+func shortRemote(remote string) string {
+	remote = strings.TrimSuffix(remote, ".git")
+
+	// SSH format: git@github.com:org/repo
+	if idx := strings.LastIndex(remote, ":"); idx >= 0 && !strings.Contains(remote, "://") {
+		return remote[idx+1:]
+	}
+
+	// HTTPS format: https://github.com/org/repo
+	parts := strings.Split(remote, "/")
+	if len(parts) >= 2 {
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+
+	return remote
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func todoFormatAge(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/internal/tui/todo_panel_test.go
+++ b/internal/tui/todo_panel_test.go
@@ -1,0 +1,175 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/colonyops/hive/internal/core/todo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testItems() []todo.Item {
+	return []todo.Item{
+		{ID: "1", Type: todo.ItemTypeFileChange, Title: "plan.md", SessionID: "sess-1", RepoRemote: "https://github.com/org/repo", CreatedAt: time.Now().Add(-5 * time.Minute)},
+		{ID: "2", Type: todo.ItemTypeCustom, Title: "Review PR #42", SessionID: "sess-2", RepoRemote: "https://github.com/org/repo", CreatedAt: time.Now().Add(-2 * time.Hour)},
+		{ID: "3", Type: todo.ItemTypeFileChange, Title: "notes.md", RepoRemote: "https://github.com/org/other", CreatedAt: time.Now().Add(-1 * time.Minute)},
+	}
+}
+
+func TestTodoActionPanel_Construction(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	require.NotNil(t, panel)
+	assert.False(t, panel.Cancelled())
+	assert.Nil(t, panel.Result())
+	assert.Equal(t, 0, panel.cursor)
+}
+
+func TestTodoActionPanel_EmptyState(t *testing.T) {
+	panel := NewTodoActionPanel(nil, 80, 24)
+
+	view := panel.View()
+	assert.Contains(t, view, "No pending TODO items")
+	assert.False(t, panel.Cancelled())
+}
+
+func TestTodoActionPanel_Navigation(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	// Move down
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "j"})
+	assert.Equal(t, 1, panel.cursor)
+
+	// Move down again
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "j"})
+	assert.Equal(t, 2, panel.cursor)
+
+	// Move down past end - should stay
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "j"})
+	assert.Equal(t, 2, panel.cursor)
+
+	// Move up
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "k"})
+	assert.Equal(t, 1, panel.cursor)
+
+	// Move up past beginning - should stay
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "k"})
+	assert.Equal(t, 0, panel.cursor)
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "k"})
+	assert.Equal(t, 0, panel.cursor)
+}
+
+func TestTodoActionPanel_Select(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.NotNil(t, panel.Result())
+	assert.Equal(t, TodoPanelSelect, panel.Result().Action)
+	assert.Equal(t, "1", panel.Result().Item.ID)
+}
+
+func TestTodoActionPanel_Dismiss(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	// Move to second item and dismiss
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "j"})
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "d"})
+	require.NotNil(t, panel.Result())
+	assert.Equal(t, TodoPanelDismiss, panel.Result().Action)
+	assert.Equal(t, "2", panel.Result().Item.ID)
+}
+
+func TestTodoActionPanel_Complete(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "c"})
+	require.NotNil(t, panel.Result())
+	assert.Equal(t, TodoPanelComplete, panel.Result().Action)
+	assert.Equal(t, "1", panel.Result().Item.ID)
+}
+
+func TestTodoActionPanel_Cancel(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.True(t, panel.Cancelled())
+}
+
+func TestTodoActionPanel_CancelWithQ(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "q"})
+	assert.True(t, panel.Cancelled())
+}
+
+func TestTodoActionPanel_EmptySelectNoop(t *testing.T) {
+	panel := NewTodoActionPanel(nil, 80, 24)
+
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Nil(t, panel.Result())
+
+	panel, _ = panel.Update(tea.KeyPressMsg{Code: -1, Text: "d"})
+	assert.Nil(t, panel.Result())
+}
+
+func TestTodoActionPanel_ViewRenders(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	view := panel.View()
+	assert.Contains(t, view, "TODO Items")
+	assert.Contains(t, view, "plan.md")
+	assert.Contains(t, view, "Review PR #42")
+	assert.Contains(t, view, "notes.md")
+}
+
+func TestTodoActionPanel_Overlay(t *testing.T) {
+	items := testItems()
+	panel := NewTodoActionPanel(items, 80, 24)
+
+	overlay := panel.Overlay("background content", 80, 24)
+	assert.NotEmpty(t, overlay)
+	assert.Contains(t, overlay, "TODO Items")
+}
+
+func TestShortRemote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://github.com/org/repo.git", "org/repo"},
+		{"https://github.com/org/repo", "org/repo"},
+		{"git@github.com:org/repo.git", "org/repo"},
+		{"git@github.com:org/repo", "org/repo"},
+		{"unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, shortRemote(tt.input))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "hello", truncate("hello", 10))
+	assert.Equal(t, "hel...", truncate("hello world", 6))
+	assert.Equal(t, "he", truncate("hello", 2))
+}
+
+func TestTodoFormatAge(t *testing.T) {
+	assert.Equal(t, "30s", todoFormatAge(time.Now().Add(-30*time.Second)))
+	assert.Equal(t, "5m", todoFormatAge(time.Now().Add(-5*time.Minute)))
+	assert.Equal(t, "3h", todoFormatAge(time.Now().Add(-3*time.Hour)))
+	assert.Equal(t, "2d", todoFormatAge(time.Now().Add(-48*time.Hour)))
+	assert.Empty(t, todoFormatAge(time.Time{}))
+}

--- a/internal/tui/views/review/review_finalize_modal.go
+++ b/internal/tui/views/review/review_finalize_modal.go
@@ -36,13 +36,22 @@ type finalizationOption struct {
 }
 
 // NewFinalizationModal creates a modal for choosing finalization action.
-func NewFinalizationModal(feedback string, width, height int) FinalizationModal {
+// If canSendToAgent is true, a "Send to agent" option is included.
+func NewFinalizationModal(feedback string, width, height int, canSendToAgent bool) FinalizationModal {
 	options := []finalizationOption{
 		{
 			label:       "Copy to clipboard",
 			description: "Copy review feedback to system clipboard",
 			action:      FinalizationActionClipboard,
 		},
+	}
+
+	if canSendToAgent {
+		options = append(options, finalizationOption{
+			label:       "Send to agent",
+			description: "Publish feedback to the source agent's inbox",
+			action:      FinalizationActionSendToAgent,
+		})
 	}
 
 	return FinalizationModal{

--- a/internal/tui/views/review/review_finalize_modal_test.go
+++ b/internal/tui/views/review/review_finalize_modal_test.go
@@ -11,7 +11,7 @@ const testFeedback = "Test feedback"
 
 func TestFinalizationModal_Creation(t *testing.T) {
 	feedback := testFeedback
-	modal := NewFinalizationModal(feedback, 100, 40)
+	modal := NewFinalizationModal(feedback, 100, 40, false)
 
 	assert.Len(t, modal.options, 1, "Expected 1 option, got %d", len(modal.options))
 	assert.Equal(t, FinalizationActionClipboard, modal.options[0].action)
@@ -19,7 +19,7 @@ func TestFinalizationModal_Creation(t *testing.T) {
 
 func TestFinalizationModal_Navigation(t *testing.T) {
 	feedback := testFeedback
-	modal := NewFinalizationModal(feedback, 100, 40)
+	modal := NewFinalizationModal(feedback, 100, 40, false)
 
 	// Initial selection should be 0
 	assert.Equal(t, 0, modal.selectedIdx, "Initial selection should be 0, got %d", modal.selectedIdx)
@@ -31,7 +31,7 @@ func TestFinalizationModal_Navigation(t *testing.T) {
 
 func TestFinalizationModal_Confirmation(t *testing.T) {
 	feedback := testFeedback
-	modal := NewFinalizationModal(feedback, 100, 40)
+	modal := NewFinalizationModal(feedback, 100, 40, false)
 
 	// Set confirmed flag
 	modal.confirmed = true
@@ -43,7 +43,7 @@ func TestFinalizationModal_Confirmation(t *testing.T) {
 
 func TestFinalizationModal_Cancellation(t *testing.T) {
 	feedback := testFeedback
-	modal := NewFinalizationModal(feedback, 100, 40)
+	modal := NewFinalizationModal(feedback, 100, 40, false)
 
 	// Set cancelled flag
 	modal.cancelled = true
@@ -52,7 +52,7 @@ func TestFinalizationModal_Cancellation(t *testing.T) {
 
 func TestFinalizationModal_View(t *testing.T) {
 	feedback := testFeedback
-	modal := NewFinalizationModal(feedback, 100, 40)
+	modal := NewFinalizationModal(feedback, 100, 40, false)
 
 	view := modal.View()
 	assert.NotEmpty(t, view, "View should not be empty")
@@ -78,7 +78,7 @@ func stringContains(s, substr string) bool {
 
 func TestFinalizationModal_KeyHandling(t *testing.T) {
 	feedback := testFeedback
-	modal := NewFinalizationModal(feedback, 100, 40)
+	modal := NewFinalizationModal(feedback, 100, 40, false)
 
 	// With single option, j/k don't change selectedIdx
 	keyMsg := tea.KeyPressMsg(tea.Key{Text: "j", Code: 'j'})
@@ -91,7 +91,7 @@ func TestFinalizationModal_KeyHandling(t *testing.T) {
 	assert.True(t, updatedModal.Confirmed(), "After pressing 'enter', modal should be confirmed")
 
 	// Test 'esc' key - should cancel
-	modal = NewFinalizationModal(feedback, 100, 40)
+	modal = NewFinalizationModal(feedback, 100, 40, false)
 	keyMsg = tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc})
 	updatedModal, _ = modal.Update(keyMsg)
 	assert.True(t, updatedModal.Cancelled(), "After pressing 'esc', modal should be cancelled")

--- a/internal/tui/views/review/review_view.go
+++ b/internal/tui/views/review/review_view.go
@@ -28,7 +28,8 @@ import (
 
 // ReviewFinalizedMsg is sent when review is finalized and copied to clipboard.
 type ReviewFinalizedMsg struct {
-	Feedback string
+	Feedback     string
+	DocumentPath string // absolute path of the finalized document
 }
 
 // reviewDiscardedMsg is sent when review is discarded (internal only).
@@ -258,8 +259,12 @@ func (v View) Update(msg tea.Msg) (View, tea.Cmd) {
 				// Execute selected action
 				switch action {
 				case FinalizationActionClipboard:
+					docPath := ""
+					if v.selectedDoc != nil {
+						docPath = v.selectedDoc.Path
+					}
 					return v, func() tea.Msg {
-						return ReviewFinalizedMsg{Feedback: v.feedbackGenerated}
+						return ReviewFinalizedMsg{Feedback: v.feedbackGenerated, DocumentPath: docPath}
 					}
 				case FinalizationActionNone, FinalizationActionSendToAgent:
 					// User cancelled or unsupported action, do nothing
@@ -317,8 +322,12 @@ func (v View) Update(msg tea.Msg) (View, tea.Cmd) {
 				// Reload document without comments
 				v.loadDocument(v.selectedDoc)
 				// Return message to trigger clipboard copy
+				docPath := ""
+				if v.selectedDoc != nil {
+					docPath = v.selectedDoc.Path
+				}
 				return v, func() tea.Msg {
-					return ReviewFinalizedMsg{Feedback: feedback}
+					return ReviewFinalizedMsg{Feedback: feedback, DocumentPath: docPath}
 				}
 			}
 

--- a/internal/tui/views/review/review_view_test.go
+++ b/internal/tui/views/review/review_view_test.go
@@ -1016,7 +1016,7 @@ func TestFinalizationModal_IntegrationWithView(t *testing.T) {
 	// Manually set up the finalization modal state (simulating pressing 'f')
 	v.fullScreen = true
 	v.selectedDoc = &docs[0]
-	modal := NewFinalizationModal("test feedback", 100, 40)
+	modal := NewFinalizationModal("test feedback", 100, 40, false)
 	v.finalizationModal = &modal
 
 	// Verify initial state

--- a/main.go
+++ b/main.go
@@ -186,6 +186,7 @@ Run 'hive new' to create a new session from the current repository.`,
 			// Create stores
 			sessionStore := stores.NewSessionStore(database)
 			msgStore := stores.NewMessageStore(database, 0) // 0 = unlimited retention
+			todoStore := stores.NewTodoStore(database)
 			kvStore := stores.NewKVStore(database)
 
 			// Start background KV sweep goroutine
@@ -260,6 +261,7 @@ Run 'hive new' to create a new session from the current repository.`,
 			*hiveApp = *hive.NewApp(
 				sessionSvc,
 				msgStore,
+				todoStore,
 				cfg,
 				bus,
 				nil, // terminal manager created in TUI command

--- a/main.go
+++ b/main.go
@@ -317,6 +317,7 @@ Run 'hive new' to create a new session from the current repository.`,
 	app = commands.NewDocCmd(flags, hiveApp).Register(app)
 	app = commands.NewSessionCmd(flags, hiveApp).Register(app)
 	app = commands.NewReviewCmd(flags, hiveApp).Register(app)
+	app = commands.NewTodoCmd(flags, hiveApp).Register(app)
 
 	// Register TUI flags on root command
 	app.Flags = append(app.Flags, tuiCmd.Flags()...)


### PR DESCRIPTION
## Summary

- Add a TODO action queue to the TUI that detects file changes in context directories, generates actionable TODO items, and routes the operator through a guided review workflow
- Full pipeline: file change detection → TODO creation → tab bar indicator → action panel → inline review → feedback delivery to agent inbox
- `hive todo list/create/dismiss` CLI commands for scripting and agent-initiated TODOs

## Implementation (7 phases)

**Phase 1 – Data Model & Store**: `todo.Item` domain model, SQLite schema (v7), sqlc queries, `TodoStore` with deduplication and rate limiting

**Phase 2 – Service & Watcher**: `TodoService` with frontmatter parsing for session attribution, `TodoWatcher` using fsnotify with debounce, EventBus events (`todo.created`, `todo.dismissed`)

**Phase 3 – Config & CLI**: `TodoConfig` with enable/disable and notification settings, `hive todo list/create/dismiss` subcommands

**Phase 4a – TUI Watcher & Tab Bar**: Wire `TodoWatcher` into TUI model, `[N todo]` indicator in tab bar using warning style

**Phase 4b – Action Panel Modal**: `TodoActionPanel` with items grouped by repo, tree-branch rendering, j/k navigation, enter/d/c actions, compositor overlay

**Phase 4c – Hotkey & Review Integration**: `t` hotkey opens panel, item selection opens Review tab, review finalization auto-completes TODO items

**Phase 5 – Feedback Delivery**: "Send to agent" finalization option publishes feedback to `agent.<id>.inbox` via `MessageService`, threaded from TODO item's `session_id` frontmatter

**Phase 6 – Notifications**: Toast notifications via `notifyBus`, OSC 9 (iTerm2/Kitty) + OSC 777 (Ghostty/WezTerm/Foot) terminal notifications with tmux DCS passthrough

**Phase 7 – Agent Plugin**: `ID` field added to `SpawnData` for `HIVE_SESSION_ID` env var, `hive:todo` Claude plugin skill documenting frontmatter and `hive todo create`

## Test plan

- [ ] `mise run check` passes (tidy + lint + test)
- [ ] Create a `.md` file in `.hive/plans/` → tab bar shows `[1 todo]`, toast appears
- [ ] Press `t` → action panel opens with item grouped by repo
- [ ] Select item → Review tab loads the document
- [ ] Add comments, finalize with "Send to agent" → feedback published to inbox
- [ ] Delete file → TODO auto-dismissed, indicator decrements
- [ ] `hive todo list` / `hive todo create` / `hive todo dismiss` CLI commands work
- [ ] With `todo.enabled: false` → no watcher, no indicator, `t` key is no-op