### PR TITLE
feat: add hive install skills command with embedded AI skills/commands

### DIFF
--- a/internal/commands/cmd_install.go
+++ b/internal/commands/cmd_install.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/hive"
+	"github.com/colonyops/hive/internal/skillsinstall"
 	"github.com/colonyops/hive/internal/tui/install"
 )
 
@@ -33,6 +34,20 @@ func (cmd *InstallCmd) Register(app *cli.Command) *cli.Command {
 		UsageText:   "hive install",
 		Description: "Guides you through configuring workspaces, config files, and shell aliases.",
 		Action:      cmd.run,
+		Commands: []*cli.Command{
+			{
+				Name:        "skills",
+				Usage:       "Install bundled AI skills and commands",
+				UsageText:   "hive install skills [--claude] [--codex] [--force]",
+				Description: "Extracts bundled skills and commands to ~/.config/hive/ and symlinks them into agent config directories.",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "claude", Value: true, Usage: "install for Claude Code (~/.claude)"},
+					&cli.BoolFlag{Name: "codex", Value: true, Usage: "install for Codex (~/.codex)"},
+					&cli.BoolFlag{Name: "force", Usage: "overwrite existing non-symlink files"},
+				},
+				Action: cmd.runSkills,
+			},
+		},
 	})
 	return app
 }
@@ -71,6 +86,13 @@ func (cmd *InstallCmd) run(ctx context.Context, c *cli.Command) error {
 		}
 	}
 
+	// Install skills if the user selected any agents.
+	if len(result.SkillAgents) > 0 {
+		if err := cmd.installSkillsFor(result.SkillAgents, false); err != nil {
+			fmt.Printf("Warning: failed to install skills: %v\n", err)
+		}
+	}
+
 	fmt.Println()
 	fmt.Println(styles.TextSuccessStyle.Render("Setup complete!"))
 
@@ -84,6 +106,64 @@ func (cmd *InstallCmd) run(ctx context.Context, c *cli.Command) error {
 		fmt.Println(styles.TextPrimaryBoldStyle.Render("  " + sourceCmd))
 		fmt.Println()
 		fmt.Println("Then use " + styles.TextPrimaryBoldStyle.Render("hv") + " to launch Hive.")
+	}
+
+	return nil
+}
+
+func (cmd *InstallCmd) runSkills(ctx context.Context, c *cli.Command) error {
+	var agents []string
+	if c.Bool("claude") {
+		agents = append(agents, string(skillsinstall.AgentClaude))
+	}
+	if c.Bool("codex") {
+		agents = append(agents, string(skillsinstall.AgentCodex))
+	}
+
+	if len(agents) == 0 {
+		fmt.Println("No agents selected. Use --claude or --codex.")
+		return nil
+	}
+
+	return cmd.installSkillsFor(agents, c.Bool("force"))
+}
+
+// installSkillsFor runs the skills installer for the given agent names.
+func (cmd *InstallCmd) installSkillsFor(agents []string, force bool) error {
+	var skillAgents []skillsinstall.Agent
+	for _, a := range agents {
+		agent, ok := skillsinstall.ParseAgent(a)
+		if !ok {
+			fmt.Printf("Warning: unknown agent %q — skipping\n", a)
+			continue
+		}
+		skillAgents = append(skillAgents, agent)
+	}
+
+	if len(skillAgents) == 0 {
+		return nil
+	}
+
+	installer := &skillsinstall.Installer{
+		ConfigDir: defaultConfigDir(),
+		Agents:    skillAgents,
+		Force:     force,
+	}
+
+	if err := installer.Install(); err != nil {
+		return err
+	}
+
+	configDir := defaultConfigDir()
+	fmt.Printf("Skills extracted to %s/skills/\n", configDir)
+	fmt.Printf("Commands extracted to %s/commands/\n", configDir)
+	for _, agent := range skillAgents {
+		switch agent {
+		case skillsinstall.AgentClaude:
+			fmt.Println("Linked ~/.claude/skills and ~/.claude/commands")
+		case skillsinstall.AgentCodex:
+			fmt.Println("Linked ~/.codex/skills/claude and ~/.codex/prompts")
+		}
 	}
 
 	return nil

--- a/internal/skillsinstall/assets_embed.go
+++ b/internal/skillsinstall/assets_embed.go
@@ -1,0 +1,6 @@
+package skillsinstall
+
+import "embed"
+
+//go:embed skills commands
+var Assets embed.FS

--- a/internal/skillsinstall/commands/catchup.md
+++ b/internal/skillsinstall/commands/catchup.md
@@ -1,0 +1,40 @@
+---
+allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git status:*), Bash(git branch:*), Read, Grep, Glob
+description: Show changes compared to base branch (defaults to main) (project, gitignored)
+argument-hint: [any additional context, branch name, or git options]
+---
+
+Review what has changed compared to a base branch and provide a comprehensive summary.
+
+## Arguments
+
+User may provide any arguments: $ARGUMENTS
+
+These could include:
+- Base branch name (e.g., `develop`, `master`, `production`) - defaults to "main" if not specified
+- Git diff options (e.g., `--stat`, `--name-only`)
+- File paths (e.g., `src/components/`)
+- Any other context or instructions they want you to consider
+
+Be flexible and intelligent in interpreting what the user wants.
+
+## Instructions
+
+1. First, run `git status` to understand the current state
+2. Intelligently parse $ARGUMENTS and determine:
+   - What base branch to compare against (default to "main" if unclear)
+   - Any additional git diff options or paths to include
+   - Any other context the user provided
+3. Run appropriate git commands to show the changes (typically `git diff <base-branch>...HEAD`)
+4. If there are no changes, check `git log <base-branch>..HEAD` to see commits
+5. Analyze the changes and provide a clear summary including:
+   - Which files were modified, added, or deleted
+   - Key changes in each file (what was added, removed, or modified)
+   - Overall purpose and impact of these changes
+   - Any patterns or themes across the changes
+
+## Important Notes
+
+- This is a **read-only** command - do NOT modify any files or create commits
+- Be flexible with arguments - interpret user intent intelligently
+- Focus on understanding and explaining the changes, not implementing new features

--- a/internal/skillsinstall/commands/check.md
+++ b/internal/skillsinstall/commands/check.md
@@ -1,0 +1,47 @@
+---
+# Source: https://github.com/Veraticus/nix-config/blob/main/home-manager/claude-code/commands/check.md
+allowed-tools: all
+description: Verify code quality and fix all issues
+---
+
+# Code Quality Check
+
+Fix all issues found during quality verification. Do not just report problems.
+
+## Workflow
+
+1. **Identify** - Run all validation commands
+2. **Fix** - Address every issue found
+3. **Verify** - Re-run until all checks pass
+
+## Validation Commands
+
+Find and run all applicable commands:
+
+- **Lint**: `make lint`, `golangci-lint run`, `npm run lint`, `ruff check`
+- **Test**: `make test`, `go test ./...`, `npm test`, `pytest`
+- **Build**: `make build`, `go build ./...`, `npm run build`
+- **Format**: `gofmt`, `prettier`, `black`
+- **Security**: `gosec`, `npm audit`, `bandit`
+
+## Parallel Fixing Strategy
+
+When multiple issues exist, spawn agents to fix in parallel:
+
+```
+Agent 1: Fix linting issues in module A
+Agent 2: Fix test failures
+Agent 3: Fix type errors
+```
+
+## Go-Specific Standards
+
+- Use concrete types, not `interface{}`
+- Wrap errors with context
+- Add godoc comments
+- Use channels for synchronization
+- No `time.Sleep()` for coordination
+
+## Success Criteria
+
+All validation commands pass with zero warnings or errors.

--- a/internal/skillsinstall/commands/commit.md
+++ b/internal/skillsinstall/commands/commit.md
@@ -1,0 +1,29 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit -m:*)
+description: Stage files and create commits with approval
+---
+
+Review the current changes and generate a concise commit message.
+Return ONLY the commit message text with no additional formatting or explanation.
+
+The first line should clearly summarize the change.
+Do not include backticks, quotes, or any other formatting.
+
+Example:
+Instead of something like:
+
+> Update user authentication flow to handle new validation rules
+>
+> This extends validation checks from login-only to both login and registration, preparing for broader testing across supported workflows.
+
+Write:
+Add validation rules to registration flow
+
+Keep commit messages proportional to the size of the change:
+- Small one-line changes → one-line commit message.
+- Larger features → a few lines describing what was added and why.
+
+Once the commit message is ready:
+1. Show me the list of staged files and the proposed commit message.
+2. Wait for my approval.
+3. If I approve, run `git commit -m "<message>"` with the approved message and staged files.

--- a/internal/skillsinstall/commands/create-how-to.md
+++ b/internal/skillsinstall/commands/create-how-to.md
@@ -1,0 +1,63 @@
+---
+---
+
+**Instructions for the CLI / Engineer:**
+
+1. **Prompt for Workflow Details**
+   - Ask the user for:
+     - Workflow title
+     - Description / purpose
+     - Key commands, steps, and notes
+     - Slack context or external references
+
+   _Only ask for missing information if needed._
+
+2. **Generate Markdown File**
+   - Use the `add-how-to` CLI to create the file:
+
+     ```bash
+     add-how-to "Workflow Title" -
+     ```
+
+   - The CLI will create the Markdown file in `$OBSIDIAN_HOW_TO_DIR`.
+   - Keep the document as brief and clear as possible.
+   - Your target audience is engineers who work on these systems.
+
+3. **Structure the Markdown using this template**
+
+```markdown
+---
+tags:
+  - how-to
+  - devops
+  - engineering
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# How To [Workflow Title]
+
+## Overview
+
+Goal: Describe what this guide helps achieve.
+
+## Prerequisites
+
+- [ ] Requires Time Access
+
+## Steps
+
+### 1. Prepare
+
+### 2. Execute
+
+### 3. Verify
+
+## Notes & Gotchas
+
+Add common issues, Slack conversations, or troubleshooting tips.
+
+## External Resources
+
+List useful references or documentation links.
+```

--- a/internal/skillsinstall/commands/gh-issue.md
+++ b/internal/skillsinstall/commands/gh-issue.md
@@ -1,0 +1,11 @@
+---
+allowed-tools: Bash(gh issue view:*)
+---
+
+review the contents and discussion in github issue #$ARGUMENTS. After reviewing the contents wait another command from the user to better understand the issue and to provide a fix.
+
+Here is an example command that you should use
+
+```shell
+gh issue view $ARGUMENTS --json author,body,comments,createdAt,labels,number,state,title,url
+```

--- a/internal/skillsinstall/commands/gh-pr.md
+++ b/internal/skillsinstall/commands/gh-pr.md
@@ -1,0 +1,47 @@
+---
+allowed-tools: Bash(gh pr:*), Bash(gh api:*)
+---
+
+Fetch comments in pr #$ARGUMENTS and review them and their contents. Make a plan on how to fix these and present them for review.
+
+# GitHub CLI: Extracting PR Comments
+
+Quick reference for extracting PR comments using GitHub CLI with `jq` for parsing.
+
+## Getting Inline Code Review Comments
+
+```bash
+# Get all inline code review comments for a specific PR
+gh api repos/:owner/:repo/pulls/<PR-NUMBER>/comments --paginate
+
+# For a specific repository
+gh api repos/OWNER/REPO/pulls/<PR-NUMBER>/comments --paginate
+```
+
+## Formatting Comments with jq
+
+```bash
+# Format review comments with file path, line number, and content
+gh api repos/:owner/:repo/pulls/<PR-NUMBER>/comments | jq '.[] | {file: .path, line: .line, comment: .body}'
+
+# Include author information
+gh api repos/:owner/:repo/pulls/<PR-NUMBER>/comments | jq '.[] | {file: .path, line: .line, comment: .body, author: .user.login}'
+
+# Filter for comments by a specific user
+gh api repos/:owner/:repo/pulls/<PR-NUMBER>/comments | jq '.[] | select(.user.login == "username") | {file: .path, line: .line, comment: .body}'
+```
+
+## Examples
+
+```bash
+# Example for repository "hay-kot/recipinned" PR #941
+gh api repos/hay-kot/recipinned/pulls/941/comments | jq '.[] | {file: .path, line: .line, comment: .body}'
+
+# Get just comment text for all inline comments
+gh api repos/hay-kot/recipinned/pulls/941/comments | jq '.[].body'
+
+# Get file path and comment in compact format
+gh api repos/hay-kot/recipinned/pulls/941/comments | jq -c '.[] | {file: .path, comment: .body}'
+```
+
+Note: The `jq` tool is available for parsing JSON responses from GitHub CLI. These commands specifically get inline comments on code, not regular PR comments.

--- a/internal/skillsinstall/commands/plan-execute.md
+++ b/internal/skillsinstall/commands/plan-execute.md
@@ -1,0 +1,28 @@
+---
+allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git diff:*), Bash(git commit:*), Bash(git add:*), Bash(git checkout:*)
+description: executes a plan previously written to the repo
+---
+
+# Execute Plan
+
+Execute a plan from `.hive/plans/`.
+
+## Process
+
+1. If a specific plan file is provided as an argument, use that file
+2. Otherwise, find the latest plan in `.hive/plans/` (sorted by filename, which uses YYYY-MM-DD prefix)
+3. Read the plan fully to understand your task
+4. Ensure you're on a feature branch; create one if needed
+
+For each plan step:
+
+- Mark step as "IN PROGRESS" in the plan
+- Implement the necessary changes
+- Run appropriate tests/linting
+- Commit changes with descriptive messages
+- Mark step as "COMPLETED" in the plan
+- Document any deviations or blockers encountered
+- Make small, focused commits rather than large changes
+- Run final verification after completing all steps
+
+The plan is a guide - if you find a better approach during implementation, document your reasoning and proceed with the improved solution.

--- a/internal/skillsinstall/commands/plan-iterate.md
+++ b/internal/skillsinstall/commands/plan-iterate.md
@@ -1,0 +1,115 @@
+---
+allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git diff:*)
+description: Review and iterate on an existing task plan, discussing trade-offs and design decisions with the user.
+---
+
+## Overview
+
+Review an existing plan from `.hive/plans/`, analyze its quality and completeness, and collaborate with the user to improve it through discussion of trade-offs and design decisions.
+
+If a specific plan file is provided as an argument, use that file. Otherwise, find the latest plan in `.hive/plans/` (sorted by filename, which uses YYYY-MM-DD prefix).
+
+## Review Process
+
+### 1. Initial Assessment
+
+Read and evaluate the current plan against these criteria:
+
+- **Clarity**: Are the steps specific enough to execute without ambiguity?
+- **Completeness**: Does the plan cover all aspects of the task?
+- **Sequencing**: Are dependencies properly ordered? Are there steps that could be parallelized?
+- **Risk Identification**: Are potential failure points and edge cases addressed?
+- **Testability**: Does each step have clear validation criteria?
+- **Scope**: Is the plan appropriately scoped, or does it over/under-engineer the solution?
+
+### 2. Codebase Alignment Check
+
+Verify the plan against the current repository state:
+
+- Confirm referenced files and paths still exist
+- Check for recent commits that may affect the plan
+- Identify any new context that should inform the approach
+- Flag any assumptions that may no longer hold
+
+### 3. Gap Analysis
+
+Identify what's missing or could be improved:
+
+- Missing error handling considerations
+- Unaddressed edge cases
+- Opportunities for better abstraction or reuse
+- Testing gaps
+- Documentation needs
+
+## Interactive Discussion Process
+
+**After presenting your initial assessment, use AskUserQuestion tool to conduct a structured interview:**
+
+### Architecture & Design Decisions
+
+Use AskUserQuestion to gather input on:
+- Alternative approaches you've identified - which aligns better with their goals?
+- Constraints not mentioned in the plan (performance, backwards compatibility, etc.)
+- Scope boundaries—what's explicitly out of scope?
+
+### Implementation Trade-offs
+
+Use AskUserQuestion to clarify:
+- Trade-offs in the current approach (simplicity vs. flexibility, speed vs. maintainability)
+- Acceptable compromises given timeline or resource constraints
+- Build-vs-buy decisions for any components
+
+### Integration Concerns
+
+Use AskUserQuestion to determine:
+- How this work should interact with existing systems
+- Rollout strategy (feature flags, gradual rollout, etc.)
+- Backwards compatibility requirements
+
+### Validation & Success Criteria
+
+Use AskUserQuestion to confirm:
+- What "done" looks like from the user's perspective
+- Priority of different requirements if trade-offs are needed
+- Acceptable test coverage levels
+
+**Important:** Group related questions (max 4 per AskUserQuestion call). Make multiple calls if needed to cover all categories.
+
+## Output Format
+
+Structure your review as:
+
+1. **Summary of Current Plan**
+   - Brief overview of what the plan proposes
+   - Overall assessment (1-2 sentences)
+
+2. **Strengths**
+   - What the plan does well
+   - Approaches worth preserving
+
+3. **Gap Analysis**
+   - What's missing or unclear
+   - Potential issues identified
+   - Areas needing clarification
+
+4. **Interactive Interview**
+   - **Use AskUserQuestion tool** to gather structured responses
+   - Group questions by category (Design, Trade-offs, Integration, Validation)
+   - Make multiple AskUserQuestion calls if needed (max 4 questions per call)
+   - Explain context for each question category before asking
+
+5. **Suggested Improvements** (after interview)
+   - Based on user responses, propose specific changes
+   - Offer to update the plan with agreed-upon modifications
+   - Note areas you'll address based on their input
+
+## Instructions
+
+1. Read the plan file thoroughly before making any assessments
+2. Explore relevant parts of the codebase to validate your understanding
+3. **Use AskUserQuestion tool to conduct structured interviews**—user input should shape your recommendations
+4. Be specific in your questions; avoid generic queries
+5. Group related questions together (max 4 per AskUserQuestion call)
+6. After gathering all responses, propose specific improvements
+7. Offer to update the plan with agreed-upon changes
+8. Preserve the original plan structure unless the user wants it reorganized

--- a/internal/skillsinstall/commands/plan-load.md
+++ b/internal/skillsinstall/commands/plan-load.md
@@ -1,0 +1,15 @@
+---
+description: reads a plan previously written to the repo
+---
+
+# Load Plan
+
+Read a plan from `.hive/plans/` to get context for your task.
+
+## Process
+
+1. If a specific plan file is provided as an argument, read that file
+2. Otherwise, find the latest plan in `.hive/plans/` (sorted by filename, which uses YYYY-MM-DD prefix)
+3. Read the plan file fully to understand the task context
+
+Use `ls .hive/plans/` to see available plans if needed.

--- a/internal/skillsinstall/commands/pr-create-auto.md
+++ b/internal/skillsinstall/commands/pr-create-auto.md
@@ -1,0 +1,58 @@
+---
+allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git diff:*), Bash(gh pr:*), Bash(git push:*)
+description: Create a PR either from changes
+argument-hint: <tags>
+---
+
+## Task
+
+Create a pull request for the changes. If specified, ensure #$ARGUMENTS tags are added to the PR.
+
+## Workflow
+
+Since the repository state is unknown, you may need to:
+
+1. Create a new branch
+2. Commit code changes
+3. Push the branch
+4. Create the PR using the GitHub CLI
+
+## PR Template
+
+- If `PULL_REQUEST_TEMPLATE.md` exists in the repository, use it as the basis for your PR description
+- If no template exists, keep the title and description proportional to the complexity of the changes
+
+## PR Template
+
+If `PULL_REQUEST_TEMPLATE.md` exists in the repository, use it as the basis for your PR description.
+
+## Writing the Description
+
+**Be brief.** Reviewers will read the code—don't explain it line by line.
+
+- 1-3 sentences for the summary, max
+- Focus on _why_ the change was made, not _what_ changed (the diff shows that)
+- Only mention non-obvious decisions or gotchas
+- Small changes = small descriptions. A typo fix needs one line, not a paragraph.
+
+**Do NOT:**
+- List every file or function modified
+- Explain obvious code changes
+- Add sections for the sake of completeness
+- Use bullet points when a sentence will do
+
+## Example
+
+If there is no PULL_REQUEST_TEMPLATE.md, use this format:
+
+```
+## Summary
+
+Added rate limiting to the API to prevent abuse. Uses a token bucket algorithm with configurable limits per endpoint.
+```
+
+For trivial changes, a single line title is sufficient:
+
+```
+Fix typo in error message
+```

--- a/internal/skillsinstall/commands/pr-create.md
+++ b/internal/skillsinstall/commands/pr-create.md
@@ -1,0 +1,52 @@
+---
+description: Create a PR with review
+argument-hint: <tags>
+---
+
+## Task
+
+Create a pull request for the changes. If specified, ensure #$ARGUMENTS tags are added to the PR.
+
+## Workflow
+
+Since the repository state is unknown, you may need to:
+
+1. Create a new branch
+2. Commit code changes
+3. Push the branch
+4. Create the PR using the GitHub CLI
+
+## PR Template
+
+If `PULL_REQUEST_TEMPLATE.md` exists in the repository, use it as the basis for your PR description.
+
+## Writing the Description
+
+**Be brief.** Reviewers will read the code—don't explain it line by line.
+
+- 1-3 sentences for the summary, max
+- Focus on _why_ the change was made, not _what_ changed (the diff shows that)
+- Only mention non-obvious decisions or gotchas
+- Small changes = small descriptions. A typo fix needs one line, not a paragraph.
+
+**Do NOT:**
+- List every file or function modified
+- Explain obvious code changes
+- Add sections for the sake of completeness
+- Use bullet points when a sentence will do
+
+## Example
+
+If there is no PULL_REQUEST_TEMPLATE.md, use this format:
+
+```
+## Summary
+
+Added rate limiting to the API to prevent abuse. Uses a token bucket algorithm with configurable limits per endpoint.
+```
+
+For trivial changes, a single line title is sufficient:
+
+```
+Fix typo in error message
+```

--- a/internal/skillsinstall/commands/pr-summary.md
+++ b/internal/skillsinstall/commands/pr-summary.md
@@ -1,0 +1,40 @@
+---
+allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git diff:*)
+description: Generate a concise PR description by analyzing branch changes against main
+---
+
+Analyze the git changes and create a PR description following this format:
+
+## Purpose
+
+Write 1-2 sentences describing what problem this solves or what feature it adds. Focus on the "why" not the "what".
+
+Use bullets only if there are multiple distinct changes:
+
+- Feature/fix 1
+- Feature/fix 2
+
+## Implementation
+
+Include this section only for complex changes that need explanation. Describe:
+
+- Key architectural decisions
+- Non-obvious approaches taken
+- Important files/modules modified
+
+Use mermaid diagrams sparingly, only when they clarify complex flows.
+
+Example:
+Instead of something like:
+
+> Update user authentication flow to handle new validation rules
+>
+> This extends validation checks from login-only to both login and registration, preparing for broader testing across supported workflows.
+
+Write:
+Add validation rules to registration flow
+
+Keep PR summaries proportional to the size of the change:
+
+- Small one-line changes → one-line PR summary message.
+- Larger features → a few lines describing what was added and why.

--- a/internal/skillsinstall/install.go
+++ b/internal/skillsinstall/install.go
@@ -1,0 +1,140 @@
+package skillsinstall
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Agent identifies an AI agent to install skills for.
+type Agent string
+
+const (
+	AgentClaude Agent = "claude"
+	AgentCodex  Agent = "codex"
+)
+
+// Installer extracts bundled skills/commands and links them into agent config dirs.
+type Installer struct {
+	ConfigDir string  // e.g. ~/.config/hive
+	Agents    []Agent // which agents to symlink for
+	Force     bool    // overwrite non-symlinks (for --force flag)
+}
+
+// Install extracts embedded assets and creates agent symlinks.
+func (i *Installer) Install() error {
+	skillsDst := filepath.Join(i.ConfigDir, "skills")
+	commandsDst := filepath.Join(i.ConfigDir, "commands")
+
+	if err := i.extractDir("skills", skillsDst); err != nil {
+		return fmt.Errorf("extract skills: %w", err)
+	}
+
+	if err := i.extractDir("commands", commandsDst); err != nil {
+		return fmt.Errorf("extract commands: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	for _, agent := range i.Agents {
+		skillsLink, commandsLink := agentLinks(homeDir, agent)
+
+		if err := i.ensureSymlink(skillsDst, skillsLink); err != nil {
+			return fmt.Errorf("link skills for %s: %w", agent, err)
+		}
+
+		if err := i.ensureSymlink(commandsDst, commandsLink); err != nil {
+			return fmt.Errorf("link commands for %s: %w", agent, err)
+		}
+	}
+
+	return nil
+}
+
+// extractDir copies all files from the embedded src subtree into dst on disk.
+func (i *Installer) extractDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+
+	return fs.WalkDir(Assets, src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		data, readErr := Assets.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+// ensureSymlink creates or refreshes a symlink at link pointing to target.
+// If link already exists and is a symlink, it is removed and recreated.
+// If link exists and is NOT a symlink, it is left alone unless Force is set.
+func (i *Installer) ensureSymlink(target, link string) error {
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		return fmt.Errorf("create parent dir: %w", err)
+	}
+
+	info, err := os.Lstat(link)
+	switch {
+	case err == nil && info.Mode()&os.ModeSymlink != 0:
+		// Existing symlink — remove and recreate.
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("remove existing symlink: %w", err)
+		}
+	case err == nil && i.Force:
+		// Not a symlink but --force was given.
+		if err := os.RemoveAll(link); err != nil {
+			return fmt.Errorf("remove existing path: %w", err)
+		}
+	case err == nil:
+		return fmt.Errorf("%s already exists and is not a symlink (use --force to overwrite)", link)
+	case !os.IsNotExist(err):
+		return fmt.Errorf("stat link path: %w", err)
+	}
+
+	return os.Symlink(target, link)
+}
+
+// agentLinks returns the skill and command symlink paths for a given agent.
+func agentLinks(homeDir string, a Agent) (skillsLink, commandsLink string) {
+	switch a {
+	case AgentClaude:
+		return filepath.Join(homeDir, ".claude", "skills"),
+			filepath.Join(homeDir, ".claude", "commands")
+	case AgentCodex:
+		return filepath.Join(homeDir, ".codex", "skills", "claude"),
+			filepath.Join(homeDir, ".codex", "prompts")
+	default:
+		return "", ""
+	}
+}
+
+// ParseAgent parses an agent string into an Agent constant. Returns false if unrecognised.
+func ParseAgent(s string) (Agent, bool) {
+	switch Agent(s) {
+	case AgentClaude, AgentCodex:
+		return Agent(s), true
+	default:
+		return "", false
+	}
+}

--- a/internal/skillsinstall/skills/design-doc/SKILL.md
+++ b/internal/skillsinstall/skills/design-doc/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: design-doc
+description: >
+  Generate a design doc from template. Use when the user asks to create, draft, or
+  write a design doc, design proposal, or technical proposal.
+allowed-tools: "Read,Write,Bash(mkdir:*),Bash(git:*),Bash(echo:*)"
+version: "1.0.0"
+author: "User"
+---
+
+# Design Doc Generator
+
+Generate design documents from a team template, saving to the Obsidian notebook by default.
+
+## Template Location
+
+The template lives at a path relative to this skill:
+
+```
+.ai/skills/design-doc/templates/design-doc.md
+```
+
+Read the template file before generating. If the template is missing, tell the user it needs to be created (it is gitignored and must be set up locally).
+
+## Workflow
+
+1. **Read the template** from the path above
+2. **Gather information** from the user and codebase:
+   - Title of the design
+   - Background and problem statement
+   - At least two proposals (including "do nothing")
+3. **Research the codebase** to inform the proposals — understand existing architecture, relevant code, and constraints
+4. **Fill in the template** replacing placeholders:
+   - `{{TITLE}}` — design doc title
+   - `{{AUTHOR}}` — infer from git config (`git config user.name`) or ask
+   - `{{DATE}}` — today's date in display format (e.g. `Feb 18, 2026`)
+   - `{{PROPOSAL_NAME}}` — name of the first real proposal
+5. **Present the draft** to the user for review before saving
+6. **Save to Obsidian** — this is the default. Before saving, read the `obsidian` skill and follow its conventions for vault resolution, frontmatter, slug filenames, and folder creation. Save to the `Design Docs` folder. Only save elsewhere if the user explicitly requests it.
+
+## Audience
+
+Assume readers work on the same codebase or a related codebase. They have general context on the project but not the specifics of what this design addresses. Don't over-explain the system — focus on the specific problem and proposals.
+
+## Writing Style
+
+- **Be brief.** Readers' time is valuable. Use only enough text to make each point clear and useful.
+- Use tables, bullet points, and lists to aid readability over prose paragraphs.
+- Keep language direct and concise — no filler, no hedging.
+
+## Section Guidelines
+
+- **Background**: Brief context on the relevant part of the system, enough to frame the problem
+- **Problem**: Be specific about the pain point and its impact
+- **Goals**: Distinguish must-haves from nice-to-haves
+- **Proposals**: Each proposal should include:
+  - A clear description of the approach
+  - Trade-offs (pros/cons) — tables work well here
+  - Rough scope/effort
+  - Risks or unknowns
+- **Proposal 0 (Do nothing)**: Always include — describe the cost of inaction
+- Add additional proposal sections as needed (`### Proposal 2: ...`, etc.)

--- a/internal/skillsinstall/skills/go-benchmark/SKILL.md
+++ b/internal/skillsinstall/skills/go-benchmark/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: go-benchmark
+description: Write and analyze Go benchmarks using modern patterns and tools
+argument-hint: [benchmark-task]
+---
+
+# Go Benchmarking - Modern Patterns and Best Practices
+
+Write effective Go benchmarks using the new Loop pattern and analyze results with benchstat.
+
+## Core Pattern: The Loop Method
+
+Use `b.Loop()` instead of explicit `for i := 0; i < b.N; i++` loops:
+
+```go
+func BenchmarkExample(b *testing.B) {
+    // Setup - not measured
+    data := generateTestData()
+
+    for b.Loop() {
+        // Code to measure
+        result := processData(data)
+        _ = result // Keep result alive
+    }
+
+    // Cleanup - not measured
+}
+```
+
+### Why Loop?
+
+- Automatically manages timer (resets on first call, stops after loop)
+- Prevents compiler optimizations that would invalidate results
+- Disables inlining of functions called within the loop body
+- Runs benchmark function once per measurement (vs multiple times with b.N)
+- Keeps arguments and results alive to prevent dead code elimination
+
+### Critical Rules
+
+1. **Loop condition must be exactly `b.Loop()`** - variations don't work
+2. **Only use Loop OR b.N, never both** - mixing creates incorrect measurements
+3. **Optimizations apply only within loop braces** - called functions optimize normally
+4. **Setup before loop, cleanup after** - neither counts toward measurement
+
+## Incremental Approach
+
+**Philosophy:** Make small changes, measure each change, understand impact before proceeding.
+
+### Workflow
+
+1. **Baseline first**: Write benchmark for current code
+2. **Run multiple times**: `go test -bench=. -count=10 > old.txt`
+3. **Make one change**: Modify one aspect of the implementation
+4. **Measure again**: `go test -bench=. -count=10 > new.txt`
+5. **Compare**: `benchstat old.txt new.txt`
+6. **Decide**: Keep change if improvement is significant and stable
+7. **Repeat**: Make next change from proven baseline
+
+Never change multiple things at once - you won't know which change caused the impact.
+
+## benchstat - Statistical Analysis
+
+Install: `go install golang.org/x/perf/cmd/benchstat@latest`
+
+### Basic Comparison
+
+```bash
+# Run old version
+go test -bench=BenchmarkProcess -count=10 > old.txt
+
+# Make changes, run new version
+go test -bench=BenchmarkProcess -count=10 > new.txt
+
+# Compare with statistical significance
+benchstat old.txt new.txt
+```
+
+### Reading benchstat Output
+
+```
+name          old time/op    new time/op    delta
+Process-8     1.23µs ± 2%    0.98µs ± 1%  -20.33%  (p=0.000 n=10+10)
+```
+
+- `±` indicates variance (lower is more stable)
+- `delta` shows percentage change
+- `p` value indicates statistical significance (< 0.05 is significant)
+- `n` shows sample size
+
+**Ignore changes under 5%** - measurement noise is real.
+
+## Best Practices
+
+### Prevent Compiler Optimizations
+
+```go
+// BAD: Result not used, entire loop may be optimized away
+for b.Loop() {
+    processData(data)
+}
+
+// GOOD: Assign to package-level var
+var result int
+for b.Loop() {
+    result = processData(data)
+}
+
+// GOOD: Use within loop body (Loop keeps it alive)
+for b.Loop() {
+    r := processData(data)
+    _ = r
+}
+```
+
+### Benchmark Allocations
+
+```go
+func BenchmarkAllocations(b *testing.B) {
+    b.ReportAllocs() // Include allocation stats in output
+
+    for b.Loop() {
+        data := make([]byte, 1024) // Measure this allocation
+        _ = data
+    }
+}
+```
+
+Look for `allocs/op` in output - reducing allocations often improves performance more than CPU optimization.
+
+### Sub-benchmarks for Variations
+
+```go
+func BenchmarkEncode(b *testing.B) {
+    sizes := []int{1, 10, 100, 1000}
+
+    for _, size := range sizes {
+        b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+            data := make([]byte, size)
+            for b.Loop() {
+                encode(data)
+            }
+        })
+    }
+}
+```
+
+Run specific sub-benchmark: `go test -bench=BenchmarkEncode/size=100`
+
+### Avoid Timer Manipulation
+
+```go
+// BAD: Manual timer management is error-prone
+for b.Loop() {
+    b.StopTimer()
+    setup := prepareData()
+    b.StartTimer()
+    process(setup)
+}
+
+// GOOD: Move setup outside loop
+for b.Loop() {
+    setup := prepareData()
+    process(setup)
+}
+
+// BEST: If setup must be per-iteration, benchmark it separately
+```
+
+Loop handles timer automatically - manual control usually indicates wrong benchmark structure.
+
+### Parallel Benchmarks
+
+```go
+func BenchmarkParallel(b *testing.B) {
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() { // Use pb.Next() not b.Loop() in parallel
+            doWork()
+        }
+    })
+}
+```
+
+Note: `RunParallel` uses `pb.Next()` not `b.Loop()` - different API for concurrent execution.
+
+## Common Patterns
+
+### Benchmarking HTTP Handlers
+
+```go
+func BenchmarkHandler(b *testing.B) {
+    handler := NewHandler()
+    req := httptest.NewRequest("GET", "/api/data", nil)
+
+    for b.Loop() {
+        w := httptest.NewRecorder()
+        handler.ServeHTTP(w, req)
+    }
+}
+```
+
+### Benchmarking Database Operations
+
+```go
+func BenchmarkQuery(b *testing.B) {
+    db := setupTestDB(b)
+    defer db.Close()
+
+    b.ResetTimer() // Don't measure setup
+
+    for b.Loop() {
+        rows, err := db.Query("SELECT * FROM users WHERE age > ?", 18)
+        if err != nil {
+            b.Fatal(err)
+        }
+        rows.Close()
+    }
+}
+```
+
+### Table-Driven Benchmarks
+
+```go
+func BenchmarkHash(b *testing.B) {
+    cases := []struct {
+        name string
+        size int
+    }{
+        {"small", 16},
+        {"medium", 1024},
+        {"large", 65536},
+    }
+
+    for _, tc := range cases {
+        b.Run(tc.name, func(b *testing.B) {
+            data := make([]byte, tc.size)
+            for b.Loop() {
+                hash(data)
+            }
+        })
+    }
+}
+```
+
+## Running Benchmarks
+
+```bash
+# All benchmarks in package
+go test -bench=.
+
+# Specific benchmark
+go test -bench=BenchmarkEncode
+
+# With memory allocations
+go test -bench=. -benchmem
+
+# Multiple runs for stability
+go test -bench=. -count=10
+
+# Longer runs for accuracy
+go test -bench=. -benchtime=10s
+
+# CPU profiling
+go test -bench=. -cpuprofile=cpu.prof
+
+# Memory profiling
+go test -bench=. -memprofile=mem.prof
+```
+
+## Analysis Tools
+
+### CPU Profiling
+
+```bash
+go test -bench=BenchmarkProcess -cpuprofile=cpu.prof
+go tool pprof cpu.prof
+# Then: top, list FunctionName, web
+```
+
+### Memory Profiling
+
+```bash
+go test -bench=BenchmarkProcess -memprofile=mem.prof
+go tool pprof -alloc_space mem.prof
+```
+
+### Comparing Multiple Changes
+
+```bash
+# Run baseline
+go test -bench=. -count=10 > baseline.txt
+
+# After change 1
+go test -bench=. -count=10 > change1.txt
+benchstat baseline.txt change1.txt
+
+# After change 2
+go test -bench=. -count=10 > change2.txt
+benchstat baseline.txt change2.txt
+
+# Compare all three
+benchstat baseline.txt change1.txt change2.txt
+```
+
+## Red Flags
+
+**Unstable results (high variance):**
+- Increase `-count` to get more samples
+- Close other applications
+- Check for background tasks affecting CPU
+- Consider using `-cpu=1` to reduce scheduling effects
+
+**Results too good to be true:**
+- Compiler probably optimized away your code
+- Ensure results are used (assign to var or use in assertion)
+- Check with `-gcflags='-m'` to see optimization decisions
+
+**Inconsistent improvements:**
+- Results under 5% change are often noise
+- Need more samples (`-count=20`)
+- Consider using `-benchtime=5s` for longer, more stable runs
+
+## Guidelines
+
+1. **Always use b.Loop()** - never explicit `for i := 0; i < b.N` loops
+2. **One change at a time** - incremental measurement reveals real impact
+3. **Use benchstat** - statistical significance matters more than single runs
+4. **Report allocations** - `b.ReportAllocs()` often finds easy wins
+5. **Keep results alive** - assign to var or use `_` to prevent dead code elimination
+6. **Setup outside loop** - only measure what matters
+7. **Run multiple times** - `-count=10` minimum for reliable comparison
+8. **Ignore small changes** - under 5% is probably noise
+9. **Profile when stuck** - CPU and memory profiles show bottlenecks
+10. **Measure before optimizing** - assumptions are usually wrong
+
+## Implementation Checklist
+
+When /go-benchmark is invoked:
+
+1. ✓ Use `b.Loop()` pattern
+2. ✓ Add `b.ReportAllocs()` if allocations matter
+3. ✓ Keep results alive (assign to var or `_ =`)
+4. ✓ Setup before loop, cleanup after
+5. ✓ Run with `-count=10` for baseline
+6. ✓ Make one incremental change
+7. ✓ Measure and compare with `benchstat`
+8. ✓ Verify improvement is significant (> 5%, low p-value)
+9. ✓ Document findings in commit message
+10. ✓ Consider profiling if results unexpected

--- a/internal/skillsinstall/skills/go/SKILL.md
+++ b/internal/skillsinstall/skills/go/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: go
+description: >
+  Best practices for working with Go codebases. Use when writing, debugging,
+  or exploring Go code, including reading dependency sources and documentation.
+allowed-tools: "Read,Bash(go:*)"
+version: "1.0.0"
+author: "User"
+license: "MIT"
+source: https://github.com/grafana/loki/pull/20609/files
+---
+
+# Go Programming Language
+
+Guidelines for working effectively with Go projects.
+
+## Reading Dependency Source Files
+
+To see source files from a dependency, or to answer questions about a dependency:
+
+```bash
+go mod download -json MODULE
+```
+
+Use the returned Dir path to read the source files.
+
+## Reading Documentation
+
+Use go doc to read documentation for packages, types, functions, etc:
+
+```bash
+go doc foo.Bar       # Documentation for a specific symbol
+go doc -all foo      # All documentation for a package
+```
+
+## Running Programs
+
+Use go run instead of go build to avoid leaving behind build artifacts:
+
+```bash
+go run .             # Run the current package
+go run ./cmd/foo     # Run a specific command
+```

--- a/internal/skillsinstall/skills/hc-loop/SKILL.md
+++ b/internal/skillsinstall/skills/hc-loop/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: hc-loop
+description: >
+  Orchestration loop for hive hc tasks. Reads pending tasks, dispatches
+  general-purpose sub-agents (via the Agent tool) to implement each task,
+  critically reviews the output, and commits only code that passes quality
+  checks.
+allowed-tools: "Bash(hive hc:*),Bash(git:*),Bash(task:*),Bash(make:*),Bash(go:*),Bash(bun:*),Read,Agent(*)"
+version: "2.0.0"
+author: "Hayden"
+license: "MIT"
+argument-hint: "[task-id | --all | --limit N]"
+---
+
+# Task Loop — Agent-Dispatched Implementation
+
+You are the **manager**. You do NOT implement tasks yourself. You dispatch sub-agents
+using the `Agent` tool, review their output, and commit approved work.
+
+**CRITICAL RULE**: Never write or edit application code directly. ALL implementation
+work MUST be delegated to a sub-agent via the `Agent` tool.
+
+## Prerequisites Check
+
+Before starting the loop, verify the environment:
+
+```bash
+hive hc list --status open   # confirm tasks exist
+git status                   # confirm clean working tree
+git branch --show-current    # confirm on a feature branch (never main)
+```
+
+If the working tree is dirty, stop and ask the user to stash or commit existing changes first.
+If on `main`, stop and ask the user to create a feature branch.
+
+## Step 1: Select Tasks
+
+**If an argument was given** (e.g., `hc-42` or `hc-42,hc-43`):
+- Use those specific task IDs
+
+**If `--all` was given**:
+- Run `hive hc list --status open` to get all open tasks
+- Check parent/child hierarchy — skip tasks with open blockers
+
+**If `--limit N` was given**:
+- Take the first N tasks from `hive hc list --status open`
+
+**Default (no args)**:
+- Run `hive hc list --status open`
+- Present the list to the user and ask which tasks to run this loop iteration
+
+## Step 2: Build Context for Each Task
+
+For each selected task, gather:
+
+1. **Task details**: `hive hc show <id>` — get full description, acceptance criteria, labels
+2. **Recent git history**: `git log --oneline -15`
+3. **Relevant files**: Based on task description, identify and read the files most likely affected
+4. **Test command**: Determine the correct test runner (`task test`, `go test ./...`, `bun test`, etc.)
+5. **Lint command**: Determine the correct lint runner (`task lint`, `golangci-lint run`, etc.)
+
+## Step 3: Dispatch Workers via Agent Tool
+
+**You MUST use the `Agent` tool** to dispatch each task to a sub-agent using
+`subagent_type: "general-purpose"`.
+
+For each task, call the Agent tool like this:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "Implement hc-<ID>: <short title>",
+  prompt: <see template below>
+)
+```
+
+### Worker Prompt Template
+
+```
+You are implementing hive hc task <ID>: <TITLE>
+
+## Task Description
+<full hive hc show output>
+
+## Codebase Context
+<relevant file contents with line numbers>
+
+## Recent History
+<git log output>
+
+## Commands
+- Run tests with: <test command>
+- Run lint with: <lint command>
+
+## Instructions
+1. Mark this task in-progress: hive hc update <ID> --status in_progress --assign
+2. Implement the task as described
+3. Run tests and lint — fix any failures
+4. Do NOT commit — leave changes unstaged or staged but uncommitted
+5. Report back with:
+   a) Summary of changes made
+   b) List of files modified
+   c) Test and lint results
+   d) Any open questions
+```
+
+### Parallelism Decision
+
+- Dispatch tasks **sequentially** (one at a time) since workers share the same working tree
+- Wait for each worker to complete and be reviewed before dispatching the next
+
+## Step 4: Review Each Completed Worker
+
+When a worker agent returns, perform a critical code review of its output.
+
+### Automated Checks
+
+After the worker finishes, check the results:
+
+```bash
+git diff HEAD              # read every line
+<test command>             # must pass
+<lint command>             # must pass
+```
+
+### Review Checklist
+
+- [ ] Changes are scoped to the task — no unrelated modifications
+- [ ] No introduced security vulnerabilities
+- [ ] Error cases handled at system boundaries (not deep in business logic)
+- [ ] No over-engineered abstractions for a single use case
+- [ ] No TODO/FIXME left in new code
+- [ ] Existing tests still pass; new tests added for non-trivial logic
+- [ ] Follows codebase naming and structure conventions
+
+### Decision
+
+**APPROVE**: All checks pass and review is clean.
+
+Stage and commit the changes:
+
+```bash
+git add -p                              # stage only task-related changes
+git commit -m "<clear message>          # see commit message format below
+                                        # closes hc-<id>"
+hive hc update <id> --status done       # mark task done
+```
+
+**REVISE**: Minor issues that a worker can fix.
+
+Resume the worker agent (using its agent ID) with specific feedback and required changes.
+Limit to 2 revision cycles before escalating to the user.
+
+**REJECT / ESCALATE**: Fundamental design issue, scope creep, or two failed revisions.
+
+```bash
+git checkout -- .                        # discard changes
+hive hc update <id> --status open        # return to queue
+```
+
+Report the issue to the user with the specific problem and a recommended path forward.
+
+## Step 5: Commit Message Format
+
+```
+<imperative summary, max 72 chars>
+
+- <what changed and why, bullet point per file/area>
+- <any non-obvious decisions>
+
+closes hc-<id>
+```
+
+Example:
+```
+add pagination to user list endpoint
+
+- add limit/offset query params to GET /users handler
+- update UserRepo.List to accept pagination params
+- add integration test for edge cases (empty page, last page)
+
+closes hc-47
+```
+
+## Step 6: Loop Summary
+
+After all tasks are processed, report:
+
+```
+Loop complete.
+- Dispatched: N tasks
+- Committed:  N tasks (list with commit hashes)
+- Revised:    N tasks (list)
+- Escalated:  N tasks (list with reasons)
+
+Remaining open: <hive hc list --status open count>
+```
+
+## Notes
+
+- **Agent dispatch**: Always use `Agent` tool with `subagent_type: "general-purpose"`.
+  Dispatch tasks sequentially since workers share the working tree.
+- **Revisions**: Use the `resume` parameter on the Agent tool to continue a worker's
+  context when requesting revisions.
+- **Branch safety**: Never run on `main`. Always on a feature branch.
+- **Context window**: For large tasks, include only the most relevant files in the
+  worker prompt. Workers have limited context windows.
+- **You are the manager**: Your job is to orchestrate, review, and commit. Never
+  implement directly.

--- a/internal/skillsinstall/skills/hc-next/SKILL.md
+++ b/internal/skillsinstall/skills/hc-next/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: hc-next
+description: Start the next hive hc task, prioritizing work related to current branch
+argument-hint:
+---
+
+# Next - Start Working
+
+Find and start the next task, prioritizing current work context.
+
+## Workflow
+
+1. **Check current branch**: `git branch --show-current`
+2. **Find related work** (in order of priority):
+   - In-progress issues: `hive hc list --status in_progress`
+   - Ready tasks with no blockers: `hive hc next <epic-id> --assign`
+3. **Load the task**: `hive hc show <issue-id>` for full context
+4. **Start working**: Mark as in-progress if needed, then begin implementation
+
+## Output
+
+Report which task you're starting and why, then get to work.

--- a/internal/skillsinstall/skills/obsidian/SKILL.md
+++ b/internal/skillsinstall/skills/obsidian/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: obsidian
+description: >
+  Save documents to Obsidian notebook. Use when the user asks to save, write, or put
+  a document (test plan, design doc, etc.) into their Obsidian notebook.
+allowed-tools: "Bash(mkdir:*),Write,Read"
+version: "1.1.0"
+author: "User"
+---
+
+# Obsidian Notebook
+
+Save structured documents into the user's Obsidian vault.
+
+## Vault Location
+
+The vault root is stored in `$OBSIDIAN_NOTEBOOK_DIR`. Always resolve this before writing:
+
+```bash
+echo "$OBSIDIAN_NOTEBOOK_DIR"
+```
+
+If the variable is empty, stop and tell the user to set `OBSIDIAN_NOTEBOOK_DIR`.
+
+## Document Types
+
+When saving a `design-doc` or `research` document, check whether a project context is
+available (the user mentions a project, or the document is being created as part of
+`project-advance`). If a project is known, save under the project folder. Otherwise fall
+back to the vault-root folder.
+
+| Type       | With project context                                    | Without project context   | Filename Pattern              |
+| ---------- | ------------------------------------------------------- | ------------------------- | ----------------------------- |
+| test-plan  | _(no project variant)_                                  | Test Plans                | `YYYY-MM-DD-<slug>.md`        |
+| design-doc | Projects/\<Project Name\>/Design Docs                   | Design Docs               | `YYYY-MM-DD-<slug>.md`        |
+| research   | Projects/\<Project Name\>/Research                      | Research                  | `YYYY-MM-DD-<slug>.md`        |
+| project    | Projects/\<Project Name\>                               | _(always project-scoped)_ | `<Project Name>.md`           |
+| work-item  | Projects/\<Project Name\>/Work Items                    | _(always project-scoped)_ | `<Work Item Name>.md`         |
+
+For `project` and `work-item` types, use the `project-draft` skill instead — it handles the full interview and folder structure automatically.
+
+If the user requests a type not in this table, ask which folder to use and suggest they add it to this table.
+
+## Writing a Document
+
+1. **Resolve the vault path** from `$OBSIDIAN_NOTEBOOK_DIR`
+2. **Determine the document type** from user intent
+3. **Create the target folder** if it doesn't exist:
+   ```bash
+   mkdir -p "$OBSIDIAN_NOTEBOOK_DIR/<Folder>"
+   ```
+4. **Generate the filename**: `YYYY-MM-DD-<slugified-title>.md` using today's date
+5. **Write the file** using the Write tool with the frontmatter and content
+
+## Frontmatter
+
+Every document must start with YAML frontmatter:
+
+```yaml
+---
+title: "<Document Title>"
+repository: "<owner>/<repo>"
+created: YYYY-MM-DD
+status: draft
+---
+```
+
+Field details:
+- **title**: Descriptive title for the document
+- **repository**: Infer from the current git remote (`git remote get-url origin`, extract `owner/repo`). If not in a git repo, ask the user.
+- **created**: Today's date
+- **status**: Always `draft` unless the user specifies otherwise
+
+## Slug Generation
+
+Convert the title to a filename-safe slug:
+- Lowercase
+- Replace spaces and non-alphanumeric characters with hyphens
+- Strip leading/trailing hyphens
+
+Example: `Auth Service Redesign` -> `auth-service-redesign`
+
+## Creating hive todos for Obsidian documents
+
+After saving a document, if a `hive todo` item should be created pointing to it, use the
+`obsidian://vault/<VaultName>/<url-encoded-path>` URI scheme. The vault name is the last
+path component of `$OBSIDIAN_NOTEBOOK_DIR`.
+
+```bash
+# Derive vault name from $OBSIDIAN_NOTEBOOK_DIR
+VAULT=$(basename "$OBSIDIAN_NOTEBOOK_DIR")
+
+hive todo add \
+  --title "Review <document title>" \
+  --uri "obsidian://vault/${VAULT}/Projects/Foo%20Bar/doc.md"
+```
+
+- Spaces in path segments must be percent-encoded as `%20`.
+- Do **not** use bare `obsidian://Projects/...` — the vault name is required.
+
+## Example
+
+User says: "Save this test plan for the auth refactor to my obsidian notebook"
+
+Result: `$OBSIDIAN_NOTEBOOK_DIR/Test Plans/2026-02-18-auth-refactor-test-plan.md`
+
+```markdown
+---
+title: "Auth Refactor Test Plan"
+repository: "hay-kot/hive"
+created: 2026-02-18
+status: draft
+---
+
+<content from the conversation>
+```

--- a/internal/skillsinstall/skills/plan-to-hc/SKILL.md
+++ b/internal/skillsinstall/skills/plan-to-hc/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: plan-to-hc
+description: >
+  Create a hive hc epic from the current plan file, inserting the ENTIRE PLAN TEXT
+  into the epic and creating subtasks to track all work items.
+allowed-tools: "Read,Bash(hive hc:*),Bash(echo:*),Bash(bpcopy:*)"
+version: "1.0.0"
+author: "User"
+license: "MIT"
+---
+
+# Plan to Hive HC
+
+Converts a Claude Code plan file into a hive hc epic with subtasks.
+
+## Instructions
+
+When this command is invoked:
+
+1. **Locate the most recent (active) plan file**: Read the current plan file from the plans directory
+
+2. **Extract the plan content**: Get the ENTIRE TEXT of the plan
+
+3. **Create a hive hc epic**: Use `hive hc create --type epic` to create an epic with:
+   - A descriptive title based on the plan's goal
+   - The complete plan text in the description
+
+4. **Create subtasks**: Analyze the plan and create subtasks for each major work item or implementation step using `hive hc create --parent <epic-id>` with:
+   - Clear, actionable titles
+   - Parent reference to the epic
+   - Appropriate status and labels
+
+5. **Link dependencies**: If the plan has sequential steps, link the subtasks with appropriate dependencies
+
+6. **Copy the plan id**: Put the epic id on the clipboard
+   - echo <plan id> | bpcopy
+
+## Expected Workflow
+
+```bash
+# User runs:
+/plan-to-hc
+
+# Agent should:
+# 1. Read the plan file
+# 2. Create epic with full plan text
+# 3. Create subtasks for each work item
+# 4. Link dependencies as needed
+```
+
+## Notes
+
+- The epic description should contain the COMPLETE plan text for reference
+- Subtasks should capture all trackable work items from the plan
+- Use clear, descriptive titles for easy identification
+- Preserve any dependencies or sequential ordering from the plan

--- a/internal/skillsinstall/skills/plan-write/SKILL.md
+++ b/internal/skillsinstall/skills/plan-write/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: plan-write
+description: >
+  Create detailed implementation plans through interactive research and iteration.
+  Use when the user wants to plan a feature, task, or ticket before implementing.
+  Expects a research document as input. Interviews the user, then uses sub-agents
+  to draft and review the plan before writing a structured plan to .hive/plans/.
+allowed-tools: "Bash(git status:*),Bash(git log:*),Bash(git diff:*),Read,Write,Task(*)"
+version: "2.0.0"
+author: "User"
+---
+
+# Implementation Plan
+
+Create detailed implementation plans from an existing research document. Be skeptical,
+thorough, and work collaboratively to produce high-quality technical specifications.
+
+This skill assumes a research document already exists in `.hive/research/` — produced
+by the `/research` skill. If no research doc exists, run that skill first.
+
+## Context Directory
+
+Plans are stored in `.hive/plans/` managed by `hive ctx`.
+
+**IMPORTANT:** `.hive` must be a symlink, not a directory. If it doesn't exist, run
+`hive ctx init` to create it — NEVER use `mkdir`.
+
+---
+
+## Step 1: Read the Research Document
+
+Read the provided research document **fully** using the Read tool WITHOUT limit/offset
+parameters. Do not proceed until you have read it completely.
+
+If no research document is specified, ask the user which research doc to use:
+```bash
+hive ctx ls  # list available research docs
+```
+
+---
+
+## Step 2: Interview the User
+
+Present your understanding of the research and resolve all open decisions before
+dispatching sub-agents. Sub-agents cannot ask the user questions — all ambiguity
+must be resolved here.
+
+### 2a. Present informed understanding
+
+Summarize what the research doc says we need to build:
+
+```
+Based on the research, I understand we need to [accurate summary].
+
+Key findings:
+- [Current implementation detail with file:line reference]
+- [Relevant pattern or constraint]
+- [Potential complexity or edge case]
+
+Open questions from research:
+- [Any items marked as open questions in the research doc]
+```
+
+### 2b. Use AskUserQuestion for decisions
+
+- Design preferences between valid alternatives
+- Scope boundaries and explicit out-of-scope items
+- Business logic decisions the research doc couldn't answer
+- Performance or compatibility requirements
+- Approved implementation approach when multiple are valid
+
+Only ask questions you genuinely cannot answer from the research doc.
+
+### 2c. Ambiguity checkpoint
+
+Before proceeding, ask yourself:
+
+> "What decisions would a fresh agent, reading only the research doc and approved
+> approach, have to guess at?"
+
+For each answer: resolve it now with the user. Do not leave implicit assumptions.
+
+### 2d. Confirm the phase structure
+
+Propose how you'll break the work into phases:
+
+```
+Here's my proposed plan structure:
+
+1. [Phase name] — [what it accomplishes]
+2. [Phase name] — [what it accomplishes]
+3. [Phase name] — [what it accomplishes]
+```
+
+Get explicit approval before dispatching sub-agents.
+
+---
+
+## Step 3: Sub-Agent Dispatch
+
+Spawn sub-agents in two sequential waves.
+
+### Wave 1: Draft Plan
+
+Spawn a single **general-purpose** sub-agent to write the initial plan draft.
+
+**Prompt template:**
+```
+You are writing an implementation plan. Read the research document at:
+  [path to research doc]
+
+The approved approach and phase structure are:
+  [paste the approved approach and phases from Step 2]
+
+User decisions made:
+  [paste all decisions from the Step 2 interview]
+
+Out of scope:
+  [paste explicit out-of-scope items]
+
+Write a detailed implementation plan to:
+  .hive/plans/[YYYY-MM-DD-description.md]
+
+Use this exact template: [embed the Plan Template from the appendix below]
+
+Requirements:
+- Include specific file paths and line numbers from the research doc
+- Every phase must have both Automated and Manual success criteria
+- Testing strategy must explicitly address unit, integration, and e2e tests
+- Do not invent decisions not documented above
+- If you encounter a gap, write "[OPEN: description]" — do not guess
+```
+
+Wait for the draft agent to complete before proceeding.
+
+### Wave 2: Parallel Reviews
+
+Spawn both reviewers simultaneously. Each receives the research doc path AND the
+plan file path written by the draft agent.
+
+#### Design Reviewer
+
+**Agent type:** general-purpose
+
+**Prompt:**
+```
+You are a design reviewer. Critique an implementation plan for design quality.
+Do not rewrite it — only identify issues and make recommendations.
+
+Research doc: [path]
+Plan file: [path]
+
+Review for:
+1. Code duplication — does the plan recreate patterns that already exist in the
+   codebase? Reference file:line for any duplication found.
+2. Testability — are proposed components testable in isolation? Flag tight coupling
+   or hidden dependencies.
+3. Abstraction level — is the plan over-engineered for the scope? Is anything
+   under-abstracted that will cause maintenance pain?
+4. Language/framework best practices — flag patterns that violate conventions for
+   the tech stack described in the research doc.
+
+Output format:
+
+## Design Review
+
+### Critical Issues
+- [issue]: [location in plan] — [recommendation]
+
+### Minor Issues
+- [issue]: [location in plan] — [recommendation]
+
+### Looks Good
+- [what is well-designed and why]
+```
+
+#### Spec Reviewer
+
+**Agent type:** general-purpose
+
+**Prompt:**
+```
+You are a specification reviewer. Ensure the implementation plan has complete,
+verifiable success criteria. Do not critique the design.
+
+Research doc: [path]
+Plan file: [path]
+
+Review for:
+1. Missing integration tests — does each phase explicitly call out integration
+   test coverage? Unit tests alone are not sufficient.
+2. Missing e2e tests — if there is a separate integration/ or e2e/ test directory
+   implied by the tech stack, are tests for it specified?
+3. Vague success criteria — flag any criteria that can't be verified by running
+   a specific command or following a specific manual step.
+4. Missing edge cases — what failure modes or boundary conditions are not covered
+   in the testing strategy?
+5. Incomplete manual steps — are manual verification steps specific enough for
+   someone unfamiliar with the feature to execute?
+
+Output format:
+
+## Spec Review
+
+### Missing Coverage
+- [gap]: [which phase] — [specific test or criterion needed]
+
+### Vague Criteria
+- [criterion]: [why it's ambiguous] — [how to make it specific]
+
+### Looks Good
+- [what is well-specified]
+```
+
+Wait for **both** reviewers to complete before proceeding.
+
+---
+
+## Step 4: Synthesis & Final Review
+
+### 4a. Read all outputs
+
+Read the draft plan file and both reviewer outputs fully.
+
+### 4b. Resolve any `[OPEN:]` items
+
+If the draft agent flagged open questions, resolve them now. If you can't resolve
+from context, use **AskUserQuestion** before revising.
+
+### 4c. Reconcile conflicts
+
+If design and spec reviewers disagree, prefer the recommendation that serves the
+user's stated goals from Step 2. When genuinely ambiguous, use **AskUserQuestion**.
+
+### 4d. Revise the plan
+
+Apply findings to the plan file:
+- All Critical Issues from design review → fix or explicitly defer with rationale
+- All Missing Coverage gaps from spec review → add the missing criteria
+- Minor Issues → apply judgment based on scope; skip if not worth the complexity
+
+### 4e. Create review todo
+
+```bash
+hive todo add \
+  --title "Review plan: <description>" \
+  --uri "review://.hive/plans/<filename>"
+```
+
+---
+
+## Step 5: Present to User
+
+```
+Implementation plan written to:
+  `.hive/plans/YYYY-MM-DD-description.md`
+
+Design review: [N critical issues fixed, M minor issues addressed]
+Spec review: [N coverage gaps closed]
+
+Please review and let me know:
+- Are the phases properly scoped?
+- Are the success criteria specific enough?
+- Any technical details that need adjustment?
+- Missing edge cases or considerations?
+```
+
+Iterate based on feedback until the user is satisfied.
+
+---
+
+## Appendix: Plan Template
+
+Use this template in the Wave 1 draft agent prompt and for the final plan file.
+
+```markdown
+# [Feature/Task Name] Implementation Plan
+
+## Overview
+
+[Brief description of what we're implementing and why]
+
+## Current State Analysis
+
+[What exists now, what's missing, key constraints — drawn from research doc]
+
+## Desired End State
+
+[Specification of the desired end state and how to verify it]
+
+### Key Discoveries:
+
+- [Important finding with file:line reference]
+- [Pattern to follow]
+- [Constraint to work within]
+
+## What We're NOT Doing
+
+[Explicitly list out-of-scope items to prevent scope creep]
+
+## Implementation Approach
+
+[High-level strategy and reasoning — the approved approach from user interview]
+
+## Phase 1: [Descriptive Name]
+
+### Overview
+
+[What this phase accomplishes]
+
+### Changes Required:
+
+#### 1. [Component/File Group]
+
+**File**: `path/to/file.ext`
+**Changes**: [Summary of changes]
+
+```[language]
+// Specific code to add/modify
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] [Command that proves this phase works]: `make test-X`
+- [ ] Linting passes: `make lint`
+- [ ] Type checking passes: `make typecheck`
+
+#### Manual Verification:
+
+- [ ] [Specific step with expected observable outcome]
+- [ ] No regressions in [specific related feature]
+
+**Implementation Note**: After completing this phase and all automated verification
+passes, pause here for manual confirmation from the human before proceeding.
+
+---
+
+## Phase 2: [Descriptive Name]
+
+[Similar structure...]
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- [What to test]
+- [Key edge cases]
+
+### Integration Tests:
+- [Cross-component scenarios]
+- [External dependency interaction tests]
+
+### E2E Tests:
+- [Full workflow scenarios]
+- [Location: `tests/e2e/` or equivalent]
+
+### Manual Testing Steps:
+1. [Specific step to verify feature]
+2. [Edge case to test manually]
+
+## Performance Considerations
+
+[Any performance implications or optimizations needed]
+
+## Migration Notes
+
+[If applicable, how to handle existing data/systems]
+
+## References
+
+- Original ticket: `[ticket reference]`
+- Research doc: `.hive/research/[filename]`
+- Similar implementation: `[file:line]`
+```
+
+---
+
+## Guidelines
+
+### No Open Questions in the Final Plan
+- Resolve all ambiguity in Step 2 before dispatching
+- Sub-agents document gaps as `[OPEN: description]` rather than guessing
+- Main agent resolves all `[OPEN:]` markers before presenting to user
+
+### Success Criteria Format
+
+**Automated Verification** (runnable by execution agents):
+- Commands: `make test`, `npm run lint`, etc.
+- Specific files that should exist
+- Code compilation/type checking
+
+**Manual Verification** (requires human):
+- UI/UX functionality
+- Performance under real conditions
+- Edge cases that are hard to automate
+- User acceptance criteria
+
+### Common Patterns
+
+**Database Changes**
+Schema/migration → store methods → business logic → API → clients
+
+**New Features**
+Data model → backend logic → API endpoints → UI last
+
+**Refactoring**
+Document current behavior → incremental changes → migration strategy

--- a/internal/skillsinstall/skills/project-advance/SKILL.md
+++ b/internal/skillsinstall/skills/project-advance/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: project-advance
+description: >
+  Advance a project work item through its lifecycle. Reads work items from the Obsidian
+  Projects folder, finds the next ready item by priority and phase, then runs the
+  appropriate workflow (research, design-doc, plan-write, hive hc). Use when you want to
+  continue project work or let AI pick and execute the next task autonomously.
+allowed-tools: "Bash(*),Read,Write,Task(*)"
+version: "1.1.0"
+author: "User"
+---
+
+# Project Advance
+
+Find the next work item to progress and run the appropriate AI workflow for its current phase.
+
+## Vault Resolution
+
+```bash
+echo "$OBSIDIAN_NOTEBOOK_DIR"
+```
+
+If empty, stop and tell the user to set `OBSIDIAN_NOTEBOOK_DIR`.
+
+## Step 1: Discover Work Items
+
+Scan all work item notes:
+
+```bash
+find "$OBSIDIAN_NOTEBOOK_DIR/Projects" -path "*/Work Items/*.md" -type f
+```
+
+Read the frontmatter of each file to extract: `phase`, `priority`, `project`, `repos`.
+
+## Step 2: Select Work Item
+
+**If an argument was provided** (file path or partial title), use that specific work item.
+
+**Otherwise**, filter and rank candidates:
+- Exclude `phase: done`, `phase: review`, and `phase: blocked` (those need human attention)
+- Prefer items already in an active phase (`research`, `design`, `planning`, `building`) over `backlog`
+- Then by priority: `high` → `medium` → `low`
+- Then by phase progression order: `research` → `design` → `planning` → `building`
+
+Show the user the top 3 candidates and confirm which to advance before proceeding.
+
+## Step 3: Resolve Project Context
+
+Before running any workflow, determine the project name from the work item's `project` field
+(e.g., `"[[Adaptive Logs API Alignment]]"` → `Adaptive Logs API Alignment`).
+
+All artifacts for this work item are stored under the project folder:
+
+```
+$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/
+├── Research/       ← research docs go here
+├── Design Docs/    ← design docs go here
+└── Work Items/
+    └── <Work Item Name>.md
+```
+
+Ensure these subdirectories exist before writing:
+
+```bash
+mkdir -p "$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Research"
+mkdir -p "$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Design Docs"
+```
+
+## Step 4: Run Workflow by Phase
+
+### `backlog`
+
+Help refine the work item into something actionable:
+1. Review the current objective and acceptance criteria with the user
+2. Ask clarifying questions: what does done look like? what are the constraints?
+3. Update the note with refined content
+4. Ask if it's ready to move to `research` phase
+
+### `research`
+
+Run deep codebase and context research:
+1. Read the work item's objective, repos, and any existing notes
+2. Use parallel research agents (codebase-analyzer, codebase-locator) focused on the repos listed
+3. Produce a research summary document
+4. Save to Obsidian under the project:
+   - Folder: `$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Research/`
+   - Filename: `YYYY-MM-DD-<slugified-work-item-title>.md`
+   - Frontmatter: include `work-item: "[[<Work Item Name>]]"` and `project: "[[<Project Name>]]"`
+5. Update the work item's Artifacts section: `- Research: [[<filename>]]`
+6. Advance `phase` to `design`
+
+Create a review todo pointing to the research doc in Obsidian:
+
+```bash
+VAULT="${OBSIDIAN_NOTEBOOK_DIR##*/}"
+VAULT_ENC="${VAULT// /%20}"
+FILE_ENC="Projects/${PROJECT// /%20}/Research/${FILENAME// /%20}"
+hive todo add \
+  --title "Review research: <work-item-title>" \
+  --uri "obsidian://vault/${VAULT_ENC}/${FILE_ENC}"
+```
+
+### `design`
+
+Create a design document:
+1. Read the work item and its linked research doc (if exists)
+2. Invoke the `design-doc` skill with this context
+3. Save to the project folder:
+   - Folder: `$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Design Docs/`
+   - Follow the obsidian skill conventions for frontmatter and slug filenames
+4. Update the work item's Artifacts section: `- Design Doc: [[<filename>]]`
+5. Advance `phase` to `planning`
+
+Create a review todo pointing to the design doc in Obsidian:
+
+```bash
+VAULT="${OBSIDIAN_NOTEBOOK_DIR##*/}"
+VAULT_ENC="${VAULT// /%20}"
+FILE_ENC="Projects/${PROJECT// /%20}/Design%20Docs/${FILENAME// /%20}"
+hive todo add \
+  --title "Review design: <work-item-title>" \
+  --uri "obsidian://vault/${VAULT_ENC}/${FILE_ENC}"
+```
+
+### `planning`
+
+Write an implementation plan:
+1. Read the work item, research doc, and design doc
+2. Invoke the `plan-write` command with this context — it will save the plan to `.hive/plans/`
+3. Update the work item's Artifacts section:
+   - `- Plan: .hive/plans/<filename>`
+4. Leave `phase` at `planning` — the work item is now ready to dispatch via `project-dispatch`
+
+Create a review todo for the plan:
+
+```bash
+hive todo add \
+  --title "Review & dispatch: <work-item-title>" \
+  --uri "review://.hive/plans/<plan-filename>"
+```
+
+### `building`
+
+Check implementation status:
+1. Check hive hc for any linked issues: `hive hc list`
+2. Check for open PRs in the linked repos (if using gh CLI)
+3. Summarize: what's done, what's in flight, what's blocked
+4. If all hive hc issues are done and PRs merged, prompt user to advance to `review`
+
+### `review`
+
+Surface what's ready for human review:
+1. List linked PRs and their status
+2. Summarize what was built and what acceptance criteria were met
+3. Prompt user to verify against acceptance criteria and mark `phase: done` when complete
+
+## Step 5: Update Work Item Note
+
+After completing the workflow step, update the note using the Edit tool:
+- Append new artifact links to the Artifacts section
+- Update the `phase` frontmatter field to the next phase
+
+When updating frontmatter, do a targeted Edit of just the changed property line — don't rewrite the whole file.
+
+## Advancement Map
+
+| Current Phase | Next Phase | Workflow Triggered        |
+|---------------|------------|---------------------------|
+| backlog       | research   | refine with user          |
+| research      | design     | research agents           |
+| design        | planning   | design-doc skill          |
+| planning      | —          | plan-write (then dispatch) |
+| building      | review     | status check              |
+| review        | done       | human verification        |

--- a/internal/skillsinstall/skills/project-dispatch/SKILL.md
+++ b/internal/skillsinstall/skills/project-dispatch/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: project-dispatch
+description: >
+  Dispatch ready work items to parallel hive agents. Scans Obsidian Projects for work
+  items at `research`, `design`, or `planning` phase, lets the user select which to
+  dispatch, then runs `hive batch` to spawn one agent per item. Use when you have a
+  queue of work items ready to run in parallel.
+allowed-tools: "Bash(*),Read,Write"
+version: "1.1.0"
+author: "User"
+---
+
+# Project Dispatch
+
+Scan the Obsidian project board for work items ready to dispatch and spawn parallel
+hive agent sessions for them.
+
+## Vault Resolution
+
+```bash
+echo "$OBSIDIAN_NOTEBOOK_DIR"
+```
+
+If empty, stop and tell the user to set `OBSIDIAN_NOTEBOOK_DIR`.
+
+## Step 1: Find Dispatchable Work Items
+
+Scan all work item notes:
+
+```bash
+find "$OBSIDIAN_NOTEBOOK_DIR/Projects" -path "*/Work Items/*.md" -type f
+```
+
+Read each file fully to extract frontmatter and Artifacts section. Classify each item:
+
+| Phase | Dispatchable when... |
+|---|---|
+| `research` | Always — agent will run the research workflow |
+| `design` | Always — agent will run the design-doc workflow |
+| `planning` | Always — agent will write a plan if none exists, or execute if plan exists |
+
+Items at `building`, `review`, `done`, or `blocked` are excluded.
+
+For each dispatchable item, extract:
+- Work item title (filename without `.md`)
+- Project name (from `project` frontmatter, strip `[[` and `]]`)
+- Phase
+- Priority
+- Repos (from `repos` frontmatter)
+- Objective (from `## Objective` section body)
+- Acceptance Criteria (from `## Acceptance Criteria` section body)
+- Plan file path (from `- Plan:` in Artifacts, if present)
+
+## Step 2: Show Dispatch Board
+
+Present items grouped by phase, then project, sorted by priority:
+
+```
+Dispatchable work items:
+
+── PLANNING (ready to build) ──────────────────────────────
+[Adaptive Logs API Alignment]
+  1. Fix HTTP Status Codes        (high)   ✓ plan exists
+  2. Validation Consolidation     (high)   ✗ no plan yet
+  3. Consolidate Response Types   (low)    ✓ plan exists
+
+── DESIGN ─────────────────────────────────────────────────
+[Adaptive Logs Observability]
+  4. Logging Infrastructure       (high)
+
+── RESEARCH ───────────────────────────────────────────────
+  (none)
+```
+
+Ask the user which to dispatch — they can say "all", "1 2 3", a phase name, or a
+project name.
+
+## Step 3: Build Agent Prompts
+
+Construct the prompt for each selected item based on its phase.
+
+### Research phase prompt
+
+```
+Work Item: <title>
+Project: <project>
+Repos: <repos>
+
+Objective:
+<objective>
+
+Run deep codebase research for this work item using the `research` skill. Conduct
+parallel research across the listed repos focused on the objective above.
+
+Save the research document to:
+  $OBSIDIAN_NOTEBOOK_DIR/Projects/<project>/Research/YYYY-MM-DD-<slug>.md
+
+Include frontmatter:
+  work-item: "[[<title>]]"
+  project: "[[<project>]]"
+
+After saving, update the work item file at:
+  <work-item-file-path>
+Add the research doc filename to the Artifacts section: `- Research: [[<filename>]]`
+Then update `phase: design` in the frontmatter.
+```
+
+### Design phase prompt
+
+```
+Work Item: <title>
+Project: <project>
+Repos: <repos>
+
+Objective:
+<objective>
+
+Acceptance Criteria:
+<acceptance-criteria>
+
+Create a design document for this work item using the `design-doc` skill. Read any
+linked research doc from the work item's Artifacts section first if one exists.
+
+Save the design doc to:
+  $OBSIDIAN_NOTEBOOK_DIR/Projects/<project>/Design Docs/YYYY-MM-DD-<slug>.md
+
+After saving, update the work item file at:
+  <work-item-file-path>
+Add the design doc to Artifacts: `- Design Doc: [[<filename>]]`
+Then update `phase: planning` in the frontmatter.
+```
+
+### Planning phase — plan exists
+
+```
+Work Item: <title>
+Project: <project>
+Repos: <repos>
+
+Objective:
+<objective>
+
+Acceptance Criteria:
+<acceptance-criteria>
+
+An implementation plan exists at: <plan-path>
+
+Read the plan fully. Then use the `plan-to-hc` skill to load the plan into hive hc
+tasks for this session. Execute each task in order. When all tasks are complete and
+a PR is open, you are done.
+```
+
+### Planning phase — no plan yet
+
+```
+Work Item: <title>
+Project: <project>
+Repos: <repos>
+
+Objective:
+<objective>
+
+Acceptance Criteria:
+<acceptance-criteria>
+
+No implementation plan exists yet. Use the `plan-write` skill to create one. Save the
+plan to `.hive/plans/`. Do not implement any code changes — the plan will be reviewed
+before execution begins.
+
+After saving the plan, update the work item file at:
+  <work-item-file-path>
+Add the plan path to Artifacts: `- Plan: .hive/plans/<filename>`
+```
+
+## Step 4: Build Batch JSON
+
+Combine selected items into the batch input:
+
+```json
+{
+  "sessions": [
+    { "name": "<slugified-title>", "prompt": "<prompt>" },
+    { "name": "<slugified-title>", "prompt": "<prompt>" }
+  ]
+}
+```
+
+Show the session names and a brief summary (title, phase, plan status) for review.
+Do NOT show the full prompts — keep the confirmation concise. Ask for confirmation
+before dispatching.
+
+## Step 5: Dispatch
+
+```bash
+echo '<json>' | hive batch
+```
+
+## Step 5a: Create Progress Todo
+
+After a successful dispatch, create a follow-up reminder:
+
+```bash
+hive todo add \
+  --title "Check dispatch progress: <session-names>" \
+  --uri "session://"
+```
+
+List the spawned session names in the title (comma-separated if multiple).
+
+## Step 6: Update Work Items
+
+After `hive batch` succeeds, update each dispatched work item's `phase` to `building`:
+
+```
+phase: building
+```
+
+Use a targeted Edit on just the `phase:` line — don't rewrite the whole file.
+
+**Exception:** planning-phase items with no plan go to `building` too — the agent
+will write the plan and stop, so `building` here means "agent is working on it."
+
+## After Dispatch
+
+Report:
+- How many sessions spawned, grouped by phase
+- Session names
+- Remind user: `hive ls` to check status

--- a/internal/skillsinstall/skills/project-draft/SKILL.md
+++ b/internal/skillsinstall/skills/project-draft/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: project-draft
+description: >
+  Draft a new project and initial work items in Obsidian. Use when the user wants to
+  capture a new project idea, plan work streams, or organize a coding initiative.
+allowed-tools: "Bash(mkdir:*),Bash(echo:*),Bash(git:*),Read,Write"
+version: "1.1.0"
+author: "User"
+---
+
+# Project Draft
+
+Create a new project note and initial work items in the Obsidian vault.
+
+## Vault Resolution
+
+The vault root is stored in `$OBSIDIAN_NOTEBOOK_DIR`. Always resolve before writing:
+
+```bash
+echo "$OBSIDIAN_NOTEBOOK_DIR"
+```
+
+If the variable is empty, stop and tell the user to set `OBSIDIAN_NOTEBOOK_DIR`.
+
+## Interview
+
+Ask the user for the following before writing anything:
+
+1. **Project name** — used as the folder and note title (title case, spaces OK)
+2. **Goal** — one or two sentences describing what success looks like
+3. **Repos** — which repositories are involved (if any)
+4. **Initial work items** — the first concrete things to work on
+   - For each item: name, objective, starting phase, priority
+
+Phases: `backlog | research | design | planning | building | review | done | blocked`
+Priorities: `high | medium | low`
+
+## File Structure
+
+```
+$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/
+├── <Project Name>.md         ← project note
+├── Research/                 ← research docs created during project-advance
+├── Design Docs/              ← design docs created during project-advance
+└── Work Items/
+    └── <Work Item Name>.md   ← one file per work item
+```
+
+Create all directories before writing:
+
+```bash
+mkdir -p "$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Work Items"
+mkdir -p "$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Research"
+mkdir -p "$OBSIDIAN_NOTEBOOK_DIR/Projects/<Project Name>/Design Docs"
+```
+
+## Project Note Format
+
+```markdown
+---
+tags:
+  - project
+type: project
+status: active
+repos: [<repo1>, <repo2>]
+created: YYYY-MM-DD
+---
+
+# <Project Name>
+
+## Goal
+
+<goal statement>
+
+## Context
+
+<why this matters and what problem it solves>
+
+## Work Items
+
+- [[<Work Item Name>]]
+
+## Notes
+```
+
+## Work Item Note Format
+
+```markdown
+---
+tags:
+  - work-item
+type: work-item
+project: "[[<Project Name>]]"
+phase: <backlog|research|design|planning|building|review|done|blocked>
+priority: <high|medium|low>
+repos: []
+created: YYYY-MM-DD
+---
+
+# <Work Item Name>
+
+## Objective
+
+<what this work item accomplishes>
+
+## Acceptance Criteria
+
+- [ ]
+
+## Artifacts
+
+- Research:
+- Design Doc:
+- Plan:
+- PRs:
+
+## Notes
+```
+
+## Dates
+
+Use today's date for all `created` fields:
+
+```bash
+date +%Y-%m-%d
+```
+
+## After Writing
+
+1. List all files created with their full paths
+2. Create a review todo pointing to the new project note in Obsidian:
+
+```bash
+VAULT="${OBSIDIAN_NOTEBOOK_DIR##*/}"
+VAULT_ENC="${VAULT// /%20}"
+PROJECT_ENC="${PROJECT_NAME// /%20}"
+hive todo add \
+  --title "Review new project: <project-name>" \
+  --uri "obsidian://vault/${VAULT_ENC}/Projects/${PROJECT_ENC}/${PROJECT_ENC}.md"
+```
+
+3. Tell the user they can run `/project-advance` to start progressing any work item
+4. Remind them to open `Projects/index.base` in Obsidian for the full dashboard

--- a/internal/skillsinstall/skills/research/SKILL.md
+++ b/internal/skillsinstall/skills/research/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: research
+description: >
+  Research codebase comprehensively using parallel sub-agents. Use when the user asks
+  for deep research, wants to understand how a feature works, or needs thorough analysis
+  of patterns and architecture across the codebase.
+allowed-tools: "Bash(git status:*),Bash(git log:*),Bash(git diff:*),WebSearch,Read,Write,Task(*)"
+version: "1.0.0"
+author: "User"
+---
+
+# Research Codebase
+
+Conduct comprehensive research across the codebase by spawning parallel sub-agents and
+synthesizing their findings into a research document.
+
+## Context Directory
+
+Research documents are stored in `.hive/research/` managed by `hive ctx`.
+
+**IMPORTANT:** `.hive` must be a symlink, not a directory. If it doesn't exist, run
+`hive ctx init` to create it — NEVER use `mkdir`.
+
+## Step 1: Read Mentioned Files
+
+If the user mentions specific files (tickets, docs, JSON), read them **fully** first
+using the Read tool WITHOUT limit/offset parameters. Do this before spawning any sub-tasks.
+
+## Step 2: Decompose the Research Question
+
+Break down the query into composable research areas. Identify:
+- Specific components, patterns, or concepts to investigate
+- Which directories, files, or architectural patterns are relevant
+- Cross-component connections and architectural implications
+
+## Step 3: Spawn Parallel Sub-Agent Tasks
+
+Create multiple Task agents to research different aspects concurrently.
+
+Strategy:
+- Start with **codebase-locator** agents to find what exists
+- Follow up with **codebase-analyzer** agents on the most promising findings
+- Run multiple agents in parallel when searching for different things
+- Tell agents **what** to look for, not **how** to search
+
+## Step 4: Synthesize Findings
+
+Wait for **all** sub-agents to complete before proceeding.
+
+- Prioritize live codebase findings as primary source of truth
+- Use `.hive/` as supplementary historical context
+- Connect findings across components
+- Include specific file paths and line numbers
+- Highlight patterns, connections, and architectural decisions
+
+## Step 5: Gather Metadata
+
+Before writing the document, gather:
+
+```bash
+git branch --show-current
+git rev-parse HEAD
+date -u +"%Y-%m-%dT%H:%M:%SZ"
+```
+
+## Step 6: Write the Research Document
+
+**Filename format:** `.hive/research/YYYY-MM-DD-ENG-XXXX-description.md`
+- With ticket: `2025-01-08-ENG-1478-parent-child-tracking.md`
+- Without ticket: `2025-01-08-authentication-flow.md`
+
+```markdown
+---
+date: [ISO datetime with timezone]
+researcher: [git config user.name]
+git_commit: [current commit hash]
+branch: [current branch]
+repository: [repo name]
+topic: "[Research question/topic]"
+tags: [research, codebase, relevant-component-names]
+status: complete
+last_updated: [YYYY-MM-DD]
+last_updated_by: [researcher name]
+---
+
+# Research: [Topic]
+
+**Date**: [datetime]
+**Researcher**: [name]
+**Git Commit**: [hash]
+**Branch**: [branch]
+**Repository**: [repo]
+
+## Research Question
+
+[Original query]
+
+## Summary
+
+[High-level findings answering the question]
+
+## Detailed Findings
+
+### [Component/Area 1]
+
+- Finding with reference (file.ext:line)
+- Connection to other components
+- Implementation details
+
+### [Component/Area 2]
+
+...
+
+## Code References
+
+- `path/to/file.py:123` - Description
+- `another/file.ts:45-67` - Description
+
+## Architecture Insights
+
+[Patterns, conventions, and design decisions discovered]
+
+## Historical Context
+
+[Relevant insights from `.hive/` directory]
+
+## Related Research
+
+[Links to other research documents in `.hive/research/`]
+
+## Open Questions
+
+[Areas needing further investigation]
+```
+
+## Step 6a: Create Review Todo
+
+After writing the research document, create a todo for human review:
+
+```bash
+hive todo add \
+  --title "Review research: <topic-slug>" \
+  --uri "review://.hive/research/<filename>"
+```
+
+Use the actual filename from Step 6.
+
+## Step 7: Add GitHub Permalinks (if applicable)
+
+If on main or a pushed branch:
+```bash
+git branch --show-current
+gh repo view --json owner,name
+```
+
+Replace local file references with permalinks:
+`https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+
+## Step 8: Present Findings
+
+Summarize key findings concisely to the user. Include file references for navigation.
+Ask if follow-up questions or clarification is needed.
+
+## Step 9: Handle Follow-up Questions
+
+Append follow-up research to the same document:
+- Update `last_updated` and `last_updated_by` in frontmatter
+- Add `last_updated_note: "Added follow-up research for [brief description]"`
+- Add a new section: `## Follow-up Research [timestamp]`
+- Spawn new sub-agents as needed
+
+## Important Notes
+
+- Always run fresh codebase research — never rely solely on existing research documents
+- Read mentioned files FULLY before spawning sub-tasks
+- Wait for ALL sub-agents to complete before synthesizing
+- Gather metadata before writing (never use placeholder values)
+- Keep the main agent focused on synthesis, not deep file reading
+- Encourage sub-agents to find examples and usage patterns, not just definitions
+- Check `.hive/` for existing research and context

--- a/internal/skillsinstall/skills/review-code/SKILL.md
+++ b/internal/skillsinstall/skills/review-code/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: review-code
+description: >
+  Comprehensive code review of the current branch against a base branch using parallel
+  sub-agents for correctness, design, comments, and tests. Use when reviewing local changes
+  before opening a PR, or when the user asks for a code review.
+argument-hint: "[base-branch]"
+---
+
+# Code Review
+
+Orchestrate a comprehensive review of the current branch's changes by dispatching parallel
+sub-agent reviews, then synthesize findings into a single cohesive report.
+
+## Scope
+
+Review ALL changes in the current branch compared to the base branch, including unstaged changes.
+
+**Default base branch:** `main`
+**Override:** If an argument is provided, use it as the base branch (e.g., `/review-code develop`).
+
+## Step 1: Gather the Diff
+
+```bash
+# Get the full diff including unstaged changes against the base branch
+git diff <base-branch>...HEAD
+
+# Also capture unstaged changes not yet committed
+git diff
+
+# List changed files for context
+git diff --name-only <base-branch>...HEAD
+git diff --name-only
+```
+
+Combine both diffs to get the complete picture of what will differ from the base branch.
+
+## Step 2: Dispatch Sub-Agent Reviews
+
+Spawn **four sub-agents in parallel** using the Task tool, each focused on one review dimension.
+Provide each sub-agent with the full diff and the list of changed files.
+
+**Critical:** Sub-agents do not have skills loaded automatically. Each sub-agent prompt MUST
+instruct the agent to first read the skill file, then follow its instructions. Include the
+full diff content in the prompt so the sub-agent has the code to review.
+
+### Sub-Agent 1: Correctness Review
+> Read the `review-correctness` skill and follow its instructions. Review all changed code
+> for logic bugs, error handling gaps, edge cases, race conditions, resource leaks, and
+> security vulnerabilities. For Go projects, run `deadcode -test ./...` in the repo root
+> to identify unreachable functions as part of the dead code analysis step — do not skip
+> this even though you have the diff; the tool requires the full build graph. Return findings
+> in the output format specified by the skill.
+
+### Sub-Agent 2: Design Review
+> Read the `review-design` skill and follow its instructions. Review all changed code for
+> naming, structure, abstraction quality, API surface, boundary clarity, and coupling. Return
+> findings in the output format specified by the skill.
+
+### Sub-Agent 3: Comment Review
+> Read the `review-comments` skill and follow its instructions. Review all comments in the
+> changed code for relevance and purpose. Identify comments that restate code, are stale, or
+> are missing where they would help. Return findings in the output format specified by the skill.
+
+### Sub-Agent 4: Test Review
+> Read the `review-tests` skill and follow its instructions. Review all test files in the
+> changed code for coverage quality, redundancy, and value. For Go projects, run
+> `go test ./... -coverprofile=coverage.out -covermode=atomic && go tool cover -func=coverage.out`
+> in the repo root to get per-function coverage data before analyzing the diff — do not skip
+> this even though you have the diff; coverage requires actually running the tests. Identify
+> missing tests for new code paths. Return findings in the output format specified by the skill.
+
+## Step 3: Synthesize Results
+
+After all sub-agents complete, aggregate their findings into a single review.
+
+### Severity Classification
+
+Classify every finding into one of three levels:
+
+| Level | Meaning | Requires Action? |
+|-------|---------|-----------------|
+| **Critical** | Bug, security issue, data loss risk, race condition | Yes -- must fix before merge |
+| **Suggestion** | Design improvement, missing error context, better naming | Recommended |
+| **Nit** | Style, comment quality, minor naming preference | Optional |
+
+### Deduplication
+
+Sub-agents may flag the same location for different reasons. When this happens:
+- Merge findings for the same location into one entry
+- List all applicable categories (e.g., "Correctness + Design")
+- Use the highest severity across the merged findings
+
+## Output Format
+
+```markdown
+# Code Review: <branch-name> → <base-branch>
+
+## Overview
+[2-3 sentence summary: what this branch does, overall quality assessment, and whether
+it is ready to merge]
+
+## Critical Issues
+[Items that MUST be fixed before merge. If none, say "None found."]
+
+| # | Location | Category | Issue | Recommendation |
+|---|----------|----------|-------|----------------|
+| 1 | file:line | Correctness | Description | Fix |
+
+## Suggestions
+[Items worth improving but not blocking]
+
+| # | Location | Category | Issue | Recommendation |
+|---|----------|----------|-------|----------------|
+| 1 | file:line | Design | Description | Suggestion |
+
+## Nits
+[Minor items, optional to address]
+
+| # | Location | Category | Issue | Recommendation |
+|---|----------|----------|-------|----------------|
+| 1 | file:line | Comments | Description | Suggestion |
+
+## Test Coverage
+[Summary from test review: are new code paths covered? Any redundant tests?]
+
+## Verdict
+**[APPROVE / REQUEST CHANGES / NEEDS DISCUSSION]**
+[One sentence justification]
+```
+
+## Guidelines
+
+1. **Be direct** - State what's wrong and how to fix it. Skip the compliments.
+2. **Prioritize** - Critical issues first. Don't bury a race condition under nits.
+3. **Be specific** - Reference exact files and lines. Vague feedback is useless.
+4. **Assume competence** - The author can read code. Don't explain what the code does.
+5. **Suggest, don't demand** - For non-critical items, frame as suggestions.
+6. **Acknowledge good work** - A brief note in the overview if the code is solid. Don't over-praise.

--- a/internal/skillsinstall/skills/review-comments/SKILL.md
+++ b/internal/skillsinstall/skills/review-comments/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: review-comments
+description: Review code comments for relevance and purpose. Identifies comments that restate what code does instead of explaining why. Use when reviewing PRs, refactoring, or when the user asks to evaluate comment quality.
+argument-hint: [file-or-directory]
+---
+
+# Comment Review - Why Over What
+
+Evaluate comments for purpose and relevance. Every comment should earn its place by adding context the code cannot express on its own.
+
+## Philosophy
+
+**Assume the reader can read code.** Comments exist to capture intent, constraints, trade-offs, and non-obvious context that code alone cannot convey.
+
+- A comment that restates code is noise
+- A comment that explains _why_ a decision was made is documentation
+- No comment is better than a misleading or stale comment
+
+## When to Use This Skill
+
+- When reviewing a PR that adds or modifies comments
+- When refactoring and deciding which comments to keep
+- When auditing a file or module for comment quality
+
+## Comment Value Criteria
+
+### A comment provides value when it:
+
+1. **Explains why** - Captures intent, motivation, or constraints behind a decision
+2. **Warns about non-obvious behavior** - Edge cases, gotchas, or surprising side effects
+3. **Provides context the code cannot** - Links to specs, tickets, or external requirements
+4. **Clarifies unintuitive logic** - Only when the code genuinely cannot be made clearer through naming or structure
+
+### A comment does NOT provide value when it:
+
+1. **Restates the code** - `// increment counter` above `counter++`
+2. **Describes what is obvious** - `// loop through users` above `for _, user := range users`
+3. **Repeats the function/variable name** - `// GetUser gets a user`
+4. **Is stale or wrong** - Describes behavior that no longer matches the code
+5. **Compensates for bad naming** - The fix is renaming, not commenting
+
+## Evaluation Process
+
+### Step 1: Classify Each Comment
+
+For every comment in scope, classify it:
+
+| Category | Keep? | Example |
+|----------|-------|---------|
+| **Why** - Explains reasoning or constraints | Yes | `// Use insertion sort here; n is always < 10 and cache locality matters` |
+| **Warning** - Flags non-obvious risk | Yes | `// This must run before InitDB; order matters due to schema migration lock` |
+| **Context** - Links to external info | Yes | `// Per RFC 7231 §6.5.1, return 400 for malformed request bodies` |
+| **What** - Restates code | No | `// Create a new HTTP client` |
+| **Filler** - Noise or decoration | No | `// ====== HELPERS ======` |
+| **Stale** - No longer accurate | No | `// Returns nil if not found` (but code now returns an error) |
+
+### Step 2: Evaluate "What" Comments
+
+Some "what" comments deserve a second look. Keep them only if:
+
+- The code is genuinely unintuitive (bit manipulation, complex regex, unusual algorithms)
+- Renaming or restructuring cannot make the code self-explanatory
+- Domain knowledge is required that a general developer would not have
+
+### Step 3: Check for Missing Comments
+
+Good code sometimes _lacks_ comments where they would help:
+
+- Non-obvious performance choices
+- Workarounds for bugs in dependencies
+- Business rules that drive control flow
+- Concurrency or ordering constraints
+- Magic numbers or thresholds
+
+## Examples
+
+### Good Comments
+
+```go
+// We retry 3 times because the upstream billing API intermittently
+// returns 503 during their rolling deploys (see INCIDENT-1234).
+resp, err := retryRequest(billingURL, 3)
+```
+
+```go
+// Sorting by CreatedAt descending so the UI shows newest first.
+// The API contract guarantees this order (see docs/api-spec.md).
+sort.Slice(items, func(i, j int) bool {
+    return items[i].CreatedAt.After(items[j].CreatedAt)
+})
+```
+
+```go
+// Must hold mu before calling; callers are responsible for locking.
+func (c *Cache) evictOldest() { ... }
+```
+
+### Bad Comments
+
+```go
+// Create a new server
+srv := &http.Server{Addr: ":8080"}
+```
+
+```go
+// GetUserByID gets a user by ID
+func GetUserByID(id string) (*User, error) { ... }
+```
+
+```go
+// Loop through all items and check if they are valid
+for _, item := range items {
+    if !item.Valid() { ... }
+}
+```
+
+```go
+// Set the timeout to 30 seconds
+client.Timeout = 30 * time.Second
+// Better: explain WHY 30 seconds
+// 30s matches the upstream gateway timeout; going higher causes
+// the LB to kill the connection before we get a response.
+client.Timeout = 30 * time.Second
+```
+
+## Review Checklist
+
+When /review-comments is invoked, evaluate:
+
+1. **Purpose**: Does each comment explain why, not what?
+2. **Accuracy**: Do comments match current code behavior?
+3. **Necessity**: Could the comment be removed by improving naming or structure?
+4. **Gaps**: Are there non-obvious decisions missing a comment?
+5. **Staleness**: Do any comments reference outdated behavior?
+
+## Output Format
+
+```markdown
+## Comment Review: [file/scope]
+
+### Issues Found
+| Location | Type | Comment | Recommendation |
+|----------|------|---------|----------------|
+| file.go:23 | What | `// Create new client` | Remove - obvious from code |
+| file.go:45 | Stale | `// Returns nil on error` | Update or remove - code returns error |
+| file.go:67 | What | `// Parse the config` | Remove - rename func to `ParseConfig` |
+
+### Missing Comments
+| Location | Suggestion |
+|----------|-----------|
+| file.go:89 | Explain why retry count is 5 |
+| file.go:112 | Document concurrency constraint on `mu` |
+
+### Summary
+[N] comments reviewed → [X] remove, [Y] update, [Z] missing comments suggested
+```
+
+## Guidelines
+
+1. **Why > What** - If a comment only says what, it should say why or be deleted
+2. **Fix the code first** - If a comment compensates for bad naming, rename instead
+3. **Stale comments are bugs** - Wrong documentation is worse than none
+4. **Brevity matters** - Comments should be concise; a paragraph is usually too much
+5. **Not every line needs a comment** - Well-written code with good names is self-documenting
+6. **Godoc is different** - Exported symbol documentation follows its own rules and is expected

--- a/internal/skillsinstall/skills/review-correctness/SKILL.md
+++ b/internal/skillsinstall/skills/review-correctness/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: review-correctness
+description: Review code for correctness including logic bugs, error handling, edge cases, race conditions, and security vulnerabilities. Use when reviewing PRs or auditing code for bugs.
+argument-hint: [file-or-directory]
+---
+
+# Correctness Review
+
+Find bugs before users do. Evaluate logic, error handling, edge cases, concurrency, and security.
+
+## Philosophy
+
+**Assume the code has bugs. Prove it doesn't.**
+
+- Every branch is a potential bug
+- Every error path is a potential crash
+- Every shared state is a potential race
+
+## When to Use This Skill
+
+- When reviewing a PR for functional correctness
+- When auditing code after an incident
+- When evaluating error handling and edge cases
+
+## Correctness Criteria
+
+### Check for:
+
+1. **Logic errors** - Off-by-one, wrong operator, inverted condition, missing case
+2. **Error handling** - Swallowed errors, missing context, panics in library code
+3. **Edge cases** - Nil/zero/empty inputs, boundary values, integer overflow
+4. **Concurrency** - Races, deadlocks, shared state without synchronization
+5. **Security** - Injection, unvalidated input, hardcoded secrets, path traversal
+6. **Resource leaks** - Unclosed files/connections, goroutine leaks, missing defers
+
+## Evaluation Process
+
+### Step 1: Trace the Happy Path
+
+Walk through the intended flow. Verify:
+- Inputs are validated before use
+- Each transformation produces the expected result
+- The return value matches the function contract
+
+### Step 2: Break the Sad Paths
+
+For each error/failure point:
+
+| Check | What to Look For |
+|-------|-----------------|
+| Error propagation | Is the error wrapped with context? Or silently dropped? |
+| Partial state | If step 3 of 5 fails, is state rolled back or left corrupt? |
+| Caller expectations | Does the caller handle all documented error cases? |
+| Panic safety | Could this panic in a goroutine without recovery? |
+
+### Step 3: Probe Edge Cases
+
+- What happens with nil, zero, empty string, empty slice?
+- What happens at integer boundaries (0, -1, MaxInt)?
+- What if the map key doesn't exist?
+- What if the context is already cancelled?
+- What if the input is valid but very large?
+
+### Step 4: Concurrency Audit
+
+For any shared mutable state:
+- Is access synchronized (mutex, channel, atomic)?
+- Can a goroutine outlive its parent and access freed resources?
+- Are channels properly closed by the sender?
+- Could `select` with `default` cause a busy loop?
+
+### Step 5: Dead Code Analysis (Go projects only)
+
+Run `deadcode` to find unreachable functions and methods:
+
+```bash
+# Install if needed
+go install golang.org/x/tools/cmd/deadcode@latest
+
+# Analyze from the main entry point(s)
+deadcode -test ./...
+
+# For a specific binary
+deadcode ./cmd/myapp/...
+```
+
+Interpret findings critically — not all reported dead code is a bug:
+
+| Finding | Likely Cause | Action |
+|---------|-------------|--------|
+| Unexported func, never called | Genuinely dead — remove | Delete |
+| Exported func, never called internally | May be public API or used by external consumers | Investigate before removing |
+| Interface method never called | Stale interface — check if interface is still needed | Remove method or interface |
+| Function only called in deleted branch | Leftover from prior refactor | Delete |
+| `//go:build` gated code | May be intentionally excluded in current build | Skip or verify |
+
+Flag dead code as a correctness issue when it:
+- Suggests a missing call site (e.g., a cleanup function that was supposed to be deferred)
+- Indicates an unreachable error branch that should be reachable
+- Points to orphaned logic after a refactor that left callers removed
+
+### Step 6: Security Scan
+
+| Category | Check |
+|----------|-------|
+| Input validation | User input validated and sanitized before use? |
+| SQL/command injection | Using parameterized queries? Avoiding string interpolation? |
+| Path traversal | User-controlled paths joined with `filepath.Join` and validated? |
+| Secrets | No hardcoded tokens, passwords, or keys? |
+| Crypto | Using `crypto/rand` not `math/rand` for security-sensitive values? |
+| Auth | Permission checks on every protected endpoint? |
+
+## Examples
+
+### Swallowed Error
+
+```go
+// BUG: Error silently ignored -- caller thinks success
+data, err := fetchData(url)
+if err != nil {
+    log.Println(err)
+    return nil // should return error
+}
+```
+
+### Race Condition
+
+```go
+// BUG: concurrent map read/write
+go func() { cache[key] = value }()
+go func() { v := cache[key] }()
+
+// FIX: use sync.Map or mutex
+```
+
+### Missing Nil Check
+
+```go
+// BUG: user could be nil if not found
+user, _ := store.FindByID(id)
+fmt.Println(user.Name) // panic
+
+// FIX: check error and nil
+user, err := store.FindByID(id)
+if err != nil { return fmt.Errorf("find user %s: %w", id, err) }
+```
+
+### Resource Leak
+
+```go
+// BUG: body never closed on early return
+resp, err := http.Get(url)
+if err != nil { return err }
+if resp.StatusCode != 200 {
+    return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+    // resp.Body leaked
+}
+defer resp.Body.Close()
+
+// FIX: defer immediately after nil check
+resp, err := http.Get(url)
+if err != nil { return err }
+defer resp.Body.Close()
+```
+
+## Review Checklist
+
+When /review-correctness is invoked, evaluate:
+
+1. **Error handling**: Are all errors propagated with context?
+2. **Nil safety**: Are pointer/interface values checked before use?
+3. **Edge cases**: Does the code handle zero, empty, and boundary inputs?
+4. **Concurrency**: Is shared state properly synchronized?
+5. **Resource management**: Are all resources cleaned up (defer, close)?
+6. **Security**: Are inputs validated and outputs sanitized?
+7. **Dead code**: Run `deadcode -test ./...` — are there unreachable functions signaling missing call sites or orphaned logic?
+
+## Output Format
+
+```markdown
+## Correctness Review: [scope]
+
+### Bugs Found
+| Location | Severity | Issue | Fix |
+|----------|----------|-------|-----|
+| api.go:45 | Critical | Swallowed error in HandleCreate | Return error to caller |
+| cache.go:12 | Critical | Race on map without mutex | Add sync.RWMutex |
+| user.go:89 | Warning | Nil deref if user not found | Check err before accessing |
+
+### Security Issues
+| Location | Category | Issue | Fix |
+|----------|----------|-------|-----|
+| query.go:34 | Injection | String interpolation in SQL | Use parameterized query |
+
+### Dead Code
+| Function | Location | Assessment | Action |
+|----------|----------|------------|--------|
+| processLegacy | legacy.go:88 | Orphaned after refactor | Delete |
+| validateToken | auth.go:201 | Exported — verify no external callers | Investigate |
+
+### Edge Cases
+| Location | Input | Behavior | Expected |
+|----------|-------|----------|----------|
+| parse.go:12 | empty string | panic | return ErrEmptyInput |
+
+### Summary
+[N] issues found: [X] critical, [Y] warnings. Top priority: [most important fix]
+```
+
+## Guidelines
+
+1. **Every error must be handled** - Logging is not handling
+2. **Nil is the billion-dollar mistake** - Check before you dereference
+3. **Shared state needs synchronization** - No exceptions
+4. **Close what you open** - defer immediately after acquisition
+5. **Validate at the boundary** - Trust nothing from outside your package
+6. **Wrap errors with context** - `fmt.Errorf("doing X: %w", err)` always

--- a/internal/skillsinstall/skills/review-design/SKILL.md
+++ b/internal/skillsinstall/skills/review-design/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: review-design
+description: Review code for design quality including API surface, naming, structure, separation of concerns, and adherence to project conventions. Use when reviewing PRs, refactoring, or evaluating architecture decisions.
+argument-hint: [file-or-directory]
+---
+
+# Design Review
+
+Evaluate code design: naming, structure, abstractions, and separation of concerns. Good design makes code easy to change.
+
+## Philosophy
+
+**Simple beats clever. Obvious beats implicit.**
+
+- Code should be easy to delete, not easy to extend
+- The best abstraction is often no abstraction
+- Naming is design -- bad names signal bad boundaries
+
+## When to Use This Skill
+
+- When reviewing a PR for structural quality
+- When evaluating whether an abstraction is justified
+- When assessing API surface or public interfaces
+
+## Design Criteria
+
+### Good design exhibits:
+
+1. **Clear boundaries** - Each package/module has a single, obvious responsibility
+2. **Honest naming** - Names accurately describe what things do, not what they might do
+3. **Minimal API surface** - Only expose what consumers need
+4. **Direct dependencies** - Depend on concrete types, not unnecessary interfaces
+5. **Obvious data flow** - Reader can trace how data moves without jumping between files
+
+### Design smells:
+
+1. **Premature abstraction** - Interface with one implementation, generic code used once
+2. **Shotgun surgery** - One change requires edits across many files
+3. **Feature envy** - Function mostly operates on another package's data
+4. **God object** - One type/package knows too much or does too much
+5. **Indirection without purpose** - Wrappers, factories, or registries that add complexity without value
+6. **Naming lies** - `utils`, `helpers`, `common`, `base`, `manager` -- vague names hiding unclear responsibilities
+
+## Evaluation Process
+
+### Step 1: Assess Boundaries
+
+For each new or modified package/type, ask:
+
+| Question | Red Flag |
+|----------|----------|
+| Can I describe its purpose in one sentence? | Needs "and" to explain it |
+| Does it depend on its consumers? | Circular or upward dependencies |
+| Could I delete it without rewriting callers? | Tightly coupled to internals |
+| Does it have a clear owner? | Shared mutable state across boundaries |
+
+### Step 2: Evaluate Naming
+
+- **Functions**: Should describe the action and imply the return. `ParseConfig` > `HandleConfig` > `DoConfig`
+- **Types**: Should describe what it IS, not what it does. `User` > `UserManager`
+- **Packages**: Should be short, singular nouns. `auth` > `authentication` > `authHelpers`
+- **Variables**: Scope determines length. `i` in a 3-line loop is fine. `i` across 50 lines is not.
+
+### Step 3: Check Abstraction Level
+
+For each abstraction (interface, generic, factory):
+
+1. **Count implementations** - One implementation means the interface is speculative
+2. **Check call sites** - If callers always use the concrete type, the interface adds nothing
+3. **Test-only interfaces** - Acceptable only if the real dependency is expensive (network, DB)
+
+### Step 4: Evaluate Helper Functions
+
+For any function named `helper`, placed in a `helpers`/`utils`/`common` package, or that exists solely to wrap another call, apply these tests:
+
+| Question | Verdict |
+|----------|---------|
+| Is it called in more than one place? | Single call site — inline it |
+| Does it have a name that describes *why* it exists, not *what* it does? | Vague name (`formatHelper`) — the abstraction has no identity |
+| Does extracting it make the caller clearer, or just shorter? | Shorter-but-obscure — not worth it |
+| Does it own any logic, or just delegate? | Pure delegation — remove the wrapper |
+| Would a future reader know where to find this without searching? | Buried in `utils.go` — wrong location |
+
+**Helper functions justify their existence when:**
+- Called from 3+ distinct locations
+- The extracted name communicates *intent* the call site cannot (`sanitizeUserInput` vs `strings.TrimSpace(strings.ToLower(...))`)
+- They encapsulate a non-obvious decision (not just syntax compression)
+
+**Inline when:** The helper is only called once, or its body is as readable as its name.
+
+### Step 5: Review API Surface
+
+- Are unexported things that should be? (Default to unexported)
+- Do exported functions have clear input/output contracts?
+- Are options/config types growing unbounded? (Consider builder or functional options)
+- Could the API be misused easily? (Pit of success vs pit of despair)
+
+## Examples
+
+### Unnecessary Abstraction
+
+```go
+// BAD: Interface with one implementation, no external consumers
+type UserRepository interface {
+    GetUser(id string) (*User, error)
+}
+type userRepo struct{ db *sql.DB }
+
+// GOOD: Just use the concrete type
+type UserStore struct{ db *sql.DB }
+func (s *UserStore) GetUser(id string) (*User, error) { ... }
+```
+
+### Naming That Communicates
+
+```go
+// BAD: What does "process" mean?
+func ProcessOrder(o Order) error
+
+// GOOD: Says exactly what happens
+func ValidateAndSubmitOrder(o Order) error
+
+// BETTER: Split into two clear functions
+func ValidateOrder(o Order) error
+func SubmitOrder(o Order) error
+```
+
+### Boundary Violation
+
+```go
+// BAD: HTTP handler knows about SQL
+func HandleCreateUser(w http.ResponseWriter, r *http.Request) {
+    db.Exec("INSERT INTO users ...")
+}
+
+// GOOD: Handler delegates to domain logic
+func HandleCreateUser(w http.ResponseWriter, r *http.Request) {
+    user := decodeUser(r)
+    err := userStore.Create(user)
+    // ...
+}
+```
+
+## Review Checklist
+
+When /review-design is invoked, evaluate:
+
+1. **Boundaries**: Does each unit have a clear, single responsibility?
+2. **Naming**: Do names honestly describe what things do?
+3. **Abstractions**: Is every interface/generic justified by multiple consumers?
+4. **Helpers**: Is every helper called from multiple sites, named for intent, and non-trivially useful?
+5. **API surface**: Are exports minimal and hard to misuse?
+6. **Data flow**: Can you trace data without a debugger?
+7. **Coupling**: Could you change one module without cascading edits?
+
+## Output Format
+
+```markdown
+## Design Review: [scope]
+
+### Findings
+| Location | Issue | Severity | Recommendation |
+|----------|-------|----------|----------------|
+| pkg/auth | God package - handles auth, sessions, and permissions | Critical | Split into auth, session, permission packages |
+| UserManager | Vague name | Suggestion | Rename to UserStore or UserService based on actual role |
+| IProcessor | Single implementation | Suggestion | Remove interface, use concrete ProcessorImpl directly |
+
+### Positive Patterns
+- [Note any good design decisions worth calling out]
+
+### Summary
+[Brief assessment of overall design quality and top priority changes]
+```
+
+## Guidelines
+
+1. **Delete over deprecate** - Remove dead abstractions entirely
+2. **Concrete over abstract** - Interfaces should be discovered, not predicted
+3. **Small over clever** - A 10-line function beats a 3-line function nobody understands
+4. **Flat over nested** - Prefer early returns; deep nesting hides logic
+5. **Explicit over implicit** - Direct function calls over service locators or magic registration

--- a/internal/skillsinstall/skills/review-format/SKILL.md
+++ b/internal/skillsinstall/skills/review-format/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: review-format
+description: Standard template and structure for code review output. Use when producing review findings to ensure consistent, actionable, evidence-backed feedback.
+---
+
+# Review Output Format
+
+Every review must follow this structure. Do not invent alternative formats.
+
+## Severity Levels
+
+| Level | Meaning | Requires Action? |
+|-------|---------|-----------------|
+| **Critical** | Bug, data loss, race condition, security vulnerability | Yes — must fix before merge |
+| **Suggestion** | Design improvement, missing error context, better naming | Recommended |
+| **Nit** | Style, minor naming preference, optional cleanup | Optional |
+
+**Default to the lower severity when uncertain.** A misclassified Critical erodes trust in the review.
+
+## Template
+
+```markdown
+# Code Review: [scope or branch]
+
+> Iteration [N] of [M] | Focus: [skill focus for this iteration]
+
+## Critical Issues
+
+_Must be resolved before merge. If none: "None found."_
+
+| # | File:Line | Issue | Evidence | Fix |
+|---|-----------|-------|----------|-----|
+| 1 | auth.go:45 | Swallowed error discards failure context | `if err != nil { log.Println(err) }` — error not returned | Return `fmt.Errorf("creating user: %w", err)` |
+
+## Suggestions
+
+_Worth fixing but not blocking._
+
+| # | File:Line | Issue | Evidence | Recommendation |
+|---|-----------|-------|----------|----------------|
+| 1 | user.go:88 | Helper `formatName` only called once — inline it | Single call site at handler.go:32 | Inline the 2-line body, delete helper |
+
+## Nits
+
+_Optional. Omit section entirely if none._
+
+| # | File:Line | Issue |
+|---|-----------|-------|
+| 1 | cache.go:12 | Comment restates code: `// increment counter` above `count++` |
+
+## Verdict
+
+**[SHIP / DO NOT SHIP / NEEDS DISCUSSION]**
+
+[One sentence. If SHIP: note any conditions. If DO NOT SHIP: name the blocking issue(s).]
+```
+
+## Evidence Requirements
+
+Every **Critical** and **Suggestion** finding must include:
+
+1. **File and line number** from the diff — no vague "somewhere in auth.go"
+2. **Quoted or described code** that demonstrates the problem
+3. **A concrete fix** — not "consider improving" or "think about refactoring"
+
+Findings that cannot cite specific evidence belong at **Nit** severity or should be dropped.
+
+## Iterative Review Rules
+
+When a previous review exists, apply these rules before writing:
+
+1. **Validate each prior finding** — find its evidence in the diff. If you can't, downgrade to Nit or drop it.
+2. **Promote or demote** — a finding with strong evidence from your skill focus can be upgraded; weak evidence downgrades.
+3. **Add new findings** — from your skill focus this iteration.
+4. **Consolidate, don't append** — the output is a single coherent review, not a chain of critiques. Rewrite entries, do not stack them.

--- a/internal/skillsinstall/skills/review-tests/SKILL.md
+++ b/internal/skillsinstall/skills/review-tests/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: review-tests
+description: Evaluate test quality and coverage to ensure tests provide value without redundancy
+argument-hint: [file-or-function]
+---
+
+# Test Review - Quality Over Quantity
+
+Evaluate tests for coverage quality, redundancy, and value. Every test should justify its existence.
+
+## Philosophy
+
+**The goal is confidence, not coverage percentage.**
+
+- A test that exercises the same code path as another test adds maintenance burden without value
+- Tests should document behavior, not implementation details
+- Fewer high-quality tests beat many low-quality tests
+
+## When to Use This Skill
+
+- Before writing new tests for a function/module
+- When reviewing a PR that adds tests
+- When tests are failing and you're unsure if they're worth fixing
+- When refactoring and deciding which tests to keep
+
+## Test Value Criteria
+
+### A test provides value when it:
+
+1. **Covers a distinct execution path** - Different branch, error condition, or state
+2. **Documents expected behavior** - Someone can read it to understand requirements
+3. **Catches real bugs** - Would fail if the code breaks in a meaningful way
+4. **Is maintainable** - Doesn't break on unrelated changes
+
+### A test does NOT provide value when it:
+
+1. **Duplicates another test's path** - Same branches, same assertions, different inputs
+2. **Tests implementation details** - Breaks when refactoring without behavior change
+3. **Has flaky results** - Sometimes passes, sometimes fails
+4. **Tests framework/library code** - Verifying that Go's `append` works
+
+## Evaluation Process
+
+When reviewing tests, start by collecting coverage data, then analyze each test case:
+
+### Step 0: Collect Coverage Data (Go projects only)
+
+Before analyzing tests manually, run the coverage tool to get objective data:
+
+```bash
+# Run with coverage profiling
+go test ./... -coverprofile=coverage.out -covermode=atomic
+
+# Per-function coverage breakdown
+go tool cover -func=coverage.out
+
+# For a specific package
+go test ./path/to/pkg/... -coverprofile=coverage.out && go tool cover -func=coverage.out
+```
+
+Use the coverage output to:
+- **Identify uncovered functions** - 0% coverage functions are gaps
+- **Find partially covered functions** - low % signals untested branches
+- **Validate existing tests** - high % with redundant tests confirms candidates for removal
+- **Focus review effort** - prioritize functions with coverage below 70%
+
+Interpret coverage numbers critically — 100% line coverage does not mean all logical paths are tested (e.g., different error values hitting the same return statement). Use coverage as a floor check, not a ceiling.
+
+### Step 1: Map Execution Paths
+
+```
+Function: ProcessOrder(order Order) error
+Paths:
+  1. order.Items is empty → return ErrEmptyOrder
+  2. order.Total < 0 → return ErrInvalidTotal
+  3. order.Customer is nil → return ErrNoCustomer
+  4. happy path → process and return nil
+```
+
+### Step 2: Map Test Cases to Paths
+
+```
+TestProcessOrder_EmptyItems     → Path 1 ✓
+TestProcessOrder_NoItems        → Path 1 ✗ REDUNDANT
+TestProcessOrder_ZeroItems      → Path 1 ✗ REDUNDANT
+TestProcessOrder_NegativeTotal  → Path 2 ✓
+TestProcessOrder_NilCustomer    → Path 3 ✓
+TestProcessOrder_Success        → Path 4 ✓
+```
+
+### Step 3: Identify Gaps and Redundancy
+
+- **Redundant**: Multiple tests covering Path 1 with trivially different inputs
+- **Gap**: No test for Path 2 with exactly zero total (boundary)
+- **Action**: Remove redundant tests, add boundary test if meaningful
+
+## Table Tests: When and How
+
+### Use table tests when:
+- Testing the same function with multiple valid inputs
+- Each case exercises a DIFFERENT path or boundary
+- Cases are truly independent
+
+### Structure table tests by path:
+
+```go
+func TestProcessOrder(t *testing.T) {
+    tests := []struct {
+        name    string
+        order   Order
+        wantErr error
+    }{
+        // Error paths - one per distinct error condition
+        {"empty items", Order{Items: nil}, ErrEmptyOrder},
+        {"negative total", Order{Items: items, Total: -1}, ErrInvalidTotal},
+        {"nil customer", Order{Items: items, Customer: nil}, ErrNoCustomer},
+
+        // Happy path - minimal case that succeeds
+        {"valid order", validOrder(), nil},
+    }
+    // ...
+}
+```
+
+### Anti-pattern: Redundant table entries
+
+```go
+// BAD: These all test the same path (empty items)
+{"nil items", Order{Items: nil}, ErrEmptyOrder},
+{"empty slice", Order{Items: []Item{}}, ErrEmptyOrder},
+{"zero length", Order{Items: make([]Item, 0)}, ErrEmptyOrder},
+```
+
+## Boundary Testing
+
+Test boundaries that matter:
+
+| Boundary | Test if... |
+|----------|-----------|
+| Zero/Empty | Code has explicit zero handling |
+| One element | Code has single-element special case |
+| Max value | Code has upper limit logic |
+| Nil vs Empty | Code distinguishes between them |
+
+**Don't test boundaries that don't exist in the code.**
+
+## Integration vs Unit Tests
+
+### Unit tests should:
+- Test a single function/method in isolation
+- Mock external dependencies
+- Run fast (< 100ms)
+- Be deterministic
+
+### Integration tests should:
+- Test component interactions
+- Use real dependencies where practical
+- Cover critical user flows
+- Be clearly marked (separate file, build tag)
+
+**One integration test covering a flow > many unit tests mocking everything**
+
+## Red Flags in Test Code
+
+### 1. Testing the mock
+
+```go
+// BAD: This tests that mockDB.Get returns what we told it to
+mockDB.On("Get", "key").Return("value", nil)
+result, _ := mockDB.Get("key")
+assert.Equal(t, "value", result) // Useless!
+```
+
+### 2. Assertion-heavy tests
+
+```go
+// BAD: Testing implementation details
+assert.Equal(t, 3, len(result.calls))
+assert.Equal(t, "init", result.calls[0])
+assert.Equal(t, "process", result.calls[1])
+assert.Equal(t, "cleanup", result.calls[2])
+
+// GOOD: Testing behavior
+assert.NoError(t, result.Error())
+assert.True(t, result.Completed())
+```
+
+### 3. Fragile setup
+
+```go
+// BAD: Test breaks if any field is added to Config
+config := Config{Field1: "a", Field2: "b", Field3: "c", ...}
+
+// GOOD: Only set what matters for this test
+config := Config{RelevantField: "value"}
+```
+
+### 4. Time-dependent tests
+
+```go
+// BAD: Flaky
+time.Sleep(100 * time.Millisecond)
+assert.True(t, completed)
+
+// GOOD: Synchronize properly
+<-done
+assert.True(t, completed)
+```
+
+**Go 1.24+: Use `testing/synctest` for concurrent code.**
+
+The `testing/synctest` package (experimental, requires `GOEXPERIMENT=synctest`) provides
+deterministic testing of concurrent code without `time.Sleep`. It runs goroutines in an
+isolated "bubble" with a fake clock. `synctest.Wait()` blocks until all goroutines in the
+bubble are durably blocked, giving you a reliable synchronization point.
+
+```go
+// BAD: Slow and flaky — time.Sleep is never the right synchronization
+time.Sleep(100 * time.Millisecond)
+if !called {
+    t.Fatal("expected function to be called")
+}
+
+// GOOD: Deterministic — synctest.Wait() returns when all goroutines block
+synctest.Run(func() {
+    called := false
+    go func() { called = true }()
+    synctest.Wait()
+    if !called {
+        t.Fatal("expected function to be called")
+    }
+})
+```
+
+Key rules for `synctest`:
+- Wrap test body in `synctest.Run(func() { ... })`
+- Call `synctest.Wait()` before assertions to ensure goroutines have settled
+- `time.Sleep` inside a bubble advances the fake clock instantly — useful for testing timeouts
+- All goroutines in the bubble must exit before `Run` returns; clean up background goroutines
+- Use `net.Pipe` for in-memory network connections (real I/O is not durably blocking)
+
+See https://go.dev/blog/synctest for details.
+
+## Review Checklist
+
+When /review-tests is invoked, evaluate:
+
+1. **Coverage baseline**: Run `go test -coverprofile` and check per-function percentages first
+2. **Path coverage**: Does each test cover a distinct execution path?
+3. **Redundancy**: Are there multiple tests covering the same path?
+4. **Boundaries**: Are tested boundaries actually present in the code?
+5. **Maintainability**: Will these tests break on refactors?
+6. **Clarity**: Can someone understand the requirements from the tests?
+7. **Speed**: Are unit tests fast? Are slow tests justified?
+
+## Output Format
+
+When reviewing tests, provide:
+
+```markdown
+## Test Review: [function/file]
+
+### Coverage Report
+| Function | Coverage | Status |
+|----------|----------|--------|
+| FuncA    | 87.5%    | ✓ Good |
+| FuncB    | 33.3%    | ⚠ Low  |
+| FuncC    | 0.0%     | ✗ Gap  |
+
+### Execution Paths Identified
+1. [path description]
+2. [path description]
+...
+
+### Coverage Analysis
+| Test Case | Path | Status |
+|-----------|------|--------|
+| TestX | 1 | ✓ Covers |
+| TestY | 1 | ✗ Redundant with TestX |
+| - | 3 | ✗ Gap - no coverage |
+
+### Recommendations
+- Remove: [TestY] - duplicates TestX
+- Add: Test for [uncovered path]
+- Refactor: [TestZ] tests implementation, not behavior
+
+### Summary
+Coverage: X% overall | [N] tests → [M] recommended (removed X redundant, added Y for gaps)
+```
+
+## Guidelines
+
+1. **One test per path** - Additional tests for the same path rarely add value
+2. **Test behavior, not implementation** - Tests should survive refactors
+3. **Boundaries only when meaningful** - Don't test boundaries the code doesn't have
+4. **Integration over excessive mocking** - Real interactions catch real bugs
+5. **Delete flaky tests** - A flaky test is worse than no test
+6. **Readability matters** - Tests are documentation

--- a/internal/skillsinstall/skills/scooter-find-replace/SKILL.md
+++ b/internal/skillsinstall/skills/scooter-find-replace/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: scooter-find-replace
+description: Use the scooter CLI for find and replace operations across codebases. Use when the user asks for bulk find-and-replace, renaming symbols across files, codebase-wide text substitution, or when sed/awk would be too fragile for multi-file replacements.
+---
+
+# Scooter Find and Replace
+
+scooter is an interactive find-and-replace terminal tool. It respects `.gitignore` and `.ignore` files, supports regex with capture groups, and can run in both TUI and non-interactive modes.
+
+## When to Use Scooter
+
+Prefer scooter over `sed`, `awk`, or manual multi-file edits when:
+- Replacing text across many files at once
+- The user wants interactive review of replacements before applying
+- Regex capture groups are needed in replacements
+- File filtering by glob pattern is required
+
+For single-file, single-location edits, use the StrReplace tool instead.
+
+## Non-Interactive Mode (Agent Use)
+
+Since agents cannot operate TUIs, use `--no-tui` (`-N`) for automated replacements:
+
+```bash
+scooter -N -s "search_pattern" -r "replacement" [directory]
+```
+
+The `-N` flag combines immediate search, immediate replace, and stdout output with no UI.
+
+### Common Flags
+
+| Flag | Short | Purpose |
+|------|-------|---------|
+| `--search-text` | `-s` | Text/regex to search for |
+| `--replace-text` | `-r` | Replacement text |
+| `--fixed-strings` | `-f` | Plain string match (not regex) |
+| `--case-insensitive` | `-i` | Ignore case |
+| `--match-whole-word` | `-w` | Match whole words only |
+| `--files-to-include` | `-I` | Comma-separated glob patterns to include |
+| `--files-to-exclude` | `-E` | Comma-separated glob patterns to exclude |
+| `--hidden` | `-.` | Include hidden files/directories |
+| `--advanced-regex` | `-a` | Enable lookahead and other advanced regex features |
+| `--no-tui` | `-N` | Fully non-interactive (search + replace + print) |
+| `--immediate-search` | `-S` | Skip search screen, jump to results |
+| `--immediate-replace` | `-R` | Replace without confirmation |
+| `--immediate` | `-X` | Combines `-S`, `-R`, and print results |
+| `--print-results` | `-P` | Print results to stdout |
+
+## Examples
+
+### Simple string replacement across codebase
+
+```bash
+scooter -N -f -s "oldFunctionName" -r "newFunctionName"
+```
+
+### Regex with capture groups
+
+Capture groups in the search are referenced with `$1`, `$2`, etc. in the replacement:
+
+```bash
+scooter -N -s '(\w+)\.toFixed\(2\)' -r 'formatCurrency($1)'
+```
+
+### Scoped to specific file types
+
+```bash
+scooter -N -f -s "old_name" -r "new_name" -I "*.go,*.ts"
+```
+
+### Exclude directories
+
+```bash
+scooter -N -f -s "TODO" -r "FIXME" -E "vendor/**,node_modules/**"
+```
+
+### Case-insensitive whole-word replacement
+
+```bash
+scooter -N -f -i -w -s "colour" -r "color"
+```
+
+### Scoped to a specific directory
+
+```bash
+scooter -N -f -s "old_api" -r "new_api" src/services/
+```
+
+### Stdin piping
+
+```bash
+cat input.txt | scooter -N -s "before" -r "after" > output.txt
+```
+
+## Interactive Mode (User-Driven)
+
+When the user wants to review replacements interactively, suggest the TUI mode:
+
+```bash
+# Launch with pre-populated fields
+scooter -s "pattern" -r "replacement"
+
+# Launch with pre-populated fields and skip to results
+scooter -S -s "pattern" -r "replacement"
+```
+
+In TUI mode, the user can toggle individual replacements on/off with `space`, toggle all with `a`, and press `enter` to apply.
+
+## Key Behaviors
+
+- Respects `.gitignore` and `.ignore` automatically
+- Glob patterns follow ripgrep conventions (e.g., `dir1/**` not just `dir1`)
+- If a matched line has changed since the search (e.g., branch switch), that replacement is safely skipped
+- By default uses a fast regex engine; use `-a` for advanced features like negative lookahead
+
+## Safety
+
+- Always do a dry run first when unsure: use `scooter -X -s "pattern" -r "replacement"` to see what would change (prints to stdout without `-N` replacing)
+- For destructive or wide-reaching replacements, prefer the interactive TUI so the user can review each match
+- Suggest `git diff` after replacements to verify changes

--- a/internal/skillsinstall/skills/tea/SKILL.md
+++ b/internal/skillsinstall/skills/tea/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: tea
+description: >
+  Gitea/Forgejo CLI and API usage. Use when working with tea CLI commands
+  or making direct API calls to Gitea/Forgejo instances.
+allowed-tools: "Bash(tea:*),Bash(teaapi:*)"
+version: "1.0.0"
+author: "User"
+license: "MIT"
+---
+
+# Tea CLI and Gitea API
+
+Guidelines for working with Gitea/Forgejo using the tea CLI and direct API calls.
+
+## API Documentation
+
+OpenAPI/Swagger specification: https://gitea.kotel.app/swagger.v1.json
+
+Use WebFetch to retrieve endpoint details when needed.
+
+## Tea CLI Commands
+
+Common tea commands for repository management:
+
+```bash
+tea repo list                    # List repositories
+tea repo view owner/repo         # View repository details
+tea pr list                      # List pull requests
+tea pr view NUMBER               # View PR details
+tea issue list                   # List issues
+tea issue view NUMBER            # View issue details
+tea release list                 # List releases
+```
+
+## Direct API Access
+
+Use `teaapi` to make authenticated API calls with token redaction:
+
+```bash
+teaapi curl https://gitea.kotel.app/api/v1/user
+teaapi curl https://gitea.kotel.app/api/v1/repos/owner/repo
+teaapi curl -X POST -d '{"title":"test"}' https://gitea.kotel.app/api/v1/repos/owner/repo/issues
+```
+
+The `teaapi` wrapper:
+- Injects the token from tea config as `Authorization: token <TOKEN>`
+- Redacts the token value from all output
+- Blocks DELETE requests by default (use `--allow-delete` flag to permit, requires approval)
+- Supports all curl options
+
+## Common API Endpoints
+
+```bash
+# User info
+teaapi curl https://gitea.kotel.app/api/v1/user
+
+# Repository
+teaapi curl https://gitea.kotel.app/api/v1/repos/OWNER/REPO
+teaapi curl https://gitea.kotel.app/api/v1/repos/OWNER/REPO/branches
+teaapi curl https://gitea.kotel.app/api/v1/repos/OWNER/REPO/pulls
+teaapi curl https://gitea.kotel.app/api/v1/repos/OWNER/REPO/issues
+
+# Search
+teaapi curl "https://gitea.kotel.app/api/v1/repos/search?q=QUERY"
+
+# Create issue
+teaapi curl -X POST -H "Content-Type: application/json" \
+  -d '{"title":"Issue title","body":"Description"}' \
+  https://gitea.kotel.app/api/v1/repos/OWNER/REPO/issues
+
+# Create PR
+teaapi curl -X POST -H "Content-Type: application/json" \
+  -d '{"title":"PR title","head":"branch","base":"main"}' \
+  https://gitea.kotel.app/api/v1/repos/OWNER/REPO/pulls
+```

--- a/internal/skillsinstall/skills/tidy/SKILL.md
+++ b/internal/skillsinstall/skills/tidy/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: tidy
+description: Clean up workspace and complete session - commit, push, sync issues, and verify
+argument-hint:
+---
+
+# Tidy - Session Completion Checklist
+
+Complete all work and clean up the workspace. Work is NOT complete until `git push` succeeds.
+
+## Usage
+
+```
+/tidy
+```
+
+Run this at the end of any work session to ensure all changes are committed, pushed, and issues are updated.
+
+## Mandatory Workflow
+
+Execute ALL steps in order. Do not skip steps.
+
+### Step 1: Assess Current State
+
+Run these commands to understand the workspace state:
+
+```bash
+git status
+git stash list
+hive hc list --status in_progress
+```
+
+Identify:
+- Uncommitted changes
+- Untracked files that should be committed or deleted
+- Stashed changes that need resolution
+- In-progress issues that need updates
+
+### Step 2: Handle Uncommitted Changes
+
+If there are changes:
+
+1. **Review what changed**: `git diff`
+2. **Stage relevant files**: `git add <specific-files>` (avoid `git add -A`)
+3. **Commit with clear message**: Follow repo's commit style
+4. **Delete temporary files**: Remove any scratch files, debug logs, etc.
+
+If changes shouldn't be committed:
+- Stash if needed later: `git stash push -m "description"`
+- Or discard: `git checkout -- <file>` (only if truly unwanted)
+
+### Step 3: Run Quality Gates (if code changed)
+
+Only run if actual code was modified (not just docs or config):
+
+```bash
+# Language-specific - run what applies
+go test ./...
+go vet ./...
+npm test
+npm run lint
+cargo test
+cargo clippy
+```
+
+Fix any failures before proceeding. Do not push broken code.
+
+### Step 4: Update Issue Status
+
+```bash
+# Check current issues
+hive hc list
+
+# Close completed work
+hive hc update <issue-id> --status done
+
+# Update in-progress items
+hive hc update <issue-id> --status open
+```
+
+### Step 5: File Issues for Remaining Work
+
+If there's follow-up work needed:
+
+```bash
+hive hc create --title "Follow-up: description"
+```
+
+Include:
+- What needs to be done
+- Why it wasn't done now
+- Any relevant context or file references
+
+### Step 6: Sync and Push
+
+This is **MANDATORY**. Work is not complete until pushed.
+
+```bash
+# Pull any remote changes
+git pull --rebase
+
+# Push all changes
+git push
+
+# Verify push succeeded
+git status
+```
+
+The output MUST show "Your branch is up to date with 'origin/...'"
+
+If push fails:
+1. Resolve conflicts
+2. Re-run quality gates
+3. Push again
+4. Repeat until successful
+
+### Step 7: Clean Up
+
+```bash
+# Clear resolved stashes
+git stash list
+git stash drop <stash@{n}>  # For each resolved stash
+
+# Prune deleted remote branches
+git fetch --prune
+
+# Clean up merged local branches (optional)
+git branch --merged | grep -v "main\|master\|\*" | xargs git branch -d
+```
+
+### Step 8: Final Verification
+
+Run final checks:
+
+```bash
+git status                    # Should show clean working tree
+git log -1 --oneline         # Verify last commit is yours
+git log origin/main..HEAD    # Show commits ahead of main (if on branch)
+hive hc list --status open   # Show remaining open issues
+```
+
+## Output Format
+
+After completing all steps, report:
+
+```markdown
+## Session Tidy Complete
+
+### Commits
+- [commit-sha] [commit-message]
+
+### Issues Updated
+- Closed: #[id] [title]
+- Created: #[id] [title]
+
+### Status
+- Working tree: Clean
+- Remote sync: Up to date
+- Open issues: [N] remaining
+
+### Notes
+[Any follow-up context for next session]
+```
+
+## Critical Rules
+
+1. **NEVER stop before pushing** - Local-only commits are lost work
+2. **NEVER say "ready to push when you are"** - YOU must push
+3. **NEVER skip quality gates** - Don't push broken code
+4. **NEVER commit sensitive files** - Check for .env, credentials, keys
+5. **ALWAYS verify push succeeded** - Check `git status` output
+
+## Error Recovery
+
+### Push rejected (non-fast-forward)
+
+```bash
+git pull --rebase
+# Resolve any conflicts
+git push
+```
+
+### Tests failing
+
+```bash
+# Fix the issue first
+# Re-run tests
+# Only then commit and push
+```
+
+### Merge conflicts
+
+```bash
+# Resolve conflicts in each file
+git add <resolved-files>
+git rebase --continue
+git push
+```
+
+### Stash conflicts
+
+```bash
+# Apply stash to see conflicts
+git stash pop
+# Resolve conflicts
+# Either commit or re-stash with new context
+```
+
+## When NOT to Use /tidy
+
+- In the middle of active work (finish the task first)
+- When you need to context-switch urgently (use `git stash` instead)
+- For quick questions or research sessions (no code changed)
+
+## Guidelines
+
+1. **Complete the loop** - Every session should end with a clean, pushed state
+2. **Document what's left** - File issues for any incomplete work
+3. **Update issue status** - Keep the backlog accurate
+4. **Verify everything** - Don't assume commands succeeded
+5. **Hand off cleanly** - Next session (or person) should have full context

--- a/internal/skillsinstall/skills/tui-dev/SKILL.md
+++ b/internal/skillsinstall/skills/tui-dev/SKILL.md
@@ -1,0 +1,670 @@
+---
+name: tui-dev
+description: >
+  Expert guidance for building TUI applications with the Charm Bracelet ecosystem
+  (Bubbletea, Lipgloss, Bubbles). Use when implementing components, styling, or
+  working with MVU architecture.
+---
+
+# TUI Development Expert
+
+Expert guidance for building Terminal User Interfaces with the Charm Bracelet ecosystem (Bubbletea, Lipgloss, Bubbles).
+
+## When to Use This Skill
+
+Activate this skill when:
+- Building or debugging TUI applications
+- Implementing Bubbletea components
+- Styling with Lipgloss
+- Creating dialogs or overlays
+- Testing TUI rendering
+- Implementing keyboard/mouse handling
+- Managing application state with MVU pattern
+
+## Core Principles
+
+### 1. Model-View-Update (MVU) Architecture
+
+**Always follow the MVU pattern:**
+
+```go
+type Model struct {
+    // Pure state only - no I/O, no channels, no goroutines
+    value    string
+    cursor   int
+    focused  bool
+}
+
+func (m Model) Init() tea.Cmd {
+    // Return initial commands (I/O operations)
+    return tea.Batch(
+        fetchData(),
+        startTimer(),
+    )
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    // Pure state updates only
+    // Side effects returned as commands
+    switch msg := msg.(type) {
+    case tea.KeyPressMsg:
+        // Update state
+        m.cursor++
+        // Return command for side effects
+        return m, doSomething()
+    }
+    return m, nil
+}
+
+func (m Model) View() tea.View {
+    // Pure rendering function
+    // No side effects, just transform state to visual output
+    var v tea.View
+    v.Content = lipgloss.NewStyle().Render(m.value)
+    v.AltScreen = true
+    v.MouseMode = tea.MouseModeCellMotion
+    return v
+}
+```
+
+**Key Rules:**
+- Model holds pure state (no channels, mutexes, goroutines)
+- Update is pure (no I/O, returns new model + command)
+- View is pure (no side effects, just rendering)
+- View returns tea.View struct with Content field
+- Commands handle all I/O and side effects
+
+### 2. Component Structure
+
+**Standard component pattern:**
+
+```go
+type Component struct {
+    // State
+    value    string
+    focused  bool
+
+    // Sub-components (embed, don't wrap in pointers)
+    textarea textarea.Model
+    spinner  spinner.Model
+
+    // Configuration
+    width    int
+    styles   Styles
+}
+
+// Constructor with functional options
+func New(opts ...Option) Component {
+    c := Component{
+        width: 80,
+        styles: DefaultStyles(),
+    }
+    for _, opt := range opts {
+        opt(&c)
+    }
+    return c
+}
+
+type Option func(*Component)
+
+func WithWidth(w int) Option {
+    return func(c *Component) { c.width = w }
+}
+
+// Standard methods
+func (c *Component) Focus() tea.Cmd
+func (c *Component) Blur()
+func (c Component) Focused() bool
+func (c *Component) SetValue(v string)
+func (c Component) Value() string
+```
+
+### 3. Message Propagation
+
+**Route messages correctly:**
+
+```go
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    var cmds []tea.Cmd
+
+    // Handle own messages first
+    switch msg := msg.(type) {
+    case tea.KeyPressMsg:
+        if msg.String() == "tab" {
+            m.activeView = (m.activeView + 1) % 2
+            return m, nil
+        }
+    }
+
+    // Broadcast to all (e.g., window size)
+    if _, ok := msg.(tea.WindowSizeMsg); ok {
+        m.header, _ = m.header.Update(msg)
+        m.content, _ = m.content.Update(msg)
+    }
+
+    // Route to active component only
+    var cmd tea.Cmd
+    switch m.activeView {
+    case 0:
+        m.editor, cmd = m.editor.Update(msg)
+    case 1:
+        m.table, cmd = m.table.Update(msg)
+    }
+    cmds = append(cmds, cmd)
+
+    return m, tea.Batch(cmds...)
+}
+```
+
+### 4. Styling with Lipgloss
+
+**Organize styles in structs:**
+
+```go
+type Styles struct {
+    Header    lipgloss.Style
+    Content   lipgloss.Style
+    Error     lipgloss.Style
+    Button    lipgloss.Style
+    ButtonActive lipgloss.Style
+}
+
+func DefaultStyles() Styles {
+    base := lipgloss.NewStyle()
+
+    button := base.Copy().
+        Padding(0, 3).
+        Background(lipgloss.Color("240"))
+
+    return Styles{
+        Header: base.Copy().
+            Bold(true).
+            Foreground(lipgloss.Color("230")),
+        Content: base.Copy().
+            Padding(1, 2),
+        Button: button,
+        ButtonActive: button.Copy().
+            Background(lipgloss.Color("63")).
+            Underline(true),
+        Error: base.Copy().
+            Foreground(lipgloss.Color("196")),
+    }
+}
+
+// Make themeable
+func NewThemedStyles(hasDarkBG bool) Styles {
+    lightDark := lipgloss.LightDark(hasDarkBG)
+
+    return Styles{
+        Header: lipgloss.NewStyle().
+            Foreground(lightDark(
+                lipgloss.Color("#000"),
+                lipgloss.Color("#FFF"),
+            )),
+    }
+}
+```
+
+**Styling rules:**
+- Never embed ANSI codes in strings
+- Styles are immutable (methods return copies)
+- Use `lipgloss.Println()` for automatic color downsampling
+- Organize styles in theme structs
+- Support light/dark backgrounds
+
+### 5. Dialog Pattern
+
+**Implement overlay system for dialogs:**
+
+```go
+// Dialog interface
+type Dialog interface {
+    ID() string
+    HandleMsg(msg tea.Msg) Action
+    Draw(scr Screen, area Rectangle) *tea.Cursor
+}
+
+// Action types for dialog responses
+type Action any
+type ActionClose struct{}
+type ActionConfirm struct{ Value string }
+
+// Overlay manager with stack
+type Overlay struct {
+    dialogs []Dialog
+}
+
+func (o *Overlay) OpenDialog(d Dialog) {
+    o.dialogs = append(o.dialogs, d)
+}
+
+func (o *Overlay) Update(msg tea.Msg) Action {
+    if len(o.dialogs) == 0 {
+        return nil
+    }
+    // Only top dialog receives messages
+    return o.dialogs[len(o.dialogs)-1].HandleMsg(msg)
+}
+
+// In main model Update:
+if m.overlay.HasDialogs() {
+    action := m.overlay.Update(msg)
+    switch action := action.(type) {
+    case ActionClose:
+        m.overlay.CloseFrontDialog()
+        return m, nil
+    }
+    if action != nil {
+        return m, nil  // Dialog handled it
+    }
+}
+```
+
+### 6. Testing Strategy
+
+**Write testable TUI code:**
+
+```go
+// 1. Golden file testing for rendering
+func TestRender(t *testing.T) {
+    m := Model{title: "Test", width: 80}
+    output := m.View().Content
+    golden.RequireEqual(t, output)
+}
+
+// 2. Test Update directly
+func TestUpdateKeyPress(t *testing.T) {
+    m := Model{cursor: 0}
+    newModel, _ := m.Update(tea.KeyPressMsg{Type: tea.KeyDown})
+
+    if newModel.(Model).cursor != 1 {
+        t.Errorf("cursor = %v, want 1", newModel.(Model).cursor)
+    }
+}
+
+// 3. Use teatest for integration
+func TestProgram(t *testing.T) {
+    tm := teatest.NewTestModel(t, NewModel(),
+        teatest.WithInitialTermSize(80, 24),
+    )
+    t.Cleanup(func() { tm.Quit() })
+
+    tm.Type("hello")
+    tm.Send(tea.KeyPressMsg{Type: tea.KeyEnter})
+
+    output := tm.FinalOutput(t)
+    golden.RequireEqual(t, output)
+}
+```
+
+**Testing rules:**
+- Golden files for visual regression
+- Test Update functions directly
+- Mock I/O with `bytes.Buffer`
+- Use table-driven tests
+- Verify state, not implementation
+- Access view content via `.Content` field
+
+### 7. Keyboard Handling
+
+**Implement consistent key bindings:**
+
+```go
+import "github.com/charmbracelet/bubbles/key"
+
+type KeyMap struct {
+    Up    key.Binding
+    Down  key.Binding
+    Quit  key.Binding
+}
+
+func DefaultKeyMap() KeyMap {
+    return KeyMap{
+        Up: key.NewBinding(
+            key.WithKeys("up", "k"),
+            key.WithHelp("↑/k", "move up"),
+        ),
+        Quit: key.NewBinding(
+            key.WithKeys("q", "ctrl+c"),
+            key.WithHelp("q", "quit"),
+        ),
+    }
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyPressMsg:
+        switch {
+        case key.Matches(msg, m.keyMap.Up):
+            m.cursor--
+        case key.Matches(msg, m.keyMap.Quit):
+            return m, tea.Quit
+        }
+    }
+    return m, nil
+}
+```
+
+**For safe cancellation (two-press pattern):**
+
+```go
+case tea.KeyPressMsg:
+    switch msg.String() {
+    case "esc":
+        if m.isCanceling {
+            // Second press - actually cancel
+            return m, cancelWork()
+        }
+        // First press - start 2s timer
+        m.isCanceling = true
+        return m, cancelTimer(2 * time.Second)
+    }
+
+case cancelTimerExpiredMsg:
+    m.isCanceling = false
+```
+
+## Common Patterns
+
+### Focus Management
+
+```go
+type FocusState int
+
+const (
+    focusNone FocusState = iota
+    focusEditor
+    focusTable
+)
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    if !m.focused {
+        return m, nil  // Early return when not focused
+    }
+
+    // Handle input...
+}
+
+func (m *Model) Focus() tea.Cmd {
+    m.focused = true
+    return m.subComponent.Focus()
+}
+
+func (m *Model) Blur() {
+    m.focused = false
+    m.subComponent.Blur()
+}
+```
+
+### State Machines
+
+```go
+type State int
+
+const (
+    stateLoading State = iota
+    stateReady
+    stateEditing
+    stateConfirming
+)
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    // Route based on state
+    switch m.state {
+    case stateLoading:
+        return m.handleLoading(msg)
+    case stateEditing:
+        return m.handleEditing(msg)
+    }
+    return m, nil
+}
+```
+
+### Layout
+
+```go
+// Vertical layout
+view := lipgloss.JoinVertical(
+    lipgloss.Left,
+    m.headerStyle.Render(header),
+    m.contentStyle.Render(content),
+    m.footerStyle.Render(footer),
+)
+
+// Horizontal layout
+view := lipgloss.JoinHorizontal(
+    lipgloss.Top,
+    leftPanel,
+    rightPanel,
+)
+
+// Centered
+view := lipgloss.Place(
+    m.width, m.height,
+    lipgloss.Center, lipgloss.Middle,
+    content,
+)
+```
+
+### Commands
+
+```go
+// Simple command
+func fetchData() tea.Msg {
+    data := callAPI()
+    return dataReceivedMsg{data}
+}
+
+// Parameterized command
+func fetchDataByID(id int) tea.Cmd {
+    return func() tea.Msg {
+        data := callAPI(id)
+        return dataReceivedMsg{id, data}
+    }
+}
+
+// Tick command for animations
+func tick() tea.Cmd {
+    return tea.Tick(time.Second/20, func(time.Time) tea.Msg {
+        return tickMsg{}
+    })
+}
+```
+
+### View Composition
+
+**When composing sub-component views, access .Content field:**
+
+```go
+func (m Model) View() tea.View {
+    var v tea.View
+
+    // Get content from sub-components
+    headerContent := m.header.View().Content
+    contentContent := m.content.View().Content
+    footerContent := m.footer.View().Content
+
+    // Compose the layout
+    v.Content = lipgloss.JoinVertical(
+        lipgloss.Left,
+        headerContent,
+        contentContent,
+        footerContent,
+    )
+
+    // Set view options for full-screen apps
+    v.AltScreen = true
+    v.MouseMode = tea.MouseModeCellMotion
+
+    return v
+}
+```
+
+## Anti-Patterns to Avoid
+
+❌ **Don't put I/O in Update:**
+```go
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    data := http.Get("...") // NO! Use a command
+}
+```
+
+❌ **Don't use pointers for Bubbletea components:**
+```go
+type Model struct {
+    textarea *textarea.Model // NO! Use value type
+}
+```
+
+❌ **Don't embed ANSI codes:**
+```go
+return "\x1b[1mBold\x1b[0m" // NO! Use Lipgloss
+```
+
+❌ **Don't mutate in View:**
+```go
+func (m Model) View() tea.View {
+    m.rendered = true // NO! View must be pure
+}
+```
+
+❌ **Don't block in commands:**
+```go
+func badCommand() tea.Msg {
+    time.Sleep(5 * time.Second) // NO! Use tea.Tick
+}
+```
+
+❌ **Don't return string from View:**
+```go
+func (m Model) View() string { // NO! Return tea.View in v2
+    return "content"
+}
+```
+
+❌ **Don't compose views as strings:**
+```go
+func (m Model) View() tea.View {
+    var v tea.View
+    v.Content = m.header.View() + m.content.View() // NO! Access .Content
+    return v
+}
+```
+
+## Checklist for New TUI Apps
+
+Before starting:
+- [ ] Define model struct with pure state
+- [ ] Implement Init, Update, View
+- [ ] Create Styles struct for theming
+- [ ] Define KeyMap for all keyboard shortcuts
+- [ ] Plan component hierarchy
+- [ ] Decide on dialog/overlay needs
+
+During development:
+- [ ] Keep Update pure (no I/O)
+- [ ] Use commands for all side effects
+- [ ] Handle tea.WindowSizeMsg
+- [ ] Implement focus management
+- [ ] Support light/dark themes
+- [ ] Add help text (bubbles/help)
+- [ ] Return tea.View from View() methods
+- [ ] Access .Content when composing sub-component views
+
+Before release:
+- [ ] Write golden file tests
+- [ ] Test all keyboard shortcuts
+- [ ] Test window resize behavior
+- [ ] Test color profiles (8, 256, truecolor)
+- [ ] Add cancellation for long operations
+- [ ] Handle errors gracefully
+
+## Program Options Reference
+
+```go
+p := tea.NewProgram(model,
+    // Testing
+    tea.WithInput(&input),
+    tea.WithOutput(&output),
+    tea.WithWindowSize(80, 24),
+
+    // Production
+    tea.WithAltScreen(),
+    tea.WithMouseCellMotion(),
+    tea.WithColorProfile(colorprofile.TrueColor),
+
+    // Daemon mode
+    tea.WithoutRenderer(),
+
+    // Cancellation
+    tea.WithContext(ctx),
+
+    // Message filtering
+    tea.WithFilter(filterFunc),
+)
+```
+
+## Quick Reference: Built-in Messages
+
+```go
+tea.KeyPressMsg      // Keyboard input
+tea.KeyReleaseMsg
+tea.MouseClickMsg    // Mouse events
+tea.MouseWheelMsg
+tea.WindowSizeMsg    // Terminal resize
+tea.QuitMsg          // Program should quit
+tea.InterruptMsg     // ctrl+c
+tea.SuspendMsg       // ctrl+z
+tea.ColorProfileMsg  // Color capability
+```
+
+## Installation
+
+Install Bubbletea v2 packages (RC/Beta versions):
+
+```bash
+go get charm.land/bubbletea/v2@v2.0.0-rc.2
+go get charm.land/lipgloss/v2@v2.0.0-beta.3
+go get charm.land/bubbles/v2@v2.0.0-rc.1
+```
+
+Import in your code:
+
+```go
+import (
+    tea "charm.land/bubbletea/v2"
+    "charm.land/lipgloss/v2"
+    "charm.land/bubbles/v2/textinput"
+    "charm.land/bubbles/v2/textarea"
+    "charm.land/bubbles/v2/spinner"
+    "charm.land/bubbles/v2/list"
+    "charm.land/bubbles/v2/table"
+)
+```
+
+## Resources
+
+- Bubbletea: https://github.com/charmbracelet/bubbletea
+- Lipgloss: https://github.com/charmbracelet/lipgloss
+- Bubbles: https://github.com/charmbracelet/bubbles
+- Examples: https://github.com/charmbracelet/bubbletea/tree/master/examples
+
+## Implementation Guidelines
+
+When implementing TUI features:
+
+1. **Start with the model** - Define state structure first
+2. **Implement Init** - Return initial commands
+3. **Implement Update** - Handle all message types
+4. **Implement View** - Return tea.View with Content set
+5. **Add tests** - Golden files for rendering, unit tests for Update
+6. **Add keyboard shortcuts** - Use KeyMap pattern
+7. **Add help** - Use bubbles/help component
+
+When debugging:
+- Log to file (not stdout)
+- Use `tea.Println()` for debugging output
+- Test with `WithInput/WithOutput` for reproducibility
+- Check message flow with filter function
+
+Remember: **Bubbletea is architecture, Lipgloss is styling, Bubbles is components.**

--- a/internal/skillsinstall/skills/tui-dialog/SKILL.md
+++ b/internal/skillsinstall/skills/tui-dialog/SKILL.md
@@ -1,0 +1,620 @@
+---
+name: tui-dialog
+description: >
+  Specialized guidance for implementing dialog and overlay systems in Bubbletea v2
+  applications, including modal patterns, command palettes, and compositor-based
+  overlay rendering.
+---
+
+# TUI Dialog System Expert
+
+Specialized guidance for implementing dialog and overlay systems in Bubbletea v2 applications.
+
+## When to Use This Skill
+
+Activate when:
+- Implementing modal dialogs
+- Creating overlay systems
+- Building confirmation dialogs
+- Implementing command palettes
+- Managing dialog state
+- Handling modal input routing
+
+## Core Modal Pattern (Bubble Tea v2)
+
+Bubble Tea v2 uses **lipgloss compositor** for proper modal overlay rendering.
+
+### Three Essential Methods
+
+Every modal MUST implement:
+
+```go
+type Modal struct {
+    visible bool
+    // ... modal state
+}
+
+// 1. View() - Renders modal content (no positioning)
+func (m *Modal) View() string {
+    if !m.visible {
+        return ""
+    }
+
+    // Build modal content with styles
+    style := lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        BorderForeground(lipgloss.Color("#7dcfff")).
+        Padding(1, 2)
+
+    return style.Render(content)
+}
+
+// 2. Update() - Handles input, returns result
+func (m *Modal) Update(msg tea.Msg) (*Result, tea.Cmd) {
+    if !m.visible {
+        return nil, nil
+    }
+
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "esc":
+            m.visible = false
+            return &Result{Cancelled: true}, nil
+        case "enter":
+            m.visible = false
+            return &Result{Confirmed: true, Value: m.value}, nil
+        }
+    }
+
+    return nil, nil
+}
+
+// 3. Overlay() - Layers modal on top using compositor
+func (m *Modal) Overlay(background string, width, height int) string {
+    if !m.visible {
+        return background
+    }
+
+    modal := m.View()
+
+    // Create layers
+    bgLayer := lipgloss.NewLayer(background)
+    modalLayer := lipgloss.NewLayer(modal)
+
+    // Center the modal
+    modalW := lipgloss.Width(modal)
+    modalH := lipgloss.Height(modal)
+    centerX := (width - modalW) / 2
+    centerY := (height - modalH) / 4  // Upper quarter
+
+    // Set position and z-index (CRITICAL)
+    modalLayer.X(centerX).Y(centerY).Z(1)
+
+    // Compose layers
+    compositor := lipgloss.NewCompositor(bgLayer, modalLayer)
+    return compositor.Render()
+}
+```
+
+### Critical Input Routing Pattern
+
+**MUST BE FIRST** in parent Update() to prevent input bleed-through:
+
+```go
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.WindowSizeMsg:
+        m.width = msg.Width
+        m.height = msg.Height
+        // Update modal too
+        m.modal.Update(msg)
+        return m, nil
+
+    case tea.KeyMsg:
+        // CRITICAL: Modal check MUST be first
+        if m.modal.IsVisible() {
+            result, cmd := m.modal.Update(msg)
+            if result != nil {
+                // Handle modal result
+                m.modal = nil
+                return m, m.handleModalResult(result)
+            }
+            // Return early - prevents input reaching main view
+            return m, cmd
+        }
+
+        // Normal view handling only if modal not active
+        switch msg.String() {
+        case "ctrl+p":
+            m.modal.Show()
+            return m, m.modal.Init()
+        // ... other handlers
+        }
+    }
+
+    return m, nil
+}
+```
+
+### View Integration
+
+```go
+func (m Model) View() tea.View {
+    // Render main content
+    content := m.renderMainView()
+
+    // Overlay modal if visible
+    if m.modal != nil && m.modal.IsVisible() {
+        content = m.modal.Overlay(content, m.width, m.height)
+    }
+
+    v := tea.NewView(content)
+    v.AltScreen = true
+    return v
+}
+```
+
+## Modal Types
+
+### 1. Command Palette
+
+```go
+type CommandPalette struct {
+    commands        []Action
+    filteredResults []Action
+    input           textinput.Model
+    cursor          int
+    visible         bool
+}
+
+func NewCommandPalette(commands []Action) *CommandPalette {
+    input := textinput.New()
+    input.Placeholder = "Search commands..."
+    input.Prompt = "> "
+
+    return &CommandPalette{
+        commands:        commands,
+        filteredResults: commands,
+        input:           input,
+        visible:         false,
+    }
+}
+
+func (cp *CommandPalette) Show() tea.Cmd {
+    cp.visible = true
+    cp.input.SetValue("")
+    cp.filteredResults = cp.commands
+    cp.cursor = 0
+    cp.input.Focus()
+    return textinput.Blink
+}
+
+func (cp *CommandPalette) IsVisible() bool {
+    return cp.visible
+}
+
+func (cp *CommandPalette) Update(msg tea.Msg) (*Action, tea.Cmd) {
+    if !cp.visible {
+        return nil, nil
+    }
+
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "esc":
+            cp.visible = false
+            return nil, nil
+
+        case "enter":
+            if len(cp.filteredResults) > 0 {
+                selected := &cp.filteredResults[cp.cursor]
+                cp.visible = false
+                return selected, nil
+            }
+
+        case "up", "ctrl+k":
+            if cp.cursor > 0 {
+                cp.cursor--
+            }
+
+        case "down", "ctrl+j":
+            if cp.cursor < len(cp.filteredResults)-1 {
+                cp.cursor++
+            }
+
+        default:
+            // Update input and filter
+            var cmd tea.Cmd
+            cp.input, cmd = cp.input.Update(msg)
+            cp.filterCommands()
+            return nil, cmd
+        }
+    }
+
+    return nil, nil
+}
+
+func (cp *CommandPalette) View() string {
+    if !cp.visible {
+        return ""
+    }
+
+    style := lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        BorderForeground(lipgloss.Color("#7dcfff")).
+        Padding(1, 2).
+        Width(80)
+
+    var b strings.Builder
+    b.WriteString("Command Palette\n\n")
+    b.WriteString(cp.input.View() + "\n\n")
+
+    // Render filtered results
+    for i, cmd := range cp.filteredResults {
+        if i >= 10 {
+            break
+        }
+
+        cursor := "  "
+        if i == cp.cursor {
+            cursor = "> "
+        }
+
+        b.WriteString(cursor + cmd.Name + "\n")
+    }
+
+    b.WriteString("\n↑↓: navigate • enter: execute • esc: close")
+
+    return style.Render(b.String())
+}
+
+func (cp *CommandPalette) Overlay(background string, width, height int) string {
+    if !cp.visible {
+        return background
+    }
+
+    modal := cp.View()
+
+    bgLayer := lipgloss.NewLayer(background)
+    modalLayer := lipgloss.NewLayer(modal)
+
+    modalW := lipgloss.Width(modal)
+    modalH := lipgloss.Height(modal)
+    centerX := (width - modalW) / 2
+    centerY := (height - modalH) / 4
+
+    modalLayer.X(centerX).Y(centerY).Z(1)
+
+    compositor := lipgloss.NewCompositor(bgLayer, modalLayer)
+    return compositor.Render()
+}
+```
+
+### 2. Confirm Dialog
+
+```go
+type ConfirmDialog struct {
+    title    string
+    message  string
+    visible  bool
+    focused  int  // 0=cancel, 1=confirm
+}
+
+func (d *ConfirmDialog) Update(msg tea.Msg) (*bool, tea.Cmd) {
+    if !d.visible {
+        return nil, nil
+    }
+
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "esc":
+            d.visible = false
+            cancelled := false
+            return &cancelled, nil
+
+        case "left", "right", "tab":
+            d.focused = (d.focused + 1) % 2
+
+        case "enter":
+            d.visible = false
+            confirmed := d.focused == 1
+            return &confirmed, nil
+        }
+    }
+
+    return nil, nil
+}
+
+func (d *ConfirmDialog) View() string {
+    if !d.visible {
+        return ""
+    }
+
+    cancelBtn := "Cancel"
+    confirmBtn := "Confirm"
+
+    if d.focused == 0 {
+        cancelBtn = "[" + cancelBtn + "]"
+    } else {
+        confirmBtn = "[" + confirmBtn + "]"
+    }
+
+    buttons := lipgloss.JoinHorizontal(
+        lipgloss.Center,
+        cancelBtn, "  ", confirmBtn,
+    )
+
+    content := lipgloss.JoinVertical(
+        lipgloss.Left,
+        d.title,
+        "",
+        d.message,
+        "",
+        buttons,
+    )
+
+    style := lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        Padding(1, 2)
+
+    return style.Render(content)
+}
+
+func (d *ConfirmDialog) Overlay(background string, width, height int) string {
+    if !d.visible {
+        return background
+    }
+
+    modal := d.View()
+
+    bgLayer := lipgloss.NewLayer(background)
+    modalLayer := lipgloss.NewLayer(modal)
+
+    modalW := lipgloss.Width(modal)
+    modalH := lipgloss.Height(modal)
+    centerX := (width - modalW) / 2
+    centerY := (height - modalH) / 2
+
+    modalLayer.X(centerX).Y(centerY).Z(1)
+
+    compositor := lipgloss.NewCompositor(bgLayer, modalLayer)
+    return compositor.Render()
+}
+```
+
+### 3. Input Dialog
+
+```go
+type InputDialog struct {
+    title   string
+    input   textinput.Model
+    visible bool
+}
+
+func (d *InputDialog) Update(msg tea.Msg) (*string, tea.Cmd) {
+    if !d.visible {
+        return nil, nil
+    }
+
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "esc":
+            d.visible = false
+            return nil, nil
+
+        case "enter":
+            value := d.input.Value()
+            d.visible = false
+            return &value, nil
+        }
+    }
+
+    var cmd tea.Cmd
+    d.input, cmd = d.input.Update(msg)
+    return nil, cmd
+}
+
+func (d *InputDialog) View() string {
+    if !d.visible {
+        return ""
+    }
+
+    content := lipgloss.JoinVertical(
+        lipgloss.Left,
+        d.title,
+        "",
+        d.input.View(),
+        "",
+        "enter: confirm • esc: cancel",
+    )
+
+    style := lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        Padding(1, 2)
+
+    return style.Render(content)
+}
+
+func (d *InputDialog) Overlay(background string, width, height int) string {
+    if !d.visible {
+        return background
+    }
+
+    modal := d.View()
+
+    bgLayer := lipgloss.NewLayer(background)
+    modalLayer := lipgloss.NewLayer(modal)
+
+    modalW := lipgloss.Width(modal)
+    modalH := lipgloss.Height(modal)
+    centerX := (width - modalW) / 2
+    centerY := (height - modalH) / 3
+
+    modalLayer.X(centerX).Y(centerY).Z(1)
+
+    compositor := lipgloss.NewCompositor(bgLayer, modalLayer)
+    return compositor.Render()
+}
+```
+
+## Critical Rules
+
+### 1. Input Routing
+
+**ALWAYS** check modal visibility FIRST in Update():
+
+```go
+case tea.KeyMsg:
+    // MUST BE FIRST
+    if m.modal.IsVisible() {
+        result, cmd := m.modal.Update(msg)
+        if result != nil {
+            m.modal = nil
+            // handle result
+        }
+        return m, cmd  // EARLY RETURN
+    }
+
+    // main view handling...
+```
+
+### 2. Z-Index Required
+
+Always set Z-index on modal layer:
+
+```go
+modalLayer.X(x).Y(y).Z(1)  // Z(1) puts modal on top
+```
+
+### 3. Compositor Layers
+
+Use compositor for true overlay (background remains visible):
+
+```go
+bgLayer := lipgloss.NewLayer(background)
+modalLayer := lipgloss.NewLayer(modal)
+compositor := lipgloss.NewCompositor(bgLayer, modalLayer)
+return compositor.Render()
+```
+
+### 4. Clear Modal State
+
+Set modal to nil when done:
+
+```go
+if result != nil {
+    m.modal = nil  // Clear pointer
+    return m, m.handleResult(result)
+}
+```
+
+### 5. Window Size Updates
+
+Pass window size to modal:
+
+```go
+case tea.WindowSizeMsg:
+    m.width = msg.Width
+    m.height = msg.Height
+    m.modal.Update(msg)  // Modal needs dimensions
+```
+
+## Best Practices
+
+1. **Separate View() and Overlay()** - View renders content, Overlay handles positioning
+2. **Use early returns** - Prevent input bleed-through to main view
+3. **Center by default** - Most modals should be centered
+4. **Show help text** - Display available keybindings
+5. **Focus management** - Focus input when modal opens, blur when closes
+6. **Validate before closing** - Check input validity on enter
+7. **ESC always cancels** - Universal close binding
+8. **Return results, not booleans** - More flexible for caller
+
+## Common Mistakes
+
+### ❌ Wrong: Manual positioning in View()
+
+```go
+func (m *Modal) View() string {
+    // DON'T DO THIS
+    topPadding := strings.Repeat("\n", y)
+    leftPadding := strings.Repeat(" ", x)
+    return topPadding + leftPadding + content
+}
+```
+
+### ✅ Right: Use Overlay() with compositor
+
+```go
+func (m *Modal) Overlay(background string, width, height int) string {
+    modal := m.View()
+    bgLayer := lipgloss.NewLayer(background)
+    modalLayer := lipgloss.NewLayer(modal)
+    modalLayer.X(centerX).Y(centerY).Z(1)
+    compositor := lipgloss.NewCompositor(bgLayer, modalLayer)
+    return compositor.Render()
+}
+```
+
+### ❌ Wrong: Modal check after other handlers
+
+```go
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "q":
+            return m, tea.Quit
+        }
+
+        // TOO LATE - 'q' already handled above
+        if m.modal.IsVisible() {
+            // ...
+        }
+    }
+}
+```
+
+### ✅ Right: Modal check first
+
+```go
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        // FIRST - prevents 'q' from reaching main view
+        if m.modal.IsVisible() {
+            result, cmd := m.modal.Update(msg)
+            return m, cmd  // Early return
+        }
+
+        switch msg.String() {
+        case "q":
+            return m, tea.Quit
+        }
+    }
+}
+```
+
+## Testing Modals
+
+```go
+func TestModalInputRouting(t *testing.T) {
+    m := Model{modal: NewModal()}
+    m.modal.Show()
+
+    // Modal should intercept keys
+    m, _ = m.Update(tea.KeyMsg{String: "q"})
+
+    // Modal should still be visible (not quit)
+    if !m.modal.IsVisible() {
+        t.Error("modal should intercept 'q' key")
+    }
+}
+```
+
+## Reference Implementation
+
+See `internal/tui/dialog.go` and `internal/tui/flow.go` in the FDT CLI project for complete working examples.

--- a/internal/skillsinstall/skills/tui-test/SKILL.md
+++ b/internal/skillsinstall/skills/tui-test/SKILL.md
@@ -1,0 +1,560 @@
+---
+name: tui-test
+description: >
+  Specialized guidance for testing TUI applications with Bubbletea, including
+  golden file testing, component testing, and integration testing with teatest.
+---
+
+# TUI Testing Expert
+
+Specialized guidance for testing Terminal User Interface applications with Bubbletea, focusing on golden file testing, component testing, and integration testing.
+
+## When to Use This Skill
+
+Activate when:
+
+- Writing tests for TUI applications
+- Setting up golden file testing
+- Testing rendering output
+- Testing state transitions
+- Debugging test failures
+- Implementing test fixtures
+
+## Testing Strategy
+
+### 1. Golden File Testing (Visual Regression)
+
+**Primary method for testing TUI rendering:**
+
+```go
+package myapp
+
+import (
+    "testing"
+    "github.com/charmbracelet/x/exp/golden"
+)
+
+func TestRender(t *testing.T) {
+    m := Model{
+        title: "Test App",
+        width: 80,
+        items: []string{"one", "two", "three"},
+    }
+
+    output := m.View()
+
+    // Compares with testdata/TestRender.golden
+    golden.RequireEqual(t, output)
+}
+
+// Run tests: go test
+// Update golden files: go test -update
+```
+
+**Directory structure:**
+
+```
+myapp/
+├── component.go
+├── component_test.go
+└── testdata/
+    ├── TestRender.golden
+    ├── TestRenderEmpty.golden
+    └── TestRenderWithScroll.golden
+```
+
+**Best practices:**
+
+- One golden file per test case
+- Use descriptive test names (becomes filename)
+- Update golden files when intentionally changing UI
+- Review diffs carefully before updating
+- Strip ANSI codes for comparison if needed
+
+### 2. Testing Update Functions
+
+**Test state transitions directly:**
+
+```go
+func TestUpdateNavigation(t *testing.T) {
+    tests := []struct {
+        name         string
+        initialModel Model
+        msg          tea.Msg
+        wantCursor   int
+        wantCmd      bool
+    }{
+        {
+            name:         "down arrow increases cursor",
+            initialModel: Model{cursor: 0, items: []string{"a", "b"}},
+            msg:          tea.KeyPressMsg{Type: tea.KeyDown},
+            wantCursor:   1,
+            wantCmd:      false,
+        },
+        {
+            name:         "down at bottom wraps to top",
+            initialModel: Model{cursor: 1, items: []string{"a", "b"}},
+            msg:          tea.KeyPressMsg{Type: tea.KeyDown},
+            wantCursor:   0,
+            wantCmd:      false,
+        },
+        {
+            name:         "enter selects item",
+            initialModel: Model{cursor: 0, items: []string{"a", "b"}},
+            msg:          tea.KeyPressMsg{Type: tea.KeyEnter},
+            wantCursor:   0,
+            wantCmd:      true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            m := tt.initialModel
+            newModel, cmd := m.Update(tt.msg)
+
+            got := newModel.(Model)
+
+            if got.cursor != tt.wantCursor {
+                t.Errorf("cursor = %v, want %v", got.cursor, tt.wantCursor)
+            }
+
+            if (cmd != nil) != tt.wantCmd {
+                t.Errorf("cmd = %v, wantCmd = %v", cmd != nil, tt.wantCmd)
+            }
+        })
+    }
+}
+```
+
+### 3. Testing Components in Isolation
+
+```go
+func TestTextInputComponent(t *testing.T) {
+    ti := textinput.New()
+    ti.SetValue("initial")
+    ti.Focus()
+
+    // Test typing
+    ti, _ = ti.Update(tea.KeyPressMsg{
+        Runes: []rune{'x'},
+        Type:  tea.KeyRunes,
+    })
+
+    if ti.Value() != "initialx" {
+        t.Errorf("value = %q, want %q", ti.Value(), "initialx")
+    }
+
+    // Test backspace
+    ti, _ = ti.Update(tea.KeyPressMsg{Type: tea.KeyBackspace})
+
+    if ti.Value() != "initial" {
+        t.Errorf("value = %q, want %q", ti.Value(), "initial")
+    }
+
+    // Test view contains expected text
+    view := ti.View()
+    if !strings.Contains(view, "initial") {
+        t.Error("view doesn't contain expected text")
+    }
+}
+```
+
+### 4. Integration Testing with teatest
+
+```go
+import (
+    "testing"
+    "time"
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/x/exp/teatest"
+)
+
+func TestFullProgram(t *testing.T) {
+    m := NewModel()
+
+    tm := teatest.NewTestModel(
+        t, m,
+        teatest.WithInitialTermSize(80, 24),
+    )
+
+    t.Cleanup(func() {
+        if err := tm.Quit(); err != nil {
+            t.Fatal(err)
+        }
+    })
+
+    // Wait for initialization
+    time.Sleep(100 * time.Millisecond)
+
+    // Simulate user input
+    tm.Type("hello world")
+    tm.Send(tea.KeyPressMsg{Type: tea.KeyEnter})
+
+    // Wait for specific output
+    teatest.WaitFor(
+        t,
+        tm.Output(),
+        func(bts []byte) bool {
+            return bytes.Contains(bts, []byte("Success"))
+        },
+        teatest.WithCheckInterval(50*time.Millisecond),
+        teatest.WithDuration(3*time.Second),
+    )
+
+    // Get final output
+    output := tm.FinalOutput(t)
+    golden.RequireEqual(t, output)
+
+    // Verify final model state
+    fm := tm.FinalModel(t)
+    finalModel, ok := fm.(Model)
+    if !ok {
+        t.Fatal("wrong model type")
+    }
+
+    if finalModel.state != stateComplete {
+        t.Errorf("state = %v, want %v", finalModel.state, stateComplete)
+    }
+}
+```
+
+### 5. Mock I/O Testing
+
+```go
+func TestProgramWithMockIO(t *testing.T) {
+    var output bytes.Buffer
+    var input bytes.Buffer
+
+    // Pre-fill input
+    input.WriteString("test input\n")
+    input.WriteByte('q')
+
+    ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+    defer cancel()
+
+    m := NewModel()
+    p := tea.NewProgram(m,
+        tea.WithContext(ctx),
+        tea.WithInput(&input),
+        tea.WithOutput(&output),
+    )
+
+    finalModel, err := p.Run()
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    // Verify output
+    if output.Len() == 0 {
+        t.Error("no output produced")
+    }
+
+    // Verify final state
+    fm, ok := finalModel.(Model)
+    if !ok {
+        t.Fatal("wrong model type")
+    }
+
+    if fm.value != "test input" {
+        t.Errorf("value = %q, want %q", fm.value, "test input")
+    }
+}
+```
+
+## Test Helpers
+
+### Key Press Helper
+
+```go
+func keyPress(key rune) tea.Msg {
+    return tea.KeyPressMsg{
+        Runes: []rune{key},
+        Type:  tea.KeyRunes,
+    }
+}
+
+func keyPressString(s string) tea.Msg {
+    return tea.KeyPressMsg{
+        Runes: []rune(s),
+        Type:  tea.KeyRunes,
+    }
+}
+
+func keyDown() tea.Msg {
+    return tea.KeyPressMsg{Type: tea.KeyDown}
+}
+
+func keyEnter() tea.Msg {
+    return tea.KeyPressMsg{Type: tea.KeyEnter}
+}
+```
+
+### String Input Helper
+
+```go
+func sendString(m Model, s string) Model {
+    for _, r := range s {
+        m, _ = m.Update(keyPress(r))
+    }
+    return m
+}
+```
+
+### ANSI Strip Helper
+
+```go
+import "github.com/charmbracelet/x/ansi"
+
+func stripANSI(s string) string {
+    s = ansi.Strip(s)
+    lines := strings.Split(s, "\n")
+    var result []string
+    for _, line := range lines {
+        trimmed := strings.TrimRight(line, " ")
+        if trimmed != "" {
+            result = append(result, trimmed)
+        }
+    }
+    return strings.Join(result, "\n")
+}
+```
+
+### Window Size Helper
+
+```go
+func windowSize(w, h int) tea.WindowSizeMsg {
+    return tea.WindowSizeMsg{Width: w, Height: h}
+}
+```
+
+## Table-Driven View Tests
+
+```go
+func TestView(t *testing.T) {
+    tests := []struct {
+        name     string
+        setup    func(Model) Model
+        wantView string
+    }{
+        {
+            name: "empty state",
+            wantView: heredoc.Doc(`
+                > No items
+                >
+            `),
+        },
+        {
+            name: "with items",
+            setup: func(m Model) Model {
+                m.items = []string{"one", "two"}
+                return m
+            },
+            wantView: heredoc.Doc(`
+                > one
+                > two
+                >
+            `),
+        },
+        {
+            name: "with cursor",
+            setup: func(m Model) Model {
+                m.items = []string{"one", "two"}
+                m.cursor = 1
+                return m
+            },
+            wantView: heredoc.Doc(`
+                >   one
+                > ❯ two
+                >
+            `),
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            m := NewModel()
+            if tt.setup != nil {
+                m = tt.setup(m)
+            }
+
+            got := stripANSI(m.View())
+            want := stripANSI(tt.wantView)
+
+            if got != want {
+                t.Errorf("View() =\n%v\nwant\n%v", got, want)
+            }
+        })
+    }
+}
+```
+
+## Testing Checklist
+
+**Unit Tests:**
+
+- [ ] Test Init returns expected commands
+- [ ] Test Update with all message types
+- [ ] Test state transitions
+- [ ] Test cursor/selection logic
+- [ ] Test validation/error handling
+- [ ] Test edge cases (empty, full, boundaries)
+
+**View Tests:**
+
+- [ ] Golden file for default state
+- [ ] Golden file for each significant state
+- [ ] Test with different widths
+- [ ] Test with different heights
+- [ ] Test overflow/truncation
+
+**Integration Tests:**
+
+- [ ] Test full user flows
+- [ ] Test keyboard navigation
+- [ ] Test window resize
+- [ ] Test with timeouts
+- [ ] Test cancellation
+
+**Component Tests:**
+
+- [ ] Test focus/blur
+- [ ] Test each public method
+- [ ] Test with sub-components
+- [ ] Test message delegation
+
+## Common Test Patterns
+
+### Test with Multiple Updates
+
+```go
+func TestSequentialUpdates(t *testing.T) {
+    m := NewModel()
+
+    // Apply sequence of updates
+    updates := []tea.Msg{
+        tea.KeyPressMsg{Type: tea.KeyDown},
+        tea.KeyPressMsg{Type: tea.KeyDown},
+        tea.KeyPressMsg{Type: tea.KeyEnter},
+    }
+
+    for _, msg := range updates {
+        m, _ = m.(Model).Update(msg)
+    }
+
+    if m.(Model).cursor != 2 {
+        t.Errorf("cursor = %v, want 2", m.(Model).cursor)
+    }
+}
+```
+
+### Test Command Execution
+
+```go
+func TestCommandExecution(t *testing.T) {
+    m := NewModel()
+
+    _, cmd := m.Update(tea.KeyPressMsg{Type: tea.KeyEnter})
+
+    if cmd == nil {
+        t.Fatal("expected command, got nil")
+    }
+
+    // Execute command
+    msg := cmd()
+
+    // Verify message type
+    if _, ok := msg.(dataLoadedMsg); !ok {
+        t.Errorf("expected dataLoadedMsg, got %T", msg)
+    }
+}
+```
+
+### Test Focus State
+
+```go
+func TestFocusHandling(t *testing.T) {
+    m := NewModel()
+
+    if m.Focused() {
+        t.Error("should not be focused initially")
+    }
+
+    m.Focus()
+
+    if !m.Focused() {
+        t.Error("should be focused after Focus()")
+    }
+
+    // Should handle input when focused
+    m, _ = m.Update(keyPress('a'))
+    if m.value != "a" {
+        t.Error("should accept input when focused")
+    }
+
+    m.Blur()
+
+    if m.Focused() {
+        t.Error("should not be focused after Blur()")
+    }
+
+    // Should ignore input when not focused
+    originalValue := m.value
+    m, _ = m.Update(keyPress('b'))
+    if m.value != originalValue {
+        t.Error("should ignore input when not focused")
+    }
+}
+```
+
+## Debugging Test Failures
+
+**Golden file mismatch:**
+
+1. Check if change was intentional
+2. Review diff output carefully
+3. Update with `go test -update` if correct
+4. Never blindly update without reviewing
+
+**Flaky tests:**
+
+1. Use deterministic input (no time.Now(), rand.Intn())
+2. Set fixed window size
+3. Mock external dependencies
+4. Use context timeouts
+
+**Missing output:**
+
+1. Check if renderer is disabled
+2. Verify output buffer is captured
+3. Check if view returns empty string
+
+## Best Practices
+
+1. **Test behavior, not implementation**
+   - Don't test internal state unless necessary
+   - Test observable behavior (view output, commands returned)
+
+2. **Use descriptive test names**
+   - Name describes what is being tested
+   - Name becomes golden filename
+
+3. **Keep tests fast**
+   - Use direct Update calls over full programs
+   - Mock slow operations
+   - Parallelize independent tests
+
+4. **Make tests deterministic**
+   - No random values
+   - Fixed window sizes
+   - Mock time-dependent operations
+
+5. **Test error paths**
+   - Invalid input
+   - Network failures
+   - Cancellation
+   - Edge cases
+
+6. **Use table-driven tests**
+   - More test cases with less code
+   - Easy to add new cases
+   - Clear test structure

--- a/internal/tui/install/model.go
+++ b/internal/tui/install/model.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -24,20 +25,22 @@ type Result struct {
 	Workspaces     []string
 	ConfigPath     string
 	SelectedShells []ShellConfig
+	SkillAgents    []string // agent names selected for skills installation
 	Cancelled      bool
 }
 
 // Model is the Bubble Tea model for the install wizard.
 type Model struct {
-	width, height  int
-	dialog         *form.Dialog
-	shellField     *form.MultiSelectField
-	detectedShells []ShellConfig
-	configPath     string
-	configExists   bool
-	homeDir        string
-	result         Result
-	quitting       bool
+	width, height    int
+	dialog           *form.Dialog
+	shellField       *form.MultiSelectField
+	skillAgentsField *form.MultiSelectField
+	detectedShells   []ShellConfig
+	configPath       string
+	configExists     bool
+	homeDir          string
+	result           Result
+	quitting         bool
 }
 
 // existingConfig holds minimal config structure for reading workspaces.
@@ -94,15 +97,31 @@ func New() Model {
 		variables = append(variables, "shells")
 	}
 
+	skillAgentOptions := []string{
+		"Claude Code (~/.claude)",
+		"Codex (~/.codex)",
+	}
+	skillAgentsField := form.NewMultiSelectFormField("Install AI skills for:", skillAgentOptions)
+	// Pre-check agents that are available in PATH.
+	if _, err := exec.LookPath("claude"); err == nil {
+		skillAgentsField.Check(0)
+	}
+	if _, err := exec.LookPath("codex"); err == nil {
+		skillAgentsField.Check(1)
+	}
+	fields = append(fields, skillAgentsField)
+	variables = append(variables, "skillAgents")
+
 	dialog := form.NewDialog("", fields, variables)
 
 	return Model{
-		dialog:         dialog,
-		shellField:     shellField,
-		detectedShells: detectedShells,
-		configPath:     configPath,
-		configExists:   configExists,
-		homeDir:        homeDir,
+		dialog:           dialog,
+		shellField:       shellField,
+		skillAgentsField: skillAgentsField,
+		detectedShells:   detectedShells,
+		configPath:       configPath,
+		configExists:     configExists,
+		homeDir:          homeDir,
 	}
 }
 
@@ -238,10 +257,19 @@ func (m Model) buildResult() Result {
 		}
 	}
 
+	agentNames := []string{"claude", "codex"}
+	var skillAgents []string
+	for _, idx := range m.skillAgentsField.SelectedIndices() {
+		if idx < len(agentNames) {
+			skillAgents = append(skillAgents, agentNames[idx])
+		}
+	}
+
 	return Result{
 		Workspaces:     workspaces,
 		ConfigPath:     m.configPath,
 		SelectedShells: selectedShells,
+		SkillAgents:    skillAgents,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bundles 24 skills and 12 commands from hayden-dotfiles into the binary via `embed.FS`
- New `internal/skillsinstall` package extracts assets to `~/.config/hive/skills|commands/` and symlinks into agent config dirs (`~/.claude`, `~/.codex`)
- Adds `hive install skills [--claude] [--codex] [--force]` standalone subcommand
- Install wizard gains an "Install AI skills for:" multi-select step, pre-checked for agents detected in PATH

## Test plan

- [ ] `hive install skills --help` shows correct usage
- [ ] `hive install skills` extracts to `~/.config/hive/skills/` and `~/.config/hive/commands/`
- [ ] `~/.claude/skills` and `~/.claude/commands` are symlinks pointing to the above
- [ ] Re-running `hive install skills` is idempotent (refreshes existing symlinks)
- [ ] `--force` overwrites non-symlink paths
- [ ] `hive install` wizard shows skills agent selection step