### PR TITLE
fix(tmux): drop unsafe slug prefix-match in session discovery

### DIFF
--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -235,7 +235,7 @@ func (t *Integration) matchesPreferredWindow(windowName string) bool {
 // sessionPathKey is the metadata key injected by the TUI to pass session path for multi-window matching.
 const sessionPathKey = "_session_path"
 
-// findSessionCache locates the sessionCache for a slug using metadata, exact match, or prefix match.
+// findSessionCache locates the sessionCache for a slug using metadata or exact match.
 // Must be called with t.mu held (read or write). Returns the session name and cache, or ("", nil).
 func (t *Integration) findSessionCache(slug string, metadata map[string]string) (string, *sessionCache) {
 	if name := metadata[session.MetaTmuxSession]; name != "" {
@@ -245,11 +245,6 @@ func (t *Integration) findSessionCache(slug string, metadata map[string]string) 
 	}
 	if sc, exists := t.cache[slug]; exists {
 		return slug, sc
-	}
-	for name, sc := range t.cache {
-		if strings.HasPrefix(name, slug+"_") || strings.HasPrefix(name, slug+"-") {
-			return name, sc
-		}
 	}
 	return "", nil
 }

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -286,23 +286,35 @@ func TestDiscoverAllWindows(t *testing.T) {
 		assert.Nil(t, infos, "expected nil with stale cache, got %v", infos)
 	})
 
-	t.Run("prefix match finds session", func(t *testing.T) {
-		// Add a session keyed with a slug prefix
-		integ.cache["myslug-extra"] = &sessionCache{
+	t.Run("does not cross-match similar slugs", func(t *testing.T) {
+		// Regression: tmux sessions with similar slug prefixes from different
+		// hive sessions must not be matched when the exact slug is missing.
+		// e.g. hive session "foo" (slug "foo") whose tmux session is gone must
+		// not pick up tmux session "foo-bar" belonging to hive session "foo bar".
+		integ.cache["foo-bar"] = &sessionCache{
 			agentWindows: []*agentWindow{
 				{windowIndex: "0", windowName: "claude"},
-				{windowIndex: "1", windowName: "aider"},
 			},
 		}
 		integ.cacheTime = time.Now()
 
-		infos, err := integ.DiscoverAllWindows(ctx, "myslug", nil)
+		infos, err := integ.DiscoverAllWindows(ctx, "foo", nil)
 		require.NoError(t, err)
-		require.Len(t, infos, 2, "expected 2 windows via prefix match, got %d", len(infos))
-		assert.Equal(t, "myslug-extra", infos[0].Name)
+		assert.Nil(t, infos, "expected nil — slug 'foo' must not match tmux session 'foo-bar'")
 	})
 
-	t.Run("metadata match takes precedence over prefix", func(t *testing.T) {
+	t.Run("hyphenated slug still found by exact match", func(t *testing.T) {
+		// Regression sibling: ensure removing the prefix-match fallback did not
+		// break the normal path where session "foo bar" (slug "foo-bar") finds
+		// its own tmux session "foo-bar".
+		integ.cacheTime = time.Now()
+		infos, err := integ.DiscoverAllWindows(ctx, "foo-bar", nil)
+		require.NoError(t, err)
+		require.Len(t, infos, 1, "expected 1 window for slug 'foo-bar'")
+		assert.Equal(t, "foo-bar", infos[0].Name)
+	})
+
+	t.Run("metadata match still works", func(t *testing.T) {
 		integ.cacheTime = time.Now()
 		infos, err := integ.DiscoverAllWindows(ctx, "myslug", map[string]string{
 			"tmux_session": "multi-sess",

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -1081,12 +1081,6 @@ func (v *View) isCurrentTmuxSession(sess *session.Session) bool {
 		return true
 	}
 
-	// Check prefix match (tmux session might be slug_suffix or slug-suffix)
-	if strings.HasPrefix(v.currentTmuxSession, sess.Slug+"_") ||
-		strings.HasPrefix(v.currentTmuxSession, sess.Slug+"-") {
-		return true
-	}
-
 	if tmuxSession := sess.Metadata[session.MetaTmuxSession]; tmuxSession != "" {
 		if v.currentTmuxSession == tmuxSession {
 			return true


### PR DESCRIPTION
## Summary
- `findSessionCache` fell back to a prefix scan (`slug+"_"` / `slug+"-"`) when no exact cache entry matched. When a hive session's tmux session was missing or not yet cached, the scan would grab another hive session's tmux cache whose name happened to start with the same prefix — e.g. slug `foo` picking up tmux session `foo-bar`. Result: two distinct hive sessions in different repos visually collapsed into one tmux session with two entry points in the tree.
- Drop the prefix-match fallback in `findSessionCache` and the same-class fallback in the TUI's `isCurrentTmuxSession`. Slug exact match + the `MetaTmuxSession` metadata path remain.
- Hive always creates tmux sessions named exactly by slug (`spawner.go:86`), so exact match covers the normal flow. The metadata path is the escape hatch for renamed tmux sessions.

## Test plan
- [ ] `mise run check` passes (tidy + lint + test)
- [ ] New regression test `TestDiscoverAllWindows/does_not_cross-match_similar_slugs` passes
- [ ] New test `TestDiscoverAllWindows/hyphenated_slug_still_found_by_exact_match` passes
- [ ] Manual: in `mise container`, create hive session `foo` in one repo and `foo bar` in another; kill the `foo` tmux session externally; confirm hive session `foo` no longer renders `foo-bar`'s windows nested under it