### PR TITLE
feat(tui): improve form input UX

### DIFF
--- a/internal/core/styles/styles.go
+++ b/internal/core/styles/styles.go
@@ -214,13 +214,9 @@ func SetTheme(p Palette) {
 		Foreground(ColorPrimary).
 		Bold(true)
 	FormFieldStyle = lipgloss.NewStyle().
-		Border(lipgloss.ThickBorder(), false, false, false, true).
-		BorderForeground(ColorMuted).
-		PaddingLeft(1)
+		PaddingLeft(2)
 	FormFieldFocusedStyle = lipgloss.NewStyle().
-		Border(lipgloss.ThickBorder(), false, false, false, true).
-		BorderForeground(ColorPrimary).
-		PaddingLeft(1)
+		PaddingLeft(2)
 
 	HelpDialogSectionStyle = lipgloss.NewStyle().
 		Foreground(ColorMuted).

--- a/internal/tui/components/form/dialog.go
+++ b/internal/tui/components/form/dialog.go
@@ -51,10 +51,6 @@ func (d *Dialog) Update(msg tea.Msg) (*Dialog, tea.Cmd) {
 	case "shift+tab":
 		return d.retreatFocus()
 	case "enter":
-		if d.isTextAreaFocused() {
-			// Let textarea handle enter for newline insertion
-			return d.updateFocusedField(msg)
-		}
 		return d.advanceFocus()
 	case "esc":
 		if d.isFocusedFieldFiltering() {
@@ -136,14 +132,6 @@ func (d *Dialog) updateFocusedField(msg tea.Msg) (*Dialog, tea.Cmd) {
 	var cmd tea.Cmd
 	d.fields[d.focusedField], cmd = d.fields[d.focusedField].Update(msg)
 	return d, cmd
-}
-
-func (d *Dialog) isTextAreaFocused() bool {
-	if len(d.fields) == 0 {
-		return false
-	}
-	_, ok := d.fields[d.focusedField].(*TextAreaField)
-	return ok
 }
 
 func (d *Dialog) isFocusedFieldFiltering() bool {

--- a/internal/tui/components/form/dialog_test.go
+++ b/internal/tui/components/form/dialog_test.go
@@ -78,7 +78,7 @@ func TestDialog(t *testing.T) {
 		assert.False(t, d.Submitted())
 	})
 
-	t.Run("enter advances focus on non-textarea", func(t *testing.T) {
+	t.Run("enter advances focus", func(t *testing.T) {
 		f1 := NewTextField("A", "", "")
 		f2 := NewTextField("B", "", "")
 		d := NewDialog("Test", []Field{f1, f2}, []string{"a", "b"})
@@ -88,7 +88,7 @@ func TestDialog(t *testing.T) {
 		assert.True(t, f2.Focused())
 	})
 
-	t.Run("enter on last non-textarea field submits", func(t *testing.T) {
+	t.Run("enter on last field submits", func(t *testing.T) {
 		f1 := NewTextField("A", "", "")
 		d := NewDialog("Test", []Field{f1}, []string{"a"})
 
@@ -96,15 +96,14 @@ func TestDialog(t *testing.T) {
 		assert.True(t, d.Submitted())
 	})
 
-	t.Run("enter on textarea does not advance", func(t *testing.T) {
+	t.Run("enter on textarea advances focus", func(t *testing.T) {
 		f1 := NewTextAreaField("Body", "", "")
 		f2 := NewTextField("Name", "", "")
 		d := NewDialog("Test", []Field{f1, f2}, []string{"body", "name"})
 
-		// Enter should be forwarded to textarea, not advance focus
 		d.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-		assert.True(t, f1.Focused())
-		assert.False(t, f2.Focused())
+		assert.False(t, f1.Focused())
+		assert.True(t, f2.Focused())
 		assert.False(t, d.Submitted())
 	})
 

--- a/internal/tui/components/form/text_field.go
+++ b/internal/tui/components/form/text_field.go
@@ -30,6 +30,7 @@ func NewTextField(label, placeholder, defaultVal string) *TextField {
 	inputStyles.Focused.Placeholder = lipgloss.NewStyle().Foreground(styles.ColorMuted)
 	inputStyles.Blurred.Placeholder = lipgloss.NewStyle().Foreground(styles.ColorMuted)
 	ti.SetStyles(inputStyles)
+	ti.KeyMap.Paste.SetEnabled(true)
 
 	return &TextField{
 		input: ti,

--- a/internal/tui/components/form/textarea_field.go
+++ b/internal/tui/components/form/textarea_field.go
@@ -20,6 +20,11 @@ func NewTextAreaField(label, placeholder, defaultVal string) *TextAreaField {
 	ta.Placeholder = placeholder
 	ta.SetHeight(4)
 	ta.SetWidth(40)
+	ta.ShowLineNumbers = false
+	// InsertNewline is disabled so Enter advances the form rather than inserting a newline.
+	// Multi-line content can still be pasted.
+	ta.KeyMap.InsertNewline.SetEnabled(false)
+	ta.KeyMap.Paste.SetEnabled(true)
 
 	if defaultVal != "" {
 		ta.SetValue(defaultVal)


### PR DESCRIPTION
## Summary

- Enter now always submits/advances focus in forms, including when a textarea field is focused
- Textarea fields no longer show line numbers or the left thick-border
- Paste enabled in all form fields (text and textarea)
- Form field styles simplified: left `ThickBorder` removed, replaced with padding

## Test plan

- [ ] Form with a textarea field: press Enter to confirm it advances to next field / submits
- [ ] Form with a textarea field: paste multi-line content to confirm it works
- [ ] Form with a text field: paste content to confirm it works
- [ ] Verify no line numbers visible in textarea fields
- [ ] Verify the left border line is gone from form fields