### PR TITLE
fix: add word wrapping to review comments and standardize content width

### DIFF
--- a/internal/commands/cmd_review.go
+++ b/internal/commands/cmd_review.go
@@ -166,12 +166,11 @@ func (cmd *ReviewCmd) runWithContextDir(ctx context.Context, c *cli.Command) err
 func (cmd *ReviewCmd) launchReviewTUI(ctx context.Context, documents []review.Document, initialDoc *review.Document, contextDir string) error {
 	// Create review-only options
 	opts := tui.ReviewOnlyOptions{
-		Documents:        documents,
-		InitialDoc:       initialDoc,
-		ContextDir:       contextDir,
-		DB:               cmd.app.DB,
-		CommentLineWidth: cmd.app.Config.Review.CommentLineWidthOrDefault(),
-		CopyCommand:      cmd.app.Config.CopyCommand,
+		Documents:   documents,
+		InitialDoc:  initialDoc,
+		ContextDir:  contextDir,
+		DB:          cmd.app.DB,
+		CopyCommand: cmd.app.Config.CopyCommand,
 	}
 
 	// Create review-only model

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -333,17 +333,7 @@ type ViewsConfig struct {
 }
 
 // ReviewConfig holds review-related configuration.
-type ReviewConfig struct {
-	CommentLineWidth int `yaml:"comment_line_width"` // minimum width for comment wrapping (default: 80)
-}
-
-// CommentLineWidthOrDefault returns the configured comment line width or 80 if not set.
-func (r ReviewConfig) CommentLineWidthOrDefault() int {
-	if r.CommentLineWidth <= 0 {
-		return 80
-	}
-	return r.CommentLineWidth
-}
+type ReviewConfig struct{}
 
 // IconsEnabled returns true if nerd font icons should be shown.
 func (t TUIConfig) IconsEnabled() bool {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -246,7 +246,7 @@ func New(deps Deps, opts Opts) Model {
 		reviewStore = stores.NewReviewStore(deps.DB)
 	}
 
-	reviewView := review.New(docs, contextDir, reviewStore, cfg.Review.CommentLineWidthOrDefault())
+	reviewView := review.New(docs, contextDir, reviewStore)
 
 	var notifyStore notify.Store
 	if deps.DB != nil {

--- a/internal/tui/review_doc_cmd_test.go
+++ b/internal/tui/review_doc_cmd_test.go
@@ -51,7 +51,7 @@ func TestHiveDocReviewCmd_Execute(t *testing.T) {
 			Type:    review.DocTypeResearch,
 		},
 	}
-	reviewView := review.New(docs, "/test", nil, 0)
+	reviewView := review.New(docs, "/test", nil)
 	reviewView.SetSize(100, 40)
 
 	// Create a minimal handler for testing
@@ -91,7 +91,7 @@ func TestOpenDocument(t *testing.T) {
 			Type:    review.DocTypeResearch,
 		},
 	}
-	reviewView := review.New(docs, "/test", nil, 0)
+	reviewView := review.New(docs, "/test", nil)
 	reviewView.SetSize(100, 40)
 
 	tests := []struct {
@@ -143,7 +143,7 @@ func TestGetAllDocuments(t *testing.T) {
 		{RelPath: "doc2.md", Type: review.DocTypeResearch},
 	}
 
-	reviewView := review.New(docs, "/test", nil, 0)
+	reviewView := review.New(docs, "/test", nil)
 
 	allDocs := reviewView.GetAllDocuments()
 

--- a/internal/tui/review_only.go
+++ b/internal/tui/review_only.go
@@ -16,12 +16,11 @@ import (
 
 // ReviewOnlyOptions configures the review-only TUI.
 type ReviewOnlyOptions struct {
-	Documents        []review.Document
-	InitialDoc       *review.Document
-	ContextDir       string // Directory for saving feedback files (e.g., context directory)
-	DB               *db.DB
-	CommentLineWidth int
-	CopyCommand      string // Shell command for copying to clipboard (e.g., "pbcopy" on macOS)
+	Documents   []review.Document
+	InitialDoc  *review.Document
+	ContextDir  string // Directory for saving feedback files (e.g., context directory)
+	DB          *db.DB
+	CopyCommand string // Shell command for copying to clipboard (e.g., "pbcopy" on macOS)
 }
 
 // ReviewOnlyModel is a minimal TUI for reviewing context documents.
@@ -42,7 +41,7 @@ func NewReviewOnly(opts ReviewOnlyOptions) ReviewOnlyModel {
 	store := stores.NewReviewStore(opts.DB)
 
 	// Create review view
-	reviewView := review.New(opts.Documents, opts.ContextDir, store, opts.CommentLineWidth)
+	reviewView := review.New(opts.Documents, opts.ContextDir, store)
 
 	return ReviewOnlyModel{
 		reviewView:  reviewView,

--- a/internal/tui/review_only_test.go
+++ b/internal/tui/review_only_test.go
@@ -31,12 +31,11 @@ func TestReviewOnly_QKeyWithActiveEditor(t *testing.T) {
 
 	// Create review-only model
 	m := NewReviewOnly(ReviewOnlyOptions{
-		Documents:        []review.Document{doc},
-		InitialDoc:       nil,
-		ContextDir:       "",
-		DB:               dbConn,
-		CommentLineWidth: 80,
-		CopyCommand:      "", // Not testing clipboard in unit tests
+		Documents:   []review.Document{doc},
+		InitialDoc:  nil,
+		ContextDir:  "",
+		DB:          dbConn,
+		CopyCommand: "", // Not testing clipboard in unit tests
 	})
 
 	// Initialize and resize to simulate real usage
@@ -88,12 +87,11 @@ func TestReviewOnly_CtrlCAlwaysQuits(t *testing.T) {
 
 	// Create review-only model
 	m := NewReviewOnly(ReviewOnlyOptions{
-		Documents:        []review.Document{doc},
-		InitialDoc:       nil,
-		ContextDir:       "",
-		DB:               dbConn,
-		CommentLineWidth: 80,
-		CopyCommand:      "", // Not testing clipboard in unit tests
+		Documents:   []review.Document{doc},
+		InitialDoc:  nil,
+		ContextDir:  "",
+		DB:          dbConn,
+		CopyCommand: "", // Not testing clipboard in unit tests
 	})
 
 	// Initialize and resize
@@ -118,7 +116,7 @@ func TestReviewOnly_CtrlCAlwaysQuits(t *testing.T) {
 // TestReviewView_HasActiveEditor verifies the HasActiveEditor method.
 func TestReviewView_HasActiveEditor(t *testing.T) {
 	// Create minimal view without database (not needed for this test)
-	v := review.New([]review.Document{}, "", nil, 80)
+	v := review.New([]review.Document{}, "", nil)
 
 	// Initially no active editor
 	assert.False(t, v.HasActiveEditor(), "Should have no active editor initially")

--- a/internal/tui/views/review/comment_modal_test.go
+++ b/internal/tui/views/review/comment_modal_test.go
@@ -17,7 +17,7 @@ func TestCommentModal_View(t *testing.T) {
 		"}",
 	}, "\n")
 
-	modal := NewCommentModal(10, 14, contextText, 80, 24, 80)
+	modal := NewCommentModal(10, 14, contextText, 80, 24)
 	output := modal.View()
 	output = testutil.StripANSI(output)
 
@@ -32,7 +32,7 @@ func TestCommentModal_ViewWithLongContext(t *testing.T) {
 	}
 	contextText := strings.Join(lines, "\n")
 
-	modal := NewCommentModal(1, 30, contextText, 80, 24, 80)
+	modal := NewCommentModal(1, 30, contextText, 80, 24)
 	output := modal.View()
 	output = testutil.StripANSI(output)
 
@@ -43,7 +43,7 @@ func TestCommentModal_ViewMultiline(t *testing.T) {
 	// Create modal with simple multiline input
 	contextText := "func example() {\n    return true\n}"
 
-	modal := NewCommentModal(1, 3, contextText, 80, 24, 80)
+	modal := NewCommentModal(1, 3, contextText, 80, 24)
 	// Simulate multiline textArea input
 	modal.textArea.SetValue("Line 1\nLine 2\nLine 3")
 
@@ -57,7 +57,7 @@ func TestCommentModal_ViewLongMultiline(t *testing.T) {
 	// Create modal with 10 lines to test textArea scrolling
 	contextText := "func example() {\n    return true\n}"
 
-	modal := NewCommentModal(1, 3, contextText, 80, 24, 80)
+	modal := NewCommentModal(1, 3, contextText, 80, 24)
 	// Simulate 10 lines of input
 	lines := make([]string, 10)
 	for i := range 10 {

--- a/internal/tui/views/review/document_view.go
+++ b/internal/tui/views/review/document_view.go
@@ -12,38 +12,31 @@ import (
 
 // DocumentView handles document rendering with line numbers, comments, and cursor highlighting.
 type DocumentView struct {
-	viewport         viewport.Model
-	document         *Document   // Currently loaded document
-	cursorLine       int         // 1-indexed cursor position
-	selectionStart   int         // 1-indexed selection anchor (0 if none)
-	lineMapping      map[int]int // Maps document line numbers to display line numbers (nil when no comments)
-	searchMatches    []int       // Line numbers of search matches (1-indexed, in document coordinates)
-	searchIndex      int         // Current match index in searchMatches
-	width            int         // Viewport width
-	height           int         // Viewport height
-	commentLineWidth int         // Configured max width for comment wrapping (from config, default: 80)
+	viewport       viewport.Model
+	document       *Document   // Currently loaded document
+	cursorLine     int         // 1-indexed cursor position
+	selectionStart int         // 1-indexed selection anchor (0 if none)
+	lineMapping    map[int]int // Maps document line numbers to display line numbers (nil when no comments)
+	searchMatches  []int       // Line numbers of search matches (1-indexed, in document coordinates)
+	searchIndex    int         // Current match index in searchMatches
+	width          int         // Viewport width
+	height         int         // Viewport height
 }
 
 // NewDocumentView creates a new DocumentView instance.
-// commentLineWidth sets the max width for comment wrapping (0 = default 80).
-func NewDocumentView(doc *Document, commentLineWidth int) DocumentView {
+func NewDocumentView(doc *Document) DocumentView {
 	vp := viewport.New()
 
-	if commentLineWidth <= 0 {
-		commentLineWidth = 80
-	}
-
 	return DocumentView{
-		viewport:         vp,
-		document:         doc,
-		cursorLine:       1,
-		selectionStart:   0,
-		lineMapping:      nil,
-		searchMatches:    nil,
-		searchIndex:      0,
-		width:            80,
-		height:           24,
-		commentLineWidth: commentLineWidth,
+		viewport:       vp,
+		document:       doc,
+		cursorLine:     1,
+		selectionStart: 0,
+		lineMapping:    nil,
+		searchMatches:  nil,
+		searchIndex:    0,
+		width:          80,
+		height:         24,
 	}
 }
 
@@ -196,15 +189,11 @@ func (dv *DocumentView) ensureCursorVisible() {
 	}
 }
 
-// wrapComment wraps comment text to fit within configured width.
-// Uses commentLineWidth as the target width, adjusting based on viewport width.
+// wrapComment wraps comment text to fit within the content width.
 // indent specifies number of spaces to add at the start of the first line.
 // Continuation lines get 2 additional spaces of indentation.
 func (dv *DocumentView) wrapComment(text string, indent int) []string {
-	// Use configured comment line width
-	minWidth := dv.commentLineWidth
-	// Reserve 15 chars for line numbers and padding
-	maxWidth := max(minWidth, dv.width-15)
+	maxWidth := contentWrapWidth(dv.width)
 
 	// Split text into words
 	words := strings.Fields(text)

--- a/internal/tui/views/review/document_view_test.go
+++ b/internal/tui/views/review/document_view_test.go
@@ -23,7 +23,7 @@ func createTestDocument(lines []string) *Document {
 
 func TestDocumentView_RenderEmpty(t *testing.T) {
 	doc := createTestDocument([]string{})
-	dv := NewDocumentView(doc, 80)
+	dv := NewDocumentView(doc)
 	dv.SetSize(80, 24)
 
 	output := dv.Render()
@@ -39,7 +39,7 @@ func TestDocumentView_RenderWithLineNumbers(t *testing.T) {
 		"This is line 3.",
 		"This is line 4.",
 	})
-	dv := NewDocumentView(doc, 80)
+	dv := NewDocumentView(doc)
 	dv.SetSize(80, 24)
 
 	output := dv.Render()
@@ -55,7 +55,7 @@ func TestDocumentView_RenderWithComments(t *testing.T) {
 		"This is line 3.",
 		"This is line 4.",
 	})
-	dv := NewDocumentView(doc, 80)
+	dv := NewDocumentView(doc)
 	dv.SetSize(80, 24)
 
 	comments := []corereview.Comment{
@@ -74,7 +74,7 @@ func TestDocumentView_RenderWithLongComment(t *testing.T) {
 		"This is line 3.",
 		"This is line 4.",
 	})
-	dv := NewDocumentView(doc, 80)
+	dv := NewDocumentView(doc)
 	dv.SetSize(80, 24)
 
 	longComment := "This is a very long comment that exceeds 80 characters to test wrapping behavior and formatting."
@@ -97,7 +97,7 @@ func TestDocumentView_RenderWithSelection(t *testing.T) {
 		"Line 6",
 		"Line 7",
 	})
-	dv := NewDocumentView(doc, 80)
+	dv := NewDocumentView(doc)
 	dv.SetSize(80, 24)
 
 	// Set selection on lines 4-6
@@ -117,7 +117,7 @@ func TestDocumentView_RenderWithSearchHighlight(t *testing.T) {
 		"Another line with search.",
 		"Last line.",
 	})
-	dv := NewDocumentView(doc, 80)
+	dv := NewDocumentView(doc)
 	dv.SetSize(80, 24)
 
 	// Highlight matches at lines 3 and 4, with current match at index 0 (line 3)
@@ -184,7 +184,7 @@ func TestDocumentView_MoveCursor(t *testing.T) {
 				"Line 5",
 			})
 
-			dv := NewDocumentView(doc, 80)
+			dv := NewDocumentView(doc)
 			dv.SetSize(80, 24)
 
 			// Override RenderedLines to bypass glamour rendering for testing
@@ -208,7 +208,7 @@ func TestDocumentView_MoveCursor(t *testing.T) {
 }
 
 func TestDocumentView_MoveCursor_NilDocument(t *testing.T) {
-	dv := NewDocumentView(nil, 80)
+	dv := NewDocumentView(nil)
 	dv.SetSize(80, 24)
 	dv.cursorLine = 1
 
@@ -269,7 +269,7 @@ func TestDocumentView_JumpToLine(t *testing.T) {
 				"Line 5",
 			})
 
-			dv := NewDocumentView(doc, 80)
+			dv := NewDocumentView(doc)
 			dv.SetSize(80, 24)
 
 			// Override RenderedLines to bypass glamour rendering for testing
@@ -291,7 +291,7 @@ func TestDocumentView_JumpToLine(t *testing.T) {
 }
 
 func TestDocumentView_JumpToLine_NilDocument(t *testing.T) {
-	dv := NewDocumentView(nil, 80)
+	dv := NewDocumentView(nil)
 	dv.SetSize(80, 24)
 	dv.cursorLine = 1
 
@@ -305,7 +305,7 @@ func TestDocumentView_JumpToLine_NilDocument(t *testing.T) {
 }
 
 func TestDocumentView_CoordinateMapping(t *testing.T) {
-	dv := NewDocumentView(nil, 80) // don't need actual document for these tests
+	dv := NewDocumentView(nil) // don't need actual document for these tests
 
 	t.Run("mapDocToDisplay with nil mapping", func(t *testing.T) {
 		// With nil mapping, document and display coordinates are the same

--- a/internal/tui/views/review/review_comment_modal.go
+++ b/internal/tui/views/review/review_comment_modal.go
@@ -25,10 +25,9 @@ type CommentModal struct {
 }
 
 // NewCommentModal creates a new comment modal.
-// maxWidth constrains the modal width (e.g., from config.Review.CommentLineWidth).
-func NewCommentModal(startLine, endLine int, contextText string, width, height int, maxWidth int) CommentModal {
-	// Constrain modal width to maxWidth (with padding for borders)
-	modalWidth := min(width-10, maxWidth+10) // +10 for padding/borders
+func NewCommentModal(startLine, endLine int, contextText string, width, height int) CommentModal {
+	// Constrain modal width to content width (with padding for borders)
+	modalWidth := min(width-10, maxContentWidth+10) // +10 for padding/borders
 
 	ta := textarea.New()
 	ta.Placeholder = "Enter your review comment..."

--- a/internal/tui/views/review/review_document.go
+++ b/internal/tui/views/review/review_document.go
@@ -11,6 +11,19 @@ import (
 	"github.com/colonyops/hive/internal/core/styles"
 )
 
+const (
+	// maxContentWidth is the maximum line width for content wrapping (markdown and comments).
+	maxContentWidth = 120
+	// lineNumberReserved is the space reserved for line numbers and separators.
+	lineNumberReserved = 6
+)
+
+// contentWrapWidth computes the wrap width for a given viewport width.
+// Used by both markdown rendering and comment wrapping to ensure consistent line lengths.
+func contentWrapWidth(viewportWidth int) int {
+	return max(min(viewportWidth-lineNumberReserved, maxContentWidth), 20)
+}
+
 // DocumentType categorizes documents.
 type DocumentType int
 
@@ -197,9 +210,7 @@ func (d *Document) Render(width int) (string, error) {
 	}
 
 	// Create glamour renderer with Tokyo Night theme
-	// Account for line numbers (4 chars) + separator (2 chars)
-	// Ensure minimum reasonable width of 20 characters, maximum of 120 for readability
-	wrapWidth := max(min(width-6, 120), 20)
+	wrapWidth := contentWrapWidth(width)
 	r, err := glamour.NewTermRenderer(
 		glamour.WithStyles(styles.GlamourStyle()),
 		glamour.WithWordWrap(wrapWidth),

--- a/internal/tui/views/review/review_view.go
+++ b/internal/tui/views/review/review_view.go
@@ -64,7 +64,6 @@ type View struct {
 	pendingDiscard    bool                     // True when waiting for discard confirmation
 	editingCommentID  string                   // ID of comment being edited (empty if creating new)
 	lineMapping       map[int]int              // Maps document line numbers to display line numbers (nil when no comments)
-	commentLineWidth  int                      // Max width for comment modal (from config, default: 80)
 
 	// Phase 1 refactor: extracted components
 	documentView        DocumentView // Document rendering and navigation
@@ -75,8 +74,7 @@ type View struct {
 // New creates a new review view.
 // If contextDir is non-empty, it will watch for file changes.
 // If store is non-nil, comments will be persisted to the database.
-// commentLineWidth sets the max width for the comment modal (0 = default 80).
-func New(documents []Document, contextDir string, store *stores.ReviewStore, commentLineWidth int) View {
+func New(documents []Document, contextDir string, store *stores.ReviewStore) View {
 	items := BuildTreeItems(documents)
 	delegate := NewReviewTreeDelegate()
 	l := list.New(items, delegate, 0, 0)
@@ -118,27 +116,21 @@ func New(documents []Document, contextDir string, store *stores.ReviewStore, com
 	// Enable paste
 	ti.KeyMap.Paste.SetEnabled(true)
 
-	// Apply default comment line width if not set
-	if commentLineWidth <= 0 {
-		commentLineWidth = 80
-	}
-
 	// Initialize Phase 1 components
-	documentView := NewDocumentView(nil, commentLineWidth) // Will be populated when document is loaded
+	documentView := NewDocumentView(nil)
 	searchModeComponent := NewSearchMode()
 	modalState := NewModalState()
 
 	return View{
-		list:             l,
-		viewport:         vp,
-		watcher:          watcher,
-		contextDir:       contextDir,
-		store:            store,
-		previewMode:      false,
-		fullScreen:       false,
-		cursorLine:       1,
-		searchInput:      ti,
-		commentLineWidth: commentLineWidth,
+		list:        l,
+		viewport:    vp,
+		watcher:     watcher,
+		contextDir:  contextDir,
+		store:       store,
+		previewMode: false,
+		fullScreen:  false,
+		cursorLine:  1,
+		searchInput: ti,
 		// Phase 1 components
 		documentView:        documentView,
 		searchModeComponent: searchModeComponent,
@@ -431,7 +423,7 @@ func (v View) Update(msg tea.Msg) (View, tea.Cmd) {
 					// Calculate selection range from anchor to cursor
 					start := min(v.selectionStart, v.cursorLine)
 					end := max(v.selectionStart, v.cursorLine)
-					modal := NewCommentModal(start, end, contextText, v.width, v.height, v.commentLineWidth)
+					modal := NewCommentModal(start, end, contextText, v.width, v.height)
 					v.commentModal = &modal
 					return v, nil
 				}
@@ -448,7 +440,6 @@ func (v View) Update(msg tea.Msg) (View, tea.Cmd) {
 								comment.ContextText,
 								v.width,
 								v.height,
-								v.commentLineWidth,
 							)
 							modal.SetExistingComment(comment.CommentText)
 							v.commentModal = &modal
@@ -920,7 +911,7 @@ func (v *View) renderSelection() {
 	// Insert comments inline if session exists and build line mapping
 	if v.activeSession != nil && len(v.activeSession.Comments) > 0 {
 		var mappedContent string
-		mappedContent, v.lineMapping = v.insertCommentsInline(rendered)
+		mappedContent, v.lineMapping = v.insertCommentsInline(rendered, previewWidth)
 		rendered = mappedContent
 	} else {
 		// Clear line mapping when no comments
@@ -1552,10 +1543,13 @@ func (v *View) updateTreeItemCommentCount() {
 	}
 }
 
-// formatCommentLines formats comment text with proper indentation.
-// Preserves explicit newlines and aligns continuation lines.
-// The first line includes the icon and base indent, subsequent lines align with text after icon.
-func (v *View) formatCommentLines(icon, text string, baseIndent int) []string {
+// formatCommentLines formats comment text with proper indentation and word wrapping.
+// Preserves explicit newlines, wraps long lines to fit the content width,
+// and aligns continuation lines with text after the icon.
+// contentWidth should match the preview width passed to Document.Render.
+func (v *View) formatCommentLines(icon, text string, baseIndent, contentWidth int) []string {
+	maxWidth := contentWrapWidth(contentWidth)
+
 	// Split by explicit newlines first (preserve user's line breaks)
 	inputLines := strings.Split(text, "\n")
 
@@ -1564,16 +1558,52 @@ func (v *View) formatCommentLines(icon, text string, baseIndent int) []string {
 	// Continuation lines use baseIndent + 3 spaces for visual separation
 	// (icon is 1 char + 1 space = 2 chars, but we add 3 for better readability)
 	continuationIndentStr := baseIndentStr + "   "
+	continuationIndentLen := baseIndent + 3
 
 	for i, line := range inputLines {
-		line = strings.TrimRight(line, " \t") // Remove trailing whitespace
+		line = strings.TrimRight(line, " \t")
+		words := strings.Fields(line)
 
+		var prefix string
 		if i == 0 {
-			// First line: add icon
-			result = append(result, baseIndentStr+icon+" "+line)
+			prefix = baseIndentStr + icon + " "
 		} else {
-			// Subsequent lines: align with first line's text
-			result = append(result, continuationIndentStr+line)
+			prefix = continuationIndentStr
+		}
+
+		if len(words) == 0 {
+			result = append(result, prefix)
+			continue
+		}
+
+		var currentLine strings.Builder
+		currentLine.WriteString(prefix)
+		currentLineLen := continuationIndentLen // both prefixes have same display width
+
+		for j, word := range words {
+			wordLen := len(word)
+			spaceLen := 0
+			if j > 0 {
+				spaceLen = 1
+			}
+
+			if currentLineLen+spaceLen+wordLen > maxWidth && currentLineLen > continuationIndentLen {
+				result = append(result, currentLine.String())
+				currentLine.Reset()
+				currentLine.WriteString(continuationIndentStr)
+				currentLine.WriteString(word)
+				currentLineLen = continuationIndentLen + wordLen
+			} else {
+				if j > 0 {
+					currentLine.WriteString(" ")
+				}
+				currentLine.WriteString(word)
+				currentLineLen += spaceLen + wordLen
+			}
+		}
+
+		if currentLine.Len() > 0 {
+			result = append(result, currentLine.String())
 		}
 	}
 
@@ -1582,7 +1612,7 @@ func (v *View) formatCommentLines(icon, text string, baseIndent int) []string {
 
 // insertCommentsInline inserts comments after their referenced lines.
 // Returns the rendered content and a mapping from document line numbers to display line numbers.
-func (v *View) insertCommentsInline(content string) (string, map[int]int) {
+func (v *View) insertCommentsInline(content string, contentWidth int) (string, map[int]int) {
 	lines := strings.Split(content, "\n")
 	originalLineCount := len(lines)
 
@@ -1625,7 +1655,7 @@ func (v *View) insertCommentsInline(content string) (string, map[int]int) {
 		for _, comment := range comments {
 			icon := styles.IconComment
 			// Format with proper indentation, preserving explicit newlines
-			formattedLines := v.formatCommentLines(icon, comment.CommentText, 6)
+			formattedLines := v.formatCommentLines(icon, comment.CommentText, 7, contentWidth)
 			// Apply styling to each formatted line
 			for _, formattedLine := range formattedLines {
 				styledLine := commentStyle.Render(formattedLine)

--- a/internal/tui/views/review/review_view_test.go
+++ b/internal/tui/views/review/review_view_test.go
@@ -111,7 +111,7 @@ func TestNew(t *testing.T) {
 		},
 	}
 
-	view := New(docs, "", nil, 0)
+	view := New(docs, "", nil)
 
 	// Should not panic and should have a list
 	require.NotNil(t, view.list.Items(), "expected list items to be initialized")
@@ -125,7 +125,7 @@ func TestDocumentWatcherIntegration(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create review view with watcher
-	view := New([]Document{}, tmpDir, nil, 0)
+	view := New([]Document{}, tmpDir, nil)
 
 	// View should have a watcher
 	require.NotNil(t, view.watcher, "expected watcher to be initialized")
@@ -144,7 +144,7 @@ func TestCommentDeletionWithConfirmation(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -196,7 +196,7 @@ func TestCommentDeletionCancellation(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -245,7 +245,7 @@ func TestReviewDiscardWithConfirmation(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -312,7 +312,7 @@ func TestReviewDiscardCancellation(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -359,7 +359,7 @@ func TestReviewDiscardWithNoComments(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -389,7 +389,7 @@ func TestCommentVisualStyling(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.selectedDoc = &doc
 
@@ -414,7 +414,7 @@ func TestCommentVisualStyling(t *testing.T) {
 
 	// Render the document with comments
 	content := "Line 1\nLine 2\nLine 3"
-	rendered, _ := view.insertCommentsInline(content)
+	rendered, _ := view.insertCommentsInline(content, 120)
 
 	// Check that the rendered output contains the comment icon
 	assert.Contains(t, rendered, styles.IconComment, "expected rendered output to contain '%s' icon", styles.IconComment)
@@ -447,7 +447,7 @@ func TestLineMappingWithComments(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.selectedDoc = &doc
 
 	// Create a session with comments on lines 2 and 4
@@ -480,7 +480,7 @@ func TestLineMappingWithComments(t *testing.T) {
 
 	// Insert comments and get line mapping
 	content := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
-	_, lineMapping := view.insertCommentsInline(content)
+	_, lineMapping := view.insertCommentsInline(content, 120)
 
 	// Verify line mapping
 	// Expected mapping:
@@ -533,7 +533,7 @@ func TestView_WithPickerModal(t *testing.T) {
 		{RelPath: "doc1.md", Type: DocTypePlan},
 	}
 
-	reviewView := New(docs, "/test", nil, 0)
+	reviewView := New(docs, "/test", nil)
 	reviewView.SetSize(100, 40)
 
 	// Show picker
@@ -546,7 +546,7 @@ func TestView_WithPickerModal(t *testing.T) {
 }
 
 func TestView_HasPickerModalField(t *testing.T) {
-	reviewView := New(nil, "", nil, 0)
+	reviewView := New(nil, "", nil)
 
 	// Access the field to ensure it exists
 	_ = reviewView.pickerModal
@@ -573,7 +573,7 @@ func TestScrollVisibilityWithComments(t *testing.T) {
 		RenderedLines: lines,
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 10) // Small height to force scrolling
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -608,7 +608,7 @@ func TestScrollVisibilityWithComments(t *testing.T) {
 
 	// Build line mapping by rendering with comments
 	rendered := content
-	rendered, lineMapping := view.insertCommentsInline(rendered)
+	rendered, lineMapping := view.insertCommentsInline(rendered, 120)
 	view.lineMapping = lineMapping
 	view.viewport.SetContent(rendered)
 
@@ -655,7 +655,7 @@ func TestJumpToMatchWithComments(t *testing.T) {
 		RenderedLines: lines,
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 10)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -690,7 +690,7 @@ func TestJumpToMatchWithComments(t *testing.T) {
 
 	// Build line mapping
 	rendered := content
-	rendered, lineMapping := view.insertCommentsInline(rendered)
+	rendered, lineMapping := view.insertCommentsInline(rendered, 120)
 	view.lineMapping = lineMapping
 	view.viewport.SetContent(rendered)
 
@@ -769,7 +769,7 @@ func TestReverseMappingCorrectness(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.selectedDoc = &doc
 
 	// Create session with comments
@@ -802,7 +802,7 @@ func TestReverseMappingCorrectness(t *testing.T) {
 
 	// Build line mapping
 	content := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
-	_, lineMapping := view.insertCommentsInline(content)
+	_, lineMapping := view.insertCommentsInline(content, 120)
 
 	// Build reverse map
 	displayToDoc := buildDisplayToDocMap(lineMapping)
@@ -870,7 +870,7 @@ func TestFinalizedSessionsNotReloaded(t *testing.T) {
 	}
 
 	// Create review view with the store
-	view := New([]Document{doc}, tmpDir, store, 0)
+	view := New([]Document{doc}, tmpDir, store)
 	view.SetSize(80, 24)
 
 	// Load document and create a session with a comment
@@ -919,7 +919,7 @@ func TestCtrlDUWithComments(t *testing.T) {
 		RenderedLines: lines,
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 10) // Small height to force scrolling
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -963,7 +963,7 @@ func TestCtrlDUWithComments(t *testing.T) {
 
 	// Build line mapping by rendering with comments
 	rendered := content
-	rendered, lineMapping := view.insertCommentsInline(rendered)
+	rendered, lineMapping := view.insertCommentsInline(rendered, 120)
 	view.lineMapping = lineMapping
 	view.viewport.SetContent(rendered)
 
@@ -1010,7 +1010,7 @@ func TestFinalizationModal_IntegrationWithView(t *testing.T) {
 			Type:    DocTypePlan,
 		},
 	}
-	v := New(docs, "/test", nil, 0)
+	v := New(docs, "/test", nil)
 	v.SetSize(100, 40)
 
 	// Manually set up the finalization modal state (simulating pressing 'f')
@@ -1046,7 +1046,7 @@ func TestHasActiveEditor(t *testing.T) {
 		Content: "Line 1\nLine 2\nLine 3",
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 	view.fullScreen = true
 	view.selectedDoc = &doc
@@ -1063,7 +1063,7 @@ func TestHasActiveEditor(t *testing.T) {
 	assert.False(t, view.HasActiveEditor(), "expected HasActiveEditor to be false after disabling search mode")
 
 	// Open comment modal - should have active editor
-	modal := NewCommentModal(1, 2, "context", 80, 24, 80)
+	modal := NewCommentModal(1, 2, "context", 80, 24)
 	view.commentModal = &modal
 	assert.True(t, view.HasActiveEditor(), "expected HasActiveEditor to be true when comment modal is active")
 

--- a/internal/tui/views/review/view_golden_test.go
+++ b/internal/tui/views/review/view_golden_test.go
@@ -27,7 +27,7 @@ func TestView_ListMode(t *testing.T) {
 		},
 	}
 
-	view := New(docs, "", nil, 0)
+	view := New(docs, "", nil)
 	view.SetSize(80, 24)
 
 	output := view.View()
@@ -59,7 +59,7 @@ func TestView_DocumentMode(t *testing.T) {
 		Content: testContent,
 	}
 
-	view := New([]Document{doc}, "", nil, 0)
+	view := New([]Document{doc}, "", nil)
 	view.SetSize(80, 24)
 
 	// Load the document to enter fullscreen mode


### PR DESCRIPTION
## Summary
- Review comments now word-wrap at the same line length as markdown content using a shared `contentWrapWidth` helper
- Removed `commentLineWidth` config field (`comment_line_width`) in favor of a unified content width constant (max 120 chars), matching the markdown renderer
- Increased comment base indent from 6 to 7 spaces

## Test plan
- [x] All existing tests pass
- [x] `mise run check` passes (tidy + lint + test)
- [x] Verify long comments wrap correctly in the review TUI
- [x] Verify comment indent aligns with document content