### PR TITLE
feat: background streaming operations with 'b' key

### DIFF
--- a/internal/tui/modal_coordinator.go
+++ b/internal/tui/modal_coordinator.go
@@ -50,6 +50,13 @@ type ModalCoordinator struct {
 	StreamCancel context.CancelFunc
 	StreamResult streamResult // session metadata from create operations
 
+	// Background streaming (dismissed but still running)
+	BgStreamOutput <-chan string
+	BgStreamDone   <-chan error
+	BgStreamCancel context.CancelFunc
+	BgStreamResult streamResult
+	BgStreamTitle  string
+
 	// Sizing
 	width, height int
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -188,6 +188,12 @@ type streamCompleteMsg struct {
 	err error
 }
 
+// bgStreamCompleteMsg is sent when a backgrounded streaming operation finishes.
+type bgStreamCompleteMsg struct {
+	err    error
+	result streamResult
+}
+
 // drainNotificationsMsg signals that buffered notifications should be drained.
 type drainNotificationsMsg struct{}
 
@@ -361,6 +367,9 @@ func New(deps Deps, opts Opts) Model {
 // quit sets the quitting flag and emits tui.stopped.
 func (m Model) quit() (Model, tea.Cmd) {
 	m.quitting = true
+	if m.modals.BgStreamCancel != nil {
+		m.modals.BgStreamCancel()
+	}
 	if m.bus != nil {
 		m.bus.PublishTuiStopped(eventbus.TUIStoppedPayload{})
 	}
@@ -555,6 +564,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		model, cmd = m.handleStreamOutput(msg)
 	case streamCompleteMsg:
 		model, cmd = m.handleStreamComplete(msg)
+	case bgStreamCompleteMsg:
+		model, cmd = m.handleBgStreamComplete(msg)
 
 	// Review delegation
 	case review.DocumentChangeMsg:
@@ -1863,6 +1874,19 @@ func listenForStreamingOutput(output <-chan string, done <-chan error) tea.Cmd {
 		case err := <-done:
 			return streamCompleteMsg{err: err}
 		}
+	}
+}
+
+// listenForBgStreamComplete drains any remaining output and waits for the done
+// signal from a backgrounded streaming operation. Individual output lines are
+// discarded since the modal is no longer visible.
+func listenForBgStreamComplete(output <-chan string, done <-chan error, result streamResult) tea.Cmd {
+	return func() tea.Msg {
+		// Drain output channel until closed.
+		for range output {
+		}
+		err := <-done
+		return bgStreamCompleteMsg{err: err, result: result}
 	}
 }
 

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -637,6 +637,26 @@ func (m Model) handleStreamingModalKey(keyStr string) (tea.Model, tea.Cmd) {
 		m.state = stateNormal
 		m.modals.Pending = Action{}
 		return m, m.refreshSessions()
+	case "b":
+		if !m.modals.Output.IsRunning() {
+			return m, nil
+		}
+		// Move the running operation to background.
+		m.modals.BgStreamOutput = m.modals.StreamOutput
+		m.modals.BgStreamDone = m.modals.StreamDone
+		m.modals.BgStreamCancel = m.modals.StreamCancel
+		m.modals.BgStreamResult = m.modals.StreamResult
+		m.modals.BgStreamTitle = m.modals.Output.title
+
+		m.modals.StreamOutput = nil
+		m.modals.StreamDone = nil
+		m.modals.StreamCancel = nil
+		m.modals.StreamResult = streamResult{}
+
+		m.state = stateNormal
+		m.modals.Pending = Action{}
+		m.publishNotificationf(notify.LevelInfo, "Moved to background: %s", m.modals.BgStreamTitle)
+		return m, listenForBgStreamComplete(m.modals.BgStreamOutput, m.modals.BgStreamDone, m.modals.BgStreamResult)
 	case keyEnter:
 		if !m.modals.Output.IsRunning() {
 			m.state = stateNormal
@@ -644,6 +664,27 @@ func (m Model) handleStreamingModalKey(keyStr string) (tea.Model, tea.Cmd) {
 			return m, m.refreshSessions()
 		}
 	}
+	return m, nil
+}
+
+// handleBgStreamComplete handles completion of a backgrounded streaming operation.
+func (m Model) handleBgStreamComplete(msg bgStreamCompleteMsg) (tea.Model, tea.Cmd) {
+	title := m.modals.BgStreamTitle
+	m.modals.BgStreamOutput = nil
+	m.modals.BgStreamDone = nil
+	m.modals.BgStreamCancel = nil
+	m.modals.BgStreamResult = streamResult{}
+	m.modals.BgStreamTitle = ""
+
+	if msg.err == nil {
+		m.publishNotificationf(notify.LevelInfo, "Complete: %s", title)
+		if msg.result.sessionID != nil && *msg.result.sessionID != "" {
+			m.sessionsView.SelectOnNextRefresh(*msg.result.sessionID)
+		}
+		return m, m.refreshSessions()
+	}
+
+	m.publishNotificationf(notify.LevelError, "Failed: %s — %v", title, msg.err)
 	return m, nil
 }
 

--- a/internal/tui/model_render.go
+++ b/internal/tui/model_render.go
@@ -72,6 +72,12 @@ func (m Model) renderTabView() string {
 		tabsLeft = lipgloss.JoinHorizontal(lipgloss.Left, tabsLeft, "  ", styles.TextPrimaryBoldStyle.Render("["+filterLabel+"]"))
 	}
 
+	// Background operation indicator
+	bgIndicator := ""
+	if m.modals.BgStreamDone != nil {
+		bgIndicator = styles.TextWarningStyle.Render("⟳ " + m.modals.BgStreamTitle + " ")
+	}
+
 	// Todo indicator: right-aligned, warning when pending or counts are degraded.
 	todoIndicator := ""
 	if m.todoBadge.degraded {
@@ -97,17 +103,18 @@ func (m Model) renderTabView() string {
 	}
 
 	// Calculate spacing to push right-side elements to right edge
-	// Layout: [margin] tabs [spacer] todoIndicator branding [margin]
+	// Layout: [margin] tabs [spacer] bgIndicator todoIndicator branding [margin]
 	margin := 1
 	tabsWidth := lipgloss.Width(tabsLeft)
 	brandingWidth := lipgloss.Width(branding)
 	todoWidth := lipgloss.Width(todoIndicator)
-	spacerWidth := max(m.width-tabsWidth-todoWidth-brandingWidth-(margin*2), 1)
+	bgWidth := lipgloss.Width(bgIndicator)
+	spacerWidth := max(m.width-tabsWidth-bgWidth-todoWidth-brandingWidth-(margin*2), 1)
 	leftMargin := components.Pad(margin)
 	spacer := components.Pad(spacerWidth)
 	rightMargin := components.Pad(margin)
 
-	header := lipgloss.JoinHorizontal(lipgloss.Left, leftMargin, tabsLeft, spacer, todoIndicator, branding, rightMargin)
+	header := lipgloss.JoinHorizontal(lipgloss.Left, leftMargin, tabsLeft, spacer, bgIndicator, todoIndicator, branding, rightMargin)
 
 	// Horizontal dividers above and below header
 	dividerWidth := m.width

--- a/internal/tui/output_modal.go
+++ b/internal/tui/output_modal.go
@@ -153,7 +153,7 @@ func (m OutputModal) Overlay(background string, width, height int) string {
 	// Build help line
 	var help string
 	if m.running {
-		help = "[esc] cancel"
+		help = "[b] background • [esc] cancel"
 	} else {
 		help = "[enter/esc] close"
 	}


### PR DESCRIPTION
## Summary

- Adds a `b` keyboard shortcut during streaming modals (clone, recycle) to dismiss the modal and continue using the TUI while the operation completes in the background
- Shows a `⟳ Creating session...` indicator in the header tab bar while a background operation is running
- Fires a toast notification on completion or failure
- Cancels background operations on app quit

## Plan

### Problem
When creating a new session, the clone streams into a modal that blocks all TUI interaction. For large repos, this can take minutes.

### Current Behavior
1. User submits the new session form → `startCreate()` spawns a goroutine returning channels
2. `handleStreamStarted()` sets `state = stateStreaming` and shows `OutputModal`
3. `handleStreamingModalKey()` only allows: **Esc** (cancel + close), **Enter** (close if done), **Ctrl+C** (cancel + quit)
4. No other keys are processed while in `stateStreaming`

### Approach: "Send to Background" keybinding

Added a `b` key in `handleStreamingModalKey` that dismisses the modal without canceling the operation.

#### Changes

**1. Background operation state on `ModalCoordinator`** (`modal_coordinator.go`)

New fields track a backgrounded stream:

```go
// Background streaming (dismissed but still running)
BgStreamOutput <-chan string
BgStreamDone   <-chan error
BgStreamCancel context.CancelFunc
BgStreamResult streamResult
BgStreamTitle  string
```

**2. `bgStreamCompleteMsg` message type** (`model.go`)

Similar to `streamCompleteMsg` but for background operations. Carries the result and error.

**3. `b` key handler in `handleStreamingModalKey`** (`model_handlers.go`)

When the user presses `b` during streaming:
- Moves `StreamOutput/StreamDone/StreamCancel/StreamResult` → `BgStream*` fields
- Closes the output modal, sets `state = stateNormal`
- Returns a command that continues listening on the background channels (`listenForBgStreamComplete`)
- Shows a toast: "Moved to background: Creating session..."

**4. `listenForBgStreamComplete` command** (`model.go`)

A Tea command that drains the background output channel and waits for the done channel. When done fires, it sends `bgStreamCompleteMsg`. Unlike the foreground listener, it doesn't relay individual output lines since the modal is closed.

**5. `handleBgStreamComplete` handler** (`model_handlers.go`)

On success:
- Pushes a toast notification ("Complete: Creating session...")
- Selects the new session and refreshes the list

On error:
- Pushes an error toast ("Failed: Creating session... — <error>")

**6. Background indicator in the header** (`model_render.go`)

While `BgStreamDone != nil`, shows `⟳ Creating session...` in warning style in the tab bar, giving visual feedback that something is happening.

**7. Quit cleanup** (`model.go`)

Cancels any background operation when the app quits via `Ctrl+C`.

**8. Help text update** (`output_modal.go`)

The streaming modal help line now shows `[b] background • [esc] cancel` while running.

#### Edge Cases
- **Multiple background ops**: For v1, only one background op at a time. If a second stream starts while one is backgrounded, the new one takes the foreground modal as it does today.
- **Esc on background**: The `BgStreamCancel` is called on app quit.
- **App quit during background op**: `Ctrl+C` cancels any background operation via cleanup in the quit path.

#### Future Enhancements
- Allow re-opening the background modal to re-attach to the stream
- Support multiple concurrent background operations
- Add a keybinding to cancel a backgrounded operation without quitting

## Test plan
- [ ] Create a new session with a large repo, press `b` during clone — modal dismisses, TUI is usable
- [ ] Verify `⟳ Creating session...` indicator appears in the header
- [ ] Wait for clone to complete — toast notification fires, session appears in list
- [ ] Create a new session, press `b`, then quit with `Ctrl+C` — background op is canceled
- [ ] Create a new session, let it complete normally (don't press `b`) — existing behavior unchanged
- [ ] Press `b` on a completed modal — nothing happens (only works while running)
- [ ] Press `esc` during streaming — still cancels as before
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)