### PR TITLE
feat: add hive install setup wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 go.work
 dist/
 .data/
-./dev.log
+dev.log
 agent-deck/
 diffnav
 site/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ RUN echo "alias hv='tmux new-session -As hive hive'" >> /root/.bashrc
 ARG SETUP=full
 ENV CONTAINER_SETUP=$SETUP
 
-COPY dev/config.dev.yaml /etc/hive/config.yaml.template
-
 RUN if [ "$SETUP" = "full" ]; then \
+    mkdir -p /root/.config/hive && \
+    printf 'workspaces:\n  - /workspace\n' > /root/.config/hive/config.yaml && \
     git clone https://github.com/colonyops/hive.git /workspace/hive; \
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,29 +15,30 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN mkdir -p /root/.claude && \
     echo '{"hasCompletedOnboarding": true}' > /root/.claude.json
 
-# Credentials will be injected at runtime via CLAUDE_CREDENTIALS env var
-
 COPY dist/hive_linux_amd64_v1/hive /usr/local/bin/hive
-
 RUN chmod +x /usr/local/bin/hive
 
 WORKDIR /workspace
 
-# shell and config
 ENV SHELL=/bin/bash
 ENV PATH="/root/.local/bin:${PATH}"
 ENV HIVE_LOG_LEVEL=debug
 ENV HIVE_LOG_FILE=/tmp/hive.log
-COPY dev/config.dev.yaml /etc/hive/config.yaml
-ENV HIVE_CONFIG=/etc/hive/config.yaml
 
 # hv alias
 RUN echo "alias hv='tmux new-session -As hive hive'" >> /root/.bashrc
 
-# working repo
-RUN git clone https://github.com/colonyops/hive.git
+# SETUP=full pre-configures a workspace and clones the hive repo.
+# SETUP=clean leaves the container vanilla for install wizard testing.
+ARG SETUP=full
+ENV CONTAINER_SETUP=$SETUP
 
-# Write credentials on startup if provided
+COPY dev/config.dev.yaml /etc/hive/config.yaml.template
+
+RUN if [ "$SETUP" = "full" ]; then \
+    git clone https://github.com/colonyops/hive.git /workspace/hive; \
+fi
+
 COPY dev/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/dev/config.dev.yaml
+++ b/dev/config.dev.yaml
@@ -1,2 +1,0 @@
-workspaces:
-  - /workspace

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -7,4 +7,11 @@ if [ -n "$CLAUDE_CREDENTIALS" ]; then
     echo "Claude credentials configured."
 fi
 
+# Full setup: install hive config pointing at /workspace
+if [ "$CONTAINER_SETUP" = "full" ]; then
+    mkdir -p /etc/hive
+    cp /etc/hive/config.yaml.template /etc/hive/config.yaml
+    export HIVE_CONFIG=/etc/hive/config.yaml
+fi
+
 exec "$@"

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -7,11 +7,4 @@ if [ -n "$CLAUDE_CREDENTIALS" ]; then
     echo "Claude credentials configured."
 fi
 
-# Full setup: install hive config pointing at /workspace
-if [ "$CONTAINER_SETUP" = "full" ]; then
-    mkdir -p /etc/hive
-    cp /etc/hive/config.yaml.template /etc/hive/config.yaml
-    export HIVE_CONFIG=/etc/hive/config.yaml
-fi
-
 exec "$@"

--- a/internal/commands/cmd_install.go
+++ b/internal/commands/cmd_install.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
+
+	"github.com/colonyops/hive/internal/core/styles"
+	"github.com/colonyops/hive/internal/hive"
+	"github.com/colonyops/hive/internal/tui/install"
+)
+
+type InstallCmd struct {
+	flags *Flags
+	app   *hive.App
+}
+
+func NewInstallCmd(flags *Flags, app *hive.App) *InstallCmd {
+	return &InstallCmd{flags: flags, app: app}
+}
+
+func (cmd *InstallCmd) Register(app *cli.Command) *cli.Command {
+	app.Commands = append(app.Commands, &cli.Command{
+		Name:        "install",
+		Usage:       "Interactive setup wizard for hive",
+		UsageText:   "hive install",
+		Description: "Guides you through configuring workspaces, config files, and shell aliases.",
+		Action:      cmd.run,
+	})
+	return app
+}
+
+func (cmd *InstallCmd) run(ctx context.Context, c *cli.Command) error {
+	m := install.New()
+
+	p := tea.NewProgram(m)
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("run install wizard: %w", err)
+	}
+
+	result := finalModel.(install.Model).Result()
+
+	if result.Cancelled {
+		fmt.Println("Setup cancelled.")
+		return nil
+	}
+
+	// Write/update config file with workspaces
+	if err := writeConfig(result.ConfigPath, result.Workspaces); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	fmt.Printf("Config written to %s\n", result.ConfigPath)
+
+	// Add shell aliases
+	var addedShells []install.ShellConfig
+	for _, shell := range result.SelectedShells {
+		if err := addShellAlias(shell); err != nil {
+			fmt.Printf("Warning: failed to add alias to %s: %v\n", shell.Path, err)
+		} else {
+			fmt.Printf("Added 'hv' alias to %s\n", shell.Path)
+			addedShells = append(addedShells, shell)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println(styles.TextSuccessStyle.Render("Setup complete!"))
+
+	checkAgentCommands()
+
+	if len(addedShells) > 0 {
+		fmt.Println()
+		sourceCmd := fmt.Sprintf("source %s", addedShells[0].Path)
+		fmt.Println("Run this to activate the alias:")
+		fmt.Println()
+		fmt.Println(styles.TextPrimaryBoldStyle.Render("  " + sourceCmd))
+		fmt.Println()
+		fmt.Println("Then use " + styles.TextPrimaryBoldStyle.Render("hv") + " to launch Hive.")
+	}
+
+	return nil
+}
+
+// writeConfig writes workspaces to the config file, preserving any existing keys.
+func writeConfig(configPath string, workspaces []string) error {
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	// Load existing config as a raw map to preserve unknown keys
+	existing := map[string]any{}
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = yaml.Unmarshal(data, &existing)
+	}
+
+	existing["workspaces"] = workspaces
+
+	data, err := yaml.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	return os.WriteFile(configPath, data, 0644)
+}
+
+// checkAgentCommands verifies that common agent commands are available in PATH.
+func checkAgentCommands() {
+	agents := []string{"claude", "codex"}
+	var missing []string
+
+	for _, agent := range agents {
+		if _, err := exec.LookPath(agent); err != nil {
+			missing = append(missing, agent)
+		}
+	}
+
+	if len(missing) > 0 {
+		fmt.Println()
+		fmt.Println(styles.TextWarningStyle.Render("Warning: ") + "The following agents were not found in PATH:")
+		for _, agent := range missing {
+			fmt.Println(styles.TextMutedStyle.Render("  - " + agent))
+		}
+		fmt.Println(styles.TextMutedStyle.Render("Install them or ensure they're in your PATH before creating sessions."))
+	}
+}
+
+// addShellAlias appends the hive alias to a shell config file.
+func addShellAlias(shell install.ShellConfig) error {
+	content, err := os.ReadFile(shell.Path)
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+
+	if strings.Contains(string(content), "alias hv=") || strings.Contains(string(content), "alias hv ") {
+		return nil
+	}
+
+	var aliasLine string
+	if shell.Name == "fish" {
+		aliasLine = "\n# Hive alias\nalias hv 'tmux new-session -As hive hive'\n"
+	} else {
+		aliasLine = "\n# Hive alias\nalias hv='tmux new-session -As hive hive'\n"
+	}
+
+	f, err := os.OpenFile(shell.Path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(aliasLine); err != nil {
+		return fmt.Errorf("write alias: %w", err)
+	}
+
+	return nil
+}

--- a/internal/commands/cmd_install.go
+++ b/internal/commands/cmd_install.go
@@ -10,9 +10,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/urfave/cli/v3"
-	"gopkg.in/yaml.v3"
 
 	"github.com/colonyops/hive/internal/core/styles"
+	"github.com/colonyops/hive/internal/defaults"
 	"github.com/colonyops/hive/internal/hive"
 	"github.com/colonyops/hive/internal/tui/install"
 )
@@ -54,11 +54,15 @@ func (cmd *InstallCmd) run(ctx context.Context, c *cli.Command) error {
 		return nil
 	}
 
-	// Write/update config file with workspaces
-	if err := writeConfig(result.ConfigPath, result.Workspaces); err != nil {
-		return fmt.Errorf("write config: %w", err)
+	// Write config only if one doesn't already exist
+	if result.ConfigExists {
+		fmt.Printf("Config already exists at %s (not modified)\n", result.ConfigPath)
+	} else {
+		if err := writeConfig(result.ConfigPath, result.Workspaces); err != nil {
+			return fmt.Errorf("write config: %w", err)
+		}
+		fmt.Printf("Config written to %s\n", result.ConfigPath)
 	}
-	fmt.Printf("Config written to %s\n", result.ConfigPath)
 
 	// Add shell aliases
 	var addedShells []install.ShellConfig
@@ -89,27 +93,24 @@ func (cmd *InstallCmd) run(ctx context.Context, c *cli.Command) error {
 	return nil
 }
 
-// writeConfig writes workspaces to the config file, preserving any existing keys.
+// writeConfig writes the default config template to a new config file.
+// It prepends the user's chosen workspaces before the template content.
 func writeConfig(configPath string, workspaces []string) error {
-	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 
-	// Load existing config as a raw map to preserve unknown keys
-	existing := map[string]any{}
-	if data, err := os.ReadFile(configPath); err == nil {
-		_ = yaml.Unmarshal(data, &existing)
+	var buf strings.Builder
+	if len(workspaces) > 0 {
+		buf.WriteString("workspaces:\n")
+		for _, ws := range workspaces {
+			buf.WriteString("  - " + ws + "\n")
+		}
+		buf.WriteString("\n")
 	}
+	buf.WriteString(defaults.HiveConfig)
 
-	existing["workspaces"] = workspaces
-
-	data, err := yaml.Marshal(existing)
-	if err != nil {
-		return fmt.Errorf("marshal config: %w", err)
-	}
-
-	return os.WriteFile(configPath, data, 0o644)
+	return os.WriteFile(configPath, []byte(buf.String()), 0o644)
 }
 
 // checkAgentCommands verifies that common agent commands are available in PATH.

--- a/internal/commands/cmd_install.go
+++ b/internal/commands/cmd_install.go
@@ -92,7 +92,7 @@ func (cmd *InstallCmd) run(ctx context.Context, c *cli.Command) error {
 // writeConfig writes workspaces to the config file, preserving any existing keys.
 func writeConfig(configPath string, workspaces []string) error {
 	// Ensure parent directory exists
-	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 
@@ -109,7 +109,7 @@ func writeConfig(configPath string, workspaces []string) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	return os.WriteFile(configPath, data, 0644)
+	return os.WriteFile(configPath, data, 0o644)
 }
 
 // checkAgentCommands verifies that common agent commands are available in PATH.
@@ -151,13 +151,17 @@ func addShellAlias(shell install.ShellConfig) error {
 		aliasLine = "\n# Hive alias\nalias hv='tmux new-session -As hive hive'\n"
 	}
 
-	f, err := os.OpenFile(shell.Path, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(shell.Path, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
-	if _, err := f.WriteString(aliasLine); err != nil {
+	if _, err = f.WriteString(aliasLine); err != nil {
 		return fmt.Errorf("write alias: %w", err)
 	}
 

--- a/internal/defaults/config.yaml
+++ b/internal/defaults/config.yaml
@@ -15,26 +15,11 @@ agents:
   #   command: codex
   #   flags: []
 
-# Git settings.
-git:
-  clone_strategy: full  # full | worktree
-
 # TUI appearance.
 tui:
-  theme: default  # default | dracula | catppuccin | nord | gruvbox | solarized
+  theme: tokyo-night  # tokyo-night | gruvbox | catppuccin | kanagawa | onedark
 
-# Context directory settings (the .hive symlink in each session clone).
-context:
-  enabled: true
-
-# History (command palette).
-history:
-  max_entries: 100
-
-# Messaging between sessions.
-messaging:
-  enabled: true
-
-# Tmux integration.
-tmux:
-  enabled: true
+# Clone strategy rules. An empty pattern matches all repos.
+# rules:
+#   - pattern: ""
+#     clone_strategy: full  # full | worktree

--- a/internal/defaults/config.yaml
+++ b/internal/defaults/config.yaml
@@ -1,0 +1,40 @@
+version: "0.2.5"
+
+# Directories containing git repositories shown in the new-session dialog.
+# workspaces:
+#   - ~/code
+#   - ~/projects
+
+# Agent profiles. The "default" key selects which profile is active.
+agents:
+  default: claude
+  claude:
+    command: claude
+    flags: []
+  # codex:
+  #   command: codex
+  #   flags: []
+
+# Git settings.
+git:
+  clone_strategy: full  # full | worktree
+
+# TUI appearance.
+tui:
+  theme: default  # default | dracula | catppuccin | nord | gruvbox | solarized
+
+# Context directory settings (the .hive symlink in each session clone).
+context:
+  enabled: true
+
+# History (command palette).
+history:
+  max_entries: 100
+
+# Messaging between sessions.
+messaging:
+  enabled: true
+
+# Tmux integration.
+tmux:
+  enabled: true

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -1,0 +1,16 @@
+// Package defaults embeds sample configuration files that hive can provide
+// to users during setup or on request. The merge/write logic lives in callers;
+// this package only supplies the raw content.
+package defaults
+
+import _ "embed"
+
+// HiveConfig is the sample hive config.yaml with annotated defaults.
+//
+//go:embed config.yaml
+var HiveConfig []byte
+
+// TmuxConfig is a sample tmux.conf tuned for use with hive.
+//
+//go:embed tmux.conf
+var TmuxConfig []byte

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -8,9 +8,9 @@ import _ "embed"
 // HiveConfig is the sample hive config.yaml with annotated defaults.
 //
 //go:embed config.yaml
-var HiveConfig []byte
+var HiveConfig string
 
 // TmuxConfig is a sample tmux.conf tuned for use with hive.
 //
 //go:embed tmux.conf
-var TmuxConfig []byte
+var TmuxConfig string

--- a/internal/defaults/tmux.conf
+++ b/internal/defaults/tmux.conf
@@ -1,0 +1,67 @@
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+
+# Prefix
+set -g prefix C-q
+set -g prefix2 C-Space
+
+# Base index from 1, renumber on close
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Status bar at top
+set -g status-position top
+
+# No escape delay (important for vim/neovim)
+set -s escape-time 0
+
+# Mouse support
+set -g mouse on
+
+# Vi copy mode
+setw -g mode-keys vi
+bind P paste-buffer
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# Pane splitting (preserve current path)
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+
+# Pane navigation (vim-style, no prefix via C-w chord)
+bind -n C-w switch-client -T pane-nav
+bind -T pane-nav h select-pane -L
+bind -T pane-nav j select-pane -D
+bind -T pane-nav k select-pane -U
+bind -T pane-nav l select-pane -R
+
+# Switch to nth session by position
+bind 1 run-shell "tmux switch-client -t $(tmux list-sessions -F '#S' | sed -n '1p')"
+bind 2 run-shell "tmux switch-client -t $(tmux list-sessions -F '#S' | sed -n '2p')"
+bind 3 run-shell "tmux switch-client -t $(tmux list-sessions -F '#S' | sed -n '3p')"
+bind 4 run-shell "tmux switch-client -t $(tmux list-sessions -F '#S' | sed -n '4p')"
+bind 5 run-shell "tmux switch-client -t $(tmux list-sessions -F '#S' | sed -n '5p')"
+
+# Jump directly to the hive session
+bind l switch-client -t hive
+
+# Reload config
+bind r source-file ~/.config/tmux/tmux.conf \; display "Config reloaded"
+
+# ── TPM Plugins ────────────────────────────────────────────────────────────────
+# Install TPM: git clone https://github.com/tmux-plugins/tpm ~/.config/tmux/plugins/tpm
+# Then press prefix + I inside tmux to install plugins.
+
+# set -g @plugin 'tmux-plugins/tpm'
+# set -g @plugin 'tmux-plugins/tmux-resurrect'
+# set -g @plugin 'tmux-plugins/tmux-continuum'
+# set -g @plugin 'janoamaral/tokyo-night-tmux'
+
+# set -g @resurrect-capture-pane-contents 'on'
+# set -g @continuum-restore 'on'
+# set -g @continuum-save-interval '15'
+
+# run '~/.config/tmux/plugins/tpm/tpm'

--- a/internal/tui/components/form/multi_select_field.go
+++ b/internal/tui/components/form/multi_select_field.go
@@ -154,6 +154,13 @@ func (f *MultiSelectField) Value() any {
 	return selected
 }
 
+// Check sets the checked state of the item at the given index.
+func (f *MultiSelectField) Check(index int) {
+	if index >= 0 && index < len(f.options) {
+		f.checked[index] = true
+	}
+}
+
 // SelectedIndices returns the indices of checked items.
 func (f *MultiSelectField) SelectedIndices() []int {
 	var indices []int

--- a/internal/tui/install/model.go
+++ b/internal/tui/install/model.go
@@ -107,11 +107,12 @@ func New() Model {
 }
 
 func findConfigPath(homeDir string) (string, bool) {
-	if envPath := os.Getenv("HIVE_CONFIG"); envPath != "" {
-		if _, err := os.Stat(envPath); err == nil {
-			return envPath, true
-		}
-		return envPath, false
+	// If HIVE_CONFIG is explicitly set, use it — but only if it points inside
+	// the user's home directory. System paths like /etc/hive/config.yaml are
+	// runtime defaults shipped with the software, not the user's config.
+	if envPath := os.Getenv("HIVE_CONFIG"); envPath != "" && strings.HasPrefix(envPath, homeDir) {
+		_, err := os.Stat(envPath)
+		return envPath, err == nil
 	}
 
 	configDir := filepath.Join(homeDir, ".config", "hive")

--- a/internal/tui/install/model.go
+++ b/internal/tui/install/model.go
@@ -1,0 +1,277 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	"gopkg.in/yaml.v3"
+
+	"github.com/colonyops/hive/internal/core/styles"
+	"github.com/colonyops/hive/internal/tui/components/form"
+)
+
+// ShellConfig represents a detected shell configuration file.
+type ShellConfig struct {
+	Name string // e.g., "zsh", "bash", "fish"
+	Path string // absolute path to config file
+}
+
+// Result contains the wizard outputs.
+type Result struct {
+	Workspaces     []string
+	ConfigPath     string
+	SelectedShells []ShellConfig
+	Cancelled      bool
+}
+
+// Model is the Bubble Tea model for the install wizard.
+type Model struct {
+	width, height  int
+	dialog         *form.Dialog
+	shellField     *form.MultiSelectField
+	detectedShells []ShellConfig
+	configPath     string
+	configExists   bool
+	homeDir        string
+	result         Result
+	quitting       bool
+}
+
+// existingConfig holds minimal config structure for reading workspaces.
+type existingConfig struct {
+	Workspaces []string `yaml:"workspaces"`
+}
+
+// New creates a new install wizard model.
+func New() Model {
+	homeDir, _ := os.UserHomeDir()
+
+	configPath, configExists := findConfigPath(homeDir)
+
+	var existingWorkspaces []string
+	if configExists {
+		existingWorkspaces = loadExistingWorkspaces(configPath)
+	}
+
+	var defaultWorkspaces string
+	if len(existingWorkspaces) > 0 {
+		for i, ws := range existingWorkspaces {
+			existingWorkspaces[i] = shortenPath(ws, homeDir)
+		}
+		defaultWorkspaces = strings.Join(existingWorkspaces, "\n")
+	} else {
+		defaultWorkspaces = "~/code"
+	}
+
+	detectedShells := detectShellConfigs()
+	shellOptions := make([]string, len(detectedShells))
+	for i, s := range detectedShells {
+		shellOptions[i] = s.Name + " (" + shortenPath(s.Path, homeDir) + ")"
+	}
+
+	var fields []form.Field
+	var variables []string
+
+	workspacesField := form.NewTextAreaField(
+		"Workspace Directories (one per line)",
+		"~/code\n~/projects",
+		defaultWorkspaces,
+	)
+	fields = append(fields, workspacesField)
+	variables = append(variables, "workspaces")
+
+	var shellField *form.MultiSelectField
+	if len(shellOptions) > 0 {
+		shellField = form.NewMultiSelectFormField("Install 'hv' alias to:", shellOptions)
+		// Pre-select all shells by default
+		for i := range detectedShells {
+			shellField.Check(i)
+		}
+		fields = append(fields, shellField)
+		variables = append(variables, "shells")
+	}
+
+	dialog := form.NewDialog("", fields, variables)
+
+	return Model{
+		dialog:         dialog,
+		shellField:     shellField,
+		detectedShells: detectedShells,
+		configPath:     configPath,
+		configExists:   configExists,
+		homeDir:        homeDir,
+	}
+}
+
+func findConfigPath(homeDir string) (string, bool) {
+	if envPath := os.Getenv("HIVE_CONFIG"); envPath != "" {
+		if _, err := os.Stat(envPath); err == nil {
+			return envPath, true
+		}
+		return envPath, false
+	}
+
+	configDir := filepath.Join(homeDir, ".config", "hive")
+	configNames := []string{"config.yaml", "config.yml", "hive.yaml", "hive.yml"}
+
+	for _, name := range configNames {
+		path := filepath.Join(configDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path, true
+		}
+	}
+
+	return filepath.Join(configDir, "config.yaml"), false
+}
+
+func loadExistingWorkspaces(configPath string) []string {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+
+	var cfg existingConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+
+	return cfg.Workspaces
+}
+
+func detectShellConfigs() []ShellConfig {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	candidates := []struct {
+		name string
+		path string
+	}{
+		{"zsh", filepath.Join(homeDir, ".zshrc")},
+		{"bash", filepath.Join(homeDir, ".bashrc")},
+		{"bash_profile", filepath.Join(homeDir, ".bash_profile")},
+		{"fish", filepath.Join(homeDir, ".config", "fish", "config.fish")},
+	}
+
+	var found []ShellConfig
+	for _, c := range candidates {
+		if _, err := os.Stat(c.path); err == nil {
+			found = append(found, ShellConfig{Name: c.name, Path: c.path})
+		}
+	}
+	return found
+}
+
+func shortenPath(path, homeDir string) string {
+	if strings.HasPrefix(path, homeDir) {
+		return "~" + path[len(homeDir):]
+	}
+	return path
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		if msg.String() == "ctrl+c" {
+			m.quitting = true
+			m.result.Cancelled = true
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.dialog, cmd = m.dialog.Update(msg)
+
+	if m.dialog.Submitted() {
+		m.result = m.buildResult()
+		return m, tea.Quit
+	}
+
+	if m.dialog.Cancelled() {
+		m.quitting = true
+		m.result.Cancelled = true
+		return m, tea.Quit
+	}
+
+	return m, cmd
+}
+
+func (m Model) buildResult() Result {
+	values := m.dialog.FormValues()
+
+	var workspaces []string
+	if ws, ok := values["workspaces"].(string); ok {
+		for _, line := range strings.Split(ws, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if strings.HasPrefix(line, "~/") {
+				line = filepath.Join(m.homeDir, line[2:])
+			} else if line == "~" {
+				line = m.homeDir
+			}
+			workspaces = append(workspaces, line)
+		}
+	}
+
+	var selectedShells []ShellConfig
+	if m.shellField != nil {
+		for _, idx := range m.shellField.SelectedIndices() {
+			if idx < len(m.detectedShells) {
+				selectedShells = append(selectedShells, m.detectedShells[idx])
+			}
+		}
+	}
+
+	return Result{
+		Workspaces:     workspaces,
+		ConfigPath:     m.configPath,
+		SelectedShells: selectedShells,
+	}
+}
+
+func (m Model) View() tea.View {
+	if m.quitting {
+		return tea.NewView("")
+	}
+
+	title := styles.TextPrimaryBoldStyle.Render("Hive Setup")
+
+	var configInfo string
+	if m.configExists {
+		configInfo = styles.TextSuccessStyle.Render("Found config: ") +
+			styles.TextMutedStyle.Render(shortenPath(m.configPath, m.homeDir))
+	} else {
+		configInfo = styles.TextMutedStyle.Render("Config will be created at: " +
+			shortenPath(m.configPath, m.homeDir))
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		title,
+		"",
+		configInfo,
+		"",
+		m.dialog.View(),
+	)
+
+	return tea.NewView(content)
+}
+
+// Result returns the wizard result. Call after the program exits.
+func (m Model) Result() Result {
+	return m.result
+}

--- a/internal/tui/install/model.go
+++ b/internal/tui/install/model.go
@@ -23,6 +23,7 @@ type ShellConfig struct {
 type Result struct {
 	Workspaces     []string
 	ConfigPath     string
+	ConfigExists   bool
 	SelectedShells []ShellConfig
 	Cancelled      bool
 }
@@ -241,6 +242,7 @@ func (m Model) buildResult() Result {
 	return Result{
 		Workspaces:     workspaces,
 		ConfigPath:     m.configPath,
+		ConfigExists:   m.configExists,
 		SelectedShells: selectedShells,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -385,6 +385,7 @@ Run 'hive new' to create a new session from the current repository.`,
 	app = commands.NewTodoCmd(flags, hiveApp).Register(app)
 	app = commands.NewConfigCmd(flags, hiveApp).Register(app)
 	app = commands.NewHoneycombCmd(flags, hiveApp).Register(app)
+	app = commands.NewInstallCmd(flags, hiveApp).Register(app)
 
 	// Register TUI flags on root command
 	app.Flags = append(app.Flags, tuiCmd.Flags()...)

--- a/mise.toml
+++ b/mise.toml
@@ -107,6 +107,11 @@ depends = ["build"]
 run = "docker build -f Dockerfile.test -t hive-integration-test . && docker run --rm hive-integration-test"
 
 [tasks."container"]
-description = "Build Docker image and run ephemeral container"
+description = "Build and run container with pre-configured workspace and hive repo"
 depends = ["build"]
-run = "docker run --rm -it -e CLAUDE_CREDENTIALS=\"$CLAUDE_CREDENTIALS\" $(docker build -q .)"
+run = "docker run --rm -it -e CLAUDE_CREDENTIALS=\"$CLAUDE_CREDENTIALS\" $(docker build -q --build-arg SETUP=full .)"
+
+[tasks."container:clean"]
+description = "Build and run vanilla container for install wizard testing"
+depends = ["build"]
+run = "docker run --rm -it -e CLAUDE_CREDENTIALS=\"$CLAUDE_CREDENTIALS\" $(docker build -q --build-arg SETUP=clean .)"


### PR DESCRIPTION
## Summary

- Adds `hive install` — an interactive TUI wizard for first-time setup
- Detects existing config and pre-populates workspace directories
- Writes/updates `~/.config/hive/config.yaml` with selected workspaces, preserving existing keys
- Detects shell configs (zsh, bash, bash_profile, fish) and appends `hv` alias; skips if already present
- Warns if agent commands (`claude`, `codex`) are not found in PATH
- Adds `Check(index int)` method to `MultiSelectField` for pre-selecting items programmatically
- Adds `internal/defaults` package with embedded `config.yaml` and `tmux.conf` samples for use in setup flows
- Adds `SETUP` build arg to Dockerfile: `full` (default) pre-configures XDG config and clones hive repo; `clean` leaves container vanilla

## Test plan

**Full setup (smoke test)**
- [x] `export CLAUDE_CREDENTIALS=$(cat ~/.claude/.credentials.json) && mise run build && mise run container`
- [x] Verify `/root/.config/hive/config.yaml` exists with `/workspace` as the workspace
- [x] Run `hive` — verify the TUI opens with the hive repo visible as a workspace

**Clean setup (install wizard)**
- [x] `mise run build && mise run container:clean`
- [x] Run `hive install` and enter a workspace path (e.g. `/workspace`)
- [x] Verify `~/.config/hive/config.yaml` is created with the entered workspace
- [x] Re-run `hive install` — verify the workspace field is pre-populated from the existing config
- [x] Submit without changing anything — verify existing config keys are preserved
- [x] Cancel with `ctrl+c` — verify the config file is unchanged