### PR TITLE
feat: pane support with naming cleanup and correctness fixes

### DIFF
--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -418,7 +418,7 @@ type GitConfig struct {
 type PaneConfig struct {
 	Command    string `yaml:"command,omitempty"`    // Command to run (template string, empty = shell)
 	Dir        string `yaml:"dir,omitempty"`        // Working directory override (template string)
-	Focus      bool   `yaml:"focus,omitempty"`      // Select this pane after creation
+	Focus      bool   `yaml:"focus,omitempty"`      // Select this pane after creation (at most one per window)
 	Horizontal bool   `yaml:"horizontal,omitempty"` // true = left/right split, false = top/bottom
 }
 

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -412,12 +412,23 @@ type GitConfig struct {
 	StatusWorkers int `yaml:"status_workers"`
 }
 
+// PaneConfig defines an additional tmux pane (split) within a window.
+// Panes are created after the parent window's command and are always companion
+// tools — the agent occupies pane 0 (the window's initial process).
+type PaneConfig struct {
+	Command    string `yaml:"command,omitempty"`    // Command to run (template string, empty = shell)
+	Dir        string `yaml:"dir,omitempty"`        // Working directory override (template string)
+	Focus      bool   `yaml:"focus,omitempty"`      // Select this pane after creation
+	Horizontal bool   `yaml:"horizontal,omitempty"` // true = left/right split, false = top/bottom
+}
+
 // WindowConfig defines a tmux window to create when spawning a session.
 type WindowConfig struct {
-	Name    string `yaml:"name"`              // Window name (template string, required)
-	Command string `yaml:"command,omitempty"` // Command to run (template string, empty = shell)
-	Dir     string `yaml:"dir,omitempty"`     // Working directory override (template string)
-	Focus   bool   `yaml:"focus,omitempty"`   // Select this window after creation
+	Name    string       `yaml:"name"`              // Window name (template string, required)
+	Command string       `yaml:"command,omitempty"` // Command to run (template string, empty = shell)
+	Dir     string       `yaml:"dir,omitempty"`     // Working directory override (template string)
+	Focus   bool         `yaml:"focus,omitempty"`   // Select this window after creation
+	Panes   []PaneConfig `yaml:"panes,omitempty"`   // additional pane splits within this window
 }
 
 // Rule defines actions to take for matching repositories.

--- a/internal/core/config/validate.go
+++ b/internal/core/config/validate.go
@@ -71,6 +71,27 @@ func (c *Config) Warnings() []ValidationWarning {
 				Message:  "rule has neither commands nor copy defined",
 			})
 		}
+		for j, w := range rule.Windows {
+			if len(w.Panes) > 0 && w.Command == "" {
+				warnings = append(warnings, ValidationWarning{
+					Category: "Rules",
+					Item:     fmt.Sprintf("rule %d window %d (%s)", i, j, w.Name),
+					Message:  "window has panes but no command; agent will not be in pane 0",
+				})
+			}
+		}
+	}
+
+	for name, cmd := range c.UserCommands {
+		for j, w := range cmd.Windows {
+			if len(w.Panes) > 0 && w.Command == "" {
+				warnings = append(warnings, ValidationWarning{
+					Category: "UserCommands",
+					Item:     fmt.Sprintf("%s window %d (%s)", name, j, w.Name),
+					Message:  "window has panes but no command; agent will not be in pane 0",
+				})
+			}
+		}
 	}
 
 	return warnings

--- a/internal/core/config/validate.go
+++ b/internal/core/config/validate.go
@@ -79,6 +79,13 @@ func (c *Config) Warnings() []ValidationWarning {
 					Message:  "window has panes but no command; agent will not be in pane 0",
 				})
 			}
+			if focusCount := countFocusedPanes(w.Panes); focusCount > 1 {
+				warnings = append(warnings, ValidationWarning{
+					Category: "Rules",
+					Item:     fmt.Sprintf("rule %d window %d (%s)", i, j, w.Name),
+					Message:  fmt.Sprintf("window has %d panes with focus:true; only the last will be selected", focusCount),
+				})
+			}
 		}
 	}
 
@@ -91,10 +98,28 @@ func (c *Config) Warnings() []ValidationWarning {
 					Message:  "window has panes but no command; agent will not be in pane 0",
 				})
 			}
+			if focusCount := countFocusedPanes(w.Panes); focusCount > 1 {
+				warnings = append(warnings, ValidationWarning{
+					Category: "UserCommands",
+					Item:     fmt.Sprintf("%s window %d (%s)", name, j, w.Name),
+					Message:  fmt.Sprintf("window has %d panes with focus:true; only the last will be selected", focusCount),
+				})
+			}
 		}
 	}
 
 	return warnings
+}
+
+// countFocusedPanes returns the number of panes with Focus set to true.
+func countFocusedPanes(panes []PaneConfig) int {
+	count := 0
+	for _, p := range panes {
+		if p.Focus {
+			count++
+		}
+	}
+	return count
 }
 
 // validateFileAccess checks config file, data directory, and git executable.
@@ -196,6 +221,19 @@ func (c *Config) validateRules() error {
 					errs = errs.Append(prefix+".dir", fmt.Errorf("template error: %w", err))
 				}
 			}
+			for k, p := range w.Panes {
+				pprefix := fmt.Sprintf("%s.panes[%d]", prefix, k)
+				if p.Command != "" {
+					if err := validateTemplate(p.Command, BatchSpawnTemplateData{}); err != nil {
+						errs = errs.Append(pprefix+".command", fmt.Errorf("template error: %w", err))
+					}
+				}
+				if p.Dir != "" {
+					if err := validateTemplate(p.Dir, BatchSpawnTemplateData{}); err != nil {
+						errs = errs.Append(pprefix+".dir", fmt.Errorf("template error: %w", err))
+					}
+				}
+			}
 		}
 	}
 	return errs.ToError()
@@ -240,6 +278,20 @@ func (c *Config) validateUserCommandTemplates() error {
 				}
 				if err := validateTemplate(tmplStr, testData); err != nil {
 					errs = errs.Append(wfield+tname, err)
+				}
+			}
+			for j, p := range w.Panes {
+				pfield := fmt.Sprintf("%s.panes[%d]", wfield, j)
+				for tname, tmplStr := range map[string]string{
+					".command": p.Command,
+					".dir":     p.Dir,
+				} {
+					if tmplStr == "" {
+						continue
+					}
+					if err := validateTemplate(tmplStr, testData); err != nil {
+						errs = errs.Append(pfield+tname, err)
+					}
 				}
 			}
 		}

--- a/internal/core/session/session.go
+++ b/internal/core/session/session.go
@@ -30,7 +30,7 @@ const (
 // Metadata keys for terminal integration.
 const (
 	MetaTmuxSession = "tmux_session" // tmux session name
-	MetaTmuxPane    = "tmux_pane"    // tmux pane identifier
+	MetaTmuxWindow  = "tmux_window"  // tmux window index
 )
 
 // Session represents an isolated git environment for an AI agent.

--- a/internal/core/terminal/terminal.go
+++ b/internal/core/terminal/terminal.go
@@ -16,7 +16,7 @@ const (
 // SessionInfo holds information about a discovered terminal session.
 type SessionInfo struct {
 	Name         string // terminal session name (e.g., tmux session name)
-	Pane         string // pane identifier if applicable (window index for tmux)
+	WindowIndex  string // tmux window index (e.g., "0", "1")
 	WindowName   string // window name (for display and template data)
 	Status       Status // current detected status
 	DetectedTool string // detected AI tool (claude, gemini, etc.)

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -269,11 +269,11 @@ func (t *Integration) DiscoverSession(_ context.Context, slug string, metadata m
 		return nil, nil
 	}
 
-	// If explicit pane given, use it directly
-	if pane := metadata[session.MetaTmuxPane]; pane != "" {
-		w := sc.findWindow(pane)
+	// If explicit window index given, use it directly
+	if windowIndex := metadata[session.MetaTmuxWindow]; windowIndex != "" {
+		w := sc.findWindow(windowIndex)
 		if w == nil {
-			log.Debug().Str("session", sessionName).Str("pane", pane).Msg("explicit pane not found, falling back to best window")
+			log.Debug().Str("session", sessionName).Str("window", windowIndex).Msg("explicit window not found, falling back to best window")
 			w = sc.bestWindow()
 		}
 		return t.sessionInfoFromWindow(sessionName, sc, w), nil
@@ -326,9 +326,9 @@ func (t *Integration) sessionInfoFromWindow(sessionName string, _ *sessionCache,
 		return &terminal.SessionInfo{Name: sessionName}
 	}
 	return &terminal.SessionInfo{
-		Name:       sessionName,
-		Pane:       w.windowIndex,
-		WindowName: w.windowName,
+		Name:        sessionName,
+		WindowIndex: w.windowIndex,
+		WindowName:  w.windowName,
 	}
 }
 
@@ -347,9 +347,9 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 		return terminal.StatusMissing, nil
 	}
 
-	w := sc.findWindow(info.Pane)
+	w := sc.findWindow(info.WindowIndex)
 	if w == nil {
-		log.Debug().Str("session", info.Name).Str("pane", info.Pane).Msg("window not found in cache, falling back to best window")
+		log.Debug().Str("session", info.Name).Str("window", info.WindowIndex).Msg("window not found in cache, falling back to best window")
 		w = sc.bestWindow()
 	}
 	if w == nil {
@@ -387,7 +387,7 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 	default:
 		// Activity changed and rate limit allows, capture fresh
 		var err error
-		content, err = t.capturePane(ctx, info.Name, windowIndex)
+		content, err = t.captureWindow(ctx, info.Name, windowIndex)
 		if err != nil {
 			return terminal.StatusMissing, err
 		}
@@ -446,11 +446,14 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 	return status, nil
 }
 
-// capturePane captures the content of a tmux pane.
-func (t *Integration) capturePane(_ context.Context, sessionName, pane string) (string, error) {
+// captureWindow captures the content of a tmux window.
+// Always targets pane 0: hive creates agent commands via new-window which places
+// the process in pane 0. Additional panes (companion tools) are appended after,
+// so pane 0 is always the agent pane.
+func (t *Integration) captureWindow(_ context.Context, sessionName, windowIndex string) (string, error) {
 	target := sessionName
-	if pane != "" {
-		target = sessionName + ":" + pane
+	if windowIndex != "" {
+		target = sessionName + ":" + windowIndex + ".0"
 	}
 
 	// -p: print to stdout
@@ -484,9 +487,9 @@ func (t *Integration) DiscoverAllWindows(_ context.Context, slug string, metadat
 	infos := make([]*terminal.SessionInfo, 0, len(sc.agentWindows))
 	for _, w := range sc.agentWindows {
 		infos = append(infos, &terminal.SessionInfo{
-			Name:       sessionName,
-			Pane:       w.windowIndex,
-			WindowName: w.windowName,
+			Name:        sessionName,
+			WindowIndex: w.windowIndex,
+			WindowName:  w.windowName,
 		})
 	}
 	return infos, nil

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -450,6 +450,8 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 // Always targets pane 0: hive creates agent commands via new-window which places
 // the process in pane 0. Additional panes (companion tools) are appended after,
 // so pane 0 is always the agent pane.
+// Assumes pane-base-index=0 (tmux default); non-default configurations will target
+// the wrong pane and may cause status detection to return StatusMissing.
 func (t *Integration) captureWindow(_ context.Context, sessionName, windowIndex string) (string, error) {
 	target := sessionName
 	if windowIndex != "" {

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -147,7 +147,7 @@ func TestSessionInfoFromWindow(t *testing.T) {
 		sc := &sessionCache{}
 		info := integ.sessionInfoFromWindow("mysess", sc, nil)
 		assert.Equal(t, "mysess", info.Name)
-		assert.Empty(t, info.Pane)
+		assert.Empty(t, info.WindowIndex)
 		assert.Empty(t, info.WindowName)
 	})
 
@@ -156,7 +156,7 @@ func TestSessionInfoFromWindow(t *testing.T) {
 		sc := &sessionCache{agentWindows: []*agentWindow{w}}
 		info := integ.sessionInfoFromWindow("mysess", sc, w)
 		assert.Equal(t, "mysess", info.Name)
-		assert.Equal(t, "2", info.Pane)
+		assert.Equal(t, "2", info.WindowIndex)
 		assert.Equal(t, "claude", info.WindowName)
 	})
 
@@ -166,7 +166,7 @@ func TestSessionInfoFromWindow(t *testing.T) {
 		sc := &sessionCache{agentWindows: []*agentWindow{w1, w2}}
 		info := integ.sessionInfoFromWindow("mysess", sc, w2)
 		assert.Equal(t, "mysess", info.Name)
-		assert.Equal(t, "1", info.Pane)
+		assert.Equal(t, "1", info.WindowIndex)
 		assert.Equal(t, "aider", info.WindowName)
 	})
 }
@@ -193,7 +193,7 @@ func TestDiscoverSession_MultiWindow(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, info, "expected info")
-		assert.Equal(t, "1", info.Pane)
+		assert.Equal(t, "1", info.WindowIndex)
 		assert.Equal(t, "claude", info.WindowName)
 	})
 
@@ -208,7 +208,7 @@ func TestDiscoverSession_MultiWindow(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, info, "expected info")
 		// No path match, no name match for slug "my-session" in window names — should pick highest activity
-		assert.Equal(t, "0", info.Pane)
+		assert.Equal(t, "0", info.WindowIndex)
 	})
 }
 
@@ -260,9 +260,9 @@ func TestDiscoverAllWindows(t *testing.T) {
 		infos, err := integ.DiscoverAllWindows(ctx, "multi-sess", nil)
 		require.NoError(t, err)
 		require.Len(t, infos, 2, "expected 2 windows, got %d", len(infos))
-		assert.Equal(t, "0", infos[0].Pane)
+		assert.Equal(t, "0", infos[0].WindowIndex)
 		assert.Equal(t, "claude", infos[0].WindowName)
-		assert.Equal(t, "1", infos[1].Pane)
+		assert.Equal(t, "1", infos[1].WindowIndex)
 		assert.Equal(t, "aider", infos[1].WindowName)
 	})
 
@@ -270,7 +270,7 @@ func TestDiscoverAllWindows(t *testing.T) {
 		infos, err := integ.DiscoverAllWindows(ctx, "single-sess", nil)
 		require.NoError(t, err)
 		require.Len(t, infos, 1, "expected 1 window, got %d", len(infos))
-		assert.Equal(t, "0", infos[0].Pane)
+		assert.Equal(t, "0", infos[0].WindowIndex)
 	})
 
 	t.Run("returns nil for unknown session", func(t *testing.T) {

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -147,7 +147,32 @@ func renderWindowCommon(w config.WindowConfig, render func(string) (string, erro
 		}
 	}
 
-	return coretmux.RenderedWindow{Name: name, Command: command, Dir: dir, Focus: w.Focus}, nil
+	panes := make([]coretmux.RenderedPane, 0, len(w.Panes))
+	for i, p := range w.Panes {
+		var paneCmd string
+		if p.Command != "" {
+			paneCmd, err = render(p.Command)
+			if err != nil {
+				return coretmux.RenderedWindow{}, fmt.Errorf("pane %d command template: %w", i, err)
+			}
+			paneCmd = strings.TrimSpace(paneCmd)
+		}
+		var paneDir string
+		if p.Dir != "" {
+			paneDir, err = render(p.Dir)
+			if err != nil {
+				return coretmux.RenderedWindow{}, fmt.Errorf("pane %d dir template: %w", i, err)
+			}
+		}
+		panes = append(panes, coretmux.RenderedPane{
+			Command:    paneCmd,
+			Dir:        paneDir,
+			Focus:      p.Focus,
+			Horizontal: p.Horizontal,
+		})
+	}
+
+	return coretmux.RenderedWindow{Name: name, Command: command, Dir: dir, Focus: w.Focus, Panes: panes}, nil
 }
 
 // renderWindow renders a single WindowConfig against SpawnData.

--- a/internal/hive/spawner_test.go
+++ b/internal/hive/spawner_test.go
@@ -28,6 +28,29 @@ func TestRenderWindowCommon(t *testing.T) {
 	assert.True(t, rw.Focus)
 }
 
+func TestRenderWindowCommon_Panes(t *testing.T) {
+	r := testRenderer()
+	w := config.WindowConfig{
+		Name:    "agent",
+		Command: "claude",
+		Panes: []config.PaneConfig{
+			{Command: "tail -f {{ .Name }}.log", Horizontal: true},
+			{Dir: "/logs/{{ .Name }}"},
+		},
+	}
+
+	rw, err := renderWindow(r, w, SpawnData{Name: "my-sess", Path: "/tmp/test"})
+	require.NoError(t, err)
+
+	require.Len(t, rw.Panes, 2)
+
+	assert.Equal(t, "tail -f my-sess.log", rw.Panes[0].Command)
+	assert.True(t, rw.Panes[0].Horizontal)
+
+	assert.Empty(t, rw.Panes[1].Command)
+	assert.Equal(t, "/logs/my-sess", rw.Panes[1].Dir)
+}
+
 func TestRenderUserCommandWindows(t *testing.T) {
 	r := testRenderer()
 	windows := []config.WindowConfig{

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -144,11 +144,11 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 				// Get per-window status and content
 				wStatus, wErr := integration.GetStatus(ctx, wi)
 				if wErr != nil {
-					log.Debug().Err(wErr).Str("session", sess.Slug).Str("window", wi.Pane).Msg("per-window status failed, marking missing")
+					log.Debug().Err(wErr).Str("session", sess.Slug).Str("window", wi.WindowIndex).Msg("per-window status failed, marking missing")
 					wStatus = terminal.StatusMissing
 				}
 				windows = append(windows, WindowStatus{
-					WindowIndex: wi.Pane,
+					WindowIndex: wi.WindowIndex,
 					WindowName:  wi.WindowName,
 					Status:      wStatus,
 					Tool:        wi.DetectedTool,


### PR DESCRIPTION
## Purpose

Adds tmux split-window pane support and fixes correctness/validation gaps found during review.

## Proposed Changes

  - `addPanes` now passes the resolved window dir (via `windowDir` helper) instead of raw session workDir, so panes inherit window `Dir` overrides correctly
  - Added pane template validation in `ValidateDeep` so bad templates surface at config load rather than spawn time
  - Added `Warnings()` check for multiple `Focus:true` panes in a window
  - Renamed `SessionInfo.Pane→WindowIndex`, `MetaTmuxPane→MetaTmuxWindow`, `capturePane→captureWindow`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)