### PR TITLE
fix: window sub-item selection always targeting first window

### DIFF
--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -490,6 +490,14 @@ func (v *View) handleKey(msg tea.KeyMsg) (*View, tea.Cmd) {
 
 	selected := v.SelectedSession()
 
+	// Set window override before Resolve so TmuxOpen/TmuxStart actions
+	// target the selected window sub-item instead of the default.
+	if treeItem != nil && treeItem.IsWindowItem {
+		v.handler.SetSelectedWindow(treeItem.WindowIndex)
+	} else {
+		v.handler.SetSelectedWindow("")
+	}
+
 	// Resolve keybinding actions before the nil-session guard so that
 	// session-independent actions (GroupToggle, filters, etc.) work even
 	// when the cursor is on a header row.
@@ -507,12 +515,6 @@ func (v *View) handleKey(msg tea.KeyMsg) (*View, tea.Cmd) {
 		var cmd tea.Cmd
 		v.list, cmd = v.list.Update(msg)
 		return v, cmd
-	}
-
-	if treeItem != nil && treeItem.IsWindowItem {
-		v.handler.SetSelectedWindow(treeItem.WindowIndex)
-	} else {
-		v.handler.SetSelectedWindow("")
 	}
 
 	if cmdName, cmd, hasForm := v.handler.ResolveFormCommand(keyStr, *selected); hasForm {


### PR DESCRIPTION
## Summary

- Fixed ordering bug where `SetSelectedWindow` was called after `Resolve` in the key handler, causing `consumeWindowOverride` to always fall back to `tmuxWindowLookup` (which returns the first/active window)
- Moved `SetSelectedWindow` before `Resolve` so the correct window index is available when `TmuxOpen`/`TmuxStart` actions are resolved

## Test plan

- [x] Open TUI with a session that has multiple tmux windows
- [x] Navigate to the second window sub-item and press Enter
- [x] Verify tmux switches to the correct (second) window, not the first