### PR TITLE
chore: configure renovate for Go dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,35 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:base"
+        "config:recommended",
+        ":semanticCommits",
+        ":separateMultipleMajorReleases"
     ],
     "postUpdateOptions": [
         "gomodTidy"
+    ],
+    "schedule": [
+        "before 7am on monday"
+    ],
+    "packageRules": [
+        {
+            "description": "Group all non-major Go dependencies",
+            "matchManagers": ["gomod"],
+            "matchUpdateTypes": ["minor", "patch", "digest"],
+            "groupName": "go dependencies (non-major)",
+            "automerge": true
+        },
+        {
+            "description": "Group all Go major updates separately",
+            "matchManagers": ["gomod"],
+            "matchUpdateTypes": ["major"],
+            "dependencyDashboardApproval": true
+        },
+        {
+            "description": "Group GitHub Actions updates",
+            "matchManagers": ["github-actions"],
+            "groupName": "github actions",
+            "automerge": true
+        }
     ]
 }


### PR DESCRIPTION
## Summary

- Replaced minimal `config:base` renovate config with `config:recommended` plus Go-specific settings
- Groups non-major Go dependency updates into a single PR with automerge enabled
- Major Go updates require dependency dashboard approval before opening PRs
- Groups GitHub Actions updates with automerge
- Runs on a weekly schedule (Monday mornings) to avoid noise
- Keeps `gomodTidy` post-update option

Closes #127

## Test plan

- [ ] Verify Renovate onboarding detects the updated config
- [ ] Confirm grouped PRs appear as expected on next schedule run