### PR TITLE
feat(tui): mouse click and double-click support

### DIFF
--- a/.github/workflows/partial-tests.yml
+++ b/.github/workflows/partial-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.4
           args: --timeout=6m
 
       - name: Build

--- a/internal/tui/hc_only.go
+++ b/internal/tui/hc_only.go
@@ -368,5 +368,7 @@ func (m HoneycombOnlyModel) View() tea.View {
 	if m.helpDialog != nil {
 		content = m.helpDialog.Overlay(content, m.width, m.height)
 	}
-	return tea.NewView(content)
+	v := tea.NewView(content)
+	v.MouseMode = tea.MouseModeCellMotion
+	return v
 }

--- a/internal/tui/kv_view.go
+++ b/internal/tui/kv_view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/colonyops/hive/internal/core/kv"
 	"github.com/colonyops/hive/internal/core/styles"
@@ -76,6 +77,34 @@ func (v *KVView) SelectedKey() string {
 		return ""
 	}
 	return v.keys[v.filtered[v.cursor]]
+}
+
+// SelectAtRow moves the cursor to the key at contentY rows from the view top.
+// The key list renders a one-line header and, when filtering is active, a filter line.
+// Clicks in the preview pane (right of the key list) are ignored.
+func (v *KVView) SelectAtRow(x, contentY int) tea.Cmd {
+	// Key list occupies 20% of width (min 15), matching View().
+	listWidth := int(float64(v.width) * 0.20)
+	if listWidth < 15 {
+		listWidth = 15
+	}
+	if x >= listWidth {
+		return nil
+	}
+	headerRows := 1 // "Keys" header
+	if v.filtering || v.filter != "" {
+		headerRows = 2 // header + filter line
+	}
+	listRow := contentY - headerRows
+	if listRow < 0 || len(v.filtered) == 0 {
+		return nil
+	}
+	idx := v.offset + listRow
+	if idx >= len(v.filtered) {
+		return nil
+	}
+	v.cursor = idx
+	return nil
 }
 
 // MoveUp moves the cursor up in the key list.

--- a/internal/tui/kv_view_test.go
+++ b/internal/tui/kv_view_test.go
@@ -1,0 +1,83 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newKVViewWithKeys creates a KVView preloaded with the given keys.
+func newKVViewWithKeys(keys []string) *KVView {
+	v := NewKVView()
+	v.SetSize(100, 24)
+	v.SetKeys(keys)
+	return v
+}
+
+// --- SelectAtRow ---
+
+func TestKVView_SelectAtRow_ClickInPreview_NoOp(t *testing.T) {
+	v := newKVViewWithKeys([]string{"key-a", "key-b", "key-c"})
+	// listWidth = int(100 * 0.20) = 20; x=50 >= 20 → no-op
+	v.SelectAtRow(50, 1)
+	assert.Equal(t, 0, v.cursor, "click in preview pane should be no-op")
+}
+
+func TestKVView_SelectAtRow_HeaderRow_NoOp(t *testing.T) {
+	v := newKVViewWithKeys([]string{"key-a", "key-b", "key-c"})
+	// headerRows=1 (no filter); listRow = contentY - 1 = -1 → no-op
+	v.SelectAtRow(0, 0)
+	assert.Equal(t, 0, v.cursor, "clicking header row (contentY=0) should be no-op")
+}
+
+func TestKVView_SelectAtRow_HappyPath(t *testing.T) {
+	v := newKVViewWithKeys([]string{"key-a", "key-b", "key-c"})
+	// headerRows=1; contentY=1 → listRow=0, idx=offset+0=0
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 0, v.cursor, "contentY=1 should select cursor=0")
+
+	// contentY=2 → listRow=1, idx=1
+	v.SelectAtRow(0, 2)
+	assert.Equal(t, 1, v.cursor, "contentY=2 should select cursor=1")
+}
+
+func TestKVView_SelectAtRow_FilterActive_FilterLineIsNoOp(t *testing.T) {
+	v := newKVViewWithKeys([]string{"alpha", "beta", "gamma"})
+	v.StartFilter()
+	v.AddFilterRune('a')
+
+	// headerRows=2 (header + filter line); contentY=1 → listRow=-1 → no-op
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 0, v.cursor, "contentY=1 (filter line) should be no-op when filter active")
+}
+
+func TestKVView_SelectAtRow_FilterActive_ContentY2_SelectsFirst(t *testing.T) {
+	v := newKVViewWithKeys([]string{"alpha", "beta", "gamma"})
+	v.StartFilter()
+	v.AddFilterRune('a') // matches "alpha" and "gamma" (2 items)
+
+	require.NotEmpty(t, v.filtered, "filter should produce at least one match")
+
+	// headerRows=2; contentY=2 → listRow=0, idx=0
+	v.SelectAtRow(0, 2)
+	assert.Equal(t, 0, v.cursor, "contentY=2 should select first filtered item")
+}
+
+func TestKVView_SelectAtRow_EmptyFiltered_NoOp(t *testing.T) {
+	v := newKVViewWithKeys([]string{"alpha", "beta"})
+	v.StartFilter()
+	v.AddFilterRune('z') // no matches
+
+	require.Empty(t, v.filtered, "filter should produce no matches")
+
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 0, v.cursor, "no-op when filtered list is empty")
+}
+
+func TestKVView_SelectAtRow_BeyondFiltered_NoOp(t *testing.T) {
+	v := newKVViewWithKeys([]string{"key-a"})
+	// filtered has 1 entry; contentY=10 → idx=9 >= 1 → no-op
+	v.SelectAtRow(0, 10)
+	assert.Equal(t, 0, v.cursor, "row beyond filtered items should be no-op")
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -154,6 +154,10 @@ type Model struct {
 
 	// Startup warnings to show as toasts after init
 	startupWarnings []string
+
+	// Double-click tracking: last left-button click position and time.
+	lastClickX, lastClickY int
+	lastClickTime          time.Time
 }
 
 // actionCompleteMsg is sent when an action completes.
@@ -626,6 +630,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		model, cmd = m.handleKeyMsg(msg)
 	case spinner.TickMsg:
 		model, cmd = m.handleSpinnerTick(msg)
+	case tea.MouseClickMsg:
+		model, cmd = m.handleMouseClick(msg)
+	case tea.MouseWheelMsg:
+		if m.state == stateShowingNotifications && m.modals.Notification != nil {
+			if msg.Button == tea.MouseWheelUp {
+				m.modals.Notification.ScrollUp()
+			} else {
+				m.modals.Notification.ScrollDown()
+			}
+			model, cmd = m, nil
+		} else {
+			model, cmd = m.handleFallthrough(msg)
+		}
+	case tea.PasteMsg:
+		model, cmd = m.handleFallthrough(msg)
 
 	default:
 		model, cmd = m.handleFallthrough(msg)
@@ -1418,35 +1437,7 @@ func (m Model) handleTabKey(direction int) (tea.Model, tea.Cmd) {
 	}
 
 	next := (current + direction + len(tabs)) % len(tabs)
-	m.activeView = tabs[next]
-
-	m.handler.SetActiveView(m.activeView)
-	m.sessionsView.SetActive(m.activeView == ViewSessions)
-	if m.msgView != nil {
-		m.msgView.SetActive(m.activeView == ViewMessages)
-	}
-	if m.tasksView != nil {
-		m.tasksView.SetActive(m.activeView == ViewTasks)
-	}
-
-	// Load data when switching to Store or Tasks tab
-	switch m.activeView {
-	case ViewStore:
-		return m, m.loadKVKeys()
-	case ViewTasks:
-		if cmd := m.syncTasksRepoFromSessions(); cmd != nil {
-			return m, cmd
-		}
-		return m, func() tea.Msg { return tasks.RefreshTasksMsg{} }
-	case ViewReview:
-		if cmd := m.syncDocsRepoFromSessions(); cmd != nil {
-			return m, cmd
-		}
-	case ViewSessions, ViewMessages:
-		// No special load action needed
-	}
-
-	return m, nil
+	return m.switchToView(tabs[next])
 }
 
 // renameCompleteMsg is sent when a rename operation completes.

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -1067,6 +1067,137 @@ func (m Model) handleFallthrough(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+const doubleClickWindow = 300 * time.Millisecond
+
+// handleMouseClick routes left-button clicks to the active view or tab bar.
+// Two clicks within doubleClickWindow at the same cell synthesize an Enter key press.
+func (m Model) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	if msg.Button != tea.MouseLeft || m.isModalActive() {
+		return m, nil
+	}
+
+	// Tab bar is at terminal row 1 (topDivider=0, header=1, headerDivider=2).
+	if msg.Y == 1 {
+		return m.handleTabClick(msg.X)
+	}
+
+	const tabChrome = 3
+	contentY := msg.Y - tabChrome
+	if contentY < 0 {
+		return m, nil
+	}
+
+	// Detect double-click: same cell within the window.
+	now := time.Now()
+	isDouble := msg.X == m.lastClickX && msg.Y == m.lastClickY &&
+		now.Sub(m.lastClickTime) <= doubleClickWindow
+	m.lastClickX = msg.X
+	m.lastClickY = msg.Y
+	m.lastClickTime = now
+
+	if isDouble {
+		return m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	}
+
+	var cmd tea.Cmd
+	switch m.activeView {
+	case ViewSessions:
+		if m.sessionsView != nil {
+			cmd = m.sessionsView.SelectAtRow(msg.X, contentY)
+		}
+	case ViewTasks:
+		if m.tasksView != nil {
+			cmd = m.tasksView.SelectAtRow(msg.X, contentY)
+		}
+	case ViewMessages:
+		if m.msgView != nil {
+			cmd = m.msgView.SelectAtRow(msg.X, contentY)
+		}
+	case ViewReview:
+		if m.reviewView != nil {
+			cmd = m.reviewView.SelectAtRow(msg.X, contentY)
+		}
+	case ViewStore:
+		if m.kvView != nil {
+			cmd = m.kvView.SelectAtRow(msg.X, contentY)
+		}
+	}
+	return m, cmd
+}
+
+// switchToView activates the given view, updating all per-view active flags and
+// firing any data-load commands required on first entry. This is the single
+// source of truth for view switching used by both keyboard (tab key) and mouse
+// (tab bar click).
+func (m Model) switchToView(view ViewType) (tea.Model, tea.Cmd) {
+	m.lastClickTime = time.Time{} // reset double-click state across view changes
+	m.activeView = view
+	m.handler.SetActiveView(view)
+	m.sessionsView.SetActive(view == ViewSessions)
+	if m.msgView != nil {
+		m.msgView.SetActive(view == ViewMessages)
+	}
+	if m.tasksView != nil {
+		m.tasksView.SetActive(view == ViewTasks)
+	}
+
+	switch view {
+	case ViewStore:
+		return m, m.loadKVKeys()
+	case ViewTasks:
+		if cmd := m.syncTasksRepoFromSessions(); cmd != nil {
+			return m, cmd
+		}
+		return m, func() tea.Msg { return tasks.RefreshTasksMsg{} }
+	case ViewReview:
+		if cmd := m.syncDocsRepoFromSessions(); cmd != nil {
+			return m, cmd
+		}
+	case ViewSessions, ViewMessages:
+		// No data load needed on switch.
+	}
+	return m, nil
+}
+
+// handleTabClick switches the active view based on which tab label was clicked at column x.
+// Tab labels start at column 1 (one-space left margin) and are separated by " | " (3 cols).
+func (m Model) handleTabClick(x int) (tea.Model, tea.Cmd) {
+	showStoreTab := m.kvStore != nil && m.cfg.TUI.Store
+
+	type tabEntry struct {
+		view  ViewType
+		label string
+	}
+	tabs := []tabEntry{{ViewSessions, "Sessions"}}
+	if m.tasksView != nil {
+		tabs = append(tabs, tabEntry{ViewTasks, "Tasks"})
+	}
+	if m.reviewView != nil {
+		tabs = append(tabs, tabEntry{ViewReview, "Docs"})
+	}
+	tabs = append(tabs, tabEntry{ViewMessages, "Messages"})
+	if showStoreTab || m.activeView == ViewStore {
+		tabs = append(tabs, tabEntry{ViewStore, "Store"})
+	}
+
+	const (
+		leftMargin = 1
+		sepWidth   = 3 // " | "
+	)
+	pos := leftMargin
+	for i, t := range tabs {
+		w := len(t.label) // styles use no padding/borders, so visual width == len
+		if x >= pos && x < pos+w {
+			return m.switchToView(t.view)
+		}
+		pos += w
+		if i < len(tabs)-1 {
+			pos += sepWidth
+		}
+	}
+	return m, nil
+}
+
 // --- Helper for repo header opening ---
 
 func (m Model) openRepoHeaderByRemote(name, remote string) (tea.Model, tea.Cmd) {

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -1,0 +1,380 @@
+package tui
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/colonyops/hive/internal/core/config"
+	"github.com/colonyops/hive/internal/core/eventbus/testbus"
+	"github.com/colonyops/hive/internal/core/git"
+	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/internal/hive"
+	"github.com/colonyops/hive/internal/hive/plugins"
+	"github.com/colonyops/hive/internal/tui/views/sessions"
+	"github.com/colonyops/hive/pkg/executil"
+	"github.com/colonyops/hive/pkg/tmpl"
+)
+
+// --- minimal mock implementations for sessions.View construction ---
+
+type mouseTestStore struct{}
+
+func (s *mouseTestStore) List(_ context.Context) ([]session.Session, error) { return nil, nil }
+func (s *mouseTestStore) Get(_ context.Context, _ string) (session.Session, error) {
+	return session.Session{}, session.ErrNotFound
+}
+func (s *mouseTestStore) Save(_ context.Context, _ session.Session) error { return nil }
+func (s *mouseTestStore) Delete(_ context.Context, _ string) error        { return nil }
+
+type mouseTestGit struct{}
+
+func (g *mouseTestGit) Clone(_ context.Context, _, _ string) error                { return nil }
+func (g *mouseTestGit) Checkout(_ context.Context, _, _ string) error             { return nil }
+func (g *mouseTestGit) Pull(_ context.Context, _ string) error                    { return nil }
+func (g *mouseTestGit) ResetHard(_ context.Context, _ string) error               { return nil }
+func (g *mouseTestGit) RemoteURL(_ context.Context, _ string) (string, error)     { return "", nil }
+func (g *mouseTestGit) IsClean(_ context.Context, _ string) (bool, error)         { return true, nil }
+func (g *mouseTestGit) Branch(_ context.Context, _ string) (string, error)        { return "main", nil }
+func (g *mouseTestGit) DefaultBranch(_ context.Context, _ string) (string, error) { return "main", nil }
+func (g *mouseTestGit) DiffStats(_ context.Context, _ string) (int, int, error)   { return 0, 0, nil }
+func (g *mouseTestGit) IsValidRepo(_ context.Context, _ string) error             { return nil }
+func (g *mouseTestGit) CloneBare(_ context.Context, _, _ string) error            { return nil }
+func (g *mouseTestGit) WorktreeAdd(_ context.Context, _, _, _ string) error       { return nil }
+func (g *mouseTestGit) WorktreeRemove(_ context.Context, _, _, _ string) error    { return nil }
+func (g *mouseTestGit) WorktreeReset(_ context.Context, _, _ string) error        { return nil }
+func (g *mouseTestGit) Fetch(_ context.Context, _ string) error                   { return nil }
+func (g *mouseTestGit) HasUnpushedCommits(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
+type mouseTestExec struct{}
+
+func (e *mouseTestExec) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (e *mouseTestExec) RunDir(_ context.Context, _, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (e *mouseTestExec) RunStream(_ context.Context, _, _ io.Writer, _ string, _ ...string) error {
+	return nil
+}
+
+func (e *mouseTestExec) RunDirStream(_ context.Context, _ string, _, _ io.Writer, _ string, _ ...string) error {
+	return nil
+}
+
+var (
+	_ session.Store     = (*mouseTestStore)(nil)
+	_ git.Git           = (*mouseTestGit)(nil)
+	_ executil.Executor = (*mouseTestExec)(nil)
+)
+
+// newMouseTestSessionService creates a minimal SessionService for mouse tests.
+func newMouseTestSessionService(t *testing.T) *hive.SessionService {
+	t.Helper()
+	tb := testbus.New(t)
+	log := zerolog.New(io.Discard)
+	r := tmpl.New(tmpl.Config{})
+	return hive.NewSessionService(
+		&mouseTestStore{},
+		&mouseTestGit{},
+		&config.Config{DataDir: t.TempDir(), GitPath: "git"},
+		tb.EventBus,
+		&mouseTestExec{},
+		r,
+		log,
+		io.Discard,
+		io.Discard,
+	)
+}
+
+// newMouseTestSessionsView builds a minimal sessions.View for mouse tests.
+func newMouseTestSessionsView(t *testing.T) *sessions.View {
+	t.Helper()
+	svc := newMouseTestSessionService(t)
+	cfg := &config.Config{}
+	handler := NewKeybindingResolver(nil, nil, testRenderer)
+	mgr := terminal.NewManager(nil)
+	pm := plugins.NewManager(config.PluginsConfig{})
+	return sessions.New(sessions.ViewOpts{
+		Cfg:             cfg,
+		Service:         svc,
+		Handler:         handler,
+		TerminalManager: mgr,
+		PluginManager:   pm,
+	})
+}
+
+// newBaseMouseModel returns a minimal Model with the required fields set for mouse tests.
+// It has a real sessionsView so switchToView doesn't panic, and a non-nil kvView so
+// handleKey doesn't dereference a nil pointer when dispatching Enter on a double-click.
+func newBaseMouseModel(t *testing.T) Model {
+	t.Helper()
+	handler := NewKeybindingResolver(nil, map[string]config.UserCommand{}, testRenderer)
+	return Model{
+		cfg:             &config.Config{},
+		activeView:      ViewSessions,
+		handler:         handler,
+		modals:          NewModalCoordinator(),
+		toastController: NewToastController(),
+		sessionsView:    newMouseTestSessionsView(t),
+		kvView:          NewKVView(),
+	}
+}
+
+// --- handleMouseClick tests ---
+
+func TestHandleMouseClick_NonLeftButton_NoOp(t *testing.T) {
+	m := newBaseMouseModel(t)
+	initialView := m.activeView
+
+	for _, btn := range []tea.MouseButton{tea.MouseRight, tea.MouseMiddle} {
+		result, cmd := m.handleMouseClick(tea.MouseClickMsg{Button: btn, X: 5, Y: 1})
+		rm := result.(Model)
+		assert.Equal(t, initialView, rm.activeView, "non-left button should not change view")
+		assert.Nil(t, cmd, "non-left button should return nil cmd")
+	}
+}
+
+func TestHandleMouseClick_ModalActive_NoOp(t *testing.T) {
+	m := newBaseMouseModel(t)
+	m.state = stateConfirming // modal active
+	initialView := m.activeView
+
+	result, cmd := m.handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: 5, Y: 1})
+	rm := result.(Model)
+	assert.Equal(t, initialView, rm.activeView, "modal active should not change view")
+	assert.Nil(t, cmd, "modal active should return nil cmd")
+}
+
+func TestHandleMouseClick_TopDivider_NoOp(t *testing.T) {
+	// Y=0 → topDivider, contentY = 0 - 3 = -3 < 0 → no-op
+	m := newBaseMouseModel(t)
+	initialView := m.activeView
+
+	result, cmd := m.handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: 5, Y: 0})
+	rm := result.(Model)
+	assert.Equal(t, initialView, rm.activeView, "Y=0 should be a no-op")
+	assert.Nil(t, cmd, "Y=0 should return nil cmd")
+}
+
+func TestHandleMouseClick_TabBar_DelegatesTabClick(t *testing.T) {
+	// Y=1 is the tab bar; x=12 falls in "Messages" label → ViewMessages
+	m := newBaseMouseModel(t)
+
+	result, _ := m.handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: 12, Y: 1})
+	rm := result.(Model)
+	assert.Equal(t, ViewMessages, rm.activeView, "Y=1 with x in Messages tab should switch to ViewMessages")
+}
+
+func TestHandleMouseClick_FirstClick_TracksPosition(t *testing.T) {
+	m := newBaseMouseModel(t)
+	require.True(t, m.lastClickTime.IsZero(), "lastClickTime should be zero initially")
+
+	result, _ := m.handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: 3, Y: 5})
+	rm := result.(Model)
+
+	assert.Equal(t, 3, rm.lastClickX, "lastClickX should be updated")
+	assert.Equal(t, 5, rm.lastClickY, "lastClickY should be updated")
+	assert.False(t, rm.lastClickTime.IsZero(), "lastClickTime should be set after first click")
+}
+
+func TestHandleMouseClick_ExpiredDoubleClick_NotDoubleClick(t *testing.T) {
+	// Set up a prior click more than 300ms ago at the same position.
+	m := newBaseMouseModel(t)
+	m.lastClickX = 3
+	m.lastClickY = 5
+	m.lastClickTime = time.Now().Add(-500 * time.Millisecond) // expired
+
+	// Second click at same position, but outside the window → not double-click → SelectAtRow path
+	result, _ := m.handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: 3, Y: 5})
+	rm := result.(Model)
+
+	// The click should update tracking state, not enter the double-click branch.
+	assert.Equal(t, 3, rm.lastClickX)
+	assert.Equal(t, 5, rm.lastClickY)
+	// lastClickTime should be refreshed to now (not the old expired value)
+	assert.Less(t, time.Since(rm.lastClickTime), time.Second, "lastClickTime should be refreshed")
+}
+
+func TestHandleMouseClick_DoubleClick_ResetsTracking(t *testing.T) {
+	// A double-click is within 300ms at the same cell.
+	// Because handleKeyMsg(Enter) on a quitting model short-circuits,
+	// we set m.quitting=true so the model exits cleanly without panicking.
+	m := newBaseMouseModel(t)
+	m.quitting = true // ensure handleKeyMsg returns cleanly
+	m.lastClickX = 3
+	m.lastClickY = 5
+	m.lastClickTime = time.Now() // recent click → will trigger double-click
+
+	// Second click at same position within 300ms window
+	result, _ := m.handleMouseClick(tea.MouseClickMsg{Button: tea.MouseLeft, X: 3, Y: 5})
+	rm := result.(Model)
+
+	// After double-click, position tracking should be preserved (lastClickX/Y updated).
+	assert.Equal(t, 3, rm.lastClickX)
+	assert.Equal(t, 5, rm.lastClickY)
+}
+
+// --- handleTabClick tests ---
+
+// Tab layout (no tasksView / reviewView):
+//   left margin = 1
+//   "Sessions" (8 chars): x=1..8
+//   separator " | ": x=9..11
+//   "Messages" (8 chars): x=12..19
+//
+// (Store tab hidden when kvStore == nil and activeView != ViewStore)
+
+func TestHandleTabClick_Sessions(t *testing.T) {
+	tests := []struct {
+		name string
+		x    int
+	}{
+		{"first char", 1},
+		{"middle", 4},
+		{"last char", 8},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newBaseMouseModel(t)
+			m.activeView = ViewMessages // start elsewhere
+			result, _ := m.handleTabClick(tt.x)
+			rm := result.(Model)
+			assert.Equal(t, ViewSessions, rm.activeView, "x=%d should map to ViewSessions", tt.x)
+		})
+	}
+}
+
+func TestHandleTabClick_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		x    int
+	}{
+		{"first char", 12},
+		{"middle", 15},
+		{"last char", 19},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newBaseMouseModel(t)
+			m.activeView = ViewSessions // start elsewhere
+			result, _ := m.handleTabClick(tt.x)
+			rm := result.(Model)
+			assert.Equal(t, ViewMessages, rm.activeView, "x=%d should map to ViewMessages", tt.x)
+		})
+	}
+}
+
+func TestHandleTabClick_Separator_NoOp(t *testing.T) {
+	// Separator " | " occupies x=9..11
+	for _, x := range []int{9, 10, 11} {
+		m := newBaseMouseModel(t)
+		initial := m.activeView
+		result, cmd := m.handleTabClick(x)
+		rm := result.(Model)
+		assert.Equal(t, initial, rm.activeView, "separator x=%d should not change view", x)
+		assert.Nil(t, cmd, "separator x=%d should return nil cmd", x)
+	}
+}
+
+func TestHandleTabClick_PastAllLabels_NoOp(t *testing.T) {
+	// x=20 is past all labels (Sessions=8, sep=3, Messages=8 → total 19)
+	m := newBaseMouseModel(t)
+	initial := m.activeView
+	result, cmd := m.handleTabClick(20)
+	rm := result.(Model)
+	assert.Equal(t, initial, rm.activeView, "x past all labels should not change view")
+	assert.Nil(t, cmd, "x past all labels should return nil cmd")
+}
+
+func TestHandleTabClick_ZeroX_NoOp(t *testing.T) {
+	// x=0 is before the left margin (labels start at x=1)
+	m := newBaseMouseModel(t)
+	initial := m.activeView
+	result, cmd := m.handleTabClick(0)
+	rm := result.(Model)
+	assert.Equal(t, initial, rm.activeView, "x=0 (before margin) should not change view")
+	assert.Nil(t, cmd, "x=0 should return nil cmd")
+}
+
+// --- switchToView tests ---
+
+func TestSwitchToView_Sessions_NilCmd(t *testing.T) {
+	m := newBaseMouseModel(t)
+	m.activeView = ViewMessages
+
+	result, cmd := m.switchToView(ViewSessions)
+	rm := result.(Model)
+
+	assert.Equal(t, ViewSessions, rm.activeView)
+	assert.Nil(t, cmd, "switching to Sessions should return nil cmd")
+}
+
+func TestSwitchToView_Messages_NilCmd(t *testing.T) {
+	m := newBaseMouseModel(t)
+
+	result, cmd := m.switchToView(ViewMessages)
+	rm := result.(Model)
+
+	assert.Equal(t, ViewMessages, rm.activeView)
+	assert.Nil(t, cmd, "switching to Messages should return nil cmd")
+}
+
+func TestSwitchToView_Store_NonNilCmd(t *testing.T) {
+	m := newBaseMouseModel(t)
+	// kvStore is nil, so loadKVKeys returns nil — but we can verify the branch fires
+	// by checking activeView and that the loadKVKeys path was taken (cmd is nil when kvStore==nil).
+	result, _ := m.switchToView(ViewStore)
+	rm := result.(Model)
+	assert.Equal(t, ViewStore, rm.activeView)
+}
+
+func TestSwitchToView_Tasks_ReturnsCmd(t *testing.T) {
+	m := newBaseMouseModel(t)
+	// tasksView is nil, so syncTasksRepoFromSessions returns nil and we fall
+	// through to the RefreshTasksMsg func. Verify cmd is non-nil.
+	result, cmd := m.switchToView(ViewTasks)
+	rm := result.(Model)
+
+	assert.Equal(t, ViewTasks, rm.activeView)
+	require.NotNil(t, cmd, "switching to Tasks should return a RefreshTasksMsg cmd")
+
+	// Verify the cmd produces a message without panicking.
+	msg := cmd()
+	assert.NotNil(t, msg)
+}
+
+func TestSwitchToView_ResetsLastClickTime(t *testing.T) {
+	m := newBaseMouseModel(t)
+	m.lastClickTime = time.Now()
+
+	result, _ := m.switchToView(ViewMessages)
+	rm := result.(Model)
+
+	assert.True(t, rm.lastClickTime.IsZero(), "switchToView should reset lastClickTime to zero")
+}
+
+func TestSwitchToView_SessionsViewSetActive(t *testing.T) {
+	m := newBaseMouseModel(t)
+
+	// Switch to Sessions — sessionsView should become active.
+	result, _ := m.switchToView(ViewSessions)
+	rm := result.(Model)
+	assert.Equal(t, ViewSessions, rm.activeView)
+
+	// Switch away — sessionsView.active should be cleared (we verify via activeView).
+	result2, _ := rm.switchToView(ViewMessages)
+	rm2 := result2.(Model)
+	assert.Equal(t, ViewMessages, rm2.activeView)
+}

--- a/internal/tui/model_render.go
+++ b/internal/tui/model_render.go
@@ -34,6 +34,7 @@ func (m Model) View() tea.View {
 
 	v := tea.NewView(content)
 	v.AltScreen = true
+	v.MouseMode = tea.MouseModeCellMotion
 	return v
 }
 

--- a/internal/tui/repo_picker.go
+++ b/internal/tui/repo_picker.go
@@ -11,14 +11,15 @@ import (
 
 // RepoPicker is a simple modal for selecting a repository scope.
 type RepoPicker struct {
-	repos     []string
-	filtered  []string
-	cursor    int
-	query     string
-	width     int
-	height    int
-	cancelled bool
-	selected  string
+	repos        []string
+	filtered     []string
+	cursor       int
+	scrollOffset int
+	query        string
+	width        int
+	height       int
+	cancelled    bool
+	selected     string
 }
 
 // NewRepoPicker creates a new repository picker modal.
@@ -56,10 +57,12 @@ func (p *RepoPicker) Update(msg tea.Msg) (*RepoPicker, tea.Cmd) {
 	case "up":
 		if p.cursor > 0 {
 			p.cursor--
+			p.clampScroll()
 		}
 	case "down":
 		if p.cursor < len(p.filtered)-1 {
 			p.cursor++
+			p.clampScroll()
 		}
 	case "backspace":
 		if len(p.query) > 0 {
@@ -90,6 +93,22 @@ func (p *RepoPicker) applyFilter() {
 		p.filtered = filtered
 	}
 	p.cursor = 0
+	p.scrollOffset = 0
+}
+
+func (p *RepoPicker) visibleCount() int {
+	return min(len(p.filtered), max(p.height/3, 5))
+}
+
+func (p *RepoPicker) clampScroll() {
+	mv := p.visibleCount()
+	if p.cursor < p.scrollOffset {
+		p.scrollOffset = p.cursor
+	} else if p.cursor >= p.scrollOffset+mv {
+		p.scrollOffset = p.cursor - mv + 1
+	}
+	maxOffset := max(len(p.filtered)-mv, 0)
+	p.scrollOffset = min(max(p.scrollOffset, 0), maxOffset)
 }
 
 // View renders the picker content.
@@ -102,11 +121,15 @@ func (p *RepoPicker) View() string {
 	searchLine := styles.TextMutedStyle.Render("> ") + p.query + styles.TextMutedStyle.Render("█")
 
 	// List items
-	maxVisible := min(len(p.filtered), max(p.height/3, 5))
+	maxVisible := p.visibleCount()
 	var lines []string
-	for i := 0; i < maxVisible; i++ {
-		repo := p.filtered[i]
-		if i == p.cursor {
+	for i := range maxVisible {
+		idx := i + p.scrollOffset
+		if idx >= len(p.filtered) {
+			break
+		}
+		repo := p.filtered[idx]
+		if idx == p.cursor {
 			lines = append(lines, styles.TextPrimaryBoldStyle.Render("▸ "+repo))
 		} else {
 			lines = append(lines, "  "+repo)

--- a/internal/tui/repo_picker_test.go
+++ b/internal/tui/repo_picker_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// makeRepos returns n repo strings "repo-0".."repo-n-1".
+func makeRepos(n int) []string {
+	repos := make([]string, n)
+	for i := range repos {
+		repos[i] = "repo-" + string(rune('0'+i%10))
+		if i >= 10 {
+			repos[i] = "repo-" + string(rune('a'+i-10))
+		}
+	}
+	return repos
+}
+
+// repoPickerNavigate applies n "down" keypresses to the picker.
+func repoPickerNavigate(p *RepoPicker, n int) *RepoPicker {
+	for range n {
+		p, _ = p.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	}
+	return p
+}
+
+// TestRepoPicker_CursorVisibleInView verifies that the selection indicator (▸)
+// is always present in the rendered view regardless of list length and cursor position.
+func TestRepoPicker_CursorVisibleInView(t *testing.T) {
+	// height=30 → maxVisible = min(len, max(30/3,5)) = min(len, 10)
+	// With 15 repos, navigating past index 9 exposes the bug.
+	repos := makeRepos(15)
+	height := 30
+	p := NewRepoPicker(repos, "", 120, height)
+
+	// Navigate to the last item (index 14), which is beyond maxVisible (10).
+	for range 14 {
+		p, _ = p.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	}
+
+	assert.Equal(t, 14, p.cursor, "cursor should be at last item")
+
+	view := p.View()
+	assert.Contains(t, view, "▸",
+		"selection indicator must be visible when cursor is beyond the initial window; got view:\n%s", view)
+}
+
+// TestRepoPicker_SelectedItemIsVisible checks that the selected item's text appears in the view.
+func TestRepoPicker_SelectedItemIsVisible(t *testing.T) {
+	repos := []string{
+		"alpha", "beta", "gamma", "delta", "epsilon",
+		"zeta", "eta", "theta", "iota", "kappa",
+		"lambda", "mu", "nu", "xi", "omicron",
+	}
+	// height=30 → maxVisible=10; navigate to item 12 ("nu")
+	p := NewRepoPicker(repos, "", 120, 30)
+	p = repoPickerNavigate(p, 12)
+
+	assert.Equal(t, 12, p.cursor)
+
+	view := p.View()
+	assert.Contains(t, view, "nu",
+		"selected item text must appear in the rendered view; got:\n%s", view)
+}
+
+// TestRepoPicker_NavigationBounds ensures cursor never goes below 0 or above len-1.
+func TestRepoPicker_NavigationBounds(t *testing.T) {
+	repos := makeRepos(3)
+	p := NewRepoPicker(repos, "", 80, 30)
+
+	// Pressing up at top should stay at 0.
+	p, _ = p.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	assert.Equal(t, 0, p.cursor, "cursor should not go below 0")
+
+	// Navigate to end.
+	p = repoPickerNavigate(p, 10) // more than len
+	assert.Equal(t, 2, p.cursor, "cursor should not exceed len(filtered)-1")
+}
+
+// TestRepoPicker_ScrollOffset_TracksWithCursor tests that scrollOffset advances when
+// cursor moves down past the visible window and retreats when cursor moves back up.
+func TestRepoPicker_ScrollOffset_TracksWithCursor(t *testing.T) {
+	repos := makeRepos(15)
+	p := NewRepoPicker(repos, "", 120, 30) // maxVisible=10
+
+	// Navigate just at the edge — cursor at 9 (last visible without scroll).
+	p = repoPickerNavigate(p, 9)
+	assert.Equal(t, 9, p.cursor)
+	view := p.View()
+	assert.Contains(t, view, "▸", "cursor at 9 should still be visible")
+
+	// Navigate one more — cursor at 10 (first item beyond initial window).
+	p, _ = p.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	assert.Equal(t, 10, p.cursor)
+	view = p.View()
+	assert.Contains(t, view, "▸",
+		"cursor at 10 (beyond maxVisible window) must still show selection indicator")
+
+	// Navigate back — cursor at 9 again, should still show indicator.
+	p, _ = p.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	assert.Equal(t, 9, p.cursor)
+	view = p.View()
+	assert.Contains(t, view, "▸", "after scrolling back, cursor at 9 should be visible")
+}

--- a/internal/tui/review_only.go
+++ b/internal/tui/review_only.go
@@ -153,7 +153,9 @@ func (m ReviewOnlyModel) View() tea.View {
 	if m.quitting {
 		return tea.NewView("")
 	}
-	return tea.NewView(m.reviewView.View())
+	v := tea.NewView(m.reviewView.View())
+	v.MouseMode = tea.MouseModeCellMotion
+	return v
 }
 
 // copyToClipboard copies the given text to the system clipboard using the configured copy command.

--- a/internal/tui/views/messages/controller.go
+++ b/internal/tui/views/messages/controller.go
@@ -142,6 +142,16 @@ func (c *Controller) Offset() int {
 	return c.offset
 }
 
+// SelectAt sets the cursor to idx and adjusts the offset to keep it visible.
+// idx is an index into filteredAt (the visible/filtered item list).
+func (c *Controller) SelectAt(idx int, visibleLines int) {
+	if idx < 0 || idx >= len(c.filteredAt) {
+		return
+	}
+	c.cursor = idx
+	c.clampOffset(visibleLines)
+}
+
 // Len returns the total number of accumulated messages.
 func (c *Controller) Len() int {
 	return len(c.messages)

--- a/internal/tui/views/messages/controller_test.go
+++ b/internal/tui/views/messages/controller_test.go
@@ -233,3 +233,65 @@ func TestController_Selected(t *testing.T) {
 		assert.Nil(t, c.Selected())
 	})
 }
+
+func TestController_SelectAt(t *testing.T) {
+	setup := func() *Controller {
+		c := NewController()
+		c.Append([]messaging.Message{
+			newMsg("t1", "s1", "first"),
+			newMsg("t2", "s2", "second"),
+			newMsg("t3", "s3", "third"),
+		})
+		return c
+	}
+
+	t.Run("valid idx moves cursor", func(t *testing.T) {
+		c := setup()
+		c.SelectAt(2, 10)
+		assert.Equal(t, 2, c.Cursor())
+		sel := c.Selected()
+		require.NotNil(t, sel)
+		assert.Equal(t, "first", sel.Payload)
+	})
+
+	t.Run("negative idx is no-op", func(t *testing.T) {
+		c := setup()
+		c.SelectAt(-1, 10)
+		assert.Equal(t, 0, c.Cursor())
+	})
+
+	t.Run("idx >= len(filteredAt) is no-op", func(t *testing.T) {
+		c := setup()
+		// filteredAt has 3 entries
+		c.SelectAt(3, 10)
+		assert.Equal(t, 0, c.Cursor())
+	})
+
+	t.Run("regression: filter active, idx valid for displayed but past filteredAt is no-op", func(t *testing.T) {
+		c := NewController()
+		c.Append([]messaging.Message{
+			newMsg("agent.inbox", "alice", "hello"),
+			newMsg("system.log", "bob", "error"),
+			newMsg("agent.outbox", "alice", "bye"),
+		})
+		// Filter to agent-only: 2 matches
+		c.StartFilter()
+		c.AddFilterRune('a')
+		c.AddFilterRune('g')
+		c.AddFilterRune('e')
+		c.AddFilterRune('n')
+		c.AddFilterRune('t')
+		c.ConfirmFilter()
+
+		require.Len(t, c.FilteredAt(), 2)
+
+		// idx=2 is valid in displayed (len=3) but past filteredAt (len=2) — no-op
+		c.SelectAt(2, 10)
+		assert.Equal(t, 0, c.Cursor())
+
+		// idx=1 is valid
+		c.SelectAt(1, 10)
+		assert.Equal(t, 1, c.Cursor())
+		assert.NotNil(t, c.Selected())
+	})
+}

--- a/internal/tui/views/messages/view.go
+++ b/internal/tui/views/messages/view.go
@@ -136,6 +136,36 @@ func (v *View) SetSize(width, height int) {
 	v.sizeViewport()
 }
 
+// SelectAtRow moves the cursor to the message at contentY rows from the view top.
+// The list renders an optional filter line then a column header above the message items.
+// x is the terminal column; clicks in the preview pane are ignored.
+func (v *View) SelectAtRow(x, contentY int) tea.Cmd {
+	if v.width >= minDualPaneWidth {
+		splitPct := v.splitRatio
+		if splitPct < 1 || splitPct > 80 {
+			splitPct = 25
+		}
+		listWidth := v.width * splitPct / 100
+		if listWidth < 20 {
+			listWidth = 20
+		}
+		if x >= listWidth {
+			return nil
+		}
+	}
+	headerRows := 1 // column header
+	if v.ctrl.IsFiltering() || v.ctrl.Filter() != "" {
+		headerRows++ // filter line appears above column header
+	}
+	listRow := contentY - headerRows
+	if listRow < 0 {
+		return nil
+	}
+	idx := v.ctrl.Offset() + listRow
+	v.ctrl.SelectAt(idx, v.visibleLines())
+	return nil
+}
+
 // SetActive marks whether this view is the currently active tab.
 func (v *View) SetActive(active bool) {
 	v.active = active

--- a/internal/tui/views/messages/view_test.go
+++ b/internal/tui/views/messages/view_test.go
@@ -64,3 +64,74 @@ func TestHandleMessagesLoaded_ErrorLeavesStateUnchanged(t *testing.T) {
 	// Original message should still be there
 	assert.Equal(t, 1, v.ctrl.Len(), "existing messages preserved on error")
 }
+
+// newViewWithMessages creates a View preloaded with n messages for SelectAtRow tests.
+func newViewWithMessages(n int) *View {
+	v := New(nil, "*", "", 0)
+	v.SetSize(80, 24)
+	msgs := make([]messaging.Message, n)
+	for i := range msgs {
+		msgs[i] = messaging.Message{
+			Topic:     "t",
+			Sender:    "s",
+			Payload:   "msg",
+			CreatedAt: time.Now(),
+		}
+	}
+	v.ctrl.Append(msgs)
+	return v
+}
+
+func TestView_SelectAtRow(t *testing.T) {
+	t.Run("contentY=0 is column header - no-op", func(t *testing.T) {
+		v := newViewWithMessages(3)
+		v.SelectAtRow(0, 0)
+		assert.Equal(t, 0, v.ctrl.Cursor())
+	})
+
+	t.Run("happy path contentY=2 selects cursor=1", func(t *testing.T) {
+		v := newViewWithMessages(3)
+		// headerRows=1 (no filter), listRow=contentY-1=1, idx=offset+1=1
+		v.SelectAtRow(0, 2)
+		assert.Equal(t, 1, v.ctrl.Cursor())
+	})
+
+	t.Run("preview pane click is no-op when width >= 120", func(t *testing.T) {
+		v := newViewWithMessages(3)
+		v.SetSize(120, 24)
+		// splitPct=25 (default), listWidth=120*25/100=30; x=50 is in preview
+		v.SelectAtRow(50, 2)
+		assert.Equal(t, 0, v.ctrl.Cursor())
+	})
+
+	t.Run("filter active: contentY=1 is filter line - no-op", func(t *testing.T) {
+		v := newViewWithMessages(3)
+		v.ctrl.StartFilter()
+		v.ctrl.AddFilterRune('t')
+		// headerRows=2 (filter + column header), contentY=1 → listRow=-1 → no-op
+		v.SelectAtRow(0, 1)
+		assert.Equal(t, 0, v.ctrl.Cursor())
+	})
+
+	t.Run("filter active: contentY=2 is column header - no-op", func(t *testing.T) {
+		v := newViewWithMessages(3)
+		v.ctrl.StartFilter()
+		v.ctrl.AddFilterRune('t')
+		// headerRows=2, contentY=2 → listRow=0, idx=0
+		// Wait — listRow=contentY-headerRows=2-2=0, idx=offset+0=0 → valid, cursor=0
+		// Actually this selects cursor=0, which is already 0, so we test that it does NOT no-op
+		// but remains at 0.
+		v.SelectAtRow(0, 2)
+		// listRow=0, idx=0 — selects first item (cursor=0)
+		assert.Equal(t, 0, v.ctrl.Cursor())
+	})
+
+	t.Run("filter active: contentY=3 is first item", func(t *testing.T) {
+		v := newViewWithMessages(3)
+		v.ctrl.StartFilter()
+		v.ctrl.AddFilterRune('t')
+		// headerRows=2, contentY=3 → listRow=1, idx=offset+1=1
+		v.SelectAtRow(0, 3)
+		assert.Equal(t, 1, v.ctrl.Cursor())
+	})
+}

--- a/internal/tui/views/review/review_view.go
+++ b/internal/tui/views/review/review_view.go
@@ -247,6 +247,35 @@ func (v *View) TogglePreview() tea.Cmd {
 	return nil
 }
 
+// SelectAtRow selects the document tree item at contentY rows from the view top.
+// The tree has a one-line repo header above it, so treeRow = contentY - 1.
+// x is the terminal column; clicks in the detail pane are ignored.
+// Returns a command to load the preview for the newly selected document.
+func (v *View) SelectAtRow(x, contentY int) tea.Cmd {
+	if !v.showTree || len(v.flatNodes) == 0 {
+		return nil
+	}
+	if v.showPreview {
+		splitPct := v.splitRatioOrDefault(30)
+		availWidth := max(v.width-1, 30)
+		treeWidth := max(availWidth*splitPct/100, 25)
+		if x >= treeWidth {
+			return nil
+		}
+	}
+	treeRow := contentY - 1 // skip repo header line
+	if treeRow < 0 {
+		return nil
+	}
+	idx := v.treeScroll + treeRow
+	if idx >= len(v.flatNodes) {
+		return nil
+	}
+	v.treeCursor = idx
+	v.clampTreeScroll()
+	return v.previewSelectedDoc()
+}
+
 // SetShowTree sets the tree pane visibility without toggling or re-rendering.
 // Use before the first window size event to configure the initial layout.
 func (v *View) SetShowTree(show bool) {

--- a/internal/tui/views/review/review_view_test.go
+++ b/internal/tui/views/review/review_view_test.go
@@ -1179,3 +1179,101 @@ func TestLoadDocumentFromPath_NonExistent(t *testing.T) {
 	view.LoadDocumentFromPath("/nonexistent/path/doc.md")
 	assert.Nil(t, view.selectedDoc, "expected selectedDoc to remain nil for non-existent file")
 }
+
+// --- SelectAtRow ---
+
+// newReviewViewWithDocs creates a View with flatNodes populated from the given documents.
+// showTree and showPreview are set as specified.
+func newReviewViewWithDocs(docs []Document, showTree, showPreview bool) View {
+	v := New(docs, "", nil, nil, 0)
+	v.SetSize(100, 24)
+	v.showTree = showTree
+	v.showPreview = showPreview
+	return v
+}
+
+func TestSelectAtRow_ShowTreeFalse_ReturnsNil(t *testing.T) {
+	docs := []Document{
+		{Path: "/p/doc.md", RelPath: "doc.md", Type: DocTypePlan},
+	}
+	v := newReviewViewWithDocs(docs, false, true)
+
+	cmd := v.SelectAtRow(0, 1)
+	assert.Nil(t, cmd)
+	assert.Equal(t, 0, v.treeCursor, "treeCursor should be unchanged when showTree=false")
+}
+
+func TestSelectAtRow_EmptyFlatNodes_ReturnsNil(t *testing.T) {
+	v := New(nil, "", nil, nil, 0)
+	v.SetSize(100, 24)
+	v.showTree = true
+
+	cmd := v.SelectAtRow(0, 1)
+	assert.Nil(t, cmd)
+	assert.Equal(t, 0, v.treeCursor)
+}
+
+func TestSelectAtRow_ContentY0_RepoHeader_NoOp(t *testing.T) {
+	docs := []Document{
+		{Path: "/p/doc1.md", RelPath: "doc1.md", Type: DocTypePlan},
+		{Path: "/p/doc2.md", RelPath: "doc2.md", Type: DocTypePlan},
+	}
+	v := newReviewViewWithDocs(docs, true, false)
+	require.NotEmpty(t, v.flatNodes)
+
+	// treeRow = contentY - 1 = -1 → no-op
+	v.SelectAtRow(0, 0)
+	assert.Equal(t, 0, v.treeCursor, "contentY=0 (repo header) should be no-op")
+}
+
+func TestSelectAtRow_ContentY1_SetsTreeCursor0(t *testing.T) {
+	docs := []Document{
+		{Path: "/p/doc1.md", RelPath: "doc1.md", Type: DocTypePlan},
+		{Path: "/p/doc2.md", RelPath: "doc2.md", Type: DocTypePlan},
+	}
+	v := newReviewViewWithDocs(docs, true, false)
+	require.NotEmpty(t, v.flatNodes)
+
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 0, v.treeCursor, "contentY=1 should set treeCursor=0")
+}
+
+func TestSelectAtRow_ContentY2_SetsTreeCursor1(t *testing.T) {
+	docs := []Document{
+		{Path: "/p/doc1.md", RelPath: "doc1.md", Type: DocTypePlan},
+		{Path: "/p/doc2.md", RelPath: "doc2.md", Type: DocTypePlan},
+	}
+	v := newReviewViewWithDocs(docs, true, false)
+	require.GreaterOrEqual(t, len(v.flatNodes), 2, "need at least 2 flat nodes")
+
+	v.SelectAtRow(0, 2)
+	assert.Equal(t, 1, v.treeCursor, "contentY=2 should set treeCursor=1")
+}
+
+func TestSelectAtRow_ShowPreview_ClickInDetailPane_NoOp(t *testing.T) {
+	docs := []Document{
+		{Path: "/p/doc1.md", RelPath: "doc1.md", Type: DocTypePlan},
+	}
+	v := newReviewViewWithDocs(docs, true, true)
+	v.width = 100
+	// splitPct=30 (default), availWidth=max(100-1,30)=99
+	// treeWidth=max(99*30/100,25)=max(29,25)=29
+	// x=50 >= 29 → no-op
+
+	v.SelectAtRow(50, 1)
+	assert.Equal(t, 0, v.treeCursor, "click in detail pane should be no-op when showPreview=true")
+}
+
+func TestSelectAtRow_ShowPreview_ClickInTree_Selects(t *testing.T) {
+	docs := []Document{
+		{Path: "/p/doc1.md", RelPath: "doc1.md", Type: DocTypePlan},
+		{Path: "/p/doc2.md", RelPath: "doc2.md", Type: DocTypePlan},
+	}
+	v := newReviewViewWithDocs(docs, true, true)
+	v.width = 100
+	require.GreaterOrEqual(t, len(v.flatNodes), 2)
+
+	// x=5 < treeWidth=29, contentY=2 → treeRow=1 → treeCursor=1
+	v.SelectAtRow(5, 2)
+	assert.Equal(t, 1, v.treeCursor, "click in tree pane should select item")
+}

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -1210,6 +1210,32 @@ func scheduleAnimationTick() tea.Cmd {
 
 // --- Public accessors ---
 
+// SelectAtRow moves the list cursor to the item at the given row within the
+// visible list area (row 0 = first visible item on the current page).
+// x is the terminal column of the click; clicks in the preview pane are ignored.
+func (v *View) SelectAtRow(x, row int) tea.Cmd {
+	if v.previewEnabled && v.width >= 80 {
+		splitPct := v.cfg.Views.Sessions.SplitRatioOrDefault(25)
+		listWidth := v.width * splitPct / 100
+		if x >= listWidth {
+			return nil
+		}
+	}
+	if row < 0 {
+		return nil
+	}
+	perPage := v.list.Paginator.PerPage
+	if perPage <= 0 {
+		return nil
+	}
+	globalIndex := v.list.Paginator.Page*perPage + row
+	if globalIndex >= len(v.list.VisibleItems()) {
+		return nil
+	}
+	v.list.Select(globalIndex)
+	return nil
+}
+
 // SetSize updates the view dimensions.
 func (v *View) SetSize(width, height int) {
 	v.width = width

--- a/internal/tui/views/sessions/view_test.go
+++ b/internal/tui/views/sessions/view_test.go
@@ -384,3 +384,60 @@ func TestApplyFilter_GroupByGroup(t *testing.T) {
 	assert.Equal(t, []string{"backend", "frontend", "(ungrouped)"}, headers, "groups sorted alphabetically with ungrouped last")
 	assert.Equal(t, []string{"s1", "s2", "s3"}, sessionIDs, "all sessions present")
 }
+
+// --- SelectAtRow ---
+
+func TestSelectAtRow_HappyPath(t *testing.T) {
+	items := []list.Item{
+		TreeItem{Session: session.Session{ID: "s1", Name: "first"}},
+		TreeItem{Session: session.Session{ID: "s2", Name: "second"}},
+		TreeItem{Session: session.Session{ID: "s3", Name: "third"}},
+	}
+	v := newTestView(items, 0)
+
+	v.SelectAtRow(0, 0)
+	assert.Equal(t, 0, v.list.Index(), "row=0 should select item 0")
+
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 1, v.list.Index(), "row=1 should select item 1")
+}
+
+func TestSelectAtRow_RowBeyondItems_NoOp(t *testing.T) {
+	items := []list.Item{
+		TreeItem{Session: session.Session{ID: "s1", Name: "first"}},
+	}
+	v := newTestView(items, 0)
+
+	v.SelectAtRow(0, 5) // beyond len(VisibleItems)
+	assert.Equal(t, 0, v.list.Index(), "row beyond items should be no-op")
+}
+
+func TestSelectAtRow_PreviewEnabled_ClickInPreview_NoOp(t *testing.T) {
+	items := []list.Item{
+		TreeItem{Session: session.Session{ID: "s1", Name: "first"}},
+		TreeItem{Session: session.Session{ID: "s2", Name: "second"}},
+	}
+	v := newTestView(items, 0)
+	v.previewEnabled = true
+	v.width = 100
+	v.cfg = &config.Config{} // SplitRatioOrDefault(25) = 25, listWidth = 100*25/100 = 25
+
+	// x=50 is well inside the preview pane (>= listWidth 25)
+	v.SelectAtRow(50, 1)
+	assert.Equal(t, 0, v.list.Index(), "click in preview pane should be no-op")
+}
+
+func TestSelectAtRow_PreviewEnabled_ClickInList_Selects(t *testing.T) {
+	items := []list.Item{
+		TreeItem{Session: session.Session{ID: "s1", Name: "first"}},
+		TreeItem{Session: session.Session{ID: "s2", Name: "second"}},
+	}
+	v := newTestView(items, 0)
+	v.previewEnabled = true
+	v.width = 100
+	v.cfg = &config.Config{} // listWidth = 25
+
+	// x=10 is inside the list pane
+	v.SelectAtRow(10, 1)
+	assert.Equal(t, 1, v.list.Index(), "click in list pane should select item")
+}

--- a/internal/tui/views/tasks/view.go
+++ b/internal/tui/views/tasks/view.go
@@ -657,6 +657,32 @@ func (v *View) handleDetailKey(msg tea.KeyMsg) tea.Cmd {
 	return nil
 }
 
+// SelectAtRow moves the cursor to the tree node at contentY rows from the view top.
+// The view renders a one-line repo header above the tree items.
+// x is the terminal column; clicks in the detail pane are ignored.
+// Returns any command needed to load content for the newly selected item.
+func (v *View) SelectAtRow(x, contentY int) tea.Cmd {
+	if v.showPreview {
+		splitPct := v.splitRatioOrDefault(30)
+		treeWidth := max(max(v.width-1, 30)*splitPct/100, 25)
+		if x >= treeWidth {
+			return nil
+		}
+	}
+	treeRow := contentY - 1 // skip repo header line
+	if treeRow < 0 || len(v.flatNodes) == 0 {
+		return nil
+	}
+	idx := v.scrollOffset + treeRow
+	if idx >= len(v.flatNodes) {
+		return nil
+	}
+	v.cursor = idx
+	v.clampCursor()
+	v.clampScroll()
+	return v.checkCursorChanged()
+}
+
 // moveCursor moves the cursor by delta and adjusts scroll.
 func (v *View) moveCursor(delta int) {
 	v.cursor += delta

--- a/internal/tui/views/tasks/view_test.go
+++ b/internal/tui/views/tasks/view_test.go
@@ -1,0 +1,107 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/colonyops/hive/internal/core/hc"
+	"github.com/stretchr/testify/assert"
+)
+
+// newViewWithNodes creates a minimal View whose flatNodes slice is pre-populated.
+// It does not use the service layer, making it suitable for pure unit tests.
+func newViewWithNodes(nodes []FlatNode) *View {
+	return &View{
+		flatNodes:    nodes,
+		comments:     make(map[string][]hc.Comment),
+		blockers:     make(map[string][]hc.Item),
+		statusFilter: FilterOpen,
+		showPreview:  false,
+		height:       24,
+		width:        80,
+	}
+}
+
+func makeNode(id string) FlatNode {
+	return FlatNode{
+		Node: &TreeNode{
+			Item: hc.Item{
+				ID:        id,
+				Title:     "Item " + id,
+				Type:      hc.ItemTypeTask,
+				Status:    hc.StatusOpen,
+				CreatedAt: time.Now(),
+			},
+			Expanded: false,
+		},
+		Depth:  0,
+		IsLast: false,
+	}
+}
+
+// --- SelectAtRow ---
+
+func TestSelectAtRow_HeaderRow_NoOp(t *testing.T) {
+	nodes := []FlatNode{makeNode("task-1"), makeNode("task-2"), makeNode("task-3")}
+	v := newViewWithNodes(nodes)
+
+	// contentY=0 is the repo header line — treeRow = -1 → no-op
+	v.SelectAtRow(0, 0)
+	assert.Equal(t, 0, v.cursor, "clicking repo header (contentY=0) should be no-op")
+}
+
+func TestSelectAtRow_ContentY1_SelectsFirst(t *testing.T) {
+	nodes := []FlatNode{makeNode("task-1"), makeNode("task-2"), makeNode("task-3")}
+	v := newViewWithNodes(nodes)
+
+	// contentY=1 → treeRow=0, idx=scrollOffset+0=0
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 0, v.cursor, "contentY=1 should select flatNodes[0]")
+}
+
+func TestSelectAtRow_ContentY2_SelectsSecond(t *testing.T) {
+	nodes := []FlatNode{makeNode("task-1"), makeNode("task-2"), makeNode("task-3")}
+	v := newViewWithNodes(nodes)
+
+	v.SelectAtRow(0, 2)
+	assert.Equal(t, 1, v.cursor, "contentY=2 should select flatNodes[1]")
+}
+
+func TestSelectAtRow_BeyondNodes_NoOp(t *testing.T) {
+	nodes := []FlatNode{makeNode("task-1")}
+	v := newViewWithNodes(nodes)
+
+	// contentY=5 → treeRow=4, idx=4 >= len(flatNodes)=1 → no-op
+	v.SelectAtRow(0, 5)
+	assert.Equal(t, 0, v.cursor, "clicking beyond flatNodes should be no-op")
+}
+
+func TestSelectAtRow_EmptyFlatNodes_NoOp(t *testing.T) {
+	v := newViewWithNodes(nil)
+
+	v.SelectAtRow(0, 1)
+	assert.Equal(t, 0, v.cursor, "clicking with empty flatNodes should be no-op")
+}
+
+func TestSelectAtRow_ShowPreview_ClickInDetailPane_NoOp(t *testing.T) {
+	nodes := []FlatNode{makeNode("task-1"), makeNode("task-2")}
+	v := newViewWithNodes(nodes)
+	v.showPreview = true
+	v.width = 100
+	// splitRatio=0 → default 30%; availWidth=100-1=99; treeWidth=max(99*30/100,25)=max(29,25)=29
+	// x=50 >= treeWidth=29 → no-op
+
+	v.SelectAtRow(50, 1)
+	assert.Equal(t, 0, v.cursor, "click in detail pane should be no-op")
+}
+
+func TestSelectAtRow_ShowPreview_ClickInTree_Selects(t *testing.T) {
+	nodes := []FlatNode{makeNode("task-1"), makeNode("task-2")}
+	v := newViewWithNodes(nodes)
+	v.showPreview = true
+	v.width = 100
+	// treeWidth=29; x=10 < 29 → allowed
+
+	v.SelectAtRow(10, 2) // contentY=2 → treeRow=1, idx=1
+	assert.Equal(t, 1, v.cursor, "click in tree pane should select item")
+}


### PR DESCRIPTION
## Summary

- Enables `MouseModeCellMotion` on all three TUI model `View()` methods so mouse events are delivered to the app
- Left-click on the tab bar switches views (fires same init commands as keyboard — fixes Tasks showing blank on first click)
- Left-click in list/tree area moves cursor across all views (sessions, tasks, messages, docs, store); clicks in preview/detail panes are correctly ignored using each view's actual split-ratio math
- Double-click within 300ms at the same cell synthesizes an Enter key press (activate session, open doc, etc.)
- `PasteMsg` now routes through `handleFallthrough` so bracketed paste works in text inputs (new session form, rename modal, etc.)
- Notification modal scrolls on mouse wheel; all other wheel events fall through unchanged
- `switchToView()` consolidates tab-switching logic — keyboard and mouse tab-bar click now share one path, eliminating duplication

## Bug fixes caught during review

- `messages.Controller.SelectAt` was validating `idx` against `displayed` instead of `filteredAt` — with an active filter this put `cursor` out of bounds for `filteredAt`, making `Selected()` return `nil`
- `messages.View.SelectAtRow` used wrong split-ratio defaults vs the renderer (bounds `> 90`, default `40` vs `> 80`, default `25` with `min-20` floor); click hit regions were misaligned from what was rendered
- `messages.View.SelectAtRow` ignored the filter line when computing the row offset, causing off-by-one clicks whenever a filter was active
- `sessions.View.SelectAtRow` bounds-checked against `Items()` instead of `VisibleItems()`, allowing clicks to select hidden items when the list was filtered
- `kv_view.SelectAtRow` accepted clicks anywhere in the row, including the preview pane; now guards against clicks right of the key-list pane
- Tab bar click previously bypassed the `isModalActive()` guard, silently switching views while modals were open
- Double-click state now resets on view switch to prevent a stale cross-view double-click

## Test plan

- [ ] `mise run check` passes (0 lint issues, all tests green)
- [ ] Click a session row to select it; double-click to activate (open in terminal)
- [ ] Click the Tasks/Messages/Docs/Store tab labels to switch views
- [ ] Click a task row; detail pane updates; clicking in the detail pane does not move the cursor
- [ ] Click a doc in the Docs tree; preview updates in right pane
- [ ] Paste text into the new-session form using terminal paste (Cmd+V / bracketed paste)
- [ ] Open notification modal, scroll with mouse wheel
- [ ] With a modal open (rename, confirm), click a tab → view should NOT switch