### PR TITLE
feat(tui): expose .Doc.* in usercommand templates

### DIFF
--- a/docs/configuration/commands.md
+++ b/docs/configuration/commands.md
@@ -156,6 +156,27 @@ usercommands:
 
 See the [Recipes](../recipes/index.md) for full multi-agent workflow examples.
 
+## Document Context (review scope)
+
+When a command runs from the document review view, the focused document is exposed under the `.Doc` namespace:
+
+| Variable       | Description                                                         |
+| -------------- | ------------------------------------------------------------------- |
+| `.Doc.Path`    | Absolute path to the focused document                               |
+| `.Doc.RelPath` | Path relative to the repo (e.g. `.hive/plans/2026-05-06-plan.md`)   |
+| `.Doc.Type`    | Lowercase category: `plan`, `research`, `context`, or `other`       |
+
+`.Doc.*` fields render as empty strings outside the review view or when no document is focused. Scope the command to `review` so it only appears where these values are populated.
+
+```yaml
+usercommands:
+  AnnotateDoc:
+    sh: "send-claude {{ .Name | shq }} /annotate {{ .Doc.RelPath | shq }}"
+    help: "Send the focused doc to Claude for annotation"
+    scope: [review]
+    silent: true
+```
+
 ## Using Arguments
 
 Arguments passed in the command palette are available via the `.Args` template variable:

--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -124,7 +124,7 @@ Commands support Go templates with `{{ .Variable }}` syntax and `{{ .Variable | 
 | `rules[].commands`     | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo`, `.ID` |
 | `rules[].recycle`      | `.DefaultBranch`                                                    |
 | `rules[].branch_template` | `.Name`, `.Slug`, `.Owner`, `.Repo`, `.ID`                     |
-| `usercommands.*.sh`    | `.Path`, `.Name`, `.Remote`, `.ID`, `.Tool`, `.TmuxWindow`, `.Args`, `.Form.*` |
+| `usercommands.*.sh`    | `.Path`, `.Name`, `.Remote`, `.ID`, `.Tool`, `.TmuxWindow`, `.Args`, `.Form.*`, `.Doc.Path`, `.Doc.RelPath`, `.Doc.Type` (review scope) |
 
 !!! warning "Always use `shq` for shell quoting"
     Template variables like `.Name` and `.Path` may contain spaces or special characters. Always pipe them through `shq` (e.g., `{{ .Name | shq }}`) to prevent shell injection and word-splitting issues.

--- a/internal/core/config/validate.go
+++ b/internal/core/config/validate.go
@@ -290,6 +290,11 @@ func buildValidationData(formFields []FormField) map[string]any {
 		"Tool":       "claude",
 		"TmuxWindow": "main",
 		"Args":       []string{"arg1", "arg2"},
+		"Doc": map[string]any{
+			"Path":    "/tmp/test/.hive/plans/test.md",
+			"RelPath": ".hive/plans/test.md",
+			"Type":    "plan",
+		},
 	}
 
 	if len(formFields) > 0 {

--- a/internal/core/config/validate_test.go
+++ b/internal/core/config/validate_test.go
@@ -968,6 +968,11 @@ func TestBuildValidationData(t *testing.T) {
 		assert.NotEmpty(t, data["Name"])
 		assert.NotEmpty(t, data["ID"])
 		assert.Nil(t, data["Form"])
+		doc, ok := data["Doc"].(map[string]any)
+		require.True(t, ok, "Doc should be a map for nested template access")
+		assert.NotEmpty(t, doc["Path"])
+		assert.NotEmpty(t, doc["RelPath"])
+		assert.NotEmpty(t, doc["Type"])
 	})
 
 	t.Run("text field produces string", func(t *testing.T) {
@@ -1016,6 +1021,19 @@ func TestValidateDeep_UserCommandWithFormTemplate(t *testing.T) {
 			Form: []FormField{
 				{Variable: "targets", Preset: FormPresetSessionSelector, Multi: true, Label: "Targets"},
 			},
+		},
+	}
+
+	err := cfg.ValidateDeep("")
+	assert.NoError(t, err)
+}
+
+func TestValidateDeep_UserCommandWithDocTemplate(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.UserCommands = map[string]UserCommand{
+		"copy-doc": {
+			Sh:    "echo {{ .Doc.Path }} {{ .Doc.RelPath }} {{ .Doc.Type }}",
+			Scope: []string{"review"},
 		},
 	}
 

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -19,6 +19,21 @@ import (
 // Action is an alias for the unified action type.
 type Action = action.Action
 
+// DocTemplateData exposes the focused review-view document to user-command
+// shell templates under the .Doc namespace.
+type DocTemplateData struct {
+	Path    string
+	RelPath string
+	Type    string
+}
+
+func docTemplateValue(doc *DocTemplateData) DocTemplateData {
+	if doc == nil {
+		return DocTemplateData{}
+	}
+	return *doc
+}
+
 // KeybindingResolver resolves keybindings to actions via UserCommands.
 // It handles resolution only - execution is handled by the command.Service.
 type KeybindingResolver struct {
@@ -435,7 +450,9 @@ func (h *KeybindingResolver) KeyBindings() []key.Binding {
 // ResolveUserCommand converts a user command to an Action ready for execution.
 // The name is used to display the command source (e.g., ":review").
 // Supports both action-based commands (recycle, delete) and shell commands.
-func (h *KeybindingResolver) ResolveUserCommand(name string, cmd config.UserCommand, sess session.Session, args []string) Action {
+// doc, when non-nil, populates the .Doc.* template namespace with the focused
+// review-view document; otherwise .Doc fields render as empty strings.
+func (h *KeybindingResolver) ResolveUserCommand(name string, cmd config.UserCommand, sess session.Session, args []string, doc *DocTemplateData) Action {
 	a := Action{
 		Key:           ":" + name,
 		Help:          cmd.Help,
@@ -472,6 +489,7 @@ func (h *KeybindingResolver) ResolveUserCommand(name string, cmd config.UserComm
 		"Tool":       h.toolForSession(sess.ID),
 		"TmuxWindow": h.consumeWindowOverride(sess.ID),
 		"Args":       args,
+		"Doc":        docTemplateValue(doc),
 	}
 
 	if len(cmd.Windows) > 0 {
@@ -494,12 +512,15 @@ func (h *KeybindingResolver) ResolveUserCommand(name string, cmd config.UserComm
 
 // RenderWithFormData resolves a user command with form data injected
 // into the template context under the .Form namespace.
+// doc, when non-nil, populates the .Doc.* template namespace with the focused
+// review-view document; otherwise .Doc fields render as empty strings.
 func (h *KeybindingResolver) RenderWithFormData(
 	name string,
 	cmd config.UserCommand,
 	sess session.Session,
 	args []string,
 	formData map[string]any,
+	doc *DocTemplateData,
 ) Action {
 	a := Action{
 		Key:           ":" + name,
@@ -522,6 +543,7 @@ func (h *KeybindingResolver) RenderWithFormData(
 		"TmuxWindow": h.consumeWindowOverride(sess.ID),
 		"Args":       args,
 		"Form":       formData,
+		"Doc":        docTemplateValue(doc),
 	}
 
 	if len(cmd.Windows) > 0 {

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -193,7 +193,7 @@ func TestKeybindingHandler_ResolveUserCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action := handler.ResolveUserCommand(tt.cmdName, tt.cmd, sess, tt.args)
+			action := handler.ResolveUserCommand(tt.cmdName, tt.cmd, sess, tt.args, nil)
 
 			assert.Equal(t, tt.wantKey, action.Key, "ResolveUserCommand() Key = %v, want %v", action.Key, tt.wantKey)
 			assert.Equal(t, tt.wantHelp, action.Help, "ResolveUserCommand() Help = %v, want %v", action.Help, tt.wantHelp)
@@ -416,11 +416,11 @@ func TestKeybindingResolver_TmuxWindowAndTool(t *testing.T) {
 		handler.SetSelectedWindow("override-window")
 
 		cmd := config.UserCommand{Sh: "echo {{ .TmuxWindow }}", Help: "test"}
-		action := handler.ResolveUserCommand("test", cmd, sess, nil)
+		action := handler.ResolveUserCommand("test", cmd, sess, nil, nil)
 		assert.Equal(t, "echo override-window", action.ShellCmd)
 
 		// Override should be consumed
-		action = handler.ResolveUserCommand("test", cmd, sess, nil)
+		action = handler.ResolveUserCommand("test", cmd, sess, nil, nil)
 		assert.Equal(t, "echo default-window", action.ShellCmd, "after consume")
 	})
 }
@@ -489,7 +489,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 		handler.SetSelectedWindow("editor")
 
 		cmd := config.UserCommand{Action: act.TypeTmuxOpen, Help: "open"}
-		action := handler.ResolveUserCommand("TmuxOpen", cmd, sess, nil)
+		action := handler.ResolveUserCommand("TmuxOpen", cmd, sess, nil, nil)
 		assert.Equal(t, act.TypeTmuxOpen, action.Type)
 		assert.Equal(t, "editor", action.TmuxWindow)
 	})
@@ -514,7 +514,7 @@ func TestKeybindingResolver_RenderWithFormData(t *testing.T) {
 			"message": "hello world",
 		}
 
-		action := handler.RenderWithFormData("test", cmd, sess, nil, formData)
+		action := handler.RenderWithFormData("test", cmd, sess, nil, formData, nil)
 		assert.Equal(t, act.TypeShell, action.Type)
 		assert.Equal(t, "echo hello world", action.ShellCmd)
 		assert.NoError(t, action.Err)
@@ -529,7 +529,7 @@ func TestKeybindingResolver_RenderWithFormData(t *testing.T) {
 			"env": "staging",
 		}
 
-		action := handler.RenderWithFormData("test", cmd, sess, nil, formData)
+		action := handler.RenderWithFormData("test", cmd, sess, nil, formData, nil)
 		assert.Equal(t, "echo test-name staging", action.ShellCmd)
 	})
 
@@ -540,9 +540,59 @@ func TestKeybindingResolver_RenderWithFormData(t *testing.T) {
 		}
 		formData := map[string]any{}
 
-		action := handler.RenderWithFormData("test", cmd, sess, nil, formData)
+		action := handler.RenderWithFormData("test", cmd, sess, nil, formData, nil)
 		require.Error(t, action.Err)
 		assert.Empty(t, action.ShellCmd)
+	})
+}
+
+func TestKeybindingResolver_DocTemplateData(t *testing.T) {
+	handler := NewKeybindingResolver(nil, nil, testRenderer)
+	sess := session.Session{
+		ID:   "test-id",
+		Path: "/test/path",
+		Name: "test-name",
+	}
+	cmd := config.UserCommand{
+		Sh:   "echo {{ .Doc.Path }}|{{ .Doc.RelPath }}|{{ .Doc.Type }}",
+		Help: "doc-aware",
+	}
+
+	t.Run("ResolveUserCommand renders Doc fields when provided", func(t *testing.T) {
+		doc := &DocTemplateData{
+			Path:    "/repo/.hive/plans/x.md",
+			RelPath: ".hive/plans/x.md",
+			Type:    "plan",
+		}
+		a := handler.ResolveUserCommand("review", cmd, sess, nil, doc)
+		require.NoError(t, a.Err)
+		assert.Equal(t, "echo /repo/.hive/plans/x.md|.hive/plans/x.md|plan", a.ShellCmd)
+	})
+
+	t.Run("ResolveUserCommand renders empty Doc fields when nil", func(t *testing.T) {
+		a := handler.ResolveUserCommand("review", cmd, sess, nil, nil)
+		require.NoError(t, a.Err)
+		assert.Equal(t, "echo ||", a.ShellCmd)
+	})
+
+	t.Run("RenderWithFormData renders Doc fields when provided", func(t *testing.T) {
+		doc := &DocTemplateData{
+			Path:    "/repo/.hive/research/y.md",
+			RelPath: ".hive/research/y.md",
+			Type:    "research",
+		}
+		formCmd := config.UserCommand{
+			Sh: "echo {{ .Form.note }}@{{ .Doc.RelPath }}",
+		}
+		a := handler.RenderWithFormData("annotate", formCmd, sess, nil, map[string]any{"note": "hi"}, doc)
+		require.NoError(t, a.Err)
+		assert.Equal(t, "echo hi@.hive/research/y.md", a.ShellCmd)
+	})
+
+	t.Run("RenderWithFormData renders empty Doc fields when nil", func(t *testing.T) {
+		a := handler.RenderWithFormData("review", cmd, sess, nil, map[string]any{}, nil)
+		require.NoError(t, a.Err)
+		assert.Equal(t, "echo ||", a.ShellCmd)
 	})
 }
 
@@ -658,14 +708,14 @@ func TestKeybindingResolver_ShellDirIsSessionPath(t *testing.T) {
 
 	t.Run("ResolveUserCommand sets ShellDir to sess.Path", func(t *testing.T) {
 		cmd := config.UserCommand{Sh: "echo hello", Help: "run"}
-		a := handler.ResolveUserCommand("run", cmd, sess, nil)
+		a := handler.ResolveUserCommand("run", cmd, sess, nil, nil)
 		assert.Equal(t, act.TypeShell, a.Type)
 		assert.Equal(t, sess.Path, a.ShellDir)
 	})
 
 	t.Run("RenderWithFormData sets ShellDir to sess.Path", func(t *testing.T) {
 		cmd := config.UserCommand{Sh: "echo {{ .Form.msg }}", Help: "run"}
-		a := handler.RenderWithFormData("run", cmd, sess, nil, map[string]any{"msg": "hello"})
+		a := handler.RenderWithFormData("run", cmd, sess, nil, map[string]any{"msg": "hello"}, nil)
 		assert.Equal(t, act.TypeShell, a.Type)
 		assert.Equal(t, sess.Path, a.ShellDir)
 	})
@@ -751,7 +801,7 @@ func TestResolveWindowsAction_NewSession(t *testing.T) {
 	sess := testSession()
 
 	cmd := commands["PRReview"]
-	a := handler.RenderWithFormData("PRReview", cmd, sess, nil, map[string]any{"pr": "123"})
+	a := handler.RenderWithFormData("PRReview", cmd, sess, nil, map[string]any{"pr": "123"}, nil)
 
 	assert.Equal(t, act.TypeSpawnWindows, a.Type)
 	require.NotNil(t, a.SpawnWindows)
@@ -779,7 +829,7 @@ func TestResolveWindowsAction_NewSessionInheritsRemote(t *testing.T) {
 	sess := testSession()
 
 	cmd := commands["NewWin"]
-	a := handler.ResolveUserCommand("NewWin", cmd, sess, nil)
+	a := handler.ResolveUserCommand("NewWin", cmd, sess, nil, nil)
 
 	assert.Equal(t, act.TypeSpawnWindows, a.Type)
 	require.NotNil(t, a.SpawnWindows)
@@ -805,7 +855,7 @@ func TestResolveWindowsAction_NewSessionExplicitRemote(t *testing.T) {
 	sess := testSession()
 
 	cmd := commands["NewWin"]
-	a := handler.ResolveUserCommand("NewWin", cmd, sess, nil)
+	a := handler.ResolveUserCommand("NewWin", cmd, sess, nil, nil)
 
 	require.NotNil(t, a.SpawnWindows.NewSession)
 	assert.Equal(t, "https://github.com/other/repo", a.SpawnWindows.NewSession.Remote,
@@ -828,7 +878,7 @@ func TestResolveWindowsAction_TemplateError(t *testing.T) {
 	sess := testSession()
 
 	cmd := commands["Bad"]
-	a := handler.ResolveUserCommand("Bad", cmd, sess, nil)
+	a := handler.ResolveUserCommand("Bad", cmd, sess, nil, nil)
 
 	assert.Equal(t, act.TypeSpawnWindows, a.Type)
 	require.Error(t, a.Err)
@@ -1069,7 +1119,7 @@ func TestRenderWithFormData_WindowsWithFormValues(t *testing.T) {
 	sess := testSession()
 
 	cmd := commands["Spawn"]
-	a := handler.RenderWithFormData("Spawn", cmd, sess, nil, map[string]any{"pr": "456"})
+	a := handler.RenderWithFormData("Spawn", cmd, sess, nil, map[string]any{"pr": "456"}, nil)
 
 	assert.Equal(t, act.TypeSpawnWindows, a.Type)
 	require.NotNil(t, a.SpawnWindows)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -740,11 +740,28 @@ func (m Model) updateNewSessionForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// docTemplateData returns the focused review-view document for user-command
+// templates, or nil when not in the review view or no document is selected.
+func (m Model) docTemplateData() *DocTemplateData {
+	if m.activeView != ViewReview || m.reviewView == nil {
+		return nil
+	}
+	doc := m.reviewView.SelectedDoc()
+	if doc == nil {
+		return nil
+	}
+	return &DocTemplateData{
+		Path:    doc.Path,
+		RelPath: doc.RelPath,
+		Type:    strings.ToLower(doc.Type.String()),
+	}
+}
+
 // showFormOrExecute checks if a command has form fields. If so, creates a form
 // dialog. Otherwise falls through to normal execution via ResolveUserCommand.
 func (m Model) showFormOrExecute(name string, cmd config.UserCommand, sess session.Session, args []string) (Model, tea.Cmd) {
 	if len(cmd.Form) == 0 {
-		action := m.handler.ResolveUserCommand(name, cmd, sess, args)
+		action := m.handler.ResolveUserCommand(name, cmd, sess, args, m.docTemplateData())
 		return m.dispatchAction(action)
 	}
 
@@ -780,6 +797,7 @@ func (m Model) handleFormDialogKey(msg tea.KeyPressMsg, keyStr string) (tea.Mode
 			*m.modals.PendingFormSess,
 			m.modals.PendingFormArgs,
 			formValues,
+			m.docTemplateData(),
 		)
 		m.modals.ClearFormState()
 		return m.dispatchAction(action)
@@ -1193,7 +1211,7 @@ func (m Model) handleCommandPaletteKey(msg tea.KeyPressMsg, keyStr string) (tea.
 		}
 
 		// Resolve the user command to an Action
-		action := m.handler.ResolveUserCommand(entry.Name, entry.Command, *selected, args)
+		action := m.handler.ResolveUserCommand(entry.Name, entry.Command, *selected, args, m.docTemplateData())
 		action = sessions.MaybeOverrideWindowDelete(action, m.selectedTreeItem(), m.renderer)
 
 		m.state = stateNormal


### PR DESCRIPTION
## Summary

- Adds `.Doc.Path`, `.Doc.RelPath`, and `.Doc.Type` template variables to user-command shell templates, populated when a usercommand fires from the review view with a focused document.
- Threads an optional `*DocTemplateData` through `ResolveUserCommand` / `RenderWithFormData`; outside the review view or with no selected doc, `.Doc` fields render as empty strings.
- Documents the new variables and adds a placeholder so `{{ .Doc.* }}` survives `ValidateDeep`.

## Test plan

- [x] `mi check` (tidy + lint + test + deadcode) — clean
- [x] New unit tests in `internal/tui/keybindings_test.go` cover both `nil` and populated `DocTemplateData` for `ResolveUserCommand` and `RenderWithFormData`
- [x] New unit test in `internal/core/config/validate_test.go` validates a `{{ .Doc.Path }}` usercommand template through `ValidateDeep`