### PR TITLE
fix(hc): cascade delete to subtasks when parent is deleted

### DIFF
--- a/internal/data/stores/hcstore.go
+++ b/internal/data/stores/hcstore.go
@@ -275,12 +275,35 @@ func (s *HCStore) resumeItemForSession(ctx context.Context, filter hc.NextFilter
 	return item, true, nil
 }
 
-// DeleteItem removes an HC item by ID.
+// DeleteItem removes an HC item and all its descendants by ID.
 func (s *HCStore) DeleteItem(ctx context.Context, id string) error {
-	if err := s.db.Queries().DeleteHCItem(ctx, id); err != nil {
-		return fmt.Errorf("delete hc item: %w", err)
+	allRows, err := s.db.Queries().ListAllHCItems(ctx)
+	if err != nil {
+		return fmt.Errorf("list hc items for delete: %w", err)
 	}
-	return nil
+
+	childrenByParent := make(map[string][]string, len(allRows))
+	depthByID := make(map[string]int64, len(allRows))
+	for _, row := range allRows {
+		depthByID[row.ID] = row.Depth
+		if row.ParentID != "" {
+			childrenByParent[row.ParentID] = append(childrenByParent[row.ParentID], row.ID)
+		}
+	}
+
+	deleteIDs := collectHCSubtreeIDs([]string{id}, childrenByParent)
+
+	return s.db.WithTx(ctx, func(q *db.Queries) error {
+		for _, did := range orderHCIDsByDepthDesc(deleteIDs, depthByID) {
+			if err := q.DeleteHCCommentsByItemID(ctx, did); err != nil {
+				return fmt.Errorf("delete hc comments for %q: %w", did, err)
+			}
+			if err := q.DeleteHCItem(ctx, did); err != nil {
+				return fmt.Errorf("delete hc item %q: %w", did, err)
+			}
+		}
+		return nil
+	})
 }
 
 // AddComment records a comment on an HC item.

--- a/internal/data/stores/hcstore_test.go
+++ b/internal/data/stores/hcstore_test.go
@@ -713,3 +713,60 @@ func TestHCStore_PruneScopesCommentsToStatusesAndItemUpdatedAt(t *testing.T) {
 	require.Len(t, doneRecentComments, 1)
 	assert.Equal(t, "cmt-done-recent", doneRecentComments[0].ID)
 }
+
+func TestHCStore_DeleteItemCascadesToDescendants(t *testing.T) {
+	ctx := context.Background()
+	database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	store := NewHCStore(database)
+	now := time.Now()
+
+	items := []hc.Item{
+		{ID: "epic-1", Title: "Epic", Type: hc.ItemTypeEpic, Status: hc.StatusOpen, Depth: 0, CreatedAt: now, UpdatedAt: now},
+		{ID: "task-1", EpicID: "epic-1", ParentID: "epic-1", Title: "Task 1", Type: hc.ItemTypeTask, Status: hc.StatusOpen, Depth: 1, CreatedAt: now, UpdatedAt: now},
+		{ID: "task-2", EpicID: "epic-1", ParentID: "epic-1", Title: "Task 2", Type: hc.ItemTypeTask, Status: hc.StatusDone, Depth: 1, CreatedAt: now, UpdatedAt: now},
+		{ID: "task-1-1", EpicID: "epic-1", ParentID: "task-1", Title: "Subtask", Type: hc.ItemTypeTask, Status: hc.StatusOpen, Depth: 2, CreatedAt: now, UpdatedAt: now},
+		{ID: "epic-2", Title: "Other Epic", Type: hc.ItemTypeEpic, Status: hc.StatusOpen, Depth: 0, CreatedAt: now, UpdatedAt: now},
+	}
+	require.NoError(t, store.CreateItems(ctx, items))
+
+	err = store.DeleteItem(ctx, "epic-1")
+	require.NoError(t, err)
+
+	remaining, err := store.ListItems(ctx, hc.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "epic-2", remaining[0].ID)
+}
+
+func TestHCStore_DeleteItemCascadesComments(t *testing.T) {
+	ctx := context.Background()
+	database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+	require.NoError(t, err)
+	defer func() { _ = database.Close() }()
+
+	store := NewHCStore(database)
+	now := time.Now()
+
+	items := []hc.Item{
+		{ID: "epic-1", Title: "Epic", Type: hc.ItemTypeEpic, Status: hc.StatusOpen, Depth: 0, CreatedAt: now, UpdatedAt: now},
+		{ID: "task-1", EpicID: "epic-1", ParentID: "epic-1", Title: "Task", Type: hc.ItemTypeTask, Status: hc.StatusOpen, Depth: 1, CreatedAt: now, UpdatedAt: now},
+	}
+	require.NoError(t, store.CreateItems(ctx, items))
+
+	require.NoError(t, store.AddComment(ctx, hc.Comment{ID: "c1", ItemID: "epic-1", Message: "epic comment", CreatedAt: now}))
+	require.NoError(t, store.AddComment(ctx, hc.Comment{ID: "c2", ItemID: "task-1", Message: "task comment", CreatedAt: now}))
+
+	err = store.DeleteItem(ctx, "epic-1")
+	require.NoError(t, err)
+
+	epicComments, err := store.ListComments(ctx, "epic-1")
+	require.NoError(t, err)
+	assert.Empty(t, epicComments)
+
+	taskComments, err := store.ListComments(ctx, "task-1")
+	require.NoError(t, err)
+	assert.Empty(t, taskComments)
+}


### PR DESCRIPTION
## Purpose

Deleting an epic or parent task left all child items orphaned in the database. The TUI would appear to delete only the selected item while subtasks remained.

## Proposed Changes

  - `DeleteItem` now fetches the full item tree, collects all descendants via `collectHCSubtreeIDs` (same DFS helper used by `Prune`), and deletes them deepest-first in a transaction
  - Added two tests: subtree cascade and comment cascade on delete

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)