### PR TITLE
fix: resolve document paths with URI schemes and symlinks

### DIFF
--- a/internal/tui/review_doc_cmd_test.go
+++ b/internal/tui/review_doc_cmd_test.go
@@ -123,8 +123,28 @@ func TestOpenDocument(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "strip review:// URI scheme with absolute path",
+			path:    "review:///test/plans/doc1.md",
+			wantErr: false,
+		},
+		{
+			name:    "strip review:// URI scheme with .hive/ path",
+			path:    "review://.hive/plans/doc1.md",
+			wantErr: false,
+		},
+		{
+			name:    "strip arbitrary URI scheme",
+			path:    "obsidian:///test/research/doc2.md",
+			wantErr: false,
+		},
+		{
 			name:    "not found",
 			path:    "nonexistent.md",
+			wantErr: true,
+		},
+		{
+			name:    "not found with URI scheme",
+			path:    "review://nonexistent.md",
 			wantErr: true,
 		},
 	}

--- a/internal/tui/views/review/review_view.go
+++ b/internal/tui/views/review/review_view.go
@@ -1962,66 +1962,88 @@ type OpenDocumentMsg struct {
 }
 
 // OpenDocumentByPath attempts to open a specific document by path.
-// Path can be absolute, relative to context directory, or prefixed with ".hive/"
-// (the symlink name agents use to reference context files from the repo root).
+// Path can be absolute, relative to context directory, prefixed with ".hive/",
+// or a URI with a scheme (e.g. review://.hive/plans/...).
 // Returns a command that sends an OpenDocumentMsg.
 func (v *View) OpenDocumentByPath(path string) tea.Cmd {
 	return func() tea.Msg {
-		// Resolve .hive/ prefix: the .hive symlink in the repo root points to contextDir,
-		// so ".hive/foo" is equivalent to contextDir/foo. Agents use .hive/-prefixed paths
-		// in URIs, but DiscoverDocuments stores RelPath relative to contextDir (no prefix).
-		absPath := path
-		relPath := path
-		if v.contextDir != "" && strings.HasPrefix(path, ".hive/") {
-			rel := strings.TrimPrefix(path, ".hive/")
-			absPath = filepath.Join(v.contextDir, rel)
-			relPath = rel
-		}
-
-		var found *Document
-		for _, ti := range TreeItemsDocuments(v.list.Items()) {
-			if ti.Document.Path == path || ti.Document.RelPath == path ||
-				ti.Document.Path == absPath || ti.Document.RelPath == relPath {
-				doc := ti.Document
-				found = &doc
-				break
-			}
-
-			// Check suffix match to handle stored paths that include a leading
-			// symlink component (e.g. ".hive/plans/doc.md" vs RelPath "plans/doc.md").
-			if strings.HasSuffix(ti.Document.Path, "/"+path) ||
-				strings.HasSuffix(path, "/"+ti.Document.RelPath) {
-				doc := ti.Document
-				found = &doc
-				break
-			}
-
-			// Basename fallback for legacy URIs or short references
-			if filepath.Base(ti.Document.Path) == filepath.Base(path) {
-				doc := ti.Document
-				found = &doc
-				break
-			}
-		}
-
-		// If not in the indexed list, try loading directly from disk.
-		// This handles newly created files that the watcher hasn't indexed yet.
-		if found == nil && absPath != path {
-			if info, err := os.Stat(absPath); err == nil && !info.IsDir() {
-				doc := Document{
-					Path:    absPath,
-					RelPath: relPath,
-					Type:    inferDocumentType(relPath),
-					ModTime: info.ModTime(),
-				}
-				found = &doc
-			}
-		}
-
+		found := v.findDocumentByPath(path)
 		if found == nil {
 			return OpenDocumentMsg{Path: path, Err: fmt.Errorf("document not found: %s", path)}
 		}
-
 		return OpenDocumentMsg{Path: found.Path}
 	}
+}
+
+// findDocumentByPath resolves a path to a Document using progressively looser matching:
+// URI stripping, .hive/ prefix resolution, exact match, symlink resolution,
+// suffix match, basename fallback, and finally disk fallback.
+func (v *View) findDocumentByPath(path string) *Document {
+	// Strip URI scheme if present (e.g. "review://path" → "path")
+	if idx := strings.Index(path, "://"); idx >= 0 {
+		path = path[idx+3:]
+	}
+
+	// Resolve .hive/ prefix: the .hive symlink points to contextDir,
+	// so ".hive/foo" is equivalent to contextDir/foo.
+	absPath := path
+	relPath := path
+	if v.contextDir != "" && strings.HasPrefix(path, ".hive/") {
+		rel := strings.TrimPrefix(path, ".hive/")
+		absPath = filepath.Join(v.contextDir, rel)
+		relPath = rel
+	}
+
+	docs := TreeItemsDocuments(v.list.Items())
+
+	// 1. Exact match against Path or RelPath (including .hive/-resolved variants)
+	for _, ti := range docs {
+		if ti.Document.Path == path || ti.Document.RelPath == path ||
+			ti.Document.Path == absPath || ti.Document.RelPath == relPath {
+			doc := ti.Document
+			return &doc
+		}
+	}
+
+	// 2. Resolve symlinks and try again
+	if resolved, err := filepath.EvalSymlinks(path); err == nil && resolved != path {
+		for _, ti := range docs {
+			if ti.Document.Path == resolved {
+				doc := ti.Document
+				return &doc
+			}
+		}
+	}
+
+	// 3. Suffix match for paths with different prefixes
+	for _, ti := range docs {
+		if strings.HasSuffix(ti.Document.Path, "/"+path) ||
+			strings.HasSuffix(path, "/"+ti.Document.RelPath) {
+			doc := ti.Document
+			return &doc
+		}
+	}
+
+	// 4. Basename fallback
+	base := filepath.Base(path)
+	for _, ti := range docs {
+		if filepath.Base(ti.Document.Path) == base {
+			doc := ti.Document
+			return &doc
+		}
+	}
+
+	// 5. Disk fallback for files not yet indexed by the watcher
+	if absPath != path {
+		if info, err := os.Stat(absPath); err == nil && !info.IsDir() {
+			return &Document{
+				Path:    absPath,
+				RelPath: relPath,
+				Type:    inferDocumentType(relPath),
+				ModTime: info.ModTime(),
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/tui/views/review/review_view_test.go
+++ b/internal/tui/views/review/review_view_test.go
@@ -839,6 +839,73 @@ func TestReverseMappingCorrectness(t *testing.T) {
 	assert.Nil(t, nilResult, "buildDisplayToDocMap(nil) should return nil")
 }
 
+func TestFindDocumentByPath(t *testing.T) {
+	docs := []Document{
+		{Path: "/ctx/plans/design.md", RelPath: "plans/design.md", Type: DocTypePlan},
+		{Path: "/ctx/research/notes.md", RelPath: "research/notes.md", Type: DocTypeResearch},
+	}
+	view := New(docs, "/ctx", nil)
+	view.SetSize(100, 40)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantNil bool
+	}{
+		{name: "exact absolute path", path: "/ctx/plans/design.md"},
+		{name: "exact relative path", path: "plans/design.md"},
+		{name: "basename match", path: "design.md"},
+		{name: "strip review:// scheme", path: "review:///ctx/plans/design.md"},
+		{name: "strip review:// with relpath", path: "review://plans/design.md"},
+		{name: "strip arbitrary scheme", path: "obsidian:///ctx/research/notes.md"},
+		{name: "not found", path: "missing.md", wantNil: true},
+		{name: "not found with scheme", path: "review://missing.md", wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found := view.findDocumentByPath(tt.path)
+			if tt.wantNil {
+				assert.Nil(t, found)
+			} else {
+				require.NotNil(t, found, "expected document to be found for path %q", tt.path)
+			}
+		})
+	}
+}
+
+func TestFindDocumentByPath_SymlinkResolution(t *testing.T) {
+	// Create a temp directory structure with a symlink
+	tmpDir := t.TempDir()
+	realDir := filepath.Join(tmpDir, "real", "plans")
+	require.NoError(t, os.MkdirAll(realDir, 0o755))
+
+	docPath := filepath.Join(realDir, "test.md")
+	require.NoError(t, os.WriteFile(docPath, []byte("# Test"), 0o644))
+
+	// Create symlink: tmpDir/link -> tmpDir/real
+	linkPath := filepath.Join(tmpDir, "link")
+	require.NoError(t, os.Symlink(filepath.Join(tmpDir, "real"), linkPath))
+
+	// Document is stored with the real (resolved) path
+	docs := []Document{
+		{Path: docPath, RelPath: "plans/test.md", Type: DocTypePlan},
+	}
+	view := New(docs, filepath.Join(tmpDir, "real"), nil)
+	view.SetSize(100, 40)
+
+	// Look up via symlink path — should resolve and find the document
+	symlinkDocPath := filepath.Join(linkPath, "plans", "test.md")
+	found := view.findDocumentByPath(symlinkDocPath)
+	require.NotNil(t, found, "expected symlink path to resolve to document")
+	assert.Equal(t, docPath, found.Path)
+
+	// Also test with URI scheme + symlink
+	found = view.findDocumentByPath("review://" + symlinkDocPath)
+	require.NotNil(t, found, "expected URI+symlink path to resolve to document")
+	assert.Equal(t, docPath, found.Path)
+}
+
 // TestFinalizedSessionsNotReloaded verifies that finalized sessions are not
 // loaded as active sessions when opening a document.
 func TestFinalizedSessionsNotReloaded(t *testing.T) {


### PR DESCRIPTION
## Summary
- `OpenDocumentByPath` now strips URI schemes (e.g. `review://`, `obsidian://`) before matching
- Symlink paths are resolved via `filepath.EvalSymlinks` so `.hive` symlink paths match discovered documents
- Matching restructured as progressive fallback: exact → symlink-resolved → basename

This fixes todo items failing to open in the review tab when their path includes a URI scheme or goes through the `.hive` symlink.

## Test plan
- [x] Unit tests for URI scheme stripping (review://, obsidian://)
- [x] Unit tests for symlink path resolution with real temp dir symlinks
- [x] Unit tests for basename fallback
- [x] Existing tests continue to pass