### PR TITLE
feat: add opencode to default preview window matchers

### DIFF
--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -612,7 +612,7 @@ func (c *Config) applyDefaults() {
 		c.Tmux.PollInterval = 1500 * time.Millisecond
 	}
 	if len(c.Tmux.PreviewWindowMatcher) == 0 {
-		c.Tmux.PreviewWindowMatcher = []string{"claude", "aider", "codex", "cursor", "crush", "agent", "llm"}
+		c.Tmux.PreviewWindowMatcher = []string{"claude", "aider", "codex", "cursor", "crush", "agent", "llm", "opencode"}
 	}
 	if c.Database.MaxOpenConns == 0 {
 		c.Database.MaxOpenConns = 2


### PR DESCRIPTION
## Summary
- Adds `opencode` to the default `PreviewWindowMatcher` list so tmux preview sidebar recognizes opencode windows

## Test plan
- Verify opencode windows show preview content in the TUI sidebar