### PR TITLE
Add agent profile overrides for session creation

### DIFF
--- a/internal/commands/agent_profiles.go
+++ b/internal/commands/agent_profiles.go
@@ -1,0 +1,16 @@
+package commands
+
+import (
+	"sort"
+
+	"github.com/colonyops/hive/internal/core/config"
+)
+
+func agentProfileNames(cfg *config.Config) []string {
+	names := make([]string, 0, len(cfg.Agents.Profiles))
+	for k := range cfg.Agents.Profiles {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -55,6 +55,12 @@ func NewSpawner(log zerolog.Logger, executor executil.Executor, renderer *tmpl.R
 	}
 }
 
+func (s *Spawner) withRenderer(renderer *tmpl.Renderer) *Spawner {
+	clone := *s
+	clone.renderer = renderer
+	return &clone
+}
+
 // Spawn executes spawn commands sequentially with template rendering.
 func (s *Spawner) Spawn(ctx context.Context, commands []string, data SpawnData) error {
 	for _, cmdTmpl := range commands {

--- a/pkg/tmpl/tmpl.go
+++ b/pkg/tmpl/tmpl.go
@@ -64,6 +64,21 @@ func New(cfg Config) *Renderer {
 	}
 }
 
+// WithAgent returns a new Renderer whose agent template functions are
+// overridden with the provided values.
+func (r *Renderer) WithAgent(command, window, flags string) *Renderer {
+	merged := make(template.FuncMap, len(r.funcs))
+	for k, v := range r.funcs {
+		merged[k] = v
+	}
+
+	merged["agentCommand"] = func() string { return stringOrDefault(command, "claude") }
+	merged["agentWindow"] = func() string { return stringOrDefault(window, "claude") }
+	merged["agentFlags"] = func() string { return flags }
+
+	return &Renderer{funcs: merged}
+}
+
 // NewValidation creates a Renderer with safe defaults for template syntax checking.
 // Template functions return placeholder values — output is discarded, only parse errors matter.
 func NewValidation() *Renderer {

--- a/pkg/tmpl/tmpl_test.go
+++ b/pkg/tmpl/tmpl_test.go
@@ -226,3 +226,40 @@ func TestRenderers_Isolated(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "aider", got2)
 }
+
+func TestRenderer_WithAgent(t *testing.T) {
+	base := New(Config{AgentCommand: "claude", AgentWindow: "claude"})
+	override := base.WithAgent("aider", "aider", "--model sonnet")
+
+	got, err := override.Render("{{ agentCommand }}", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "aider", got)
+
+	got, err = override.Render("{{ agentWindow }}", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "aider", got)
+
+	got, err = override.Render("{{ agentFlags }}", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "--model sonnet", got)
+
+	got, err = base.Render("{{ agentCommand }}", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "claude", got)
+}
+
+func TestRenderer_WithAgent_PreservesOtherFuncs(t *testing.T) {
+	base := New(Config{
+		ScriptPaths:  map[string]string{"hive-tmux": "/bin/hive-tmux"},
+		AgentCommand: "claude",
+	})
+	override := base.WithAgent("aider", "aider", "")
+
+	got, err := override.Render("{{ hiveTmux }}", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/bin/hive-tmux", got)
+
+	got, err = override.Render("{{ agentCommand | shq }}", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "'aider'", got)
+}


### PR DESCRIPTION
## Summary
- add `Renderer.WithAgent(...)` so agent template functions can be overridden per render while keeping the base renderer immutable
- thread agent override selection through session creation via `CreateOptions.Agent`, `SessionService.resolveRenderer`, and a shallow-copy spawner renderer override
- add `--agent/-a` support to `hive new` and `hive batch`, plus per-session `agent` in batch input with validation and fallback (`session.agent` -> CLI `--agent` -> config default)
- extend command/template tests to cover override behavior, profile validation, and batch agent fallback logic

## Verification
- `go test ./pkg/tmpl/...`
- `go test ./internal/hive/...`
- `go test ./internal/commands/...`
- `mise run check`
- manual CLI checks for unknown agent validation in `hive new` and `hive batch`