### PR TITLE
feat: git worktree clone strategy

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -51,6 +51,7 @@ rules:
 | `copy_command`                | `string`   | `pbcopy` (macOS)     | Command to copy to clipboard                |
 | `auto_delete_corrupted`       | `bool`     | `true`               | Auto-delete corrupted sessions on prune     |
 | `history.max_entries`         | `int`      | `100`                | Max command palette history entries         |
+| `clone_strategy`              | `string`   | `"full"`             | Default clone strategy: `"full"` or `"worktree"` (see [Clone Strategies](#clone-strategies)) |
 
 ## Agents
 
@@ -96,6 +97,65 @@ Sessions can run multiple agents by opening additional tmux windows — use `tmu
 | `todos.limiter.rate_limit_per_session` | `duration`        | `0`     | Per-session add cooldown (`0` disables) |
 | `todos.notifications.toast`          | `bool`              | `true`  | Show toast on todo creation |
 
+## Clone Strategies
+
+Hive supports two strategies for isolating session repositories:
+
+### `full` (default)
+
+Each session gets a complete `git clone` of the remote. This is the simplest approach and works with any workflow.
+
+```
+~/.local/share/hive/repos/
+└── myproject-abc123/          ← full clone (independent .git directory)
+    ├── .git/
+    └── src/
+```
+
+### `worktree`
+
+All sessions for the same remote share a single bare clone (`repos/.bare/<owner>/<repo>/`). Each session is a [git worktree](https://git-scm.com/docs/git-worktree) pointing into the shared bare clone. This avoids re-downloading repository history for each session and makes fetches faster.
+
+```
+~/.local/share/hive/repos/
+├── .bare/
+│   └── acme/myproject/        ← shared bare clone (fetch target)
+├── myproject-wt-abc123/       ← session worktree (.git is a file)
+│   ├── .git                   ← gitdir: .../.bare/.../worktrees/...
+│   └── src/
+└── myproject-wt-def456/       ← another session worktree
+    ├── .git
+    └── src/
+```
+
+**When to use worktree:**
+
+- Large repositories where cloning takes a long time
+- Many parallel sessions for the same repository
+- Teams or workflows requiring fast session recycling
+
+**Set globally** in `config.yaml`:
+
+```yaml
+clone_strategy: worktree
+```
+
+**Override per rule** (see [Rules](rules.md#rule-fields)):
+
+```yaml
+rules:
+  - pattern: ".*github.com/acme/.*"
+    clone_strategy: worktree
+```
+
+**Override per session** with the CLI flag:
+
+```bash
+hive new --remote git@github.com:acme/myproject.git --clone-strategy worktree my-task
+```
+
+Priority: CLI flag > rule override > global `clone_strategy`.
+
 ## More Configuration
 
 - **[Rules](rules.md)** — Repository-specific spawn, recycle, setup commands, and file copying
@@ -116,7 +176,11 @@ All data is stored at `~/.local/share/hive/`:
 │   ├── hive-tmux              # Tmux session launcher
 │   └── agent-send             # Send text to agent in tmux
 ├── repos/                     # Cloned repositories
-│   └── myproject-feature1-abc123/
+│   ├── myproject-feature1-abc123/      # full-clone session
+│   ├── .bare/                          # worktree sessions share bare clones
+│   │   └── owner/myproject/            # bare clone (shared fetch target)
+│   ├── myproject-wt-abc123/            # worktree session
+│   └── myproject-wt-def456/            # another worktree session
 └── context/                   # Per-repo context directories
     ├── {owner}/{repo}/        # Linked via .hive symlink
     └── shared/                # Shared context

--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -39,16 +39,17 @@ rules:
 
 ## Rule Fields
 
-| Field           | Type             | Default            | Description                                       |
-| --------------- | ---------------- | ------------------ | ------------------------------------------------- |
-| `pattern`       | string           | `""`               | Regex pattern to match remote URL                 |
-| `windows`       | []WindowConfig   | see below          | Declarative tmux window layout (recommended)      |
-| `spawn`         | []string         | —                  | Shell commands run after session creation (legacy) |
-| `batch_spawn`   | []string         | —                  | Shell commands for batch session creation (legacy) |
-| `recycle`       | []string         | git fetch/checkout/reset/clean | Commands run when recycling a session |
-| `commands`      | []string         | `[]`               | Setup commands run after clone                    |
-| `copy`          | []string         | `[]`               | Glob patterns for files to copy from parent repo  |
-| `max_recycled`  | *int             | `5`                | Maximum recycled sessions to keep (0 = unlimited) |
+| Field            | Type             | Default            | Description                                       |
+| ---------------- | ---------------- | ------------------ | ------------------------------------------------- |
+| `pattern`        | string           | `""`               | Regex pattern to match remote URL                 |
+| `clone_strategy` | string           | global default     | Override clone strategy for matching remotes: `"full"` or `"worktree"` |
+| `windows`        | []WindowConfig   | see below          | Declarative tmux window layout (recommended)      |
+| `spawn`          | []string         | —                  | Shell commands run after session creation (legacy) |
+| `batch_spawn`    | []string         | —                  | Shell commands for batch session creation (legacy) |
+| `recycle`        | []string         | git fetch/checkout/reset/clean | Commands run when recycling a session |
+| `commands`       | []string         | `[]`               | Setup commands run after clone                    |
+| `copy`           | []string         | `[]`               | Glob patterns for files to copy from parent repo  |
+| `max_recycled`   | *int             | `5`                | Maximum recycled sessions to keep (0 = unlimited) |
 
 !!! warning "`windows` vs `spawn`/`batch_spawn`"
     A rule must use either `windows` or `spawn`/`batch_spawn`, not both. If neither is set, the default window layout is used (agent window + shell window).

--- a/docs/getting-started/sessions.md
+++ b/docs/getting-started/sessions.md
@@ -4,7 +4,9 @@ icon: lucide/layers
 
 # Sessions
 
-A hive session is an isolated git clone paired with a terminal environment for running AI agents. Instead of working directly in your main repository — where multiple agents would step on each other's changes — hive creates separate clones so each agent gets its own workspace. When you create a session, hive clones the repository (or reuses a recycled clone), then spawns a tmux session with windows for your AI tools.
+A hive session is an isolated git workspace paired with a terminal environment for running AI agents. Instead of working directly in your main repository — where multiple agents would step on each other's changes — hive creates separate workspaces so each agent gets its own copy. When you create a session, hive clones the repository (or reuses a recycled session), then spawns a tmux session with windows for your AI tools.
+
+Hive supports two clone strategies: **full** (default, a complete independent clone) and **worktree** (git worktrees sharing a single bare clone). See [Clone Strategies](../configuration/index.md#clone-strategies) for details.
 
 Each project (git remote) can have multiple sessions running in parallel, each working on a different task. Sessions can run multiple agents in separate tmux windows — for example, a primary Claude agent alongside a test runner.
 
@@ -43,7 +45,7 @@ An isolated git clone in a dedicated directory with its own terminal environment
 
 - Unique 6-character ID (e.g., `26kj0c`)
 - Display name (e.g., `fix-auth-bug`)
-- Isolated git clone at a specific path
+- Isolated git workspace at a specific path (full clone or worktree)
 - One or more agent windows (configured via [agent profiles](../configuration/index.md#agents))
 - Lifecycle: `active` → `recycled` → `deleted`
 
@@ -75,7 +77,7 @@ Sessions move through a managed lifecycle:
 4. **Corrupted** — If hive detects an invalid state (e.g., missing directory, broken git repo), the session is marked corrupted and can only be deleted.
 
 !!! tip "Prefer recycling over deleting"
-    Recycled sessions are reused on the next `hive new`, skipping a fresh `git clone`. This saves time and disk I/O, especially for large repositories.
+    Recycled sessions are reused on the next `hive new`, skipping a fresh `git clone`. This saves time and disk I/O, especially for large repositories. For worktree sessions, recycling removes the worktree (not the shared bare clone), so the next session can reuse the same path without re-downloading repository history.
 
 ## Status Indicators
 

--- a/internal/commands/cmd_doctor.go
+++ b/internal/commands/cmd_doctor.go
@@ -39,7 +39,7 @@ func (cmd *DoctorCmd) Register(app *cli.Command) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:        "autofix",
-				Usage:       "automatically fix issues (e.g., delete orphaned worktrees)",
+				Usage:       "automatically fix issues (e.g., delete orphaned session directories)",
 				Destination: &cmd.autofix,
 			},
 		},

--- a/internal/commands/cmd_new.go
+++ b/internal/commands/cmd_new.go
@@ -11,11 +11,12 @@ import (
 )
 
 type NewCmd struct {
-	flags      *Flags
-	app        *hive.App
-	remote     string
-	source     string
-	background bool
+	flags         *Flags
+	app           *hive.App
+	remote        string
+	source        string
+	cloneStrategy string
+	background    bool
 }
 
 // NewNewCmd creates a new new command
@@ -59,6 +60,11 @@ Example:
 				Usage:       "create session without attaching to tmux",
 				Destination: &cmd.background,
 			},
+			&cli.StringFlag{
+				Name:        "clone-strategy",
+				Usage:       `clone strategy: "full" or "worktree" (defaults to config)`,
+				Destination: &cmd.cloneStrategy,
+			},
 		},
 		Action: cmd.run,
 	})
@@ -83,10 +89,11 @@ func (cmd *NewCmd) run(ctx context.Context, c *cli.Command) error {
 	}
 
 	opts := hive.CreateOptions{
-		Name:       name,
-		Remote:     cmd.remote,
-		Source:     source,
-		Background: cmd.background,
+		Name:          name,
+		Remote:        cmd.remote,
+		Source:        source,
+		CloneStrategy: cmd.cloneStrategy,
+		Background:    cmd.background,
 	}
 
 	sess, err := cmd.app.Sessions.CreateSession(ctx, opts)

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -33,6 +33,12 @@ func ParseExitCondition(s string) bool {
 	return result
 }
 
+// Clone strategy constants.
+const (
+	CloneStrategyFull     = "full"
+	CloneStrategyWorktree = "worktree"
+)
+
 // Form field type constants.
 const (
 	FormTypeText        = "text"
@@ -230,8 +236,9 @@ type Config struct {
 	Database            DatabaseConfig         `yaml:"database"`
 	Plugins             PluginsConfig          `yaml:"plugins"`
 	Todos               TodosConfig            `yaml:"todos"`
-	RepoDirs            []string               `yaml:"repo_dirs"` // directories containing git repositories for new session dialog
-	DataDir             string                 `yaml:"-"`         // set by caller, not from config file
+	CloneStrategy       string                 `yaml:"clone_strategy"` // "full" or "worktree", default "full"
+	RepoDirs            []string               `yaml:"repo_dirs"`      // directories containing git repositories for new session dialog
+	DataDir             string                 `yaml:"-"`              // set by caller, not from config file
 }
 
 // AgentsConfig holds agent profile configuration.
@@ -459,6 +466,8 @@ type Rule struct {
 	BatchSpawn []string `yaml:"batch_spawn,omitempty"`
 	// Recycle commands to run when recycling a session.
 	Recycle []string `yaml:"recycle,omitempty"`
+	// CloneStrategy overrides the global clone strategy for matching repos.
+	CloneStrategy string `yaml:"clone_strategy,omitempty"`
 }
 
 // Keybinding defines a TUI keybinding that references a UserCommand.
@@ -737,6 +746,7 @@ func (c *Config) Validate() error {
 		c.validateKeybindingsBasic(),
 		c.validateUserCommandsBasic(),
 		c.validateMaxRecycled(),
+		c.validateCloneStrategy(),
 		c.validateAgents(),
 		c.validateWindowsBasic(),
 		c.validateTodos(),
@@ -905,6 +915,23 @@ func (c *Config) validateWindowsBasic() error {
 			}
 		}
 	}
+	return errs.ToError()
+}
+
+// validateCloneStrategy checks that clone_strategy values are valid.
+func (c *Config) validateCloneStrategy() error {
+	var errs criterio.FieldErrorsBuilder
+
+	if c.CloneStrategy != "" && c.CloneStrategy != CloneStrategyFull && c.CloneStrategy != CloneStrategyWorktree {
+		errs = errs.Append("clone_strategy", fmt.Errorf("must be %q or %q, got %q", CloneStrategyFull, CloneStrategyWorktree, c.CloneStrategy))
+	}
+
+	for i, rule := range c.Rules {
+		if rule.CloneStrategy != "" && rule.CloneStrategy != CloneStrategyFull && rule.CloneStrategy != CloneStrategyWorktree {
+			errs = errs.Append(fmt.Sprintf("rules[%d].clone_strategy", i), fmt.Errorf("must be %q or %q, got %q", CloneStrategyFull, CloneStrategyWorktree, rule.CloneStrategy))
+		}
+	}
+
 	return errs.ToError()
 }
 
@@ -1080,6 +1107,22 @@ func (c *Config) GetMaxRecycled(remote string) int {
 	}
 
 	return DefaultMaxRecycled
+}
+
+// GetCloneStrategy returns the clone strategy for the given remote URL.
+// Rules are evaluated in order; the last matching rule with clone_strategy set wins.
+// Returns CloneStrategyFull if nothing is configured.
+func (c *Config) GetCloneStrategy(remote string) string {
+	strategy := c.CloneStrategy
+	for _, rule := range c.Rules {
+		if rule.CloneStrategy != "" && rule.Matches(remote) {
+			strategy = rule.CloneStrategy
+		}
+	}
+	if strategy == "" {
+		return CloneStrategyFull
+	}
+	return strategy
 }
 
 // SpawnStrategy holds the resolved spawn method for a session.

--- a/internal/core/config/validate_test.go
+++ b/internal/core/config/validate_test.go
@@ -432,6 +432,144 @@ func TestGetMaxRecycled(t *testing.T) {
 	}
 }
 
+func TestGetCloneStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		global   string
+		rules    []Rule
+		remote   string
+		expected string
+	}{
+		{
+			name:     "default when no config",
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyFull,
+		},
+		{
+			name:     "global worktree",
+			global:   CloneStrategyWorktree,
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyWorktree,
+		},
+		{
+			name:     "global full explicit",
+			global:   CloneStrategyFull,
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyFull,
+		},
+		{
+			name:   "per-rule override takes precedence",
+			global: CloneStrategyFull,
+			rules: []Rule{
+				{Pattern: "github.com/foo/.*", CloneStrategy: CloneStrategyWorktree},
+			},
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyWorktree,
+		},
+		{
+			name:   "non-matching rule does not apply",
+			global: CloneStrategyFull,
+			rules: []Rule{
+				{Pattern: "github.com/other/.*", CloneStrategy: CloneStrategyWorktree},
+			},
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyFull,
+		},
+		{
+			name: "last matching rule wins",
+			rules: []Rule{
+				{Pattern: "github.com/.*", CloneStrategy: CloneStrategyWorktree},
+				{Pattern: "github.com/foo/.*", CloneStrategy: CloneStrategyFull},
+			},
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyFull,
+		},
+		{
+			name: "catch-all rule applies",
+			rules: []Rule{
+				{Pattern: "", CloneStrategy: CloneStrategyWorktree},
+			},
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyWorktree,
+		},
+		{
+			name:   "rule without clone_strategy inherits global",
+			global: CloneStrategyWorktree,
+			rules: []Rule{
+				{Pattern: "github.com/foo/.*", Commands: []string{"echo test"}},
+			},
+			remote:   "https://github.com/foo/bar",
+			expected: CloneStrategyWorktree,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.CloneStrategy = tt.global
+			cfg.Rules = tt.rules
+
+			result := cfg.GetCloneStrategy(tt.remote)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateCloneStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		global  string
+		rules   []Rule
+		wantErr bool
+	}{
+		{
+			name:   "empty is valid",
+			global: "",
+		},
+		{
+			name:   "full is valid",
+			global: CloneStrategyFull,
+		},
+		{
+			name:   "worktree is valid",
+			global: CloneStrategyWorktree,
+		},
+		{
+			name:    "invalid global value",
+			global:  "invalid",
+			wantErr: true,
+		},
+		{
+			name: "valid rule value",
+			rules: []Rule{
+				{Pattern: "", CloneStrategy: CloneStrategyWorktree},
+			},
+		},
+		{
+			name: "invalid rule value",
+			rules: []Rule{
+				{Pattern: "", CloneStrategy: "bogus"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.CloneStrategy = tt.global
+			cfg.Rules = tt.rules
+
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGetRecycleCommands(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/core/doctor/orphan.go
+++ b/internal/core/doctor/orphan.go
@@ -16,7 +16,7 @@ type OrphanCheck struct {
 	fix      bool
 }
 
-// NewOrphanCheck creates a new orphan worktree check.
+// NewOrphanCheck creates a new orphan session directory check.
 // If fix is true, orphaned directories will be deleted.
 func NewOrphanCheck(sessions session.Store, reposDir string, fix bool) *OrphanCheck {
 	return &OrphanCheck{
@@ -27,7 +27,7 @@ func NewOrphanCheck(sessions session.Store, reposDir string, fix bool) *OrphanCh
 }
 
 func (c *OrphanCheck) Name() string {
-	return "Orphan Worktrees"
+	return "Orphan Sessions"
 }
 
 func (c *OrphanCheck) Run(ctx context.Context) Result {
@@ -75,6 +75,10 @@ func (c *OrphanCheck) Run(ctx context.Context) Result {
 		if !entry.IsDir() {
 			continue
 		}
+		// Skip the .bare directory used for worktree bare clones
+		if entry.Name() == ".bare" {
+			continue
+		}
 
 		dirPath := filepath.Join(c.reposDir, entry.Name())
 		if !knownPaths[dirPath] {
@@ -86,7 +90,7 @@ func (c *OrphanCheck) Run(ctx context.Context) Result {
 		result.Items = append(result.Items, CheckItem{
 			Label:  "No orphans",
 			Status: StatusPass,
-			Detail: "all worktrees have session records",
+			Detail: "all session directories have records",
 		})
 		return result
 	}
@@ -106,14 +110,14 @@ func (c *OrphanCheck) Run(ctx context.Context) Result {
 				result.Items = append(result.Items, CheckItem{
 					Label:  name,
 					Status: StatusPass,
-					Detail: "deleted orphaned worktree",
+					Detail: "deleted orphaned session directory",
 				})
 			}
 		} else {
 			result.Items = append(result.Items, CheckItem{
 				Label:   name,
 				Status:  StatusWarn,
-				Detail:  "orphaned worktree (no session record)",
+				Detail:  "orphaned session directory (no session record)",
 				Fixable: true,
 			})
 		}

--- a/internal/core/git/executor.go
+++ b/internal/core/git/executor.go
@@ -170,6 +170,37 @@ func parseInt(s string) (int, error) {
 	return n, nil
 }
 
+func (e *Executor) CloneBare(ctx context.Context, url, dest string) error {
+	if _, err := e.exec.Run(ctx, e.gitPath, "clone", "--bare", url, dest); err != nil {
+		return fmt.Errorf("git clone --bare: %w", err)
+	}
+	return nil
+}
+
+func (e *Executor) WorktreeAdd(ctx context.Context, repoDir, worktreePath, branch string) error {
+	if _, err := e.exec.RunDir(ctx, repoDir, e.gitPath, "worktree", "add", "-b", branch, worktreePath); err != nil {
+		return fmt.Errorf("git worktree add: %w", err)
+	}
+	return nil
+}
+
+func (e *Executor) WorktreeRemove(ctx context.Context, repoDir, worktreePath, branch string) error {
+	if _, err := e.exec.RunDir(ctx, repoDir, e.gitPath, "worktree", "remove", "--force", worktreePath); err != nil {
+		return fmt.Errorf("git worktree remove: %w", err)
+	}
+	if _, err := e.exec.RunDir(ctx, repoDir, e.gitPath, "branch", "-D", branch); err != nil {
+		return fmt.Errorf("git branch -D: %w", err)
+	}
+	return nil
+}
+
+func (e *Executor) Fetch(ctx context.Context, dir string) error {
+	if _, err := e.exec.RunDir(ctx, dir, e.gitPath, "fetch", "origin"); err != nil {
+		return fmt.Errorf("git fetch: %w", err)
+	}
+	return nil
+}
+
 func (e *Executor) IsValidRepo(ctx context.Context, dir string) error {
 	gitDir := filepath.Join(dir, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {

--- a/internal/core/git/git.go
+++ b/internal/core/git/git.go
@@ -28,6 +28,14 @@ type Git interface {
 	DiffStats(ctx context.Context, dir string) (additions, deletions int, err error)
 	// IsValidRepo checks if dir contains a valid git repository.
 	IsValidRepo(ctx context.Context, dir string) error
+	// CloneBare creates a bare clone of url at dest.
+	CloneBare(ctx context.Context, url, dest string) error
+	// WorktreeAdd creates a new worktree at path with a new branch.
+	WorktreeAdd(ctx context.Context, repoDir, worktreePath, branch string) error
+	// WorktreeRemove removes a worktree by path and deletes its branch.
+	WorktreeRemove(ctx context.Context, repoDir, worktreePath, branch string) error
+	// Fetch fetches all refs from origin in dir.
+	Fetch(ctx context.Context, dir string) error
 }
 
 // ExtractRepoName extracts the repository name from a git remote URL.

--- a/internal/core/session/session.go
+++ b/internal/core/session/session.go
@@ -29,8 +29,9 @@ const (
 
 // Metadata keys for terminal integration.
 const (
-	MetaTmuxSession = "tmux_session" // tmux session name
-	MetaTmuxPane    = "tmux_pane"    // tmux pane identifier
+	MetaTmuxSession    = "tmux_session"    // tmux session name
+	MetaTmuxPane       = "tmux_pane"       // tmux pane identifier
+	MetaWorktreeBranch = "worktree_branch" // git branch used for worktree sessions
 )
 
 // Metadata keys for session organization.

--- a/internal/core/session/session.go
+++ b/internal/core/session/session.go
@@ -50,15 +50,16 @@ const (
 // Future: Hive will support multiple agents per session, enabling
 // concurrent agents like a primary assistant and a test runner.
 type Session struct {
-	ID        string            `json:"id"`
-	Name      string            `json:"name"`
-	Slug      string            `json:"slug"`
-	Path      string            `json:"path"`
-	Remote    string            `json:"remote"`
-	State     State             `json:"state"`
-	Metadata  map[string]string `json:"metadata,omitempty"` // integration data (e.g., tmux session name)
-	CreatedAt time.Time         `json:"created_at"`
-	UpdatedAt time.Time         `json:"updated_at"`
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Slug          string            `json:"slug"`
+	Path          string            `json:"path"`
+	Remote        string            `json:"remote"`
+	State         State             `json:"state"`
+	CloneStrategy string            `json:"clone_strategy,omitempty"` // "full" or "worktree", empty treated as "full"
+	Metadata      map[string]string `json:"metadata,omitempty"`       // integration data (e.g., tmux session name)
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
 // InboxTopic returns the conventional inbox topic name for this session.

--- a/internal/data/db/dbext.go
+++ b/internal/data/db/dbext.go
@@ -83,6 +83,14 @@ func Open(dataDir string, opts OpenOptions) (*DB, error) {
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
+	// Run migrations for existing databases
+	if err := db.runMigrations(context.Background()); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			return nil, fmt.Errorf("failed to run migrations: %w (close also failed: %w)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
 	return db, nil
 }
 
@@ -127,4 +135,48 @@ func (db *DB) WithTx(ctx context.Context, fn func(*Queries) error) error {
 // initSchema runs all pending up migrations.
 func (db *DB) initSchema(ctx context.Context) error {
 	return migrateUp(ctx, db.conn)
+}
+
+// runMigrations applies incremental schema migrations for existing databases.
+func (db *DB) runMigrations(ctx context.Context) error {
+	var version int
+	err := db.conn.QueryRowContext(ctx, "SELECT version FROM schema_version").Scan(&version)
+	if err != nil {
+		return fmt.Errorf("failed to read schema version: %w", err)
+	}
+
+	if version < 7 {
+		if err := db.migrateV6ToV7(ctx); err != nil {
+			return fmt.Errorf("migration v6→v7: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// migrateV6ToV7 adds clone_strategy column to sessions table.
+func (db *DB) migrateV6ToV7(ctx context.Context) error {
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Check if column already exists (idempotent)
+	var count int
+	err = tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'clone_strategy'").Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check column existence: %w", err)
+	}
+	if count == 0 {
+		if _, err := tx.ExecContext(ctx, "ALTER TABLE sessions ADD COLUMN clone_strategy TEXT NOT NULL DEFAULT 'full'"); err != nil {
+			return fmt.Errorf("add column: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, "UPDATE schema_version SET version = 7"); err != nil {
+		return fmt.Errorf("update version: %w", err)
+	}
+
+	return tx.Commit()
 }

--- a/internal/data/db/dbext.go
+++ b/internal/data/db/dbext.go
@@ -139,8 +139,10 @@ func (db *DB) initSchema(ctx context.Context) error {
 
 // runMigrations applies incremental schema migrations for existing databases.
 func (db *DB) runMigrations(ctx context.Context) error {
+	// Use MAX(version) for deterministic reads — the table may contain multiple
+	// rows from previous schema versions (each version was inserted as a new row).
 	var version int
-	err := db.conn.QueryRowContext(ctx, "SELECT version FROM schema_version").Scan(&version)
+	err := db.conn.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_version").Scan(&version)
 	if err != nil {
 		return fmt.Errorf("failed to read schema version: %w", err)
 	}
@@ -174,7 +176,7 @@ func (db *DB) migrateV6ToV7(ctx context.Context) error {
 		}
 	}
 
-	if _, err := tx.ExecContext(ctx, "UPDATE schema_version SET version = 7"); err != nil {
+	if _, err := tx.ExecContext(ctx, "INSERT OR REPLACE INTO schema_version (version) VALUES (7)"); err != nil {
 		return fmt.Errorf("update version: %w", err)
 	}
 

--- a/internal/data/db/dbext.go
+++ b/internal/data/db/dbext.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -139,10 +140,23 @@ func (db *DB) initSchema(ctx context.Context) error {
 
 // runMigrations applies incremental schema migrations for existing databases.
 func (db *DB) runMigrations(ctx context.Context) error {
+	// Check if the legacy schema_version table exists. Fresh databases will not
+	// have it; all their schema is handled by initSchema via the migration files.
+	var tableName string
+	err := db.conn.QueryRowContext(ctx,
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'",
+	).Scan(&tableName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check schema_version table: %w", err)
+	}
+
 	// Use MAX(version) for deterministic reads — the table may contain multiple
 	// rows from previous schema versions (each version was inserted as a new row).
 	var version int
-	err := db.conn.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_version").Scan(&version)
+	err = db.conn.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_version").Scan(&version)
 	if err != nil {
 		return fmt.Errorf("failed to read schema version: %w", err)
 	}

--- a/internal/data/db/migrations.go
+++ b/internal/data/db/migrations.go
@@ -132,6 +132,33 @@ func parseFilename(filename string) (int, string, string, error) {
 	return version, parts[1], direction, nil
 }
 
+// goMigration is a function-based migration for operations that cannot be
+// expressed purely in SQL (e.g. SQLite ALTER TABLE which lacks IF NOT EXISTS).
+type goMigration func(ctx context.Context, tx *sql.Tx) error
+
+// goMigrations maps migration versions to Go functions. When present, the Go
+// function is called instead of executing the .up.sql content directly.
+var goMigrations = map[int]goMigration{
+	8: addCloneStrategyColumn,
+}
+
+// addCloneStrategyColumn adds clone_strategy to the sessions table if missing.
+// SQLite does not support ALTER TABLE … ADD COLUMN IF NOT EXISTS, so we check
+// pragma_table_info first to keep the migration idempotent.
+func addCloneStrategyColumn(ctx context.Context, tx *sql.Tx) error {
+	var count int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'clone_strategy'",
+	).Scan(&count); err != nil {
+		return fmt.Errorf("checking for clone_strategy column: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+	_, err := tx.ExecContext(ctx, "ALTER TABLE sessions ADD COLUMN clone_strategy TEXT NOT NULL DEFAULT 'full'")
+	return err
+}
+
 // migrateUp applies all pending up migrations in version order.
 // Creates the schema_migrations table if needed and bootstraps from legacy schema_version.
 func migrateUp(ctx context.Context, conn *sql.DB) error {
@@ -159,8 +186,14 @@ func migrateUp(ctx context.Context, conn *sql.DB) error {
 		}
 
 		slog.Info("applying migration", "version", m.Version, "name", m.Name)
-		if err := applyMigration(ctx, conn, m.Version, m.Name, m.UpSQL); err != nil {
-			return fmt.Errorf("migration %04d (%s): %w", m.Version, m.Name, err)
+		if fn, ok := goMigrations[m.Version]; ok {
+			if err := applyGoMigration(ctx, conn, m.Version, m.Name, fn); err != nil {
+				return fmt.Errorf("migration %04d (%s): %w", m.Version, m.Name, err)
+			}
+		} else {
+			if err := applyMigration(ctx, conn, m.Version, m.Name, m.UpSQL); err != nil {
+				return fmt.Errorf("migration %04d (%s): %w", m.Version, m.Name, err)
+			}
 		}
 	}
 
@@ -322,6 +355,29 @@ func applyMigration(ctx context.Context, conn *sql.DB, version int, name, sqlStr
 
 	if _, err := tx.ExecContext(ctx, sqlStr); err != nil {
 		return fmt.Errorf("executing SQL: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		"INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)",
+		version, name, time.Now().UnixNano(),
+	)
+	if err != nil {
+		return fmt.Errorf("recording migration: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// applyGoMigration calls fn inside a transaction and records the version on success.
+func applyGoMigration(ctx context.Context, conn *sql.DB, version int, name string, fn goMigration) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := fn(ctx, tx); err != nil {
+		return fmt.Errorf("executing migration: %w", err)
 	}
 
 	_, err = tx.ExecContext(ctx,

--- a/internal/data/db/migrations/0001_initial_sessions.up.sql
+++ b/internal/data/db/migrations/0001_initial_sessions.up.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     path TEXT NOT NULL,
     remote TEXT NOT NULL,
     state TEXT NOT NULL CHECK(state IN ('active', 'recycled', 'corrupted')),
+    clone_strategy TEXT NOT NULL DEFAULT 'full',
     metadata TEXT, -- JSON blob for map[string]string
     created_at INTEGER NOT NULL, -- Unix timestamp in nanoseconds
     updated_at INTEGER NOT NULL -- Unix timestamp in nanoseconds

--- a/internal/data/db/migrations/0001_initial_sessions.up.sql
+++ b/internal/data/db/migrations/0001_initial_sessions.up.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS sessions (
     path TEXT NOT NULL,
     remote TEXT NOT NULL,
     state TEXT NOT NULL CHECK(state IN ('active', 'recycled', 'corrupted')),
-    clone_strategy TEXT NOT NULL DEFAULT 'full',
     metadata TEXT, -- JSON blob for map[string]string
     created_at INTEGER NOT NULL, -- Unix timestamp in nanoseconds
     updated_at INTEGER NOT NULL -- Unix timestamp in nanoseconds

--- a/internal/data/db/migrations/0008_add_clone_strategy.down.sql
+++ b/internal/data/db/migrations/0008_add_clone_strategy.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN clone_strategy;

--- a/internal/data/db/migrations/0008_add_clone_strategy.up.sql
+++ b/internal/data/db/migrations/0008_add_clone_strategy.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN clone_strategy TEXT NOT NULL DEFAULT 'full';

--- a/internal/data/db/migrations_test.go
+++ b/internal/data/db/migrations_test.go
@@ -138,15 +138,23 @@ func TestMigrateDown(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	// Revert the last migration (todo_items).
+	// Revert the last migration (add_clone_strategy).
 	err = MigrateDown(ctx, conn, 1)
 	require.NoError(t, err)
 
-	// todo_items table should be gone.
-	_, err = conn.ExecContext(ctx, "SELECT 1 FROM todo_items LIMIT 0")
-	require.Error(t, err, "todo_items should not exist after down migration")
+	// clone_strategy column should be gone.
+	var colCount int
+	err = conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'clone_strategy'",
+	).Scan(&colCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, colCount, "clone_strategy column should not exist after down migration")
 
-	// sessions table should still exist.
+	// todo_items table should still exist.
+	_, err = conn.ExecContext(ctx, "SELECT 1 FROM todo_items LIMIT 0")
+	require.NoError(t, err, "todo_items should still exist")
+
+	// sessions table should still exist with the row.
 	var count int
 	err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM sessions").Scan(&count)
 	require.NoError(t, err)

--- a/internal/data/db/models.go
+++ b/internal/data/db/models.go
@@ -57,15 +57,16 @@ type ReviewSession struct {
 }
 
 type Session struct {
-	ID        string         `json:"id"`
-	Name      string         `json:"name"`
-	Slug      string         `json:"slug"`
-	Path      string         `json:"path"`
-	Remote    string         `json:"remote"`
-	State     string         `json:"state"`
-	Metadata  sql.NullString `json:"metadata"`
-	CreatedAt int64          `json:"created_at"`
-	UpdatedAt int64          `json:"updated_at"`
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Slug          string         `json:"slug"`
+	Path          string         `json:"path"`
+	Remote        string         `json:"remote"`
+	State         string         `json:"state"`
+	CloneStrategy string         `json:"clone_strategy"`
+	Metadata      sql.NullString `json:"metadata"`
+	CreatedAt     int64          `json:"created_at"`
+	UpdatedAt     int64          `json:"updated_at"`
 }
 
 type TodoItem struct {

--- a/internal/data/db/queries.sql.go
+++ b/internal/data/db/queries.sql.go
@@ -257,7 +257,7 @@ func (q *Queries) FinalizeReviewSession(ctx context.Context, arg FinalizeReviewS
 }
 
 const findRecyclableSession = `-- name: FindRecyclableSession :one
-SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at FROM sessions
+SELECT id, name, slug, path, remote, state, clone_strategy, metadata, created_at, updated_at FROM sessions
 WHERE state = 'recycled' AND remote = ?
 ORDER BY updated_at ASC
 LIMIT 1
@@ -273,6 +273,7 @@ func (q *Queries) FindRecyclableSession(ctx context.Context, remote string) (Ses
 		&i.Path,
 		&i.Remote,
 		&i.State,
+		&i.CloneStrategy,
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -377,7 +378,7 @@ func (q *Queries) GetReviewSessionByDocPathAndHash(ctx context.Context, arg GetR
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at FROM sessions
+SELECT id, name, slug, path, remote, state, clone_strategy, metadata, created_at, updated_at FROM sessions
 WHERE id = ?
 `
 
@@ -391,6 +392,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
 		&i.Path,
 		&i.Remote,
 		&i.State,
+		&i.CloneStrategy,
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -673,7 +675,7 @@ func (q *Queries) ListReviewComments(ctx context.Context, sessionID string) ([]R
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at FROM sessions
+SELECT id, name, slug, path, remote, state, clone_strategy, metadata, created_at, updated_at FROM sessions
 ORDER BY created_at DESC
 `
 
@@ -693,6 +695,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 			&i.Path,
 			&i.Remote,
 			&i.State,
+			&i.CloneStrategy,
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -880,29 +883,31 @@ func (q *Queries) SaveReviewComment(ctx context.Context, arg SaveReviewCommentPa
 
 const saveSession = `-- name: SaveSession :exec
 INSERT INTO sessions (
-    id, name, slug, path, remote, state, metadata,
+    id, name, slug, path, remote, state, clone_strategy, metadata,
     created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     slug = excluded.slug,
     path = excluded.path,
     remote = excluded.remote,
     state = excluded.state,
+    clone_strategy = excluded.clone_strategy,
     metadata = excluded.metadata,
     updated_at = excluded.updated_at
 `
 
 type SaveSessionParams struct {
-	ID        string         `json:"id"`
-	Name      string         `json:"name"`
-	Slug      string         `json:"slug"`
-	Path      string         `json:"path"`
-	Remote    string         `json:"remote"`
-	State     string         `json:"state"`
-	Metadata  sql.NullString `json:"metadata"`
-	CreatedAt int64          `json:"created_at"`
-	UpdatedAt int64          `json:"updated_at"`
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Slug          string         `json:"slug"`
+	Path          string         `json:"path"`
+	Remote        string         `json:"remote"`
+	State         string         `json:"state"`
+	CloneStrategy string         `json:"clone_strategy"`
+	Metadata      sql.NullString `json:"metadata"`
+	CreatedAt     int64          `json:"created_at"`
+	UpdatedAt     int64          `json:"updated_at"`
 }
 
 func (q *Queries) SaveSession(ctx context.Context, arg SaveSessionParams) error {
@@ -913,6 +918,7 @@ func (q *Queries) SaveSession(ctx context.Context, arg SaveSessionParams) error 
 		arg.Path,
 		arg.Remote,
 		arg.State,
+		arg.CloneStrategy,
 		arg.Metadata,
 		arg.CreatedAt,
 		arg.UpdatedAt,

--- a/internal/data/db/queries/queries.sql
+++ b/internal/data/db/queries/queries.sql
@@ -8,15 +8,16 @@ WHERE id = ?;
 
 -- name: SaveSession :exec
 INSERT INTO sessions (
-    id, name, slug, path, remote, state, metadata,
+    id, name, slug, path, remote, state, clone_strategy, metadata,
     created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     slug = excluded.slug,
     path = excluded.path,
     remote = excluded.remote,
     state = excluded.state,
+    clone_strategy = excluded.clone_strategy,
     metadata = excluded.metadata,
     updated_at = excluded.updated_at;
 

--- a/internal/data/stores/store.go
+++ b/internal/data/stores/store.go
@@ -72,16 +72,22 @@ func (s *SessionStore) Save(ctx context.Context, sess session.Session) error {
 		metadataJSON = sql.NullString{String: string(data), Valid: true}
 	}
 
+	cloneStrategy := sess.CloneStrategy
+	if cloneStrategy == "" {
+		cloneStrategy = "full"
+	}
+
 	err := s.db.Queries().SaveSession(ctx, db.SaveSessionParams{
-		ID:        sess.ID,
-		Name:      sess.Name,
-		Slug:      sess.Slug,
-		Path:      sess.Path,
-		Remote:    sess.Remote,
-		State:     string(sess.State),
-		Metadata:  metadataJSON,
-		CreatedAt: sess.CreatedAt.UnixNano(),
-		UpdatedAt: sess.UpdatedAt.UnixNano(),
+		ID:            sess.ID,
+		Name:          sess.Name,
+		Slug:          sess.Slug,
+		Path:          sess.Path,
+		Remote:        sess.Remote,
+		State:         string(sess.State),
+		CloneStrategy: cloneStrategy,
+		Metadata:      metadataJSON,
+		CreatedAt:     sess.CreatedAt.UnixNano(),
+		UpdatedAt:     sess.UpdatedAt.UnixNano(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to save session: %w", err)
@@ -138,15 +144,21 @@ func rowToSession(row db.Session) (session.Session, error) {
 		}
 	}
 
+	cloneStrategy := row.CloneStrategy
+	if cloneStrategy == "" {
+		cloneStrategy = "full"
+	}
+
 	return session.Session{
-		ID:        row.ID,
-		Name:      row.Name,
-		Slug:      row.Slug,
-		Path:      row.Path,
-		Remote:    row.Remote,
-		State:     session.State(row.State),
-		Metadata:  metadata,
-		CreatedAt: time.Unix(0, row.CreatedAt),
-		UpdatedAt: time.Unix(0, row.UpdatedAt),
+		ID:            row.ID,
+		Name:          row.Name,
+		Slug:          row.Slug,
+		Path:          row.Path,
+		Remote:        row.Remote,
+		State:         session.State(row.State),
+		CloneStrategy: cloneStrategy,
+		Metadata:      metadata,
+		CreatedAt:     time.Unix(0, row.CreatedAt),
+		UpdatedAt:     time.Unix(0, row.UpdatedAt),
 	}, nil
 }

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -142,6 +142,9 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	if strategy == "" {
 		strategy = s.config.GetCloneStrategy(remote)
 	}
+	if strategy != config.CloneStrategyFull && strategy != config.CloneStrategyWorktree {
+		return nil, fmt.Errorf("invalid clone strategy %q: must be %q or %q", strategy, config.CloneStrategyFull, config.CloneStrategyWorktree)
+	}
 
 	var sess session.Session
 	slug := session.Slugify(opts.Name)
@@ -376,7 +379,9 @@ func (s *SessionService) recycleWorktreeSession(ctx context.Context, sess *sessi
 
 	if branch != "" {
 		if err := s.git.WorktreeRemove(ctx, bareDir, sess.Path, branch); err != nil {
-			s.log.Warn().Err(err).Str("session_id", sess.ID).Msg("worktree remove failed")
+			s.log.Warn().Err(err).Str("session_id", sess.ID).Msg("worktree remove failed, marking corrupted")
+			s.markCorrupted(ctx, sess)
+			return fmt.Errorf("recycle worktree session %s: worktree remove failed: %w", sess.ID, err)
 		}
 	}
 

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -31,6 +31,7 @@ type CreateOptions struct {
 	Prompt        string // Prompt to pass to spawned terminal (batch only)
 	Remote        string // Git remote URL to clone (auto-detected if empty)
 	Source        string // Source directory for file copying
+	CloneStrategy string // "full" or "worktree" (empty = resolve from config)
 	UseBatchSpawn bool   // Use batch_spawn commands instead of spawn
 	Background    bool   // Create session without attaching to tmux
 	// SkipSpawn skips the configured spawn strategy (spawn: / batch_spawn: / windows:).
@@ -136,60 +137,68 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 		s.log.Debug().Str("remote", remote).Msg("detected remote")
 	}
 
+	// Resolve clone strategy: CLI override > config
+	strategy := opts.CloneStrategy
+	if strategy == "" {
+		strategy = s.config.GetCloneStrategy(remote)
+	}
+
 	var sess session.Session
 	slug := session.Slugify(opts.Name)
 
-	// Try to find and validate a recyclable session
-	recyclable := s.findValidRecyclable(ctx, remote)
+	// Try to find and validate a recyclable session with matching strategy
+	recyclable := s.findValidRecyclable(ctx, remote, strategy)
 
-	if recyclable != nil {
-		// Reuse existing recycled session (already cleaned up when marked for recycle)
-		s.log.Debug().Str("session_id", recyclable.ID).Msg("found valid recyclable session")
+	if recyclable != nil && strategy == config.CloneStrategyWorktree {
+		// Reuse recycled worktree: ensure bare clone is current, add fresh worktree
+		s.log.Debug().Str("session_id", recyclable.ID).Msg("reusing recycled worktree session")
 
-		// Pull latest changes before running hooks
-		s.log.Debug().Str("path", recyclable.Path).Msg("pulling latest changes")
-		if err := s.git.Pull(ctx, recyclable.Path); err != nil {
-			// Pull failed - mark as corrupted and fall through to clone
-			s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("pull failed, marking corrupted")
+		bareDir := s.bareDirForRemote(remote)
+		if err := s.ensureBareClone(ctx, remote, bareDir); err != nil {
+			s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("bare clone failed, marking corrupted")
 			s.markCorrupted(ctx, recyclable)
 			recyclable = nil
+		} else {
+			sessID := recyclable.ID
+			branch := fmt.Sprintf("hive/%s-%s", slug, sessID)
+			if err := s.git.WorktreeAdd(ctx, bareDir, recyclable.Path, branch); err != nil {
+				s.log.Warn().Err(err).Str("session_id", sessID).Msg("worktree add failed, marking corrupted")
+				s.markCorrupted(ctx, recyclable)
+				recyclable = nil
+			} else {
+				sess = *recyclable
+				sess.Name = opts.Name
+				sess.Slug = slug
+				sess.State = session.StateActive
+				sess.UpdatedAt = time.Now()
+				sess.SetMeta(session.MetaWorktreeBranch, branch)
+			}
 		}
 	}
 
-	if recyclable != nil {
-		sess = *recyclable
-		sess.Name = opts.Name
-		sess.Slug = slug
-		sess.State = session.StateActive
-		sess.UpdatedAt = time.Now()
-	} else {
-		// Create new session (either no recyclable found or it was corrupted)
-		sessID := opts.SessionID
-		if sessID == "" {
-			sessID = generateID()
+	if recyclable != nil && strategy == config.CloneStrategyFull {
+		// Reuse existing recycled full-clone session
+		s.log.Debug().Str("session_id", recyclable.ID).Msg("found valid recyclable session")
+
+		s.log.Debug().Str("path", recyclable.Path).Msg("pulling latest changes")
+		if err := s.git.Pull(ctx, recyclable.Path); err != nil {
+			s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("pull failed, marking corrupted")
+			s.markCorrupted(ctx, recyclable)
+			recyclable = nil
+		} else {
+			sess = *recyclable
+			sess.Name = opts.Name
+			sess.Slug = slug
+			sess.State = session.StateActive
+			sess.UpdatedAt = time.Now()
 		}
-		dirID := generateID()
-		repoName := git.ExtractRepoName(remote)
-		path := filepath.Join(s.config.ReposDir(), fmt.Sprintf("%s-%s", repoName, dirID))
+	}
 
-		s.log.Info().Str("remote", remote).Str("dest", path).Msg("cloning repository")
-
-		if err := s.git.Clone(ctx, remote, path); err != nil {
-			return nil, fmt.Errorf("clone repository: %w", err)
-		}
-
-		s.log.Debug().Msg("clone complete")
-
-		now := time.Now()
-		sess = session.Session{
-			ID:        sessID,
-			Name:      opts.Name,
-			Slug:      slug,
-			Path:      path,
-			Remote:    remote,
-			State:     session.StateActive,
-			CreatedAt: now,
-			UpdatedAt: now,
+	if recyclable == nil {
+		var err error
+		sess, err = s.createFreshSession(ctx, opts, remote, strategy, slug)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -216,14 +225,14 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	}
 
 	if !opts.SkipSpawn {
-		strategy := config.ResolveSpawn(s.config.Rules, remote, opts.UseBatchSpawn)
+		spawnStrategy := config.ResolveSpawn(s.config.Rules, remote, opts.UseBatchSpawn)
 		switch {
-		case strategy.IsWindows():
-			if err := s.spawner.SpawnWindows(ctx, strategy.Windows, data, opts.UseBatchSpawn || opts.Background); err != nil {
+		case spawnStrategy.IsWindows():
+			if err := s.spawner.SpawnWindows(ctx, spawnStrategy.Windows, data, opts.UseBatchSpawn || opts.Background); err != nil {
 				return nil, fmt.Errorf("spawn terminal: %w", err)
 			}
-		case len(strategy.Commands) > 0:
-			if err := s.spawner.Spawn(ctx, strategy.Commands, data); err != nil {
+		case len(spawnStrategy.Commands) > 0:
+			if err := s.spawner.Spawn(ctx, spawnStrategy.Commands, data); err != nil {
 				return nil, fmt.Errorf("spawn terminal: %w", err)
 			}
 		default:
@@ -236,6 +245,60 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	s.bus.PublishSessionCreated(eventbus.SessionCreatedPayload{Session: &sess})
 
 	return &sess, nil
+}
+
+// createFreshSession creates a brand new session (no recyclable found).
+func (s *SessionService) createFreshSession(ctx context.Context, opts CreateOptions, remote, strategy, slug string) (session.Session, error) {
+	sessID := opts.SessionID
+	if sessID == "" {
+		sessID = generateID()
+	}
+	dirID := generateID()
+	repoName := git.ExtractRepoName(remote)
+
+	now := time.Now()
+	sess := session.Session{
+		ID:            sessID,
+		Name:          opts.Name,
+		Slug:          slug,
+		Remote:        remote,
+		State:         session.StateActive,
+		CloneStrategy: strategy,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	if strategy == config.CloneStrategyWorktree {
+		bareDir := s.bareDirForRemote(remote)
+		if err := s.ensureBareClone(ctx, remote, bareDir); err != nil {
+			return session.Session{}, fmt.Errorf("ensure bare clone: %w", err)
+		}
+
+		path := filepath.Join(s.config.ReposDir(), fmt.Sprintf("%s-wt-%s", repoName, dirID))
+		branch := fmt.Sprintf("hive/%s-%s", slug, sessID)
+
+		s.log.Info().Str("bare", bareDir).Str("worktree", path).Str("branch", branch).Msg("adding worktree")
+
+		if err := s.git.WorktreeAdd(ctx, bareDir, path, branch); err != nil {
+			return session.Session{}, fmt.Errorf("add worktree: %w", err)
+		}
+
+		sess.Path = path
+		sess.SetMeta(session.MetaWorktreeBranch, branch)
+	} else {
+		path := filepath.Join(s.config.ReposDir(), fmt.Sprintf("%s-%s", repoName, dirID))
+
+		s.log.Info().Str("remote", remote).Str("dest", path).Msg("cloning repository")
+
+		if err := s.git.Clone(ctx, remote, path); err != nil {
+			return session.Session{}, fmt.Errorf("clone repository: %w", err)
+		}
+
+		s.log.Debug().Msg("clone complete")
+		sess.Path = path
+	}
+
+	return sess, nil
 }
 
 // ListSessions returns all sessions.
@@ -261,48 +324,77 @@ func (s *SessionService) RecycleSession(ctx context.Context, id string, w io.Wri
 		return fmt.Errorf("session %s cannot be recycled (state: %s)", id, sess.State)
 	}
 
-	// Validate repository before recycling
-	if err := s.git.IsValidRepo(ctx, sess.Path); err != nil {
-		s.log.Warn().Err(err).Str("session_id", id).Msg("session has corrupted repository")
-		s.markCorrupted(ctx, &sess)
-		return fmt.Errorf("session %s has corrupted repository: %w", id, err)
+	if sess.CloneStrategy == config.CloneStrategyWorktree {
+		return s.recycleWorktreeSession(ctx, &sess)
 	}
 
-	// Get default branch for template
+	return s.recycleFullSession(ctx, &sess, w)
+}
+
+// recycleFullSession handles recycling for full-clone sessions.
+func (s *SessionService) recycleFullSession(ctx context.Context, sess *session.Session, w io.Writer) error {
+	if err := s.git.IsValidRepo(ctx, sess.Path); err != nil {
+		s.log.Warn().Err(err).Str("session_id", sess.ID).Msg("session has corrupted repository")
+		s.markCorrupted(ctx, sess)
+		return fmt.Errorf("session %s has corrupted repository: %w", sess.ID, err)
+	}
+
 	defaultBranch, err := s.git.DefaultBranch(ctx, sess.Path)
 	if err != nil {
 		s.log.Warn().Err(err).Msg("failed to get default branch, using 'main'")
 		defaultBranch = "main"
 	}
 
-	data := RecycleData{
-		DefaultBranch: defaultBranch,
-	}
-
+	data := RecycleData{DefaultBranch: defaultBranch}
 	if err := s.recycler.Recycle(ctx, sess.Path, s.config.GetRecycleCommands(sess.Remote), data, w); err != nil {
-		return fmt.Errorf("recycle session %s: %w", id, err)
+		return fmt.Errorf("recycle session %s: %w", sess.ID, err)
 	}
 
-	// Kill associated tmux session (best-effort)
 	if _, err := s.executor.Run(ctx, "tmux", "kill-session", "-t", sess.Name); err != nil {
 		s.log.Debug().Err(err).Str("session", sess.Name).Msg("no tmux session to kill")
 	}
 
 	sess.MarkRecycled(time.Now())
-
-	if err := s.sessions.Save(ctx, sess); err != nil {
+	if err := s.sessions.Save(ctx, *sess); err != nil {
 		return fmt.Errorf("save session: %w", err)
 	}
 
-	// Enforce max recycled limit
 	if err := s.enforceMaxRecycled(ctx, sess.Remote); err != nil {
 		s.log.Warn().Err(err).Str("remote", sess.Remote).Msg("failed to enforce max recycled limit")
 	}
 
-	s.log.Info().Str("session_id", id).Str("path", sess.Path).Msg("session recycled")
+	s.log.Info().Str("session_id", sess.ID).Str("path", sess.Path).Msg("session recycled")
+	s.bus.PublishSessionRecycled(eventbus.SessionRecycledPayload{Session: sess})
+	return nil
+}
 
-	s.bus.PublishSessionRecycled(eventbus.SessionRecycledPayload{Session: &sess})
+// recycleWorktreeSession handles recycling for worktree sessions.
+// Removes the worktree and branch, then marks the session as recycled.
+func (s *SessionService) recycleWorktreeSession(ctx context.Context, sess *session.Session) error {
+	bareDir := s.bareDirForRemote(sess.Remote)
+	branch := sess.GetMeta(session.MetaWorktreeBranch)
 
+	if branch != "" {
+		if err := s.git.WorktreeRemove(ctx, bareDir, sess.Path, branch); err != nil {
+			s.log.Warn().Err(err).Str("session_id", sess.ID).Msg("worktree remove failed")
+		}
+	}
+
+	if _, err := s.executor.Run(ctx, "tmux", "kill-session", "-t", sess.Name); err != nil {
+		s.log.Debug().Err(err).Str("session", sess.Name).Msg("no tmux session to kill")
+	}
+
+	sess.MarkRecycled(time.Now())
+	if err := s.sessions.Save(ctx, *sess); err != nil {
+		return fmt.Errorf("save session: %w", err)
+	}
+
+	if err := s.enforceMaxRecycled(ctx, sess.Remote); err != nil {
+		s.log.Warn().Err(err).Str("remote", sess.Remote).Msg("failed to enforce max recycled limit")
+	}
+
+	s.log.Info().Str("session_id", sess.ID).Str("path", sess.Path).Msg("worktree session recycled")
+	s.bus.PublishSessionRecycled(eventbus.SessionRecycledPayload{Session: sess})
 	return nil
 }
 
@@ -367,6 +459,17 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string) error {
 	}
 
 	s.log.Info().Str("session_id", id).Str("path", sess.Path).Msg("deleting session")
+
+	// For worktree sessions, remove worktree + branch via git before removing the directory
+	if sess.CloneStrategy == config.CloneStrategyWorktree {
+		bareDir := s.bareDirForRemote(sess.Remote)
+		branch := sess.GetMeta(session.MetaWorktreeBranch)
+		if branch != "" {
+			if err := s.git.WorktreeRemove(ctx, bareDir, sess.Path, branch); err != nil {
+				s.log.Warn().Err(err).Str("session_id", id).Msg("worktree remove failed, proceeding with directory cleanup")
+			}
+		}
+	}
 
 	// Remove directory
 	if err := os.RemoveAll(sess.Path); err != nil {
@@ -510,24 +613,43 @@ func generateID() string {
 	return randid.Generate(6)
 }
 
-// findValidRecyclable finds a recyclable session and validates it.
+// findValidRecyclable finds a recyclable session matching the given strategy.
 // Returns nil if none found or all candidates are corrupted.
-func (s *SessionService) findValidRecyclable(ctx context.Context, remote string) *session.Session {
+func (s *SessionService) findValidRecyclable(ctx context.Context, remote, strategy string) *session.Session {
 	sessions, err := s.sessions.List(ctx)
 	if err != nil {
 		s.log.Warn().Err(err).Msg("failed to list sessions")
 		return nil
 	}
 
+	// Normalize: empty clone_strategy on old sessions means "full"
+	matchStrategy := strategy
+	if matchStrategy == "" {
+		matchStrategy = config.CloneStrategyFull
+	}
+
 	for i := range sessions {
 		sess := &sessions[i]
 
-		// Skip non-recyclable sessions
 		if sess.State != session.StateRecycled || sess.Remote != remote {
 			continue
 		}
 
-		// Validate the repository
+		// Filter by matching clone strategy (empty = "full" for legacy sessions)
+		sessStrategy := sess.CloneStrategy
+		if sessStrategy == "" {
+			sessStrategy = config.CloneStrategyFull
+		}
+		if sessStrategy != matchStrategy {
+			continue
+		}
+
+		// Worktree sessions: directory is intentionally removed on recycle, skip repo validation
+		if sessStrategy == config.CloneStrategyWorktree {
+			return sess
+		}
+
+		// Full-clone sessions: validate the repository
 		if err := s.git.IsValidRepo(ctx, sess.Path); err != nil {
 			s.log.Warn().Err(err).Str("session_id", sess.ID).Str("path", sess.Path).Msg("corrupted session found")
 			s.markCorrupted(ctx, sess)
@@ -687,4 +809,27 @@ func (s *SessionService) CreateSessionWithWindows(ctx context.Context, req actio
 		return fmt.Errorf("create tmux session: %w", err)
 	}
 	return nil
+}
+
+// bareDirForRemote returns the bare clone directory for a given remote URL.
+// Layout: <reposDir>/.bare/<owner>/<repo>/
+func (s *SessionService) bareDirForRemote(remote string) string {
+	owner, repo := git.ExtractOwnerRepo(remote)
+	if owner == "" || repo == "" {
+		// Fallback for unparseable remotes
+		repo = git.ExtractRepoName(remote)
+		owner = "_"
+	}
+	return filepath.Join(s.config.ReposDir(), ".bare", owner, repo)
+}
+
+// ensureBareClone creates a bare clone if it doesn't exist, or fetches if it does.
+func (s *SessionService) ensureBareClone(ctx context.Context, remote, bareDir string) error {
+	if _, err := os.Stat(bareDir); os.IsNotExist(err) {
+		s.log.Info().Str("remote", remote).Str("bare", bareDir).Msg("creating bare clone")
+		return s.git.CloneBare(ctx, remote, bareDir)
+	}
+
+	s.log.Debug().Str("bare", bareDir).Msg("fetching into existing bare clone")
+	return s.git.Fetch(ctx, bareDir)
 }

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -97,6 +97,10 @@ func (m *mockGit) DefaultBranch(_ context.Context, _ string) (string, error) {
 }
 func (m *mockGit) DiffStats(_ context.Context, _ string) (int, int, error) { return 0, 0, nil }
 func (m *mockGit) IsValidRepo(_ context.Context, _ string) error           { return nil }
+func (m *mockGit) CloneBare(_ context.Context, _, _ string) error          { return nil }
+func (m *mockGit) WorktreeAdd(_ context.Context, _, _, _ string) error     { return nil }
+func (m *mockGit) WorktreeRemove(_ context.Context, _, _, _ string) error  { return nil }
+func (m *mockGit) Fetch(_ context.Context, _ string) error                 { return nil }
 
 func newTestService(t *testing.T, store session.Store, cfg *config.Config) *SessionService {
 	t.Helper()

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -1011,9 +1011,72 @@ func TestCreateSession_DefaultsToFullClone(t *testing.T) {
 	assert.False(t, g.hasCalled("CloneBare"))
 }
 
+// failingWorktreeGit is a recordingGit that fails on WorktreeRemove.
+type failingWorktreeGit struct {
+	recordingGit
+}
+
+func (f *failingWorktreeGit) WorktreeRemove(_ context.Context, _, _, branch string) error {
+	f.calls = append(f.calls, "WorktreeRemove:"+branch)
+	return fmt.Errorf("worktree remove: directory not empty")
+}
+
+func TestCreateSession_InvalidStrategyReturnsError(t *testing.T) {
+	store := newMockStore()
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestService(t, store, cfg)
+
+	_, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:          "bad-strategy",
+		Remote:        "https://github.com/example/repo.git",
+		CloneStrategy: "worktre", // typo
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid clone strategy")
+}
+
+func TestRecycleWorktreeSession_FailsOnRemoveError(t *testing.T) {
+	store := newMockStore()
+	g := &failingWorktreeGit{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	sess := session.Session{
+		ID:            "wt-fail",
+		Name:          "wt-fail-session",
+		Slug:          "wt-fail-session",
+		State:         session.StateActive,
+		Path:          t.TempDir(),
+		Remote:        "https://github.com/example/repo.git",
+		CloneStrategy: config.CloneStrategyWorktree,
+	}
+	sess.SetMeta(session.MetaWorktreeBranch, "hive/wt-fail-session-wt-fail")
+	require.NoError(t, store.Save(context.Background(), sess))
+
+	err := svc.RecycleSession(context.Background(), "wt-fail", io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "worktree remove failed")
+
+	// Session should NOT be recycled — it should be deleted (auto_delete_corrupted)
+	// or marked corrupted
+	updated, getErr := store.Get(context.Background(), "wt-fail")
+	if getErr == nil {
+		assert.Equal(t, session.StateCorrupted, updated.State,
+			"session should be corrupted, not recycled")
+	}
+	// If auto-deleted, ErrNotFound is also acceptable
+}
+
 // Ensure the mock implements the interface at compile time.
 var (
 	_ git.Git       = (*mockGit)(nil)
 	_ git.Git       = (*recordingGit)(nil)
+	_ git.Git       = (*failingWorktreeGit)(nil)
 	_ session.Store = (*mockStore)(nil)
 )

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -750,8 +751,269 @@ func TestSetSessionGroup_TrimWhitespace(t *testing.T) {
 	assert.Equal(t, "backend", updated.Group())
 }
 
+// recordingGit wraps mockGit and records method calls.
+type recordingGit struct {
+	mockGit
+	calls []string
+}
+
+func (r *recordingGit) Clone(_ context.Context, url, dest string) error {
+	r.calls = append(r.calls, "Clone:"+url+"→"+dest)
+	return nil
+}
+
+func (r *recordingGit) CloneBare(_ context.Context, url, dest string) error {
+	r.calls = append(r.calls, "CloneBare:"+url)
+	// Create the directory so ensureBareClone's os.Stat succeeds on subsequent calls
+	_ = os.MkdirAll(dest, 0o755)
+	return nil
+}
+
+func (r *recordingGit) WorktreeAdd(_ context.Context, _, worktreePath, branch string) error {
+	r.calls = append(r.calls, "WorktreeAdd:"+branch)
+	_ = os.MkdirAll(worktreePath, 0o755)
+	return nil
+}
+
+func (r *recordingGit) WorktreeRemove(_ context.Context, _, worktreePath, branch string) error {
+	r.calls = append(r.calls, "WorktreeRemove:"+branch)
+	return nil
+}
+
+func (r *recordingGit) Fetch(_ context.Context, dir string) error {
+	r.calls = append(r.calls, "Fetch:"+dir)
+	return nil
+}
+
+func (r *recordingGit) hasCalled(method string) bool {
+	for _, c := range r.calls {
+		if strings.HasPrefix(c, method+":") {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestServiceWithGit(t *testing.T, store session.Store, cfg *config.Config, g git.Git) *SessionService {
+	t.Helper()
+	if cfg == nil {
+		cfg = &config.Config{
+			DataDir: t.TempDir(),
+			GitPath: "git",
+		}
+	}
+	log := zerolog.New(io.Discard)
+	renderer := tmpl.New(tmpl.Config{})
+	bus := testbus.New(t).EventBus
+	return NewSessionService(store, g, cfg, bus, &mockExec{}, renderer, log, io.Discard, io.Discard)
+}
+
+func TestCreateSession_WorktreeStrategy(t *testing.T) {
+	store := newMockStore()
+	g := &recordingGit{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	sess, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:          "wt-feature",
+		Remote:        "https://github.com/example/repo.git",
+		CloneStrategy: config.CloneStrategyWorktree,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, config.CloneStrategyWorktree, sess.CloneStrategy)
+	assert.Contains(t, sess.Path, "-wt-")
+	assert.NotEmpty(t, sess.GetMeta(session.MetaWorktreeBranch))
+	assert.True(t, g.hasCalled("CloneBare"))
+	assert.True(t, g.hasCalled("WorktreeAdd"))
+	assert.False(t, g.hasCalled("Clone"))
+}
+
+func TestCreateSession_WorktreeReusesRecycled(t *testing.T) {
+	store := newMockStore()
+	g := &recordingGit{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	remote := "https://github.com/example/repo.git"
+	// Seed bare dir so ensureBareClone finds it and does Fetch
+	bareDir := filepath.Join(cfg.ReposDir(), ".bare", "example", "repo")
+	require.NoError(t, os.MkdirAll(bareDir, 0o755))
+
+	recycled := session.Session{
+		ID:            "recy1",
+		Name:          "old",
+		Slug:          "old",
+		State:         session.StateRecycled,
+		Path:          filepath.Join(cfg.ReposDir(), "repo-wt-abc123"),
+		Remote:        remote,
+		CloneStrategy: config.CloneStrategyWorktree,
+	}
+	require.NoError(t, store.Save(context.Background(), recycled))
+
+	sess, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:          "new-feature",
+		Remote:        remote,
+		CloneStrategy: config.CloneStrategyWorktree,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "recy1", sess.ID, "should reuse recycled session")
+	assert.Equal(t, "new-feature", sess.Name)
+	assert.Equal(t, session.StateActive, sess.State)
+	assert.NotEmpty(t, sess.GetMeta(session.MetaWorktreeBranch))
+	// Should fetch, not bare-clone
+	assert.True(t, g.hasCalled("Fetch"))
+	assert.True(t, g.hasCalled("WorktreeAdd"))
+	assert.False(t, g.hasCalled("CloneBare"))
+}
+
+func TestFindValidRecyclable_FiltersByStrategy(t *testing.T) {
+	store := newMockStore()
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestService(t, store, cfg)
+
+	remote := "https://github.com/example/repo.git"
+	store.sessions["full1"] = session.Session{
+		ID:            "full1",
+		Remote:        remote,
+		State:         session.StateRecycled,
+		CloneStrategy: config.CloneStrategyFull,
+		Path:          t.TempDir(),
+	}
+	store.sessions["wt1"] = session.Session{
+		ID:            "wt1",
+		Remote:        remote,
+		State:         session.StateRecycled,
+		CloneStrategy: config.CloneStrategyWorktree,
+		Path:          "/does/not/exist",
+	}
+
+	// Request full → should find full1
+	found := svc.findValidRecyclable(context.Background(), remote, config.CloneStrategyFull)
+	require.NotNil(t, found)
+	assert.Equal(t, "full1", found.ID)
+
+	// Request worktree → should find wt1 (skips repo validation)
+	found = svc.findValidRecyclable(context.Background(), remote, config.CloneStrategyWorktree)
+	require.NotNil(t, found)
+	assert.Equal(t, "wt1", found.ID)
+}
+
+func TestRecycleSession_WorktreeCallsRemove(t *testing.T) {
+	store := newMockStore()
+	g := &recordingGit{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	sess := session.Session{
+		ID:            "wt-recycle",
+		Name:          "wt-session",
+		Slug:          "wt-session",
+		State:         session.StateActive,
+		Path:          t.TempDir(),
+		Remote:        "https://github.com/example/repo.git",
+		CloneStrategy: config.CloneStrategyWorktree,
+	}
+	sess.SetMeta(session.MetaWorktreeBranch, "hive/wt-session-wt-recycle")
+	require.NoError(t, store.Save(context.Background(), sess))
+
+	err := svc.RecycleSession(context.Background(), "wt-recycle", io.Discard)
+	require.NoError(t, err)
+
+	assert.True(t, g.hasCalled("WorktreeRemove"))
+
+	recycled, err := store.Get(context.Background(), "wt-recycle")
+	require.NoError(t, err)
+	assert.Equal(t, session.StateRecycled, recycled.State)
+}
+
+func TestDeleteSession_WorktreeCallsRemove(t *testing.T) {
+	store := newMockStore()
+	g := &recordingGit{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	sessDir := t.TempDir()
+	sess := session.Session{
+		ID:            "wt-del",
+		Name:          "wt-del-session",
+		Slug:          "wt-del-session",
+		State:         session.StateActive,
+		Path:          sessDir,
+		Remote:        "https://github.com/example/repo.git",
+		CloneStrategy: config.CloneStrategyWorktree,
+	}
+	sess.SetMeta(session.MetaWorktreeBranch, "hive/wt-del-session-wt-del")
+	require.NoError(t, store.Save(context.Background(), sess))
+
+	err := svc.DeleteSession(context.Background(), "wt-del")
+	require.NoError(t, err)
+
+	assert.True(t, g.hasCalled("WorktreeRemove"))
+	_, err = store.Get(context.Background(), "wt-del")
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestCreateSession_CLIOverridesConfig(t *testing.T) {
+	store := newMockStore()
+	g := &recordingGit{}
+	cfg := &config.Config{
+		DataDir:       t.TempDir(),
+		GitPath:       "git",
+		CloneStrategy: config.CloneStrategyFull, // config says full
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	sess, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:          "override-test",
+		Remote:        "https://github.com/example/repo.git",
+		CloneStrategy: config.CloneStrategyWorktree, // CLI says worktree
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, config.CloneStrategyWorktree, sess.CloneStrategy)
+	assert.True(t, g.hasCalled("CloneBare"))
+}
+
+func TestCreateSession_DefaultsToFullClone(t *testing.T) {
+	store := newMockStore()
+	g := &recordingGit{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+	}
+	svc := newTestServiceWithGit(t, store, cfg, g)
+
+	sess, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:   "full-default",
+		Remote: "https://github.com/example/repo.git",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, config.CloneStrategyFull, sess.CloneStrategy)
+	assert.True(t, g.hasCalled("Clone"))
+	assert.False(t, g.hasCalled("CloneBare"))
+}
+
 // Ensure the mock implements the interface at compile time.
 var (
 	_ git.Git       = (*mockGit)(nil)
+	_ git.Git       = (*recordingGit)(nil)
 	_ session.Store = (*mockStore)(nil)
 )

--- a/internal/tui/views/sessions/repo_scanner_test.go
+++ b/internal/tui/views/sessions/repo_scanner_test.go
@@ -14,15 +14,19 @@ type mockGit struct {
 	remotes map[string]string // path -> remote URL
 }
 
-func (m *mockGit) Clone(context.Context, string, string) error           { return nil }
-func (m *mockGit) Checkout(context.Context, string, string) error        { return nil }
-func (m *mockGit) Pull(context.Context, string) error                    { return nil }
-func (m *mockGit) ResetHard(context.Context, string) error               { return nil }
-func (m *mockGit) IsClean(context.Context, string) (bool, error)         { return true, nil }
-func (m *mockGit) Branch(context.Context, string) (string, error)        { return "main", nil }
-func (m *mockGit) DefaultBranch(context.Context, string) (string, error) { return "main", nil }
-func (m *mockGit) DiffStats(context.Context, string) (int, int, error)   { return 0, 0, nil }
-func (m *mockGit) IsValidRepo(context.Context, string) error             { return nil }
+func (m *mockGit) Clone(context.Context, string, string) error                  { return nil }
+func (m *mockGit) Checkout(context.Context, string, string) error               { return nil }
+func (m *mockGit) Pull(context.Context, string) error                           { return nil }
+func (m *mockGit) ResetHard(context.Context, string) error                      { return nil }
+func (m *mockGit) IsClean(context.Context, string) (bool, error)                { return true, nil }
+func (m *mockGit) Branch(context.Context, string) (string, error)               { return "main", nil }
+func (m *mockGit) DefaultBranch(context.Context, string) (string, error)        { return "main", nil }
+func (m *mockGit) DiffStats(context.Context, string) (int, int, error)          { return 0, 0, nil }
+func (m *mockGit) IsValidRepo(context.Context, string) error                    { return nil }
+func (m *mockGit) CloneBare(context.Context, string, string) error              { return nil }
+func (m *mockGit) WorktreeAdd(context.Context, string, string, string) error    { return nil }
+func (m *mockGit) WorktreeRemove(context.Context, string, string, string) error { return nil }
+func (m *mockGit) Fetch(context.Context, string) error                          { return nil }
 func (m *mockGit) RemoteURL(_ context.Context, dir string) (string, error) {
 	if remote, ok := m.remotes[dir]; ok {
 		return remote, nil

--- a/test/integration/batch_test.go
+++ b/test/integration/batch_test.go
@@ -10,6 +10,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBatchWorktreeStrategy verifies that batch session creation respects
+// the config-level clone_strategy: worktree setting, producing worktree
+// layouts and persisting clone_strategy in the database for each session.
+func TestBatchWorktreeStrategy(t *testing.T) {
+	h := NewHarness(t).WithConfig(`
+version: "0.2.4"
+git_path: git
+clone_strategy: worktree
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+`)
+	repo := createBareRepo(t, "batch-wt")
+
+	type batchSession struct {
+		Name   string `json:"name"`
+		Remote string `json:"remote"`
+	}
+	inputBytes, err := json.Marshal(map[string]any{
+		"sessions": []batchSession{
+			{Name: "bwt-alpha", Remote: repo},
+			{Name: "bwt-beta", Remote: repo},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := h.RunJSONWithStdin(string(inputBytes), "batch")
+	require.NoError(t, err, "batch with worktree strategy should succeed")
+
+	results, ok := result["results"].([]any)
+	require.True(t, ok, "results should be an array")
+	require.Len(t, results, 2)
+
+	for _, r := range results {
+		entry, ok := r.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "created", entry["status"], "session %s should be created", entry["name"])
+
+		path, ok := entry["path"].(string)
+		require.True(t, ok, "batch result must include path")
+		assert.NotEmpty(t, path)
+
+		assertWorktreeLayout(t, path)
+
+		name, _ := entry["name"].(string)
+		row := readSessionRowByName(t, h, name)
+		assert.Equal(t, "worktree", row.CloneStrategy)
+		assert.Equal(t, "active", row.State)
+	}
+}
+
 func TestBatchCreate(t *testing.T) {
 	h := NewHarness(t)
 	repo := createBareRepo(t, "batch-repo")

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -3,18 +3,31 @@
 package integration
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
+
+var createdSessionPathPattern = regexp.MustCompile(`(?ms)Session created\s+(/\S+)`)
+
+type sessionRow struct {
+	ID            string
+	Name          string
+	Path          string
+	State         string
+	CloneStrategy string
+}
 
 // createBareRepo creates a local bare git repository with a seeded initial commit.
 // Returns the path to the bare repo.
@@ -106,6 +119,64 @@ func cleanupTmuxSession(t *testing.T, name string) {
 	t.Cleanup(func() {
 		_ = exec.Command("tmux", "kill-session", "-t", name).Run()
 	})
+}
+
+func parseCreatedSessionPath(out string) (string, error) {
+	matches := createdSessionPathPattern.FindStringSubmatch(out)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("extract session path from output %q", out)
+	}
+	return strings.TrimSpace(matches[1]), nil
+}
+
+func assertWorktreeLayout(t *testing.T, sessionPath string) {
+	t.Helper()
+	gitPath := filepath.Join(sessionPath, ".git")
+	info, err := os.Stat(gitPath)
+	require.NoError(t, err)
+	require.False(t, info.IsDir(), ".git should be a file for worktree sessions")
+
+	data, err := os.ReadFile(gitPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "gitdir:")
+	assert.Contains(t, content, ".bare")
+}
+
+func assertFullCloneLayout(t *testing.T, sessionPath string) {
+	t.Helper()
+	gitPath := filepath.Join(sessionPath, ".git")
+	info, err := os.Stat(gitPath)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir(), ".git should be a directory for full clone sessions")
+}
+
+func readSessionRowByName(t *testing.T, h *Harness, name string) sessionRow {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", filepath.Join(h.DataDir(), "hive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	row := db.QueryRow(
+		`SELECT id, name, path, state, clone_strategy FROM sessions WHERE name = ? ORDER BY created_at DESC LIMIT 1`,
+		name,
+	)
+
+	var result sessionRow
+	require.NoError(t, row.Scan(&result.ID, &result.Name, &result.Path, &result.State, &result.CloneStrategy))
+	return result
+}
+
+func updateSessionState(t *testing.T, h *Harness, id, state string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", filepath.Join(h.DataDir(), "hive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`UPDATE sessions SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, state, id)
+	require.NoError(t, err)
 }
 
 func run(t *testing.T, name string, args ...string) string {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -175,7 +175,8 @@ func updateSessionState(t *testing.T, h *Harness, id, state string) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	_, err = db.Exec(`UPDATE sessions SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, state, id)
+	// updated_at is stored as Unix nanoseconds (INTEGER), not a text timestamp.
+	_, err = db.Exec(`UPDATE sessions SET state = ?, updated_at = ? WHERE id = ?`, state, time.Now().UnixNano(), id)
 	require.NoError(t, err)
 }
 

--- a/test/integration/worktree_test.go
+++ b/test/integration/worktree_test.go
@@ -1,0 +1,291 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorktreeExplicitFlag verifies that passing --clone-strategy worktree
+// produces a worktree layout and records the strategy in the DB.
+func TestWorktreeExplicitFlag(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "wt-explicit")
+
+	out, err := h.Run("new", "--remote", repo, "--clone-strategy", "worktree", "wt-explicit")
+	require.NoError(t, err, "hive new --clone-strategy worktree: %s", out)
+	assert.Contains(t, out, "Session created")
+
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err, "parse session path from output: %s", out)
+
+	assertWorktreeLayout(t, sessionPath)
+
+	row := readSessionRowByName(t, h, "wt-explicit")
+	assert.Equal(t, "worktree", row.CloneStrategy)
+	assert.Equal(t, "active", row.State)
+}
+
+// TestFullCloneExplicitFlag verifies that --clone-strategy full produces a
+// full-clone layout and is persisted correctly.
+func TestFullCloneExplicitFlag(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "full-explicit")
+
+	out, err := h.Run("new", "--remote", repo, "--clone-strategy", "full", "full-explicit")
+	require.NoError(t, err, "hive new --clone-strategy full: %s", out)
+
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	assertFullCloneLayout(t, sessionPath)
+
+	row := readSessionRowByName(t, h, "full-explicit")
+	assert.Equal(t, "full", row.CloneStrategy)
+}
+
+// TestWorktreeConfigDefault verifies that setting clone_strategy: worktree in
+// config is used when no CLI flag is provided.
+func TestWorktreeConfigDefault(t *testing.T) {
+	h := NewHarness(t).WithConfig(`
+version: "0.2.4"
+git_path: git
+clone_strategy: worktree
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+`)
+	repo := createBareRepo(t, "wt-config-default")
+
+	out, err := h.Run("new", "--remote", repo, "wt-config-default")
+	require.NoError(t, err, "hive new with worktree config default: %s", out)
+
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	assertWorktreeLayout(t, sessionPath)
+
+	row := readSessionRowByName(t, h, "wt-config-default")
+	assert.Equal(t, "worktree", row.CloneStrategy)
+}
+
+// TestWorktreeCLIOverridesConfig verifies that a CLI --clone-strategy flag
+// takes precedence over the config default.
+func TestWorktreeCLIOverridesConfig(t *testing.T) {
+	h := NewHarness(t).WithConfig(`
+version: "0.2.4"
+git_path: git
+clone_strategy: worktree
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+`)
+	repo := createBareRepo(t, "cli-override")
+
+	// Config says worktree, but CLI says full — CLI must win.
+	out, err := h.Run("new", "--remote", repo, "--clone-strategy", "full", "cli-override")
+	require.NoError(t, err, "hive new CLI overrides config: %s", out)
+
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	assertFullCloneLayout(t, sessionPath)
+
+	row := readSessionRowByName(t, h, "cli-override")
+	assert.Equal(t, "full", row.CloneStrategy)
+}
+
+// TestWorktreeRuleOverride verifies that a rule-based clone_strategy override
+// is applied when the remote matches the rule pattern.
+func TestWorktreeRuleOverride(t *testing.T) {
+	repo := createBareRepo(t, "rule-wt")
+
+	h := NewHarness(t).WithConfig(`
+version: "0.2.4"
+git_path: git
+clone_strategy: full
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - clone_strategy: worktree
+    spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+`)
+
+	out, err := h.Run("new", "--remote", repo, "rule-wt")
+	require.NoError(t, err, "hive new with rule worktree override: %s", out)
+
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	assertWorktreeLayout(t, sessionPath)
+
+	row := readSessionRowByName(t, h, "rule-wt")
+	assert.Equal(t, "worktree", row.CloneStrategy)
+}
+
+// TestWorktreeRuleNoMatchFallsBackToGlobal verifies that a non-matching rule
+// does not override the global clone_strategy.
+func TestWorktreeRuleNoMatchFallsBackToGlobal(t *testing.T) {
+	repo := createBareRepo(t, "rule-no-match")
+
+	h := NewHarness(t).WithConfig(`
+version: "0.2.4"
+git_path: git
+clone_strategy: full
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - pattern: "git@github.com:.*"
+    clone_strategy: worktree
+    spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+  - spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+`)
+
+	// Local repo path won't match "git@github.com:.*", so rule is skipped.
+	out, err := h.Run("new", "--remote", repo, "rule-no-match")
+	require.NoError(t, err, "hive new rule no-match: %s", out)
+
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	assertFullCloneLayout(t, sessionPath)
+
+	row := readSessionRowByName(t, h, "rule-no-match")
+	assert.Equal(t, "full", row.CloneStrategy)
+}
+
+// TestInvalidCloneStrategyRejected verifies that an invalid --clone-strategy
+// value causes a non-zero exit.
+func TestInvalidCloneStrategyRejected(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "invalid-strategy")
+
+	_, err := h.Run("new", "--remote", repo, "--clone-strategy", "bogus", "invalid-strategy")
+	require.Error(t, err, "hive new with invalid clone strategy should fail")
+}
+
+// TestWorktreePathConsistency verifies that the session path reported by the CLI
+// matches the path persisted in the database.
+func TestWorktreePathConsistency(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "path-consistency")
+
+	out, err := h.Run("new", "--remote", repo, "--clone-strategy", "worktree", "path-consistency")
+	require.NoError(t, err, "hive new: %s", out)
+
+	cliPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	row := readSessionRowByName(t, h, "path-consistency")
+	assert.Equal(t, cliPath, row.Path, "DB path must match CLI-reported path")
+}
+
+// TestWorktreeBareRootCreated verifies that the bare-clone root directory
+// (<dataDir>/repos/.bare/<owner>/<repo>/) is created for worktree sessions.
+func TestWorktreeBareRootCreated(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "bare-root")
+
+	out, err := h.Run("new", "--remote", repo, "--clone-strategy", "worktree", "bare-root")
+	require.NoError(t, err, "hive new: %s", out)
+
+	// Derive the expected bare dir path from the .git file in the worktree.
+	sessionPath, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+	bareDir := worktreeBareDir(t, sessionPath)
+
+	info, err := os.Stat(bareDir)
+	require.NoError(t, err, "bare clone directory must exist at %s", bareDir)
+	assert.True(t, info.IsDir(), "bare clone path must be a directory")
+
+	// Verify it is actually a bare repo by checking for HEAD file.
+	headPath := filepath.Join(bareDir, "HEAD")
+	_, err = os.Stat(headPath)
+	assert.NoError(t, err, "bare clone must contain HEAD file")
+}
+
+// TestWorktreeRecycleReuse verifies that a recycled worktree session is reused
+// when a new session with the same remote and worktree strategy is created.
+func TestWorktreeRecycleReuse(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "recycle-reuse")
+
+	// Step 1: Create the first session.
+	out, err := h.Run("new", "--remote", repo, "--clone-strategy", "worktree", "wt-recycle-alpha")
+	require.NoError(t, err, "create wt-recycle-alpha: %s", out)
+
+	pathOne, err := parseCreatedSessionPath(out)
+	require.NoError(t, err)
+
+	rowOne := readSessionRowByName(t, h, "wt-recycle-alpha")
+	require.Equal(t, "active", rowOne.State)
+	require.Equal(t, "worktree", rowOne.CloneStrategy)
+
+	// Step 2: Simulate recycling by removing the worktree from git and updating DB state.
+	bareDir := worktreeBareDir(t, pathOne)
+	run(t, "git", "-C", bareDir, "worktree", "remove", "--force", pathOne)
+	updateSessionState(t, h, rowOne.ID, "recycled")
+
+	// Step 3: Create a second session — it should reuse the recycled path.
+	out2, err := h.Run("new", "--remote", repo, "--clone-strategy", "worktree", "wt-recycle-beta")
+	require.NoError(t, err, "create wt-recycle-beta (reuse): %s", out2)
+
+	pathTwo, err := parseCreatedSessionPath(out2)
+	require.NoError(t, err)
+
+	assert.Equal(t, pathOne, pathTwo, "reused session must have same path as recycled session")
+
+	rowTwo := readSessionRowByName(t, h, "wt-recycle-beta")
+	assert.Equal(t, "active", rowTwo.State)
+	assert.Equal(t, "worktree", rowTwo.CloneStrategy)
+	assert.Equal(t, rowOne.ID, rowTwo.ID, "reused session must keep the same DB ID")
+}
+
+// worktreeBareDir resolves the bare clone directory from a worktree session path
+// by reading the .git file and following the gitdir pointer.
+func worktreeBareDir(t *testing.T, sessionPath string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(sessionPath, ".git"))
+	require.NoError(t, err, "reading .git file")
+
+	// .git file format: "gitdir: /path/to/.bare/<owner>/<repo>/worktrees/<name>\n"
+	line := strings.TrimSpace(string(data))
+	prefix := "gitdir: "
+	require.True(t, strings.HasPrefix(line, prefix), ".git file should start with 'gitdir: ', got: %q", line)
+	gitdirPath := strings.TrimPrefix(line, prefix)
+
+	// Walk up from worktrees/<name> to the bare root:
+	// .bare/<owner>/<repo>/worktrees/<name> → .bare/<owner>/<repo>/
+	return filepath.Clean(filepath.Join(gitdirPath, "..", ".."))
+}


### PR DESCRIPTION
Fixes #62

## Purpose

Add git worktree support as an alternative to full clones for session creation. When `clone_strategy: worktree` is configured, hive creates a shared bare clone and lightweight worktree checkouts per session instead of a full `git clone` each time. This reduces disk usage and clone time for large repos.

## Proposed Changes

  - Extend Git interface with `CloneBare`, `WorktreeAdd`, `WorktreeRemove`, `Fetch` methods
  - Add `clone_strategy` config field (global + per-rule) with validation and resolution
  - Add `CloneStrategy` to session model with DB schema migration (v6→v7)
  - Branch service layer create/recycle/delete by strategy; add `--clone-strategy` CLI flag
  - Update doctor orphan check to skip `.bare/` directory
  - Validate strategy input and fail recycle when worktree removal fails

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)