### PR TITLE
feat: hook-based agent status detection for Claude Code

### DIFF
--- a/internal/commands/cmd_hook_handler.go
+++ b/internal/commands/cmd_hook_handler.go
@@ -92,7 +92,6 @@ func (cmd *HookHandlerCmd) run(_ context.Context, _ *cli.Command) error {
 	sessionStore := stores.NewSessionStore(database)
 	kvStore := stores.NewKVStore(database)
 
-	// Resolve which Hive session this hook event belongs to.
 	resolver := terminal.NewHookResolver(sessionStore)
 	sessionID, windowIndex, err := resolver.Resolve(ctx)
 	if err != nil {

--- a/internal/commands/cmd_hook_handler.go
+++ b/internal/commands/cmd_hook_handler.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/colonyops/hive/internal/core/kv"
+	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/internal/data/db"
+	"github.com/colonyops/hive/internal/data/stores"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+)
+
+// hookPayload is the JSON payload sent by Claude Code to the hook handler via stdin.
+type hookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+	SessionID     string `json:"session_id"` // Claude's internal UUID, not Hive session ID
+	Source        string `json:"source"`
+}
+
+// HookHandlerCmd handles the `hive hook-handler` subcommand.
+type HookHandlerCmd struct {
+	flags *Flags
+}
+
+// NewHookHandlerCmd creates a new hook-handler command.
+func NewHookHandlerCmd(flags *Flags) *HookHandlerCmd {
+	return &HookHandlerCmd{flags: flags}
+}
+
+// Register adds the hook-handler command to the application.
+func (cmd *HookHandlerCmd) Register(app *cli.Command) *cli.Command {
+	app.Commands = append(app.Commands, &cli.Command{
+		Name:   "hook-handler",
+		Usage:  "Handle Claude Code lifecycle hook events (called by Claude, not users)",
+		Hidden: true,
+		Action: cmd.run,
+	})
+	return app
+}
+
+func (cmd *HookHandlerCmd) run(_ context.Context, _ *cli.Command) error {
+	// 10s overall deadline — caps total runtime including DB operations.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Decode JSON payload from stdin (5s deadline for read).
+	readCtx, readCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer readCancel()
+
+	var payload hookPayload
+	done := make(chan error, 1)
+	go func() {
+		done <- json.NewDecoder(os.Stdin).Decode(&payload)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Debug().Err(err).Msg("hook-handler: failed to decode stdin payload")
+			return nil
+		}
+	case <-readCtx.Done():
+		log.Debug().Msg("hook-handler: stdin read timeout")
+		return nil
+	}
+
+	// Map event to status. Unknown events are silently ignored.
+	status, ok := terminal.MapEventToStatus(payload.HookEventName)
+	if !ok {
+		log.Debug().Str("event", payload.HookEventName).Msg("hook-handler: unknown event, ignoring")
+		return nil
+	}
+
+	// Open DB with minimal options — no need for a full connection pool.
+	database, err := db.Open(cmd.flags.DataDir, db.OpenOptions{
+		MaxOpenConns: 1,
+		MaxIdleConns: 1,
+	})
+	if err != nil {
+		log.Warn().Err(err).Msg("hook-handler: failed to open database")
+		return nil
+	}
+	defer func() {
+		if err := database.Close(); err != nil {
+			log.Debug().Err(err).Msg("hook-handler: failed to close database")
+		}
+	}()
+
+	sessionStore := stores.NewSessionStore(database)
+	kvStore := stores.NewKVStore(database)
+
+	// Resolve which Hive session this hook event belongs to.
+	resolver := terminal.NewHookResolver(sessionStore)
+	sessionID, windowIndex, err := resolver.Resolve(ctx)
+	if err != nil {
+		log.Debug().Err(err).Msg("hook-handler: session resolution error")
+		return nil
+	}
+	if sessionID == "" {
+		log.Debug().Str("event", payload.HookEventName).Msg("hook-handler: no matching Hive session, ignoring")
+		return nil
+	}
+
+	hookKV := kv.Scoped[terminal.HookStatus](kvStore, "hook.status")
+	key := sessionID + ":" + windowIndex
+
+	if status == terminal.StatusMissing {
+		// SessionEnd: remove the key so the TUI falls back to tmux.
+		if err := hookKV.Delete(ctx, key); err != nil {
+			log.Debug().Err(err).Msg("hook-handler: failed to delete hook status")
+		}
+		return nil
+	}
+
+	hs := terminal.HookStatus{
+		Status:      status,
+		Event:       payload.HookEventName,
+		WindowIndex: windowIndex,
+		WrittenAt:   time.Now(),
+	}
+	// 24h TTL for orphan cleanup. Staleness is checked application-side via WrittenAt.
+	if err := hookKV.SetTTL(ctx, key, hs, 24*time.Hour); err != nil {
+		log.Warn().Err(err).Msg("hook-handler: failed to write hook status")
+	}
+
+	return nil
+}

--- a/internal/commands/cmd_install.go
+++ b/internal/commands/cmd_install.go
@@ -1,0 +1,159 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/urfave/cli/v3"
+)
+
+type hookEntry struct {
+	Matcher string     `json:"matcher,omitempty"`
+	Hooks   []hookItem `json:"hooks"`
+}
+
+type hookItem struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Async   bool   `json:"async"`
+}
+
+// hiveHookCommand is the command string installed into Claude's settings.
+const hiveHookCommand = "hive hook-handler"
+
+// claudeHookEvents lists the events to install, with optional matchers.
+var claudeHookEvents = []struct {
+	Event   string
+	Matcher string
+}{
+	{Event: "SessionStart"},
+	{Event: "UserPromptSubmit"},
+	{Event: "Stop"},
+	{Event: "PermissionRequest"},
+	{Event: "SessionEnd"},
+	{Event: "Notification", Matcher: "permission_prompt|elicitation_dialog"},
+}
+
+// InstallCmd handles the `hive install` subcommand.
+type InstallCmd struct {
+	flags *Flags
+}
+
+// NewInstallCmd creates a new install command.
+func NewInstallCmd(flags *Flags) *InstallCmd {
+	return &InstallCmd{flags: flags}
+}
+
+// Register adds the install command to the application.
+func (cmd *InstallCmd) Register(app *cli.Command) *cli.Command {
+	app.Commands = append(app.Commands, &cli.Command{
+		Name:  "install",
+		Usage: "Install hive integrations",
+		Commands: []*cli.Command{
+			{
+				Name:   "claude",
+				Usage:  "Install hive hooks into ~/.claude/settings.json",
+				Action: cmd.runClaude,
+			},
+		},
+	})
+	return app
+}
+
+func (cmd *InstallCmd) runClaude(_ context.Context, _ *cli.Command) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+
+	// Read existing settings, preserving all unknown fields.
+	raw := make(map[string]json.RawMessage)
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parse %s: %w", settingsPath, err)
+		}
+	}
+
+	// Decode existing hooks (may be absent).
+	var hooks map[string][]hookEntry
+	if v, ok := raw["hooks"]; ok {
+		if err := json.Unmarshal(v, &hooks); err != nil {
+			return fmt.Errorf("parse existing hooks: %w", err)
+		}
+	}
+	if hooks == nil {
+		hooks = make(map[string][]hookEntry)
+	}
+
+	installed := 0
+	for _, ev := range claudeHookEvents {
+		if addHookEntry(hooks, ev.Event, ev.Matcher) {
+			installed++
+		}
+	}
+
+	if installed == 0 {
+		fmt.Println("hive hooks already installed in", settingsPath)
+		return nil
+	}
+
+	// Re-encode hooks and merge back into the raw map.
+	hooksJSON, err := json.Marshal(hooks)
+	if err != nil {
+		return fmt.Errorf("encode hooks: %w", err)
+	}
+	raw["hooks"] = hooksJSON
+
+	// Write atomically via a temp file.
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		return fmt.Errorf("create .claude dir: %w", err)
+	}
+	tmp := settingsPath + ".tmp"
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode settings: %w", err)
+	}
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := os.Rename(tmp, settingsPath); err != nil {
+		return fmt.Errorf("replace settings file: %w", err)
+	}
+
+	fmt.Printf("installed %d hive hook(s) into %s\n", installed, settingsPath)
+
+	if _, err := exec.LookPath("hive"); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: 'hive' not found in PATH — hooks will fail silently until hive is in PATH")
+	}
+
+	return nil
+}
+
+// addHookEntry adds a hive hook-handler entry for the given event if not already present.
+// Returns true if an entry was added.
+func addHookEntry(hooks map[string][]hookEntry, event, matcher string) bool {
+	entries := hooks[event]
+	for _, entry := range entries {
+		if entry.Matcher == matcher {
+			for _, item := range entry.Hooks {
+				if item.Command == hiveHookCommand {
+					return false // already installed
+				}
+			}
+		}
+	}
+
+	hooks[event] = append(hooks[event], hookEntry{
+		Matcher: matcher,
+		Hooks: []hookItem{
+			{Type: "command", Command: hiveHookCommand, Async: true},
+		},
+	})
+	return true
+}

--- a/internal/commands/cmd_install.go
+++ b/internal/commands/cmd_install.go
@@ -71,6 +71,11 @@ func (cmd *InstallCmd) runClaude(_ context.Context, _ *cli.Command) error {
 	}
 
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	// Resolve any symlink so Rename writes to the real file, not a new regular file
+	// (important for users managing ~/.claude/settings.json via dotfile managers).
+	if resolved, err := filepath.EvalSymlinks(settingsPath); err == nil {
+		settingsPath = resolved
+	}
 
 	// Read existing settings, preserving all unknown fields.
 	raw := make(map[string]json.RawMessage)
@@ -103,7 +108,6 @@ func (cmd *InstallCmd) runClaude(_ context.Context, _ *cli.Command) error {
 		return nil
 	}
 
-	// Re-encode hooks and merge back into the raw map.
 	hooksJSON, err := json.Marshal(hooks)
 	if err != nil {
 		return fmt.Errorf("encode hooks: %w", err)

--- a/internal/commands/cmd_install_test.go
+++ b/internal/commands/cmd_install_test.go
@@ -45,6 +45,20 @@ func TestAddHookEntry(t *testing.T) {
 			want:    true,
 			wantLen: 2,
 		},
+		{
+			name: "same matcher different command adds new entry",
+			setup: func() map[string][]hookEntry {
+				h := make(map[string][]hookEntry)
+				h["SessionStart"] = []hookEntry{
+					{Matcher: "", Hooks: []hookItem{{Type: "command", Command: "other-tool", Async: false}}},
+				}
+				return h
+			},
+			event:   "SessionStart",
+			matcher: "",
+			want:    true,
+			wantLen: 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/cmd_install_test.go
+++ b/internal/commands/cmd_install_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestAddHookEntry(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func() map[string][]hookEntry // initial hooks state
+		event   string
+		matcher string
+		want    bool // expected return value
+		wantLen int  // expected len of hooks[event] after call
+	}{
+		{
+			name:    "new event adds entry",
+			setup:   func() map[string][]hookEntry { return make(map[string][]hookEntry) },
+			event:   "SessionStart",
+			matcher: "",
+			want:    true,
+			wantLen: 1,
+		},
+		{
+			name: "identical call is no-op",
+			setup: func() map[string][]hookEntry {
+				h := make(map[string][]hookEntry)
+				addHookEntry(h, "SessionStart", "")
+				return h
+			},
+			event:   "SessionStart",
+			matcher: "",
+			want:    false,
+			wantLen: 1,
+		},
+		{
+			name: "different matcher adds new entry",
+			setup: func() map[string][]hookEntry {
+				h := make(map[string][]hookEntry)
+				addHookEntry(h, "Notification", "")
+				return h
+			},
+			event:   "Notification",
+			matcher: "permission_prompt|elicitation_dialog",
+			want:    true,
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks := tt.setup()
+			got := addHookEntry(hooks, tt.event, tt.matcher)
+			if got != tt.want {
+				t.Errorf("addHookEntry() = %v, want %v", got, tt.want)
+			}
+			if len(hooks[tt.event]) != tt.wantLen {
+				t.Errorf("len(hooks[%q]) = %d, want %d", tt.event, len(hooks[tt.event]), tt.wantLen)
+			}
+		})
+	}
+}

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/colonyops/hive/internal/core/action"
 	"github.com/colonyops/hive/internal/core/styles"
+	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/colonyops/hive/pkg/pathutil"
 	"github.com/hay-kot/criterio"
 	"gopkg.in/yaml.v3"
@@ -530,12 +531,12 @@ type ClaudePluginConfig struct {
 	HookFreshnessWindow time.Duration `json:"hook_freshness_window" yaml:"hook_freshness_window"` // max age of hook status before tmux fallback (default: 2m)
 }
 
-// GetHookFreshnessWindow returns the configured freshness window, defaulting to 2 minutes.
+// GetHookFreshnessWindow returns the configured freshness window, defaulting to DefaultHookFreshnessWindow.
 func (c ClaudePluginConfig) GetHookFreshnessWindow() time.Duration {
 	if c.HookFreshnessWindow > 0 {
 		return c.HookFreshnessWindow
 	}
-	return 2 * time.Minute
+	return terminal.DefaultHookFreshnessWindow
 }
 
 // DatabaseConfig holds SQLite database configuration.

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -522,11 +522,20 @@ type ContextDirPluginConfig struct {
 
 // ClaudePluginConfig holds Claude Code plugin configuration.
 type ClaudePluginConfig struct {
-	Enabled         *bool         `json:"enabled"          yaml:"enabled"`          // nil = auto-detect, true/false = override
-	CacheTTL        time.Duration `json:"cache_ttl"        yaml:"cache_ttl"`        // status cache duration (default: 30s)
-	YellowThreshold int           `json:"yellow_threshold" yaml:"yellow_threshold"` // yellow above this % (default: 60)
-	RedThreshold    int           `json:"red_threshold"    yaml:"red_threshold"`    // red above this % (default: 80)
-	ModelLimit      int           `json:"model_limit"      yaml:"model_limit"`      // context limit (default: 200000)
+	Enabled             *bool         `json:"enabled"               yaml:"enabled"`               // nil = auto-detect, true/false = override
+	CacheTTL            time.Duration `json:"cache_ttl"             yaml:"cache_ttl"`             // status cache duration (default: 30s)
+	YellowThreshold     int           `json:"yellow_threshold"      yaml:"yellow_threshold"`      // yellow above this % (default: 60)
+	RedThreshold        int           `json:"red_threshold"         yaml:"red_threshold"`         // red above this % (default: 80)
+	ModelLimit          int           `json:"model_limit"           yaml:"model_limit"`           // context limit (default: 200000)
+	HookFreshnessWindow time.Duration `json:"hook_freshness_window" yaml:"hook_freshness_window"` // max age of hook status before tmux fallback (default: 2m)
+}
+
+// GetHookFreshnessWindow returns the configured freshness window, defaulting to 2 minutes.
+func (c ClaudePluginConfig) GetHookFreshnessWindow() time.Duration {
+	if c.HookFreshnessWindow > 0 {
+		return c.HookFreshnessWindow
+	}
+	return 2 * time.Minute
 }
 
 // DatabaseConfig holds SQLite database configuration.

--- a/internal/core/terminal/hookresolver.go
+++ b/internal/core/terminal/hookresolver.go
@@ -1,0 +1,104 @@
+package terminal
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/colonyops/hive/internal/core/messaging"
+	"github.com/colonyops/hive/internal/core/session"
+)
+
+// HookResolver identifies the Hive session and tmux window index for a Claude
+// Code hook event. It uses a waterfall of three strategies, cheapest first:
+//
+//  1. HIVE_SESSION_ID env var (injected by hive at spawn time — Phase 3)
+//  2. tmux session name: matches #{session_name} against sess.Slug
+//  3. CWD path match: delegates to messaging.DetectSessionFromPath
+type HookResolver struct {
+	store session.Store
+}
+
+// NewHookResolver creates a new HookResolver backed by the given session store.
+func NewHookResolver(store session.Store) *HookResolver {
+	return &HookResolver{store: store}
+}
+
+// Resolve returns the Hive session ID and tmux window index for the current
+// hook invocation. sessionID is empty if no matching session is found — the
+// caller should exit 0 silently (hook fired outside a Hive session).
+// windowIndex defaults to "0" when not running inside tmux.
+func (r *HookResolver) Resolve(ctx context.Context) (sessionID, windowIndex string, err error) {
+	windowIndex = r.windowIndex()
+
+	// Strategy 1: HIVE_SESSION_ID env var (fastest, set in Phase 3)
+	if id := os.Getenv("HIVE_SESSION_ID"); id != "" {
+		return id, windowIndex, nil
+	}
+
+	// Strategy 2: tmux session name matches sess.Slug
+	if tmuxName := tmuxSessionName(); tmuxName != "" {
+		sessions, err := r.store.List(ctx)
+		if err != nil {
+			return "", windowIndex, err
+		}
+		for _, sess := range sessions {
+			if sess.State == session.StateActive && sess.Slug == tmuxName {
+				return sess.ID, windowIndex, nil
+			}
+		}
+	}
+
+	// Strategy 3: CWD path match
+	detector := messaging.NewSessionDetector(r.store)
+	id, err := detector.DetectSession(ctx)
+	return id, windowIndex, err
+}
+
+// windowIndex returns the tmux window index for the current process, or "0"
+// if not running inside tmux.
+func (r *HookResolver) windowIndex() string {
+	if os.Getenv("TMUX") == "" {
+		return "0"
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "#{window_index}").Output()
+	if err != nil {
+		return "0"
+	}
+	idx := strings.TrimSpace(string(out))
+	if idx == "" {
+		return "0"
+	}
+	return idx
+}
+
+// tmuxSessionName returns the current tmux session name, or empty string if
+// not inside tmux.
+func tmuxSessionName() string {
+	if os.Getenv("TMUX") == "" {
+		return ""
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// MapEventToStatus maps a Claude Code hook event name to a Hive terminal Status.
+// Returns (status, true) for known events, ("", false) for unknown events.
+func MapEventToStatus(event string) (Status, bool) {
+	switch event {
+	case "SessionStart", "Stop":
+		return StatusReady, true
+	case "UserPromptSubmit":
+		return StatusActive, true
+	case "PermissionRequest", "Notification":
+		return StatusApproval, true
+	case "SessionEnd":
+		return StatusMissing, true
+	default:
+		return "", false
+	}
+}

--- a/internal/core/terminal/hookresolver.go
+++ b/internal/core/terminal/hookresolver.go
@@ -37,7 +37,6 @@ func (r *HookResolver) Resolve(ctx context.Context) (sessionID, windowIndex stri
 		return id, windowIndex, nil
 	}
 
-	// Strategy 2: tmux session name matches sess.Slug
 	if tmuxName := tmuxSessionName(); tmuxName != "" {
 		sessions, err := r.store.List(ctx)
 		if err != nil {
@@ -50,7 +49,6 @@ func (r *HookResolver) Resolve(ctx context.Context) (sessionID, windowIndex stri
 		}
 	}
 
-	// Strategy 3: CWD path match
 	detector := messaging.NewSessionDetector(r.store)
 	id, err := detector.DetectSession(ctx)
 	return id, windowIndex, err

--- a/internal/core/terminal/hookresolver_test.go
+++ b/internal/core/terminal/hookresolver_test.go
@@ -40,7 +40,7 @@ func TestMapEventToStatus(t *testing.T) {
 
 func TestHookResolverEnvVar(t *testing.T) {
 	t.Setenv("HIVE_SESSION_ID", "test-session-id")
-	t.Setenv("TMUX", "") // not inside tmux
+	t.Setenv("TMUX", "")
 
 	resolver := terminal.NewHookResolver(&stubSessionStore{})
 	sessionID, windowIndex, err := resolver.Resolve(context.Background())
@@ -57,7 +57,7 @@ func TestHookResolverEnvVar(t *testing.T) {
 
 func TestHookResolverCWDFallback(t *testing.T) {
 	t.Setenv("HIVE_SESSION_ID", "")
-	t.Setenv("TMUX", "") // not inside tmux
+	t.Setenv("TMUX", "")
 
 	// CWD won't match any session path → empty string returned, no error.
 	resolver := terminal.NewHookResolver(&stubSessionStore{sessions: []session.Session{}})

--- a/internal/core/terminal/hookresolver_test.go
+++ b/internal/core/terminal/hookresolver_test.go
@@ -1,0 +1,90 @@
+package terminal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/core/terminal"
+)
+
+func TestMapEventToStatus(t *testing.T) {
+	tests := []struct {
+		event      string
+		wantStatus terminal.Status
+		wantOK     bool
+	}{
+		{"SessionStart", terminal.StatusReady, true},
+		{"Stop", terminal.StatusReady, true},
+		{"UserPromptSubmit", terminal.StatusActive, true},
+		{"PermissionRequest", terminal.StatusApproval, true},
+		{"Notification", terminal.StatusApproval, true},
+		{"SessionEnd", terminal.StatusMissing, true},
+		{"UnknownEvent", "", false},
+		{"", "", false},
+		{"PreCompact", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := terminal.MapEventToStatus(tt.event)
+			if ok != tt.wantOK {
+				t.Errorf("MapEventToStatus(%q) ok = %v, want %v", tt.event, ok, tt.wantOK)
+			}
+			if got != tt.wantStatus {
+				t.Errorf("MapEventToStatus(%q) status = %q, want %q", tt.event, got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestHookResolverEnvVar(t *testing.T) {
+	t.Setenv("HIVE_SESSION_ID", "test-session-id")
+	t.Setenv("TMUX", "") // not inside tmux
+
+	resolver := terminal.NewHookResolver(&stubSessionStore{})
+	sessionID, windowIndex, err := resolver.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionID != "test-session-id" {
+		t.Errorf("sessionID = %q, want %q", sessionID, "test-session-id")
+	}
+	if windowIndex != "0" {
+		t.Errorf("windowIndex = %q, want %q (not in tmux)", windowIndex, "0")
+	}
+}
+
+func TestHookResolverCWDFallback(t *testing.T) {
+	t.Setenv("HIVE_SESSION_ID", "")
+	t.Setenv("TMUX", "") // not inside tmux
+
+	// CWD won't match any session path → empty string returned, no error.
+	resolver := terminal.NewHookResolver(&stubSessionStore{sessions: []session.Session{}})
+	sessionID, windowIndex, err := resolver.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionID != "" {
+		t.Errorf("sessionID = %q, want empty (no matching session)", sessionID)
+	}
+	if windowIndex != "0" {
+		t.Errorf("windowIndex = %q, want %q", windowIndex, "0")
+	}
+}
+
+// stubSessionStore implements session.Store for testing.
+type stubSessionStore struct {
+	sessions []session.Session
+}
+
+func (s *stubSessionStore) List(_ context.Context) ([]session.Session, error) {
+	return s.sessions, nil
+}
+
+func (s *stubSessionStore) Get(_ context.Context, _ string) (session.Session, error) {
+	return session.Session{}, nil
+}
+
+func (s *stubSessionStore) Save(_ context.Context, _ session.Session) error { return nil }
+func (s *stubSessionStore) Delete(_ context.Context, _ string) error        { return nil }

--- a/internal/core/terminal/hookstatus.go
+++ b/internal/core/terminal/hookstatus.go
@@ -1,0 +1,22 @@
+package terminal
+
+import "time"
+
+// HookStatus is stored in SQLite KV for each Claude Code hook event.
+// Key: "hook.status:<session-id>:<window-index>" (window-index "0" for single-window).
+//
+// Staleness is determined application-side via WrittenAt + freshness window,
+// not by KV TTL. The 24h TTL on the KV entry is for orphan cleanup only.
+type HookStatus struct {
+	Status      Status    `json:"status"`
+	Event       string    `json:"event"`
+	WindowIndex string    `json:"window_index"`
+	WrittenAt   time.Time `json:"written_at"`
+}
+
+// ToolClaude is the tool identifier for Claude Code hook-sourced status entries.
+const ToolClaude = "claude"
+
+// DefaultHookFreshnessWindow is the duration after which a hook status entry is
+// considered stale and tmux fallback is used instead.
+const DefaultHookFreshnessWindow = 2 * time.Minute

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -324,6 +324,7 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	// Spawn terminal
 	writeProgressf(progress, "Spawning terminal...")
 	data := SpawnData{
+		ID:         sess.ID,
 		Path:       sess.Path,
 		Name:       sess.Name,
 		Prompt:     opts.Prompt,
@@ -715,7 +716,7 @@ func (s *SessionService) DetectSession(ctx context.Context) (string, error) {
 
 // OpenTmuxSession opens (or creates) a tmux session for the given session parameters.
 // It resolves the spawn strategy, renders window templates, and delegates to the spawner.
-func (s *SessionService) OpenTmuxSession(ctx context.Context, name, path, remote, targetWindow string, background bool) error {
+func (s *SessionService) OpenTmuxSession(ctx context.Context, sessionID, name, path, remote, targetWindow string, background bool) error {
 	strategy := config.ResolveSpawn(s.config.Rules, remote, false)
 	if !strategy.IsWindows() {
 		return fmt.Errorf("tmux action requires windows config (legacy spawn commands should use shell executor)")
@@ -723,6 +724,7 @@ func (s *SessionService) OpenTmuxSession(ctx context.Context, name, path, remote
 
 	owner, repo := git.ExtractOwnerRepo(remote)
 	data := SpawnData{
+		ID:         sessionID,
 		Path:       path,
 		Name:       name,
 		Slug:       session.Slugify(name),

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -67,6 +67,8 @@ func (s *Spawner) Spawn(ctx context.Context, commands []string, data SpawnData) 
 		}
 
 		if data.ID != "" {
+			// data.ID is a hive-generated slug containing only [a-z0-9-], so unquoted
+			// concatenation is safe here — no shell injection risk.
 			rendered = "HIVE_SESSION_ID=" + data.ID + " " + rendered
 		}
 
@@ -164,6 +166,8 @@ func renderWindow(renderer *tmpl.Renderer, w config.WindowConfig, data SpawnData
 		return rw, err
 	}
 	if data.ID != "" && rw.Command != "" {
+		// data.ID is a hive-generated slug containing only [a-z0-9-], so unquoted
+		// concatenation is safe here — no shell injection risk.
 		rw.Command = "HIVE_SESSION_ID=" + data.ID + " " + rw.Command
 	}
 	return rw, nil

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -24,6 +24,7 @@ type SessionClient interface {
 
 // SpawnData is the template context for spawn commands.
 type SpawnData struct {
+	ID         string // Hive session ID (injected as HIVE_SESSION_ID env var)
 	Path       string // Absolute path to session directory
 	Name       string // Session name (display name)
 	Prompt     string // User-provided prompt (batch only)
@@ -63,6 +64,10 @@ func (s *Spawner) Spawn(ctx context.Context, commands []string, data SpawnData) 
 		rendered, err := s.renderer.Render(cmdTmpl, data)
 		if err != nil {
 			return fmt.Errorf("render spawn command %q: %w", cmdTmpl, err)
+		}
+
+		if data.ID != "" {
+			rendered = "HIVE_SESSION_ID=" + data.ID + " " + rendered
 		}
 
 		if err := s.executor.RunStream(ctx, s.stdout, s.stderr, "sh", "-c", rendered); err != nil {
@@ -152,9 +157,16 @@ func renderWindowCommon(w config.WindowConfig, render func(string) (string, erro
 
 // renderWindow renders a single WindowConfig against SpawnData.
 func renderWindow(renderer *tmpl.Renderer, w config.WindowConfig, data SpawnData) (coretmux.RenderedWindow, error) {
-	return renderWindowCommon(w, func(tmplStr string) (string, error) {
+	rw, err := renderWindowCommon(w, func(tmplStr string) (string, error) {
 		return renderer.Render(tmplStr, data)
 	})
+	if err != nil {
+		return rw, err
+	}
+	if data.ID != "" && rw.Command != "" {
+		rw.Command = "HIVE_SESSION_ID=" + data.ID + " " + rw.Command
+	}
+	return rw, nil
 }
 
 // renderWindowMap renders a single WindowConfig against a map[string]any data context.

--- a/internal/hive/spawner_test.go
+++ b/internal/hive/spawner_test.go
@@ -1,13 +1,41 @@
 package hive
 
 import (
+	"context"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/pkg/tmpl"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubExecutor captures commands passed to RunStream for inspection in tests.
+type stubExecutor struct {
+	cmds []string
+}
+
+func (s *stubExecutor) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *stubExecutor) RunDir(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *stubExecutor) RunStream(_ context.Context, _, _ io.Writer, _ string, args ...string) error {
+	if len(args) > 0 {
+		s.cmds = append(s.cmds, args[len(args)-1])
+	}
+	return nil
+}
+
+func (s *stubExecutor) RunDirStream(_ context.Context, _ string, _, _ io.Writer, _ string, _ ...string) error {
+	return nil
+}
 
 func testRenderer() *tmpl.Renderer {
 	return tmpl.New(tmpl.Config{AgentCommand: "claude", AgentWindow: "claude"})
@@ -49,6 +77,38 @@ func TestRenderWindowHIVESessionID(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, len(rw.Command) > 0 && rw.Command[:len("HIVE_SESSION_ID=")] == "HIVE_SESSION_ID=",
 			"HIVE_SESSION_ID must be first in command, got: %q", rw.Command)
+	})
+}
+
+func TestSpawnHIVESessionID(t *testing.T) {
+	r := testRenderer()
+
+	t.Run("injects env var prefix when ID is set", func(t *testing.T) {
+		exec := &stubExecutor{}
+		s := NewSpawner(zerolog.Nop(), exec, r, nil, io.Discard, io.Discard)
+		err := s.Spawn(context.Background(), []string{"claude"}, SpawnData{ID: "abc-123", Name: "s"})
+		require.NoError(t, err)
+		require.Len(t, exec.cmds, 1)
+		assert.Equal(t, "HIVE_SESSION_ID=abc-123 claude", exec.cmds[0])
+	})
+
+	t.Run("skips injection when ID is empty", func(t *testing.T) {
+		exec := &stubExecutor{}
+		s := NewSpawner(zerolog.Nop(), exec, r, nil, io.Discard, io.Discard)
+		err := s.Spawn(context.Background(), []string{"claude"}, SpawnData{ID: "", Name: "s"})
+		require.NoError(t, err)
+		require.Len(t, exec.cmds, 1)
+		assert.Equal(t, "claude", exec.cmds[0])
+	})
+
+	t.Run("env var appears at start of command", func(t *testing.T) {
+		exec := &stubExecutor{}
+		s := NewSpawner(zerolog.Nop(), exec, r, nil, io.Discard, io.Discard)
+		err := s.Spawn(context.Background(), []string{"claude"}, SpawnData{ID: "xyz-99", Name: "s"})
+		require.NoError(t, err)
+		require.Len(t, exec.cmds, 1)
+		assert.True(t, strings.HasPrefix(exec.cmds[0], "HIVE_SESSION_ID="),
+			"expected command to start with HIVE_SESSION_ID=, got: %q", exec.cmds[0])
 	})
 }
 

--- a/internal/hive/spawner_test.go
+++ b/internal/hive/spawner_test.go
@@ -28,6 +28,30 @@ func TestRenderWindowCommon(t *testing.T) {
 	assert.True(t, rw.Focus)
 }
 
+func TestRenderWindowHIVESessionID(t *testing.T) {
+	r := testRenderer()
+	w := config.WindowConfig{Name: "agent", Command: "claude"}
+
+	t.Run("injects env var prefix when ID is set", func(t *testing.T) {
+		rw, err := renderWindow(r, w, SpawnData{ID: "abc123", Name: "s"})
+		require.NoError(t, err)
+		assert.Equal(t, "HIVE_SESSION_ID=abc123 claude", rw.Command)
+	})
+
+	t.Run("skips injection when ID is empty", func(t *testing.T) {
+		rw, err := renderWindow(r, w, SpawnData{ID: "", Name: "s"})
+		require.NoError(t, err)
+		assert.Equal(t, "claude", rw.Command)
+	})
+
+	t.Run("env var appears at start of command", func(t *testing.T) {
+		rw, err := renderWindow(r, w, SpawnData{ID: "xyz99", Name: "s"})
+		require.NoError(t, err)
+		assert.True(t, len(rw.Command) > 0 && rw.Command[:len("HIVE_SESSION_ID=")] == "HIVE_SESSION_ID=",
+			"HIVE_SESSION_ID must be first in command, got: %q", rw.Command)
+	})
+}
+
 func TestRenderUserCommandWindows(t *testing.T) {
 	r := testRenderer()
 	windows := []config.WindowConfig{

--- a/internal/tui/command/executor_test.go
+++ b/internal/tui/command/executor_test.go
@@ -312,12 +312,12 @@ type mockTmuxOpener struct {
 }
 
 type tmuxOpenCall struct {
-	Name, Path, Remote, TargetWindow string
-	Background                       bool
+	SessionID, Name, Path, Remote, TargetWindow string
+	Background                                  bool
 }
 
-func (m *mockTmuxOpener) OpenTmuxSession(_ context.Context, name, path, remote, targetWindow string, background bool) error {
-	m.calls = append(m.calls, tmuxOpenCall{name, path, remote, targetWindow, background})
+func (m *mockTmuxOpener) OpenTmuxSession(_ context.Context, sessionID, name, path, remote, targetWindow string, background bool) error {
+	m.calls = append(m.calls, tmuxOpenCall{sessionID, name, path, remote, targetWindow, background})
 	return m.openErr
 }
 

--- a/internal/tui/command/service.go
+++ b/internal/tui/command/service.go
@@ -24,7 +24,7 @@ type SessionRecycler interface {
 
 // TmuxOpener opens or creates tmux sessions for hive sessions.
 type TmuxOpener interface {
-	OpenTmuxSession(ctx context.Context, name, path, remote, targetWindow string, background bool) error
+	OpenTmuxSession(ctx context.Context, sessionID, name, path, remote, targetWindow string, background bool) error
 }
 
 // WindowSpawner handles window operations for SpawnWindows actions.
@@ -94,6 +94,7 @@ func (s *Service) CreateExecutor(a Action) (Executor, error) {
 	case action.TypeTmuxOpen:
 		return &TmuxExecutor{
 			opener:       s.tmuxOpener,
+			sessionID:    a.SessionID,
 			name:         a.SessionName,
 			path:         a.SessionPath,
 			remote:       a.SessionRemote,
@@ -103,6 +104,7 @@ func (s *Service) CreateExecutor(a Action) (Executor, error) {
 	case action.TypeTmuxStart:
 		return &TmuxExecutor{
 			opener:       s.tmuxOpener,
+			sessionID:    a.SessionID,
 			name:         a.SessionName,
 			path:         a.SessionPath,
 			remote:       a.SessionRemote,

--- a/internal/tui/command/tmux.go
+++ b/internal/tui/command/tmux.go
@@ -5,6 +5,7 @@ import "context"
 // TmuxExecutor opens or creates a tmux session via the TmuxOpener interface.
 type TmuxExecutor struct {
 	opener       TmuxOpener
+	sessionID    string
 	name         string
 	path         string
 	remote       string
@@ -20,7 +21,7 @@ func (e *TmuxExecutor) Execute(ctx context.Context) (output <-chan string, done 
 
 	go func() {
 		defer close(doneCh)
-		doneCh <- e.opener.OpenTmuxSession(ctx, e.name, e.path, e.remote, e.targetWindow, e.background)
+		doneCh <- e.opener.OpenTmuxSession(ctx, e.sessionID, e.name, e.path, e.remote, e.targetWindow, e.background)
 	}()
 
 	return nil, doneCh, cancel

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -239,15 +239,17 @@ func New(deps Deps, opts Opts) Model {
 	cmdService := command.NewService(service, service, service, service, service)
 
 	sessionsView := sessions.New(sessions.ViewOpts{
-		Cfg:             cfg,
-		Service:         service,
-		Handler:         handler,
-		TerminalManager: deps.TerminalManager,
-		PluginManager:   deps.PluginManager,
-		LocalRemote:     opts.LocalRemote,
-		Workspaces:      cfg.Workspaces,
-		Renderer:        deps.Renderer,
-		Bus:             deps.Bus,
+		Cfg:                 cfg,
+		Service:             service,
+		Handler:             handler,
+		TerminalManager:     deps.TerminalManager,
+		PluginManager:       deps.PluginManager,
+		LocalRemote:         opts.LocalRemote,
+		Workspaces:          cfg.Workspaces,
+		Renderer:            deps.Renderer,
+		Bus:                 deps.Bus,
+		KVStore:             deps.KVStore,
+		HookFreshnessWindow: cfg.Plugins.Claude.GetHookFreshnessWindow(),
 	})
 
 	// Wire handler lookups through sessions view stores

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -867,9 +867,11 @@ func (m Model) handleTodoPanelKey(keyStr string) (tea.Model, tea.Cmd) {
 			m.todoBadge.clearPendingWithOpen(m.modals.TodoPanel.OpenCount())
 			m.modals.DismissTodoPanel()
 			return m, m.executeAction(act.Action{
-				Type:        act.TypeTmuxOpen,
-				SessionName: found.Name,
-				SessionPath: found.Path,
+				Type:          act.TypeTmuxOpen,
+				SessionID:     found.ID,
+				SessionName:   found.Name,
+				SessionPath:   found.Path,
+				SessionRemote: found.Remote,
 			})
 		case "review":
 			if m.reviewView != nil {

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/rs/zerolog/log"
 
+	corekv "github.com/colonyops/hive/internal/core/kv"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
 )
@@ -43,7 +44,8 @@ type TerminalStatusBatchCompleteMsg struct {
 type TerminalPollTickMsg struct{}
 
 // FetchTerminalStatusBatch returns a command that fetches terminal status for multiple sessions.
-func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int) tea.Cmd {
+// kvStore and freshnessWindow are optional: if kvStore is nil the hook KV check is skipped.
+func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int, kvStore corekv.KV, freshnessWindow time.Duration) tea.Cmd {
 	if len(sessions) == 0 || !mgr.HasEnabledIntegrations() {
 		return nil
 	}
@@ -74,7 +76,7 @@ func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session
 				ctx, cancel := context.WithTimeout(context.Background(), terminalStatusTimeout)
 				defer cancel()
 
-				status := fetchTerminalStatusForSession(ctx, mgr, s)
+				status := fetchTerminalStatusForSession(ctx, mgr, s, kvStore, freshnessWindow)
 
 				mu.Lock()
 				results[s.ID] = status
@@ -88,9 +90,24 @@ func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session
 }
 
 // fetchTerminalStatusForSession fetches terminal status for a single session.
-func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, sess *session.Session) TerminalStatus {
+// If kvStore is non-nil, hook-sourced status is checked first; tmux is used as fallback.
+func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, sess *session.Session, kvStore corekv.KV, freshnessWindow time.Duration) TerminalStatus {
 	status := TerminalStatus{
 		Status: terminal.StatusMissing,
+	}
+
+	// Check hook KV before issuing tmux commands. A fresh hook entry means the
+	// agent is alive and reporting status directly — no tmux capture needed.
+	if kvStore != nil {
+		hookKV := corekv.Scoped[terminal.HookStatus](kvStore, "hook.status")
+		if hs, err := hookKV.Get(ctx, sess.ID+":0"); err == nil {
+			if time.Since(hs.WrittenAt) < freshnessWindow {
+				return TerminalStatus{
+					Status: hs.Status,
+					Tool:   terminal.ToolClaude,
+				}
+			}
+		}
 	}
 
 	// Inject session path into metadata for multi-window disambiguation
@@ -136,11 +153,19 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 		} else if len(allInfos) > 1 {
 			windows := make([]WindowStatus, 0, len(allInfos))
 			for _, wi := range allInfos {
-				// Get per-window status and content
 				wStatus, wErr := integration.GetStatus(ctx, wi)
 				if wErr != nil {
 					log.Debug().Err(wErr).Str("session", sess.Slug).Str("window", wi.Pane).Msg("per-window status failed, marking missing")
 					wStatus = terminal.StatusMissing
+				}
+				// Override per-window status with fresh hook KV if available.
+				if kvStore != nil {
+					hookKV := corekv.Scoped[terminal.HookStatus](kvStore, "hook.status")
+					if hs, err := hookKV.Get(ctx, sess.ID+":"+wi.Pane); err == nil {
+						if time.Since(hs.WrittenAt) < freshnessWindow {
+							wStatus = hs.Status
+						}
+					}
 				}
 				windows = append(windows, WindowStatus{
 					WindowIndex: wi.Pane,

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -96,20 +96,6 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 		Status: terminal.StatusMissing,
 	}
 
-	// Check hook KV before issuing tmux commands. A fresh hook entry means the
-	// agent is alive and reporting status directly — no tmux capture needed.
-	if kvStore != nil {
-		hookKV := corekv.Scoped[terminal.HookStatus](kvStore, "hook.status")
-		if hs, err := hookKV.Get(ctx, sess.ID+":0"); err == nil {
-			if time.Since(hs.WrittenAt) < freshnessWindow {
-				return TerminalStatus{
-					Status: hs.Status,
-					Tool:   terminal.ToolClaude,
-				}
-			}
-		}
-	}
-
 	// Inject session path into metadata for multi-window disambiguation
 	metadata := sess.Metadata
 	if sess.Path != "" {

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -17,6 +17,7 @@ import (
 	act "github.com/colonyops/hive/internal/core/action"
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/eventbus"
+	corekv "github.com/colonyops/hive/internal/core/kv"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/core/terminal"
@@ -46,10 +47,12 @@ type ViewOpts struct {
 	PluginManager   *plugins.Manager
 
 	// Optional — nil disables the corresponding feature.
-	LocalRemote string
-	Workspaces  []string
-	Renderer    *tmpl.Renderer
-	Bus         *eventbus.EventBus
+	LocalRemote         string
+	Workspaces          []string
+	Renderer            *tmpl.Renderer
+	Bus                 *eventbus.EventBus
+	KVStore             corekv.KV
+	HookFreshnessWindow time.Duration
 }
 
 // View is the Bubble Tea sub-model for the sessions tab.
@@ -74,11 +77,13 @@ type View struct {
 	gitWorkers  int
 
 	// Terminal integration
-	terminalManager    *terminal.Manager
-	terminalStatuses   *kv.Store[string, TerminalStatus]
-	previewEnabled     bool
-	previewTemplates   *PreviewTemplates
-	currentTmuxSession string
+	terminalManager     *terminal.Manager
+	terminalStatuses    *kv.Store[string, TerminalStatus]
+	kvStore             corekv.KV
+	hookFreshnessWindow time.Duration
+	previewEnabled      bool
+	previewTemplates    *PreviewTemplates
+	currentTmuxSession  string
 
 	// Plugin integration
 	pluginManager      *plugins.Manager
@@ -188,11 +193,13 @@ func New(opts ViewOpts) *View {
 		gitStatuses: gitStatuses,
 		gitWorkers:  cfg.Git.StatusWorkers,
 
-		terminalManager:    opts.TerminalManager,
-		terminalStatuses:   terminalStatuses,
-		previewEnabled:     cfg.Views.Sessions.PreviewEnabled,
-		previewTemplates:   previewTemplates,
-		currentTmuxSession: currentTmux,
+		terminalManager:     opts.TerminalManager,
+		terminalStatuses:    terminalStatuses,
+		kvStore:             opts.KVStore,
+		hookFreshnessWindow: opts.HookFreshnessWindow,
+		previewEnabled:      cfg.Views.Sessions.PreviewEnabled,
+		previewTemplates:    previewTemplates,
+		currentTmuxSession:  currentTmux,
 
 		pluginManager:      opts.PluginManager,
 		pluginStatuses:     pluginStatuses,
@@ -291,7 +298,7 @@ func (v *View) handleSessionsLoaded(msg sessionsLoadedMsg) tea.Cmd {
 		for i := range v.allSessions {
 			sessPtrs[i] = &v.allSessions[i]
 		}
-		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.kvStore, v.hookFreshnessWindow))
 	}
 	return tea.Batch(cmds...)
 }
@@ -344,7 +351,7 @@ func (v *View) handleTerminalPollTick() tea.Cmd {
 	for i := range allSess {
 		sessPtrs[i] = &v.allSessions[i]
 	}
-	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.kvStore, v.hookFreshnessWindow))
 	if v.terminalManager.HasEnabledIntegrations() {
 		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
 	}

--- a/main.go
+++ b/main.go
@@ -387,6 +387,7 @@ Run 'hive new' to create a new session from the current repository.`,
 	app = commands.NewHoneycombCmd(flags, hiveApp).Register(app)
 	app = commands.NewWorkspaceCmd(flags, hiveApp).Register(app)
 	app = commands.NewExperimentalCmd(flags, hiveApp).Register(app)
+	app = commands.NewHookHandlerCmd(flags).Register(app)
 
 	// Register TUI flags on root command
 	app.Flags = append(app.Flags, tuiCmd.Flags()...)

--- a/main.go
+++ b/main.go
@@ -388,6 +388,7 @@ Run 'hive new' to create a new session from the current repository.`,
 	app = commands.NewWorkspaceCmd(flags, hiveApp).Register(app)
 	app = commands.NewExperimentalCmd(flags, hiveApp).Register(app)
 	app = commands.NewHookHandlerCmd(flags).Register(app)
+	app = commands.NewInstallCmd(flags).Register(app)
 
 	// Register TUI flags on root command
 	app.Flags = append(app.Flags, tuiCmd.Flags()...)


### PR DESCRIPTION
## Purpose

Replace tmux terminal-capture polling with Claude Code lifecycle hooks for real-time agent status updates. Hooks fire instantly (SessionStart, UserPromptSubmit, Stop, etc.) and write status to the KV store; the TUI reads from there first, falling back to tmux capture only when hook data is absent or stale.

## Proposed Changes

  - `hive hook-handler`: hidden command called by Claude's hook system; resolves the Hive session via HIVE_SESSION_ID env var, tmux name, or CWD waterfall, then writes/deletes a KV status entry
  - `hive install claude`: idempotent installer that adds the 6 hook entries to \`~/.claude/settings.json\`
  - HIVE_SESSION_ID is injected into spawn commands at session open time so hook resolution is O(1) for Claude sessions
  - TUI reads hook KV status first with a configurable freshness window (default 2m), falling back to tmux capture

## Manual Verification

Prerequisites:
- \`hive install claude\` run (check \`~/.claude/settings.json\` has hooks)
- Session created with \`hive new\` so HIVE_SESSION_ID is in tmux env
- TUI open (\`hive\`)

Steps:
1. [ ] Verify \`~/.claude/settings.json\` has 6 hook entries after \`hive install claude\`
2. [ ] Run \`hive install claude\` again — confirm no duplicate entries (idempotency)
3. [ ] Open Claude in a hive session; observe TUI status column updates without tmux capture lag
4. [ ] Submit a prompt; confirm status transitions to Active/Working
5. [ ] Wait for Claude to finish; confirm status transitions to Idle/Waiting
6. [ ] Close Claude (\`/exit\`); confirm status falls back to tmux (hook key deleted)
7. [ ] Confirm \`HIVE_SESSION_ID\` is set in Claude's environment: \`echo \$HIVE_SESSION_ID\`
8. [ ] Check \`dev.log\` — hook-handler entries should appear with correct session IDs

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)