### PR TITLE
Fix confirm modal on loading and add form field validation

### DIFF
--- a/internal/core/config/validate.go
+++ b/internal/core/config/validate.go
@@ -222,6 +222,18 @@ func (c *Config) validateUserCommandTemplates() error {
 				}
 			}
 		}
+
+		// Validate form field regex patterns
+		for i, ff := range cmd.Form {
+			if ff.Pattern != "" {
+				if _, err := regexp.Compile(ff.Pattern); err != nil {
+					errs = errs.Append(
+						fmt.Sprintf("%s.form[%d].pattern", field, i),
+						fmt.Errorf("invalid regex %q: %w", ff.Pattern, err),
+					)
+				}
+			}
+		}
 	}
 	return errs.ToError()
 }

--- a/internal/core/styles/styles.go
+++ b/internal/core/styles/styles.go
@@ -52,6 +52,7 @@ var (
 	FormTitleStyle        lipgloss.Style
 	FormFieldStyle        lipgloss.Style
 	FormFieldFocusedStyle lipgloss.Style
+	FormErrorStyle        lipgloss.Style
 
 	// Help dialog styles.
 	HelpDialogSectionStyle lipgloss.Style
@@ -202,6 +203,8 @@ func SetTheme(p Palette) {
 		Border(lipgloss.ThickBorder(), false, false, false, true).
 		BorderForeground(ColorPrimary).
 		PaddingLeft(1)
+	FormErrorStyle = lipgloss.NewStyle().
+		Foreground(ColorError)
 
 	HelpDialogSectionStyle = lipgloss.NewStyle().
 		Foreground(ColorMuted).

--- a/internal/tui/components/form/field.go
+++ b/internal/tui/components/form/field.go
@@ -9,6 +9,7 @@ type Field interface {
 	Focus() tea.Cmd
 	Blur()
 	Focused() bool
-	Value() any    // string for text/textarea/select, []string for multi-select, domain types for presets
-	Label() string // Display label for the field
+	Value() any       // string for text/textarea/select, []string for multi-select, domain types for presets
+	Label() string    // Display label for the field
+	Validate() string // Returns error message or "" if valid
 }

--- a/internal/tui/components/form/project_selector.go
+++ b/internal/tui/components/form/project_selector.go
@@ -49,11 +49,12 @@ func (f *ProjectSelectorField) Update(msg tea.Msg) (Field, tea.Cmd) {
 	return f, cmd
 }
 
-func (f *ProjectSelectorField) View() string   { return f.inner.View() }
-func (f *ProjectSelectorField) Focus() tea.Cmd { return f.inner.Focus() }
-func (f *ProjectSelectorField) Blur()          { f.inner.Blur() }
-func (f *ProjectSelectorField) Focused() bool  { return f.inner.Focused() }
-func (f *ProjectSelectorField) Label() string  { return f.label_ }
+func (f *ProjectSelectorField) View() string     { return f.inner.View() }
+func (f *ProjectSelectorField) Focus() tea.Cmd   { return f.inner.Focus() }
+func (f *ProjectSelectorField) Blur()            { f.inner.Blur() }
+func (f *ProjectSelectorField) Focused() bool    { return f.inner.Focused() }
+func (f *ProjectSelectorField) Label() string    { return f.label_ }
+func (f *ProjectSelectorField) Validate() string { return f.inner.Validate() }
 
 // Value returns Repo for single-select or []Repo for multi-select.
 func (f *ProjectSelectorField) Value() any {

--- a/internal/tui/components/form/session_selector.go
+++ b/internal/tui/components/form/session_selector.go
@@ -80,6 +80,8 @@ func (f *SessionSelectorField) Blur()          { f.inner.Blur() }
 func (f *SessionSelectorField) Focused() bool  { return f.inner.Focused() }
 func (f *SessionSelectorField) Label() string  { return f.label_ }
 
+func (f *SessionSelectorField) Validate() string { return f.inner.Validate() }
+
 // Value returns session.Session for single-select or []session.Session for multi-select.
 func (f *SessionSelectorField) Value() any {
 	labelToIdx := make(map[string]int, len(f.labels))

--- a/internal/tui/components/form/validation.go
+++ b/internal/tui/components/form/validation.go
@@ -1,0 +1,50 @@
+package form
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// FieldValidation holds runtime validation rules for a form field.
+type FieldValidation struct {
+	Required  bool
+	MinLength int
+	MaxLength int
+	Pattern   *regexp.Regexp
+	Min       int // minimum selections (multi-select)
+	Max       int // maximum selections (multi-select)
+}
+
+// ValidateText checks a text value against the validation rules.
+func (v FieldValidation) ValidateText(value string) string {
+	if v.Required && value == "" {
+		return "required"
+	}
+	if value == "" {
+		return ""
+	}
+	if v.MinLength > 0 && len(value) < v.MinLength {
+		return fmt.Sprintf("minimum %d characters", v.MinLength)
+	}
+	if v.MaxLength > 0 && len(value) > v.MaxLength {
+		return fmt.Sprintf("maximum %d characters", v.MaxLength)
+	}
+	if v.Pattern != nil && !v.Pattern.MatchString(value) {
+		return fmt.Sprintf("must match pattern: %s", v.Pattern.String())
+	}
+	return ""
+}
+
+// ValidateSelection checks a selection count against the validation rules.
+func (v FieldValidation) ValidateSelection(count int) string {
+	if v.Required && count == 0 {
+		return "at least one selection required"
+	}
+	if v.Min > 0 && count < v.Min {
+		return fmt.Sprintf("select at least %d", v.Min)
+	}
+	if v.Max > 0 && count > v.Max {
+		return fmt.Sprintf("select at most %d", v.Max)
+	}
+	return ""
+}

--- a/internal/tui/components/form/validation_test.go
+++ b/internal/tui/components/form/validation_test.go
@@ -1,0 +1,118 @@
+package form
+
+import (
+	"regexp"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldValidation_ValidateText(t *testing.T) {
+	tests := []struct {
+		name  string
+		v     FieldValidation
+		value string
+		want  string
+	}{
+		{"no rules, empty", FieldValidation{}, "", ""},
+		{"no rules, non-empty", FieldValidation{}, "hello", ""},
+		{"required, empty", FieldValidation{Required: true}, "", "required"},
+		{"required, non-empty", FieldValidation{Required: true}, "hello", ""},
+		{"min_length, too short", FieldValidation{MinLength: 5}, "hi", "minimum 5 characters"},
+		{"min_length, exact", FieldValidation{MinLength: 5}, "hello", ""},
+		{"min_length, empty skips", FieldValidation{MinLength: 5}, "", ""},
+		{"max_length, too long", FieldValidation{MaxLength: 3}, "hello", "maximum 3 characters"},
+		{"max_length, exact", FieldValidation{MaxLength: 5}, "hello", ""},
+		{"pattern, matches", FieldValidation{Pattern: regexp.MustCompile(`^\d+$`)}, "123", ""},
+		{"pattern, no match", FieldValidation{Pattern: regexp.MustCompile(`^\d+$`)}, "abc", "must match pattern: ^\\d+$"},
+		{"pattern, empty skips", FieldValidation{Pattern: regexp.MustCompile(`^\d+$`)}, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.v.ValidateText(tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFieldValidation_ValidateSelection(t *testing.T) {
+	tests := []struct {
+		name  string
+		v     FieldValidation
+		count int
+		want  string
+	}{
+		{"no rules, zero", FieldValidation{}, 0, ""},
+		{"required, zero", FieldValidation{Required: true}, 0, "at least one selection required"},
+		{"required, non-zero", FieldValidation{Required: true}, 1, ""},
+		{"min, too few", FieldValidation{Min: 2}, 1, "select at least 2"},
+		{"min, exact", FieldValidation{Min: 2}, 2, ""},
+		{"max, too many", FieldValidation{Max: 2}, 3, "select at most 2"},
+		{"max, exact", FieldValidation{Max: 2}, 2, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.v.ValidateSelection(tt.count)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDialog_ValidationBlocksSubmit(t *testing.T) {
+	t.Run("required field blocks submit", func(t *testing.T) {
+		f1 := NewTextField("Name", "", "", FieldValidation{Required: true})
+		d := NewDialog("Test", []Field{f1}, []string{"name"})
+
+		// Try to submit with empty field
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		assert.False(t, d.Submitted(), "should not submit when required field is empty")
+		assert.True(t, f1.Focused(), "focus should return to invalid field")
+	})
+
+	t.Run("valid field allows submit", func(t *testing.T) {
+		f1 := NewTextField("Name", "", "Alice", FieldValidation{Required: true})
+		d := NewDialog("Test", []Field{f1}, []string{"name"})
+
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		assert.True(t, d.Submitted(), "should submit when required field has value")
+	})
+
+	t.Run("focuses first invalid field", func(t *testing.T) {
+		f1 := NewTextField("Name", "", "Alice", FieldValidation{Required: true})
+		f2 := NewTextField("Email", "", "", FieldValidation{Required: true})
+		f3 := NewTextField("Phone", "", "", FieldValidation{Required: true})
+		d := NewDialog("Test", []Field{f1, f2, f3}, []string{"name", "email", "phone"})
+
+		// Tab to f2, then to f3
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		assert.True(t, f3.Focused())
+
+		// Try to submit (tab past f3) — should focus f2 (first invalid)
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		assert.False(t, d.Submitted())
+		assert.True(t, f2.Focused(), "should focus first invalid field (email)")
+		assert.False(t, f3.Focused())
+	})
+
+	t.Run("min_length validation", func(t *testing.T) {
+		f1 := NewTextField("Msg", "", "hi", FieldValidation{MinLength: 5})
+		d := NewDialog("Test", []Field{f1}, []string{"msg"})
+
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		assert.False(t, d.Submitted(), "should block submit when below min_length")
+	})
+
+	t.Run("error message renders in view", func(t *testing.T) {
+		f1 := NewTextField("Name", "", "", FieldValidation{Required: true})
+		d := NewDialog("Test", []Field{f1}, []string{"name"})
+
+		// Trigger validation
+		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+		view := d.View()
+		assert.Contains(t, view, "required")
+	})
+}

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -409,25 +409,35 @@ func (m Model) handleRecycleModalKey(keyStr string) (tea.Model, tea.Cmd) {
 func (m Model) handleConfirmModalKey(keyStr string) (tea.Model, tea.Cmd) {
 	switch keyStr {
 	case keyEnter:
-		m.state = stateNormal
-		if m.modals.Confirm.ConfirmSelected() {
+		confirmed := m.modals.Confirm.ConfirmSelected()
+		m.modals.DismissConfirm()
+		if confirmed {
 			action := m.modals.Pending
 			if action.Type == act.TypeRecycle {
+				m.state = stateNormal
 				return m, m.startRecycle(action.SessionID)
 			}
 			if action.Type == act.TypeDeleteRecycledBatch {
+				m.state = stateNormal
 				recycled := m.modals.PendingRecycledSessions
 				m.modals.Pending = Action{}
 				m.modals.PendingRecycledSessions = nil
 				return m, m.deleteRecycledSessionsBatch(recycled)
 			}
+			m.state = stateNormal
+			if !action.Silent {
+				m.state = stateLoading
+				m.loadingMessage = "Processing..."
+			}
 			return m, m.executeAction(action)
 		}
+		m.state = stateNormal
 		m.modals.Pending = Action{}
 		m.modals.PendingRecycledSessions = nil
 		return m, nil
 	case "esc":
 		m.state = stateNormal
+		m.modals.DismissConfirm()
 		m.modals.Pending = Action{}
 		m.modals.PendingRecycledSessions = nil
 		return m, nil


### PR DESCRIPTION
## Summary

- **Fix #179**: Confirm modal now properly dismisses before transitioning to loading state for non-silent user commands. Previously, confirm buttons remained visible during the loading screen.
- **Fix #121**: Add validation support to form fields with `required`, `min_length`, `max_length`, `pattern` (regex), `min`, and `max` constraints. Validation runs on submit with inline error display, and invalid regex patterns are caught at config load time via `ValidateDeep()`.

Closes #179, closes #121

## Test plan
- [ ] Verify confirm modal dismisses when executing a non-silent user command
- [ ] Test `required: true` blocks submit on empty text fields
- [ ] Test `min_length` / `max_length` constraints on text and textarea fields
- [ ] Test `pattern` regex validation on text fields
- [ ] Test `min` / `max` selection count constraints on multi-select fields
- [ ] Verify invalid regex in `pattern` is rejected during config validation
- [ ] Run `mise run check` (tidy + lint + test)