### PR TITLE
feat: add shell completion support

### DIFF
--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/hive"
@@ -47,4 +48,82 @@ func SessionNameCompleter(app *hive.App) cli.ShellCompleteFunc {
 			_, _ = fmt.Fprintln(w, s.Name)
 		}
 	}
+}
+
+// ConfigureCompletionCommand customises the auto-generated completion command.
+// It replaces the zsh action with a custom script using compadd (the upstream
+// urfave/cli _describe-based script inserts "name:description" as one word on
+// some zsh configurations). Bash, fish, and pwsh use the built-in scripts.
+func ConfigureCompletionCommand(cc *cli.Command) {
+	cc.Hidden = false
+	cc.Usage = "Generate shell completion scripts"
+	cc.Description = `Generate shell completion scripts for bash, zsh, fish, or powershell.
+
+To load completions:
+
+Bash:
+  source <(hive completion bash)
+
+  # To load completions for each session, add to ~/.bashrc:
+  source <(hive completion bash)
+
+Zsh:
+  source <(hive completion zsh)
+
+  # Or generate a file:
+  hive completion zsh > "${fpath[1]}/_hive"
+
+Fish:
+  hive completion fish > ~/.config/fish/completions/hive.fish
+
+PowerShell:
+  hive completion pwsh > hive.ps1 && . ./hive.ps1`
+
+	// Wrap the original action so we can intercept "zsh".
+	origAction := cc.Action
+	cc.Action = func(ctx context.Context, cmd *cli.Command) error {
+		if cmd.Args().First() == "zsh" {
+			return writeZshCompletion(cmd.Root().Writer, cmd.Root().Name)
+		}
+		return origAction(ctx, cmd)
+	}
+}
+
+// zshCompletionTmpl is a custom zsh completion script that uses compadd
+// instead of _describe. The upstream urfave/cli script uses _describe which
+// inserts the full "name:description" string on some zsh configurations.
+const zshCompletionTmpl = `#compdef %[1]s
+compdef _%[1]s %[1]s
+
+_%[1]s() {
+	local -a candidates displays
+	local line
+
+	if [[ "${words[-1]}" == "-"* ]]; then
+		while IFS= read -r line; do
+			candidates+=("${line%%%%:*}")
+			displays+=("$line")
+		done < <(${words[@]:0:#words[@]-1} ${words[-1]} --generate-shell-completion 2>/dev/null)
+	else
+		while IFS= read -r line; do
+			candidates+=("${line%%%%:*}")
+			displays+=("$line")
+		done < <(${words[@]:0:#words[@]-1} --generate-shell-completion 2>/dev/null)
+	fi
+
+	if (( ${#candidates} )); then
+		compadd -l -d displays -a candidates
+	else
+		_files
+	fi
+}
+
+if [ "$funcstack[1]" = "_%[1]s" ]; then
+	_%[1]s
+fi
+`
+
+func writeZshCompletion(w io.Writer, appName string) error {
+	_, err := fmt.Fprintf(w, zshCompletionTmpl, appName)
+	return err
 }

--- a/main.go
+++ b/main.go
@@ -128,31 +128,8 @@ Run 'hive' with no arguments to open the interactive session manager.
 Run 'hive new' to create a new session from the current repository.`,
 		Version:               build(),
 		EnableShellCompletion: true,
-		ConfigureShellCompletionCommand: func(cc *cli.Command) {
-			cc.Hidden = false
-			cc.Usage = "Generate shell completion scripts"
-			cc.Description = `Generate shell completion scripts for bash, zsh, fish, or powershell.
 
-To load completions:
-
-Bash:
-  source <(hive completion bash)
-
-  # To load completions for each session, add to ~/.bashrc:
-  source <(hive completion bash)
-
-Zsh:
-  source <(hive completion zsh)
-
-  # Or generate a file:
-  hive completion zsh > "${fpath[1]}/_hive"
-
-Fish:
-  hive completion fish > ~/.config/fish/completions/hive.fish
-
-PowerShell:
-  hive completion pwsh > hive.ps1 && . ./hive.ps1`
-		},
+		ConfigureShellCompletionCommand: commands.ConfigureCompletionCommand,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "log-level",


### PR DESCRIPTION
## Summary

- Enable urfave/cli v3 shell completion via `EnableShellCompletion`
- Expose `hive completion [bash|zsh|fish|pwsh]` subcommand
- Custom zsh completion script using `compadd -d` instead of upstream `_describe` (fixes compatibility with fzf-tab and similar completion plugins)
- Skip app initialization (database, plugins, goroutines) during completion for fast tab response
- Add `SessionNameCompleter` helper for future commands that accept session names

## Setup

```bash
# Bash
source <(hive completion bash)

# Zsh
source <(hive completion zsh)

# Fish
hive completion fish > ~/.config/fish/completions/hive.fish
```

## Why a custom zsh script?

The upstream urfave/cli v3 zsh completion uses `_describe`, which merges completion candidates and descriptions into a single `name:description` array. Plugins like fzf-tab that replace the completion widget reinterpret these entries and can insert the full string (including description) as one word. Our script uses `compadd -l -d displays -a candidates` which keeps candidates and display strings in separate arrays, compatible with both stock zsh and fzf-tab.

## Test plan

- [x] `hive completion bash` outputs a bash completion script
- [x] `hive completion zsh` outputs a custom zsh completion script
- [x] `hive completion fish` outputs a fish completion script
- [x] `hive <tab>` lists available subcommands
- [x] `hive msg <tab>` lists msg subcommands
- [x] `hive ls --<tab>` completes flags
- [x] Works with fzf-tab plugin
- [x] Tab completion runs in ~20ms (no app init)

Closes #26