### PR TITLE
fix: preserve git status across RefreshSessionsMsg

### DIFF
--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -265,6 +265,7 @@ func (v *View) Update(msg tea.Msg) tea.Cmd {
 	case animationTickMsg:
 		return v.handleAnimationTick()
 	case RefreshSessionsMsg:
+		v.refreshing = true
 		return v.loadSessions()
 	case tea.KeyMsg:
 		return v.handleKeyMsg(msg)


### PR DESCRIPTION
## Summary

Fixes #99.

`RefreshSessionsMsg` was not setting `v.refreshing = true` before calling `loadSessions()`. This caused `applyFilter()` to reset all cached git statuses to `IsLoading`, making branch names flash to `"..."` and back on every user-triggered refresh (after creating/deleting sessions).

The periodic refresh tick (`handleSessionRefreshTick`) already sets `refreshing = true` to prevent this. This PR applies the same guard to `RefreshSessionsMsg`.

## Test plan

- [x] Existing tests pass
- [x] Manual: open TUI with multiple sessions, trigger refresh actions (create/delete session), verify branch names don't flash