### PR TITLE
fix: remove macOS quarantine attribute in homebrew cask post-install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,6 +62,13 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/colonyops/hive"
     description: "CLI/TUI for managing multiple AI agent sessions in isolated git environments"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/hive"]
+          end
+    caveats: "This binary is not signed or notarized. The installer removes the macOS quarantine attribute automatically.\n\nRequires tmux and git to be installed."
 
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Manage multiple AI agent sessions in isolated git environments with real-time st
 ## Installation
 
 ```bash
+brew install tmux
 brew install colonyops/tap/hive
 ```
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -19,6 +19,7 @@ Install hive, configure your environment, and launch your first AI agent session
 ### Homebrew
 
 ```bash
+brew install tmux
 brew install colonyops/tap/hive
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ Hive manages isolated git sessions for running AI agents in parallel. Instead of
 ## Installation
 
 ```bash
+brew install tmux
 brew install colonyops/tap/hive
 ```
 


### PR DESCRIPTION
## Purpose

The unsigned hive binary triggers macOS Gatekeeper ("App is damaged and cannot be opened") when installed via Homebrew cask. This fixes the issue without requiring Apple code signing.

## Proposed Changes

  - Add post-install hook to strip `com.apple.quarantine` xattr on macOS
  - Add caveats noting the binary is unsigned and requires tmux/git
  - Add `brew install tmux` to all Homebrew install snippets in docs

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)