### PR TITLE
feat: support both .yml and .yaml config file extensions

### DIFF
--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -53,7 +53,7 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 		warnings = append(warnings, "Not running inside tmux. Some features (preview, spawn) require tmux.")
 	}
 	if _, err := os.Stat(cmd.flags.ConfigPath); cmd.flags.ConfigPath == "" || os.IsNotExist(err) {
-		warnings = append(warnings, "No config file found. Expected location: "+DefaultConfigDir())
+		warnings = append(warnings, "No config file found. Expected location: "+defaultConfigDir())
 	}
 
 	// Start profiler server if enabled

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -15,8 +15,7 @@ type Flags struct {
 
 var configNames = []string{"config.yaml", "config.yml", "hive.yaml", "hive.yml"}
 
-// DefaultConfigDir returns the default config directory using XDG_CONFIG_HOME.
-func DefaultConfigDir() string {
+func defaultConfigDir() string {
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 	if configHome == "" {
 		home, _ := os.UserHomeDir()
@@ -29,7 +28,7 @@ func DefaultConfigDir() string {
 // (config.yaml, config.yml, hive.yaml, hive.yml) and returns the first
 // match. Returns empty string when no file is found.
 func DefaultConfigPath() string {
-	dir := DefaultConfigDir()
+	dir := defaultConfigDir()
 	for _, name := range configNames {
 		path := filepath.Join(dir, name)
 		if _, err := os.Stat(path); err == nil {


### PR DESCRIPTION
Fixes #174

## Purpose

Support both `.yml` and `.yaml` extensions for config files, plus `hive.yaml`/`hive.yml` as alternative names. Warn in the TUI when no config file is detected.

## Proposed Changes

- Probe `config.yaml`, `config.yml`, `hive.yaml`, `hive.yml` in priority order, returning the first match
- Show a warning toast when no config file is found or the explicit `--config` path is missing
- Add table-driven tests for the probing logic

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)