### PR TITLE
feat(tui): hide recycled sessions from the session tree

### DIFF
--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -163,6 +163,10 @@ func BuildTreeItems(groups []RepoGroup, localRemote string) []list.Item {
 	items := make([]list.Item, 0)
 
 	for _, group := range groups {
+		if len(group.Sessions) == 0 {
+			continue
+		}
+
 		// Add header
 		header := TreeItem{
 			IsHeader:      true,
@@ -172,12 +176,9 @@ func BuildTreeItems(groups []RepoGroup, localRemote string) []list.Item {
 		}
 		items = append(items, header)
 
-		// Determine if recycled placeholder will be the last item
-		hasRecycled := group.RecycledCount > 0
-
 		// Add active sessions
 		for idx, s := range group.Sessions {
-			isLast := idx == len(group.Sessions)-1 && !hasRecycled
+			isLast := idx == len(group.Sessions)-1
 			item := TreeItem{
 				IsHeader:     false,
 				Session:      s,
@@ -185,18 +186,6 @@ func BuildTreeItems(groups []RepoGroup, localRemote string) []list.Item {
 				RepoPrefix:   group.Name,
 			}
 			items = append(items, item)
-		}
-
-		// Add recycled placeholder if there are recycled sessions
-		if hasRecycled {
-			placeholder := TreeItem{
-				IsRecycledPlaceholder: true,
-				RecycledCount:         group.RecycledCount,
-				RecycledSessions:      group.RecycledSessions,
-				IsLastInRepo:          true,
-				RepoPrefix:            group.Name,
-			}
-			items = append(items, placeholder)
 		}
 	}
 
@@ -381,9 +370,6 @@ func (d TreeDelegate) renderRecycledPlaceholder(item TreeItem, isSelected bool) 
 	}
 	prefixStyled := d.Styles.TreeLine.Render(prefix)
 
-	// Status indicator (recycled)
-	statusStr := d.Styles.StatusRecycled.Render(styles.StatusIndicatorRecycled)
-
 	// Label with count
 	labelStyle := d.Styles.StatusRecycled
 	if isSelected {
@@ -391,7 +377,7 @@ func (d TreeDelegate) renderRecycledPlaceholder(item TreeItem, isSelected bool) 
 	}
 	label := labelStyle.Render(fmt.Sprintf("Recycled (%d)", item.RecycledCount))
 
-	return fmt.Sprintf("%s %s %s", prefixStyled, statusStr, label)
+	return fmt.Sprintf("%s %s", prefixStyled, label)
 }
 
 // renderSession renders a session entry.

--- a/internal/tui/views/sessions/tree_view_test.go
+++ b/internal/tui/views/sessions/tree_view_test.go
@@ -35,7 +35,7 @@ func TestBuildTreeItems(t *testing.T) {
 				},
 			},
 			wantHeaders: 1,
-			wantItems:   3, // 1 header + 1 session + 1 recycled placeholder
+			wantItems:   2, // 1 header + 1 session (recycled placeholder hidden)
 		},
 		{
 			name: "multiple groups",
@@ -94,7 +94,7 @@ func TestBuildTreeItems_HeaderFields(t *testing.T) {
 	}
 
 	items := BuildTreeItems(groups, "git@github.com:user/local.git")
-	require.Len(t, items, 4) // 1 header + 2 active sessions + 1 recycled placeholder
+	require.Len(t, items, 3) // 1 header + 2 active sessions
 
 	header := items[0].(TreeItem)
 	assert.True(t, header.IsHeader)
@@ -116,7 +116,7 @@ func TestBuildTreeItems_SessionFields(t *testing.T) {
 	}
 
 	items := BuildTreeItems(groups, "")
-	require.Len(t, items, 4) // 1 header + 2 sessions + 1 recycled placeholder
+	require.Len(t, items, 3) // 1 header + 2 sessions
 
 	// First session
 	first := items[1].(TreeItem)
@@ -125,19 +125,12 @@ func TestBuildTreeItems_SessionFields(t *testing.T) {
 	assert.False(t, first.IsLastInRepo)
 	assert.Equal(t, "repo", first.RepoPrefix)
 
-	// Second session (not last because recycled placeholder follows)
+	// Second session is last
 	second := items[2].(TreeItem)
 	assert.False(t, second.IsHeader)
 	assert.Equal(t, "second", second.Session.Name)
-	assert.False(t, second.IsLastInRepo)
+	assert.True(t, second.IsLastInRepo)
 	assert.Equal(t, "repo", second.RepoPrefix)
-
-	// Recycled placeholder is last
-	recycled := items[3].(TreeItem)
-	assert.True(t, recycled.IsRecycledPlaceholder)
-	assert.True(t, recycled.IsLastInRepo)
-	assert.Equal(t, 1, recycled.RecycledCount)
-	assert.Equal(t, "repo", recycled.RepoPrefix)
 }
 
 func TestTreeItem_FilterValue(t *testing.T) {


### PR DESCRIPTION
## Purpose

Recycled sessions cluttered the tree view. They are now hidden entirely — recycled is a background concept, not something that needs to be visible during normal use.

## Proposed Changes

  - Repos with only recycled sessions (no active sessions) are skipped entirely to avoid empty headers
  - The recycled placeholder row is no longer inserted into the tree

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)