### PR TITLE
feat(lua): hive.ticker for interval timers and scheduled callbacks

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -132,6 +132,43 @@ hv
 
 Open the command palette with `:`, run `LuaHello`, and confirm that `.lua-plugin-output` was created in the selected session directory.
 
+### hive.ticker
+
+Schedule callbacks to run repeatedly or after a delay.
+
+| Function | Purpose |
+| -------- | ------- |
+| `hive.ticker.every(duration, fn)` | Run `fn` every `duration`. Returns a handle. |
+| `hive.ticker.after(duration, fn)` | Run `fn` once after `duration`. Returns a handle. |
+| `handle:cancel()` | Cancel the ticker. Idempotent. |
+
+`duration` accepts any Go duration string (e.g. `"5s"`, `"1m30s"`).
+
+```lua
+return function(hive)
+  local heartbeat = hive.ticker.every("5s", function()
+    hive.log.info("still alive")
+  end)
+
+  hive.ticker.after("60s", function()
+    hive.log.info("stopping heartbeat")
+    heartbeat:cancel()
+  end)
+end
+```
+
+!!! warning "1-second minimum interval"
+    Anything shorter raises a Lua error rather than silently clamping. Sub-second polling is not supported — pick reasonable cadences.
+
+!!! note "Callbacks run serially"
+    All ticker fires share the same dispatcher goroutine as your entrypoint and command handlers, so a long-running callback delays every other ticker on the plugin's Lua state.
+
+!!! warning "Backpressure: drop + log"
+    If a callback runs longer than the tick interval, additional ticks queue in a bounded buffer (currently 64 items per plugin). When the buffer is full, further ticks are dropped and a warning is logged. The module does **not** coalesce or skip cleanly — it drops, so plan for callbacks that may not fire on every tick under heavy load.
+
+!!! note "Shutdown cancels everything"
+    When hive shuts down or the plugin is reloaded, every outstanding ticker is cancelled and its callback is released for GC.
+
 ## Tmux Plugin
 
 The tmux plugin provides default commands for session management using bundled scripts (`hive-tmux`, `agent-send`) that are auto-extracted to `$HIVE_DATA_DIR/bin/`.

--- a/internal/hive/plugins/lua/module_ticker.go
+++ b/internal/hive/plugins/lua/module_ticker.go
@@ -70,10 +70,6 @@ type tickerHandle struct {
 // installs the per-instance registry sub-table used to pin Lua callback
 // functions for the lifetime of their handles.
 func (m *TickerModule) Register(state *glua.LState, hive *glua.LTable) error {
-	if m.Runtime == nil {
-		return fmt.Errorf("ticker module: Runtime is required")
-	}
-
 	m.handles = map[uint64]*tickerHandle{}
 	m.rootCtx, m.rootCancel = context.WithCancel(context.Background())
 	m.registryKey = fmt.Sprintf("%s%p", tickerRegistryKeyPrefix, m)

--- a/internal/hive/plugins/lua/module_ticker.go
+++ b/internal/hive/plugins/lua/module_ticker.go
@@ -1,0 +1,314 @@
+package lua
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// tickerMinInterval is the smallest interval a plugin may request via
+// hive.ticker.every / hive.ticker.after. The floor exists to keep runaway
+// plugins from spamming the dispatcher queue; we surface the violation as a
+// Lua error rather than silently clamping so authors notice.
+const tickerMinInterval = time.Second
+
+// tickerRegistryKeyPrefix namespaces the per-module sub-table inside the Lua
+// registry. The instance pointer is appended so multiple TickerModules on the
+// same LState (in tests, etc.) cannot stomp each other.
+const tickerRegistryKeyPrefix = "hive.ticker."
+
+// tickerHandleMetatableName is the registry key for the metatable shared by
+// every handle userdata produced by this module.
+const tickerHandleMetatableName = "hive.ticker.handle"
+
+// TickerModule exposes `hive.ticker.every` and `hive.ticker.after`, returning
+// userdata handles with a `:cancel()` method. All goroutines spawned by the
+// module bottom out at the runtime's dispatcher via Runtime.Submit so they
+// never touch the LState directly.
+type TickerModule struct {
+	Runtime    *Runtime
+	PluginName string
+
+	// rootCtx fans out to every per-handle context; cancelling it during Close
+	// stops every running ticker without per-handle bookkeeping.
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+
+	// wg tracks live ticker/timer goroutines so Close can join them.
+	wg sync.WaitGroup
+
+	// nextID hands out monotonically increasing handle IDs (also used as the
+	// registry sub-key, stringified).
+	nextID atomic.Uint64
+
+	mu      sync.Mutex
+	handles map[uint64]*tickerHandle
+
+	// registryKey is the key under which this module's function-pinning
+	// sub-table lives inside the Lua registry. Populated in Register.
+	registryKey string
+}
+
+// tickerHandle is the Go-side state behind the userdata returned to Lua.
+// Cancel is idempotent via once; the per-handle context cancel is what stops
+// the goroutine, and the registry slot is cleared via Submit so registry
+// mutations stay on the dispatcher goroutine.
+type tickerHandle struct {
+	id     uint64
+	cancel context.CancelFunc
+	once   sync.Once
+	module *TickerModule
+}
+
+// Register attaches `every` and `after` to a fresh `hive.ticker` subtable and
+// installs the per-instance registry sub-table used to pin Lua callback
+// functions for the lifetime of their handles.
+func (m *TickerModule) Register(state *glua.LState, hive *glua.LTable) error {
+	if m.Runtime == nil {
+		return fmt.Errorf("ticker module: Runtime is required")
+	}
+
+	m.handles = map[uint64]*tickerHandle{}
+	m.rootCtx, m.rootCancel = context.WithCancel(context.Background())
+	m.registryKey = fmt.Sprintf("%s%p", tickerRegistryKeyPrefix, m)
+
+	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
+	if !ok {
+		return fmt.Errorf("ticker module: lua registry is not a table")
+	}
+	state.SetField(registry, m.registryKey, state.NewTable())
+
+	m.ensureHandleMetatable(state)
+
+	ticker := state.NewTable()
+	state.SetField(ticker, "every", state.NewFunction(m.luaEvery))
+	state.SetField(ticker, "after", state.NewFunction(m.luaAfter))
+	state.SetField(hive, "ticker", ticker)
+	return nil
+}
+
+// Close stops every running ticker/timer goroutine and clears the handle map.
+// It is safe to call multiple times; the second call is a no-op because
+// rootCancel is idempotent and the map is already empty.
+func (m *TickerModule) Close() error {
+	if m.rootCancel != nil {
+		m.rootCancel()
+	}
+	m.wg.Wait()
+
+	m.mu.Lock()
+	m.handles = map[uint64]*tickerHandle{}
+	m.mu.Unlock()
+	return nil
+}
+
+// ensureHandleMetatable installs the metatable used by every handle userdata.
+// Sharing one metatable across handles keeps construction cheap and means the
+// `cancel` Go closure only allocates once per module.
+func (m *TickerModule) ensureHandleMetatable(state *glua.LState) {
+	mt := state.NewTypeMetatable(tickerHandleMetatableName)
+	state.SetField(mt, "__index", state.SetFuncs(state.NewTable(), map[string]glua.LGFunction{
+		"cancel": m.luaCancel,
+	}))
+}
+
+// luaEvery implements hive.ticker.every(duration, fn).
+func (m *TickerModule) luaEvery(state *glua.LState) int {
+	d, fn := m.checkArgs(state)
+	handle := m.spawn(state, fn, func(ctx context.Context, h *tickerHandle) {
+		t := time.NewTicker(d)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				m.fire(h)
+			}
+		}
+	})
+	state.Push(m.newHandleUserData(state, handle))
+	return 1
+}
+
+// luaAfter implements hive.ticker.after(duration, fn). The goroutine fires
+// exactly once, then auto-cancels so the registry slot and map entry are
+// released without the plugin having to call cancel explicitly.
+func (m *TickerModule) luaAfter(state *glua.LState) int {
+	d, fn := m.checkArgs(state)
+	handle := m.spawn(state, fn, func(ctx context.Context, h *tickerHandle) {
+		t := time.NewTimer(d)
+		defer t.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.fire(h)
+			h.Cancel()
+		}
+	})
+	state.Push(m.newHandleUserData(state, handle))
+	return 1
+}
+
+// luaCancel is the Lua-callable __index method on handle userdata.
+func (m *TickerModule) luaCancel(state *glua.LState) int {
+	ud := state.CheckUserData(1)
+	handle, ok := ud.Value.(*tickerHandle)
+	if !ok {
+		state.ArgError(1, "expected ticker handle")
+		return 0
+	}
+	handle.Cancel()
+	return 0
+}
+
+// checkArgs validates and parses the (duration, fn) argument pair shared by
+// every and after. It raises a Lua error on bad input, which longjmps out of
+// the calling C function — callers should treat its return as the only path
+// that survives.
+func (m *TickerModule) checkArgs(state *glua.LState) (time.Duration, *glua.LFunction) {
+	durationStr := state.CheckString(1)
+	fn := state.CheckFunction(2)
+
+	d, err := time.ParseDuration(durationStr)
+	if err != nil {
+		state.ArgError(1, fmt.Sprintf("invalid duration %q: %s", durationStr, err.Error()))
+	}
+	if d < tickerMinInterval {
+		state.ArgError(1, fmt.Sprintf("duration must be at least %s, got %s", tickerMinInterval, d))
+	}
+	return d, fn
+}
+
+// spawn pins fn in the registry, allocates a handle, and starts the supplied
+// run loop. It runs on the dispatcher goroutine, so registry and map writes
+// here are race-free with each other (but still need the mutex against
+// goroutine-side reads via Cancel-from-after).
+func (m *TickerModule) spawn(state *glua.LState, fn *glua.LFunction, run func(context.Context, *tickerHandle)) *tickerHandle {
+	id := m.nextID.Add(1)
+	ctx, cancel := context.WithCancel(m.rootCtx)
+	h := &tickerHandle{id: id, cancel: cancel, module: m}
+
+	m.storeFunction(state, id, fn)
+
+	m.mu.Lock()
+	m.handles[id] = h
+	m.mu.Unlock()
+
+	m.wg.Go(func() {
+		run(ctx, h)
+	})
+	return h
+}
+
+// fire is invoked from a ticker/timer goroutine. It hops onto the dispatcher
+// before touching the LState; if the runtime is closed Submit drops the work
+// and the goroutine exits via ctx cancellation on the next select.
+func (m *TickerModule) fire(h *tickerHandle) {
+	m.Runtime.Submit(func(state *glua.LState) {
+		fn := m.loadFunction(state, h.id)
+		if fn == nil {
+			// Handle was cancelled between fire and dispatch; nothing to do.
+			return
+		}
+		if err := state.CallByParam(glua.P{
+			Fn:      fn,
+			NRet:    0,
+			Protect: true,
+		}); err != nil {
+			log.Warn().
+				Str("plugin", m.PluginName).
+				Uint64("handle", h.id).
+				Err(err).
+				Msg("ticker callback returned error")
+		}
+	})
+}
+
+// Cancel stops the goroutine, removes the map entry, and clears the registry
+// slot. Safe to call from any goroutine and idempotent under sync.Once. The
+// registry release hops onto the dispatcher because the registry must only be
+// touched by the dispatcher goroutine.
+func (h *tickerHandle) Cancel() {
+	h.once.Do(func() {
+		h.cancel()
+
+		h.module.mu.Lock()
+		delete(h.module.handles, h.id)
+		h.module.mu.Unlock()
+
+		id := h.id
+		mod := h.module
+		mod.Runtime.Submit(func(state *glua.LState) {
+			mod.releaseFunction(state, id)
+		})
+	})
+}
+
+// newHandleUserData wraps a handle in *LUserData with the shared metatable
+// installed in Register. It must be called on the dispatcher goroutine.
+func (m *TickerModule) newHandleUserData(state *glua.LState, h *tickerHandle) *glua.LUserData {
+	ud := state.NewUserData()
+	ud.Value = h
+	state.SetMetatable(ud, state.GetTypeMetatable(tickerHandleMetatableName))
+	return ud
+}
+
+// storeFunction pins fn under the handle ID inside this module's registry
+// sub-table, preventing Lua GC from collecting it while the goroutine is
+// alive. Must run on the dispatcher goroutine.
+func (m *TickerModule) storeFunction(state *glua.LState, id uint64, fn *glua.LFunction) {
+	table := m.registryTable(state)
+	if table == nil {
+		return
+	}
+	state.SetField(table, strconv.FormatUint(id, 10), fn)
+}
+
+// loadFunction retrieves the pinned LFunction for a handle. Returns nil when
+// the handle has already been released, which races naturally with cancel
+// because both run on the dispatcher.
+func (m *TickerModule) loadFunction(state *glua.LState, id uint64) *glua.LFunction {
+	table := m.registryTable(state)
+	if table == nil {
+		return nil
+	}
+	value := state.GetField(table, strconv.FormatUint(id, 10))
+	fn, ok := value.(*glua.LFunction)
+	if !ok {
+		return nil
+	}
+	return fn
+}
+
+// releaseFunction drops the registry pin so the LFunction becomes eligible for
+// Lua GC. Must run on the dispatcher goroutine.
+func (m *TickerModule) releaseFunction(state *glua.LState, id uint64) {
+	table := m.registryTable(state)
+	if table == nil {
+		return
+	}
+	state.SetField(table, strconv.FormatUint(id, 10), glua.LNil)
+}
+
+// registryTable returns this module's pinning sub-table from the Lua
+// registry, or nil if Register has not been called yet. Must run on the
+// dispatcher goroutine.
+func (m *TickerModule) registryTable(state *glua.LState) *glua.LTable {
+	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
+	if !ok {
+		return nil
+	}
+	table, ok := state.GetField(registry, m.registryKey).(*glua.LTable)
+	if !ok {
+		return nil
+	}
+	return table
+}

--- a/internal/hive/plugins/lua/module_ticker.go
+++ b/internal/hive/plugins/lua/module_ticker.go
@@ -12,53 +12,44 @@ import (
 	glua "github.com/yuin/gopher-lua"
 )
 
-// tickerMinInterval is the smallest interval a plugin may request via
-// hive.ticker.every / hive.ticker.after. The floor exists to keep runaway
-// plugins from spamming the dispatcher queue; we surface the violation as a
-// Lua error rather than silently clamping so authors notice.
+// tickerMinInterval floors every/after; sub-second intervals raise a
+// Lua error rather than clamp silently.
 const tickerMinInterval = time.Second
 
-// tickerRegistryKeyPrefix namespaces the per-module sub-table inside the Lua
-// registry. The instance pointer is appended so multiple TickerModules on the
-// same LState (in tests, etc.) cannot stomp each other.
+// tickerRegistryKeyPrefix namespaces the per-module sub-table in the Lua
+// registry. The instance pointer is appended so tests with multiple
+// modules on one LState don't stomp each other.
 const tickerRegistryKeyPrefix = "hive.ticker."
 
-// tickerHandleMetatableName is the registry key for the metatable shared by
-// every handle userdata produced by this module.
+// tickerHandleMetatableName keys the metatable shared by every handle.
 const tickerHandleMetatableName = "hive.ticker.handle"
 
-// TickerModule exposes `hive.ticker.every` and `hive.ticker.after`, returning
-// userdata handles with a `:cancel()` method. All goroutines spawned by the
-// module bottom out at the runtime's dispatcher via Runtime.Submit so they
-// never touch the LState directly.
+// TickerModule exposes hive.ticker.every and hive.ticker.after, returning
+// userdata handles with a :cancel() method. Ticker goroutines route
+// callbacks through Runtime.Submit; they never touch the LState directly.
 type TickerModule struct {
 	Runtime    *Runtime
 	PluginName string
 
-	// rootCtx fans out to every per-handle context; cancelling it during Close
-	// stops every running ticker without per-handle bookkeeping.
+	// rootCtx fans out to every per-handle context; cancelling it during
+	// Close stops every running ticker.
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
 
-	// wg tracks live ticker/timer goroutines so Close can join them.
 	wg sync.WaitGroup
 
-	// nextID hands out monotonically increasing handle IDs (also used as the
-	// registry sub-key, stringified).
+	// nextID is also the per-handle registry sub-key, stringified.
 	nextID atomic.Uint64
 
 	mu      sync.Mutex
 	handles map[uint64]*tickerHandle
 
-	// registryKey is the key under which this module's function-pinning
-	// sub-table lives inside the Lua registry. Populated in Register.
 	registryKey string
 }
 
 // tickerHandle is the Go-side state behind the userdata returned to Lua.
-// Cancel is idempotent via once; the per-handle context cancel is what stops
-// the goroutine, and the registry slot is cleared via Submit so registry
-// mutations stay on the dispatcher goroutine.
+// Cancel is idempotent; the per-handle ctx stops the goroutine and the
+// registry slot is released via Submit.
 type tickerHandle struct {
 	id     uint64
 	cancel context.CancelFunc
@@ -66,9 +57,8 @@ type tickerHandle struct {
 	module *TickerModule
 }
 
-// Register attaches `every` and `after` to a fresh `hive.ticker` subtable and
-// installs the per-instance registry sub-table used to pin Lua callback
-// functions for the lifetime of their handles.
+// Register attaches every/after to a fresh hive.ticker subtable and
+// creates this module's registry sub-table for pinning callback functions.
 func (m *TickerModule) Register(state *glua.LState, hive *glua.LTable) error {
 	m.handles = map[uint64]*tickerHandle{}
 	m.rootCtx, m.rootCancel = context.WithCancel(context.Background())
@@ -89,9 +79,7 @@ func (m *TickerModule) Register(state *glua.LState, hive *glua.LTable) error {
 	return nil
 }
 
-// Close stops every running ticker/timer goroutine and clears the handle map.
-// It is safe to call multiple times; the second call is a no-op because
-// rootCancel is idempotent and the map is already empty.
+// Close stops every ticker goroutine and clears the handle map. Idempotent.
 func (m *TickerModule) Close() error {
 	if m.rootCancel != nil {
 		m.rootCancel()
@@ -104,9 +92,8 @@ func (m *TickerModule) Close() error {
 	return nil
 }
 
-// ensureHandleMetatable installs the metatable used by every handle userdata.
-// Sharing one metatable across handles keeps construction cheap and means the
-// `cancel` Go closure only allocates once per module.
+// ensureHandleMetatable installs the metatable shared by every handle.
+// One metatable per module means cancel allocates only once.
 func (m *TickerModule) ensureHandleMetatable(state *glua.LState) {
 	mt := state.NewTypeMetatable(tickerHandleMetatableName)
 	state.SetField(mt, "__index", state.SetFuncs(state.NewTable(), map[string]glua.LGFunction{
@@ -114,7 +101,6 @@ func (m *TickerModule) ensureHandleMetatable(state *glua.LState) {
 	}))
 }
 
-// luaEvery implements hive.ticker.every(duration, fn).
 func (m *TickerModule) luaEvery(state *glua.LState) int {
 	d, fn := m.checkArgs(state)
 	handle := m.spawn(state, fn, func(ctx context.Context, h *tickerHandle) {
@@ -133,9 +119,8 @@ func (m *TickerModule) luaEvery(state *glua.LState) int {
 	return 1
 }
 
-// luaAfter implements hive.ticker.after(duration, fn). The goroutine fires
-// exactly once, then auto-cancels so the registry slot and map entry are
-// released without the plugin having to call cancel explicitly.
+// luaAfter fires once then auto-cancels, releasing the registry slot
+// and map entry without an explicit cancel from the plugin.
 func (m *TickerModule) luaAfter(state *glua.LState) int {
 	d, fn := m.checkArgs(state)
 	handle := m.spawn(state, fn, func(ctx context.Context, h *tickerHandle) {
@@ -153,7 +138,7 @@ func (m *TickerModule) luaAfter(state *glua.LState) int {
 	return 1
 }
 
-// luaCancel is the Lua-callable __index method on handle userdata.
+// luaCancel is the __index method bound to handle userdata.
 func (m *TickerModule) luaCancel(state *glua.LState) int {
 	ud := state.CheckUserData(1)
 	handle, ok := ud.Value.(*tickerHandle)
@@ -165,10 +150,8 @@ func (m *TickerModule) luaCancel(state *glua.LState) int {
 	return 0
 }
 
-// checkArgs validates and parses the (duration, fn) argument pair shared by
-// every and after. It raises a Lua error on bad input, which longjmps out of
-// the calling C function — callers should treat its return as the only path
-// that survives.
+// checkArgs parses (duration, fn). On bad input it raises a Lua error,
+// which longjmps out of the calling C function — there is no error return.
 func (m *TickerModule) checkArgs(state *glua.LState) (time.Duration, *glua.LFunction) {
 	durationStr := state.CheckString(1)
 	fn := state.CheckFunction(2)
@@ -183,10 +166,9 @@ func (m *TickerModule) checkArgs(state *glua.LState) (time.Duration, *glua.LFunc
 	return d, fn
 }
 
-// spawn pins fn in the registry, allocates a handle, and starts the supplied
-// run loop. It runs on the dispatcher goroutine, so registry and map writes
-// here are race-free with each other (but still need the mutex against
-// goroutine-side reads via Cancel-from-after).
+// spawn pins fn, allocates a handle, and starts run on a goroutine.
+// Runs on the dispatcher; the mutex guards against goroutine-side
+// Cancel via the after-fire path.
 func (m *TickerModule) spawn(state *glua.LState, fn *glua.LFunction, run func(context.Context, *tickerHandle)) *tickerHandle {
 	id := m.nextID.Add(1)
 	ctx, cancel := context.WithCancel(m.rootCtx)
@@ -204,14 +186,13 @@ func (m *TickerModule) spawn(state *glua.LState, fn *glua.LFunction, run func(co
 	return h
 }
 
-// fire is invoked from a ticker/timer goroutine. It hops onto the dispatcher
-// before touching the LState; if the runtime is closed Submit drops the work
-// and the goroutine exits via ctx cancellation on the next select.
+// fire hops from a ticker goroutine onto the dispatcher to run the
+// callback. If the runtime is closed, Submit drops the work.
 func (m *TickerModule) fire(h *tickerHandle) {
 	m.Runtime.Submit(func(state *glua.LState) {
 		fn := m.loadFunction(state, h.id)
 		if fn == nil {
-			// Handle was cancelled between fire and dispatch; nothing to do.
+			// Cancelled between fire and dispatch.
 			return
 		}
 		if err := state.CallByParam(glua.P{
@@ -228,10 +209,8 @@ func (m *TickerModule) fire(h *tickerHandle) {
 	})
 }
 
-// Cancel stops the goroutine, removes the map entry, and clears the registry
-// slot. Safe to call from any goroutine and idempotent under sync.Once. The
-// registry release hops onto the dispatcher because the registry must only be
-// touched by the dispatcher goroutine.
+// Cancel stops the goroutine, removes the map entry, and releases the
+// registry slot via Submit. Idempotent and safe from any goroutine.
 func (h *tickerHandle) Cancel() {
 	h.once.Do(func() {
 		h.cancel()
@@ -248,8 +227,8 @@ func (h *tickerHandle) Cancel() {
 	})
 }
 
-// newHandleUserData wraps a handle in *LUserData with the shared metatable
-// installed in Register. It must be called on the dispatcher goroutine.
+// newHandleUserData wraps a handle in *LUserData with the shared metatable.
+// Must run on the dispatcher.
 func (m *TickerModule) newHandleUserData(state *glua.LState, h *tickerHandle) *glua.LUserData {
 	ud := state.NewUserData()
 	ud.Value = h
@@ -257,9 +236,8 @@ func (m *TickerModule) newHandleUserData(state *glua.LState, h *tickerHandle) *g
 	return ud
 }
 
-// storeFunction pins fn under the handle ID inside this module's registry
-// sub-table, preventing Lua GC from collecting it while the goroutine is
-// alive. Must run on the dispatcher goroutine.
+// storeFunction pins fn so Lua cannot GC it while the goroutine holds
+// a reference. Must run on the dispatcher.
 func (m *TickerModule) storeFunction(state *glua.LState, id uint64, fn *glua.LFunction) {
 	table := m.registryTable(state)
 	if table == nil {
@@ -268,9 +246,8 @@ func (m *TickerModule) storeFunction(state *glua.LState, id uint64, fn *glua.LFu
 	state.SetField(table, strconv.FormatUint(id, 10), fn)
 }
 
-// loadFunction retrieves the pinned LFunction for a handle. Returns nil when
-// the handle has already been released, which races naturally with cancel
-// because both run on the dispatcher.
+// loadFunction returns the pinned function for a handle, or nil if
+// already released. Cancel and load both run on the dispatcher.
 func (m *TickerModule) loadFunction(state *glua.LState, id uint64) *glua.LFunction {
 	table := m.registryTable(state)
 	if table == nil {
@@ -284,8 +261,8 @@ func (m *TickerModule) loadFunction(state *glua.LState, id uint64) *glua.LFuncti
 	return fn
 }
 
-// releaseFunction drops the registry pin so the LFunction becomes eligible for
-// Lua GC. Must run on the dispatcher goroutine.
+// releaseFunction drops the registry pin so Lua can GC the LFunction.
+// Must run on the dispatcher.
 func (m *TickerModule) releaseFunction(state *glua.LState, id uint64) {
 	table := m.registryTable(state)
 	if table == nil {
@@ -294,9 +271,8 @@ func (m *TickerModule) releaseFunction(state *glua.LState, id uint64) {
 	state.SetField(table, strconv.FormatUint(id, 10), glua.LNil)
 }
 
-// registryTable returns this module's pinning sub-table from the Lua
-// registry, or nil if Register has not been called yet. Must run on the
-// dispatcher goroutine.
+// registryTable returns this module's pinning sub-table, or nil if
+// Register has not run.
 func (m *TickerModule) registryTable(state *glua.LState) *glua.LTable {
 	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
 	if !ok {

--- a/internal/hive/plugins/lua/module_ticker_test.go
+++ b/internal/hive/plugins/lua/module_ticker_test.go
@@ -13,8 +13,7 @@ import (
 	glua "github.com/yuin/gopher-lua"
 )
 
-// bumpModule is a test-only HostModule that exposes `hive.test_bump()` for
-// observing how many times a Lua callback executed on the dispatcher.
+// bumpModule exposes hive.test_bump() so tests can count Lua-side fires.
 type bumpModule struct {
 	counter *atomic.Int64
 }
@@ -27,10 +26,8 @@ func (b *bumpModule) Register(state *glua.LState, hive *glua.LTable) error {
 	return nil
 }
 
-// tickerHarness wires a Runtime + TickerModule + bumpModule together and runs
-// the supplied Lua script as the entrypoint so the call to
-// `hive.ticker.every` / `hive.ticker.after` happens on the dispatcher
-// goroutine. The returned counter is bumped each time the Lua callback runs.
+// tickerHarness wires a Runtime + TickerModule + bumpModule and runs the
+// supplied Lua script as the entrypoint. counter bumps on every fire.
 type tickerHarness struct {
 	runtime *Runtime
 	module  *TickerModule
@@ -67,13 +64,11 @@ func newTickerHarness(t *testing.T, script string) *tickerHarness {
 }
 
 func (h *tickerHarness) Close() {
-	// Mirror Plugin.shutdown(): close modules in reverse order before runtime.
+	// Mirror Plugin.shutdown: module before runtime.
 	_ = h.module.Close()
 	h.runtime.Close()
 }
 
-// closeWithCleanup wires harness shutdown into t.Cleanup so each test releases
-// goroutines and the LState even on early failures.
 func (h *tickerHarness) closeWithCleanup(t *testing.T) {
 	t.Helper()
 	t.Cleanup(h.Close)
@@ -114,8 +109,7 @@ end
 func TestTickerCancelStopsFurtherFires(t *testing.T) {
 	t.Parallel()
 
-	// The Lua callback cancels its own handle on the first fire, so we should
-	// see exactly one bump regardless of how long we sleep afterwards.
+	// Callback cancels itself on first fire — exactly one bump expected.
 	h := newTickerHarness(t, `
 return function(hive)
   local handle
@@ -127,8 +121,7 @@ end
 `)
 	h.closeWithCleanup(t)
 
-	// Wait long enough for the first fire plus several intervals afterwards
-	// so a missed cancel would surface as additional bumps.
+	// 3s covers several would-be ticks if cancel were missed.
 	time.Sleep(3 * time.Second)
 
 	got := h.counter.Load()
@@ -138,8 +131,6 @@ end
 func TestTickerCallbackErrorsKeepFiring(t *testing.T) {
 	t.Parallel()
 
-	// The callback bumps the counter and then raises a Lua error. The runtime
-	// should log it and keep the ticker alive.
 	h := newTickerHarness(t, `
 return function(hive)
   hive.ticker.every("1s", function()
@@ -157,12 +148,9 @@ end
 }
 
 func TestTickerCloseCancelsAllOutstandingTickers(t *testing.T) {
-	// Intentionally NOT t.Parallel(): runtime.NumGoroutine is process-wide so
-	// concurrent ticker tests would corrupt the before/after delta.
+	// Not parallel: runtime.NumGoroutine is process-wide.
 
-	// Allow the test process a moment to settle background goroutines from
-	// the harness setup before we capture the baseline.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) // settle baseline
 	before := runtime.NumGoroutine()
 
 	h := newTickerHarness(t, `
@@ -173,18 +161,14 @@ return function(hive)
 end
 `)
 
-	// Confirm tickers are actually running before we shut them down.
 	time.Sleep(1200 * time.Millisecond)
 	require.Positive(t, h.counter.Load(), "tickers should have fired before close")
 
 	h.Close()
-
-	// Give the runtime a tick to fully unwind goroutines.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond) // let goroutines unwind
 	after := runtime.NumGoroutine()
 
-	// runtime.NumGoroutine is inherently noisy with -parallel; allow a small
-	// margin but flag any obvious leak (the 3 ticker goroutines + dispatcher).
+	// NumGoroutine is noisy; allow a small margin but flag obvious leaks.
 	assert.LessOrEqual(t, after, before+2,
 		"goroutine count should not grow appreciably after Close (before=%d, after=%d)", before, after)
 }
@@ -192,10 +176,8 @@ end
 func TestTickerEveryRejectsSubSecondDuration(t *testing.T) {
 	t.Parallel()
 
-	// The Lua entrypoint uses pcall and stashes the error message in a global
-	// so we can inspect it from Go via a follow-up bump-style probe. If the
-	// duration is rejected, no ticker is registered and the counter must stay
-	// at zero even after we sleep past the would-be interval.
+	// The entrypoint asserts via pcall that the call errored with the
+	// expected message; the counter stays zero since no ticker registers.
 	root := t.TempDir()
 	entry := filepath.Join(root, "init.lua")
 	script := `
@@ -232,7 +214,6 @@ end
 	require.NoError(t, err)
 	require.NoError(t, rt.CallEntrypoint(fn))
 
-	// Wait past 500ms to confirm no ticker was registered.
 	time.Sleep(1200 * time.Millisecond)
 	assert.Equal(t, int64(0), counter.Load(), "no ticker should have been registered")
 }

--- a/internal/hive/plugins/lua/module_ticker_test.go
+++ b/internal/hive/plugins/lua/module_ticker_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -76,41 +77,44 @@ func (h *tickerHarness) closeWithCleanup(t *testing.T) {
 
 func TestTickerEveryFiresRepeatedly(t *testing.T) {
 	t.Parallel()
-
-	h := newTickerHarness(t, `
+	synctest.Test(t, func(t *testing.T) {
+		h := newTickerHarness(t, `
 return function(hive)
   hive.ticker.every("1s", function() hive.test_bump() end)
 end
 `)
-	h.closeWithCleanup(t)
+		h.closeWithCleanup(t)
 
-	time.Sleep(2500 * time.Millisecond)
+		// 2.5s of virtual time fires the 1s ticker exactly twice.
+		time.Sleep(2500 * time.Millisecond)
+		synctest.Wait()
 
-	got := h.counter.Load()
-	assert.GreaterOrEqual(t, got, int64(2), "ticker should fire at least twice in 2.5s")
+		assert.Equal(t, int64(2), h.counter.Load())
+	})
 }
 
 func TestTickerAfterFiresOnce(t *testing.T) {
 	t.Parallel()
-
-	h := newTickerHarness(t, `
+	synctest.Test(t, func(t *testing.T) {
+		h := newTickerHarness(t, `
 return function(hive)
   hive.ticker.after("1s", function() hive.test_bump() end)
 end
 `)
-	h.closeWithCleanup(t)
+		h.closeWithCleanup(t)
 
-	time.Sleep(2500 * time.Millisecond)
+		time.Sleep(2500 * time.Millisecond)
+		synctest.Wait()
 
-	got := h.counter.Load()
-	assert.Equal(t, int64(1), got, "after should fire exactly once")
+		assert.Equal(t, int64(1), h.counter.Load())
+	})
 }
 
 func TestTickerCancelStopsFurtherFires(t *testing.T) {
 	t.Parallel()
-
-	// Callback cancels itself on first fire — exactly one bump expected.
-	h := newTickerHarness(t, `
+	synctest.Test(t, func(t *testing.T) {
+		// Callback cancels itself on first fire — exactly one bump expected.
+		h := newTickerHarness(t, `
 return function(hive)
   local handle
   handle = hive.ticker.every("1s", function()
@@ -119,19 +123,20 @@ return function(hive)
   end)
 end
 `)
-	h.closeWithCleanup(t)
+		h.closeWithCleanup(t)
 
-	// 3s covers several would-be ticks if cancel were missed.
-	time.Sleep(3 * time.Second)
+		// 3s covers several would-be ticks if cancel were missed.
+		time.Sleep(3 * time.Second)
+		synctest.Wait()
 
-	got := h.counter.Load()
-	assert.Equal(t, int64(1), got, "cancel from inside callback must stop further fires")
+		assert.Equal(t, int64(1), h.counter.Load())
+	})
 }
 
 func TestTickerCallbackErrorsKeepFiring(t *testing.T) {
 	t.Parallel()
-
-	h := newTickerHarness(t, `
+	synctest.Test(t, func(t *testing.T) {
+		h := newTickerHarness(t, `
 return function(hive)
   hive.ticker.every("1s", function()
     hive.test_bump()
@@ -139,21 +144,22 @@ return function(hive)
   end)
 end
 `)
-	h.closeWithCleanup(t)
+		h.closeWithCleanup(t)
 
-	time.Sleep(2500 * time.Millisecond)
+		time.Sleep(2500 * time.Millisecond)
+		synctest.Wait()
 
-	got := h.counter.Load()
-	assert.GreaterOrEqual(t, got, int64(2), "ticker must keep firing after callback errors")
+		assert.Equal(t, int64(2), h.counter.Load())
+	})
 }
 
 func TestTickerCloseCancelsAllOutstandingTickers(t *testing.T) {
 	// Not parallel: runtime.NumGoroutine is process-wide.
+	synctest.Test(t, func(t *testing.T) {
+		synctest.Wait()
+		before := runtime.NumGoroutine()
 
-	time.Sleep(100 * time.Millisecond) // settle baseline
-	before := runtime.NumGoroutine()
-
-	h := newTickerHarness(t, `
+		h := newTickerHarness(t, `
 return function(hive)
   hive.ticker.every("1s", function() hive.test_bump() end)
   hive.ticker.every("1s", function() hive.test_bump() end)
@@ -161,26 +167,28 @@ return function(hive)
 end
 `)
 
-	time.Sleep(1200 * time.Millisecond)
-	require.Positive(t, h.counter.Load(), "tickers should have fired before close")
+		time.Sleep(1200 * time.Millisecond)
+		synctest.Wait()
+		require.Positive(t, h.counter.Load(), "tickers should have fired before close")
 
-	h.Close()
-	time.Sleep(200 * time.Millisecond) // let goroutines unwind
-	after := runtime.NumGoroutine()
+		h.Close()
+		synctest.Wait()
+		after := runtime.NumGoroutine()
 
-	// NumGoroutine is noisy; allow a small margin but flag obvious leaks.
-	assert.LessOrEqual(t, after, before+2,
-		"goroutine count should not grow appreciably after Close (before=%d, after=%d)", before, after)
+		// NumGoroutine is noisy; allow a small margin but flag obvious leaks.
+		assert.LessOrEqual(t, after, before+2,
+			"goroutine count should not grow appreciably after Close (before=%d, after=%d)", before, after)
+	})
 }
 
 func TestTickerEveryRejectsSubSecondDuration(t *testing.T) {
 	t.Parallel()
-
-	// The entrypoint asserts via pcall that the call errored with the
-	// expected message; the counter stays zero since no ticker registers.
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	script := `
+	synctest.Test(t, func(t *testing.T) {
+		// The entrypoint asserts via pcall that the call errored with the
+		// expected message; the counter stays zero since no ticker registers.
+		root := t.TempDir()
+		entry := filepath.Join(root, "init.lua")
+		script := `
 return function(hive)
   local ok, err = pcall(hive.ticker.every, "500ms", function() hive.test_bump() end)
   if ok then
@@ -191,29 +199,31 @@ return function(hive)
   end
 end
 `
-	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+		require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
 
-	counter := &atomic.Int64{}
-	tickerModule := &TickerModule{PluginName: "lua-test"}
-	rt, err := NewRuntime(
-		root,
-		&LogModule{PluginName: "lua-test"},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		tickerModule,
-		&bumpModule{counter: counter},
-	)
-	require.NoError(t, err)
-	tickerModule.Runtime = rt
-	t.Cleanup(func() {
-		_ = tickerModule.Close()
-		rt.Close()
+		counter := &atomic.Int64{}
+		tickerModule := &TickerModule{PluginName: "lua-test"}
+		rt, err := NewRuntime(
+			root,
+			&LogModule{PluginName: "lua-test"},
+			&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+			&CommandsModule{},
+			tickerModule,
+			&bumpModule{counter: counter},
+		)
+		require.NoError(t, err)
+		tickerModule.Runtime = rt
+		t.Cleanup(func() {
+			_ = tickerModule.Close()
+			rt.Close()
+		})
+
+		fn, err := rt.LoadEntrypoint(entry)
+		require.NoError(t, err)
+		require.NoError(t, rt.CallEntrypoint(fn))
+
+		time.Sleep(1200 * time.Millisecond)
+		synctest.Wait()
+		assert.Equal(t, int64(0), counter.Load(), "no ticker should have been registered")
 	})
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
-
-	time.Sleep(1200 * time.Millisecond)
-	assert.Equal(t, int64(0), counter.Load(), "no ticker should have been registered")
 }

--- a/internal/hive/plugins/lua/module_ticker_test.go
+++ b/internal/hive/plugins/lua/module_ticker_test.go
@@ -1,0 +1,238 @@
+package lua
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// bumpModule is a test-only HostModule that exposes `hive.test_bump()` for
+// observing how many times a Lua callback executed on the dispatcher.
+type bumpModule struct {
+	counter *atomic.Int64
+}
+
+func (b *bumpModule) Register(state *glua.LState, hive *glua.LTable) error {
+	state.SetField(hive, "test_bump", state.NewFunction(func(state *glua.LState) int {
+		b.counter.Add(1)
+		return 0
+	}))
+	return nil
+}
+
+// tickerHarness wires a Runtime + TickerModule + bumpModule together and runs
+// the supplied Lua script as the entrypoint so the call to
+// `hive.ticker.every` / `hive.ticker.after` happens on the dispatcher
+// goroutine. The returned counter is bumped each time the Lua callback runs.
+type tickerHarness struct {
+	runtime *Runtime
+	module  *TickerModule
+	counter *atomic.Int64
+}
+
+func newTickerHarness(t *testing.T, script string) *tickerHarness {
+	t.Helper()
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+
+	counter := &atomic.Int64{}
+	tickerModule := &TickerModule{PluginName: "lua-test"}
+	bump := &bumpModule{counter: counter}
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		tickerModule,
+		bump,
+	)
+	require.NoError(t, err)
+	tickerModule.Runtime = rt
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	return &tickerHarness{runtime: rt, module: tickerModule, counter: counter}
+}
+
+func (h *tickerHarness) Close() {
+	// Mirror Plugin.shutdown(): close modules in reverse order before runtime.
+	_ = h.module.Close()
+	h.runtime.Close()
+}
+
+// closeWithCleanup wires harness shutdown into t.Cleanup so each test releases
+// goroutines and the LState even on early failures.
+func (h *tickerHarness) closeWithCleanup(t *testing.T) {
+	t.Helper()
+	t.Cleanup(h.Close)
+}
+
+func TestTickerEveryFiresRepeatedly(t *testing.T) {
+	t.Parallel()
+
+	h := newTickerHarness(t, `
+return function(hive)
+  hive.ticker.every("1s", function() hive.test_bump() end)
+end
+`)
+	h.closeWithCleanup(t)
+
+	time.Sleep(2500 * time.Millisecond)
+
+	got := h.counter.Load()
+	assert.GreaterOrEqual(t, got, int64(2), "ticker should fire at least twice in 2.5s")
+}
+
+func TestTickerAfterFiresOnce(t *testing.T) {
+	t.Parallel()
+
+	h := newTickerHarness(t, `
+return function(hive)
+  hive.ticker.after("1s", function() hive.test_bump() end)
+end
+`)
+	h.closeWithCleanup(t)
+
+	time.Sleep(2500 * time.Millisecond)
+
+	got := h.counter.Load()
+	assert.Equal(t, int64(1), got, "after should fire exactly once")
+}
+
+func TestTickerCancelStopsFurtherFires(t *testing.T) {
+	t.Parallel()
+
+	// The Lua callback cancels its own handle on the first fire, so we should
+	// see exactly one bump regardless of how long we sleep afterwards.
+	h := newTickerHarness(t, `
+return function(hive)
+  local handle
+  handle = hive.ticker.every("1s", function()
+    hive.test_bump()
+    handle:cancel()
+  end)
+end
+`)
+	h.closeWithCleanup(t)
+
+	// Wait long enough for the first fire plus several intervals afterwards
+	// so a missed cancel would surface as additional bumps.
+	time.Sleep(3 * time.Second)
+
+	got := h.counter.Load()
+	assert.Equal(t, int64(1), got, "cancel from inside callback must stop further fires")
+}
+
+func TestTickerCallbackErrorsKeepFiring(t *testing.T) {
+	t.Parallel()
+
+	// The callback bumps the counter and then raises a Lua error. The runtime
+	// should log it and keep the ticker alive.
+	h := newTickerHarness(t, `
+return function(hive)
+  hive.ticker.every("1s", function()
+    hive.test_bump()
+    error("boom")
+  end)
+end
+`)
+	h.closeWithCleanup(t)
+
+	time.Sleep(2500 * time.Millisecond)
+
+	got := h.counter.Load()
+	assert.GreaterOrEqual(t, got, int64(2), "ticker must keep firing after callback errors")
+}
+
+func TestTickerCloseCancelsAllOutstandingTickers(t *testing.T) {
+	// Intentionally NOT t.Parallel(): runtime.NumGoroutine is process-wide so
+	// concurrent ticker tests would corrupt the before/after delta.
+
+	// Allow the test process a moment to settle background goroutines from
+	// the harness setup before we capture the baseline.
+	time.Sleep(100 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	h := newTickerHarness(t, `
+return function(hive)
+  hive.ticker.every("1s", function() hive.test_bump() end)
+  hive.ticker.every("1s", function() hive.test_bump() end)
+  hive.ticker.after("1s", function() hive.test_bump() end)
+end
+`)
+
+	// Confirm tickers are actually running before we shut them down.
+	time.Sleep(1200 * time.Millisecond)
+	require.Positive(t, h.counter.Load(), "tickers should have fired before close")
+
+	h.Close()
+
+	// Give the runtime a tick to fully unwind goroutines.
+	time.Sleep(200 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	// runtime.NumGoroutine is inherently noisy with -parallel; allow a small
+	// margin but flag any obvious leak (the 3 ticker goroutines + dispatcher).
+	assert.LessOrEqual(t, after, before+2,
+		"goroutine count should not grow appreciably after Close (before=%d, after=%d)", before, after)
+}
+
+func TestTickerEveryRejectsSubSecondDuration(t *testing.T) {
+	t.Parallel()
+
+	// The Lua entrypoint uses pcall and stashes the error message in a global
+	// so we can inspect it from Go via a follow-up bump-style probe. If the
+	// duration is rejected, no ticker is registered and the counter must stay
+	// at zero even after we sleep past the would-be interval.
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	script := `
+return function(hive)
+  local ok, err = pcall(hive.ticker.every, "500ms", function() hive.test_bump() end)
+  if ok then
+    error("expected sub-second duration to be rejected")
+  end
+  if not string.find(tostring(err), "duration must be at least") then
+    error("unexpected error: " .. tostring(err))
+  end
+end
+`
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+
+	counter := &atomic.Int64{}
+	tickerModule := &TickerModule{PluginName: "lua-test"}
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		tickerModule,
+		&bumpModule{counter: counter},
+	)
+	require.NoError(t, err)
+	tickerModule.Runtime = rt
+	t.Cleanup(func() {
+		_ = tickerModule.Close()
+		rt.Close()
+	})
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	// Wait past 500ms to confirm no ticker was registered.
+	time.Sleep(1200 * time.Millisecond)
+	assert.Equal(t, int64(0), counter.Load(), "no ticker should have been registered")
+}

--- a/internal/hive/plugins/lua/modules.go
+++ b/internal/hive/plugins/lua/modules.go
@@ -11,3 +11,11 @@ import (
 type HostModule interface {
 	Register(state *glua.LState, hive *glua.LTable) error
 }
+
+// HostModuleCloser is an optional add-on for HostModules that own background
+// resources (goroutines, timers, channels). Callers should type-assert each
+// module to this interface and call Close before closing the LState, so the
+// module can stop its workers while Lua callbacks are still safe to invoke.
+type HostModuleCloser interface {
+	Close() error
+}

--- a/internal/hive/plugins/lua/modules.go
+++ b/internal/hive/plugins/lua/modules.go
@@ -12,10 +12,9 @@ type HostModule interface {
 	Register(state *glua.LState, hive *glua.LTable) error
 }
 
-// HostModuleCloser is an optional add-on for HostModules that own background
-// resources (goroutines, timers, channels). Callers should type-assert each
-// module to this interface and call Close before closing the LState, so the
-// module can stop its workers while Lua callbacks are still safe to invoke.
+// HostModuleCloser is an optional add-on for HostModules with background
+// resources. Plugin.Close invokes it before closing the LState so workers
+// stop while Lua callbacks are still safe to invoke.
 type HostModuleCloser interface {
 	Close() error
 }

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/hive/plugins"
 )
@@ -13,6 +15,7 @@ import (
 type Plugin struct {
 	cfg      config.LuaPluginConfig
 	runtime  *Runtime
+	modules  []HostModule
 	commands map[string]config.UserCommand
 }
 
@@ -29,16 +32,15 @@ func (p *Plugin) Available() bool {
 }
 
 func (p *Plugin) Init(_ context.Context) error {
-	if p.runtime != nil {
-		p.runtime.Close()
-		p.runtime = nil
-	}
-	p.commands = nil
+	p.shutdown()
 
 	// Build into a fresh CommandsModule so a partial init (failure during
 	// entry-file load or while calling the entrypoint) cannot leave stale
 	// commands reachable from MergedCommands.
 	cmdModule := &CommandsModule{}
+
+	tickerModule := &TickerModule{PluginName: p.Name()}
+
 	modules := []HostModule{
 		&LogModule{PluginName: p.Name()},
 		&PluginInfoModule{
@@ -47,36 +49,67 @@ func (p *Plugin) Init(_ context.Context) error {
 			ModuleRoot: p.cfg.ModuleRoot(),
 		},
 		cmdModule,
+		tickerModule,
 	}
 
 	runtime, err := NewRuntime(p.cfg.ModuleRoot(), modules...)
 	if err != nil {
 		return err
 	}
+	// Runtime is wired in after construction because NewRuntime is the function that produces it. Register stores no Runtime calls, so this is safe.
+	tickerModule.Runtime = runtime
+
+	// Stash modules and runtime now so a failure during LoadEntrypoint or
+	// CallEntrypoint can be cleaned up via shutdown(), which closes every
+	// HostModuleCloser before tearing down the runtime.
+	p.runtime = runtime
+	p.modules = modules
 
 	entrypoint, err := runtime.LoadEntrypoint(p.cfg.ResolvedEntry())
 	if err != nil {
-		runtime.Close()
+		p.shutdown()
 		return err
 	}
 
 	if err := runtime.CallEntrypoint(entrypoint); err != nil {
-		runtime.Close()
+		p.shutdown()
 		return fmt.Errorf("initialize lua plugin %q: %w", p.cfg.ResolvedEntry(), err)
 	}
 
-	p.runtime = runtime
 	p.commands = cmdModule.Commands()
 	return nil
 }
 
 func (p *Plugin) Close() error {
+	p.shutdown()
+	return nil
+}
+
+// shutdown tears down the runtime and every module that owns background
+// resources, in reverse-registration order. Module Close errors are logged
+// but do not short-circuit the loop — every module gets a chance to release
+// its resources before the runtime goes away. Safe to call on a partially
+// initialised Plugin and idempotent across repeated calls.
+func (p *Plugin) shutdown() {
+	for i := len(p.modules) - 1; i >= 0; i-- {
+		closer, ok := p.modules[i].(HostModuleCloser)
+		if !ok {
+			continue
+		}
+		if err := closer.Close(); err != nil {
+			log.Warn().
+				Str("plugin", p.Name()).
+				Err(err).
+				Msg("host module close failed")
+		}
+	}
+	p.modules = nil
+
 	if p.runtime != nil {
 		p.runtime.Close()
 		p.runtime = nil
 	}
 	p.commands = nil
-	return nil
 }
 
 func (p *Plugin) Commands() map[string]config.UserCommand {

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -56,12 +56,10 @@ func (p *Plugin) Init(_ context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Runtime is wired in after construction because NewRuntime is the function that produces it. Register stores no Runtime calls, so this is safe.
+	// Wired post-construction; Register makes no Runtime calls.
 	tickerModule.Runtime = runtime
 
-	// Stash modules and runtime now so a failure during LoadEntrypoint or
-	// CallEntrypoint can be cleaned up via shutdown(), which closes every
-	// HostModuleCloser before tearing down the runtime.
+	// Stash now so an entrypoint failure below cleans up via shutdown().
 	p.runtime = runtime
 	p.modules = modules
 
@@ -85,11 +83,9 @@ func (p *Plugin) Close() error {
 	return nil
 }
 
-// shutdown tears down the runtime and every module that owns background
-// resources, in reverse-registration order. Module Close errors are logged
-// but do not short-circuit the loop — every module gets a chance to release
-// its resources before the runtime goes away. Safe to call on a partially
-// initialised Plugin and idempotent across repeated calls.
+// shutdown closes every HostModuleCloser in reverse-registration order
+// before closing the runtime. Errors are logged but do not short-circuit.
+// Safe on a partial init; idempotent.
 func (p *Plugin) shutdown() {
 	for i := len(p.modules) - 1; i >= 0; i-- {
 		closer, ok := p.modules[i].(HostModuleCloser)

--- a/internal/hive/plugins/lua/runtime.go
+++ b/internal/hive/plugins/lua/runtime.go
@@ -2,22 +2,46 @@
 package lua
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
+	"sync"
 
+	"github.com/rs/zerolog/log"
 	glua "github.com/yuin/gopher-lua"
 )
 
-// Runtime owns a sandboxed Lua state for a Hive plugin. The state is private:
-// callers interact through LoadEntrypoint / CallEntrypoint / Close.
+// dispatcherQueueSize is the buffer size of the work-item channel feeding the
+// dispatcher goroutine. It is sized to absorb short bursts of asynchronous
+// callbacks (e.g. ticker fires) without forcing producers to block, while
+// still being small enough that a runaway producer is detected and reported
+// via the drop-and-log overflow policy.
+const dispatcherQueueSize = 64
+
+// Runtime owns a sandboxed Lua state for a Hive plugin. The state is private
+// and is touched by exactly one goroutine — the dispatcher started in
+// NewRuntime. Callers schedule work onto that goroutine via Submit or via the
+// higher-level helpers LoadEntrypoint / CallEntrypoint, and tear the runtime
+// down with Close.
 type Runtime struct {
 	state *glua.LState
+
+	work   chan func(*glua.LState)
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu     sync.Mutex
+	closed bool
 }
 
 // NewRuntime constructs a sandboxed Lua runtime, configures `require()` to
 // resolve relative to moduleRoot, and registers each HostModule onto the
-// global `hive` table in order.
+// global `hive` table in order. Setup runs synchronously on the calling
+// goroutine; once it returns the dispatcher goroutine is started and is
+// thereafter the sole owner of the underlying LState.
 func NewRuntime(moduleRoot string, modules ...HostModule) (*Runtime, error) {
 	state := glua.NewState(glua.Options{SkipOpenLibs: true})
 
@@ -47,54 +71,205 @@ func NewRuntime(moduleRoot string, modules ...HostModule) (*Runtime, error) {
 	}
 	state.SetGlobal("hive", hive)
 
-	return &Runtime{state: state}, nil
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &Runtime{
+		state:  state,
+		work:   make(chan func(*glua.LState), dispatcherQueueSize),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	r.wg.Add(1)
+	go r.dispatch()
+
+	return r, nil
 }
 
-// LoadEntrypoint executes the plugin entry file and returns the function it
-// must yield as its single return value.
+// dispatch drains the work channel on a single goroutine, which is the only
+// goroutine permitted to touch r.state. It returns once the context has been
+// cancelled and the channel has been fully drained.
+func (r *Runtime) dispatch() {
+	defer r.wg.Done()
+	for {
+		select {
+		case fn := <-r.work:
+			if fn != nil {
+				fn(r.state)
+			}
+		case <-r.ctx.Done():
+			// Drain any items already in the buffer so synchronous submitters
+			// that won the race against Close still get their result (or, for
+			// items that produced a panic, their error).
+			for {
+				select {
+				case fn := <-r.work:
+					if fn != nil {
+						fn(r.state)
+					}
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+// Submit enqueues fn to run on the dispatcher goroutine. It is fire-and-forget
+// and never blocks the caller: if the dispatcher queue is full the work item
+// is dropped and a warning is logged. Submit is also safe to call after Close
+// — the call becomes a no-op.
+func (r *Runtime) Submit(fn func(*glua.LState)) {
+	if r == nil || fn == nil {
+		return
+	}
+
+	r.mu.Lock()
+	closed := r.closed
+	r.mu.Unlock()
+	if closed {
+		log.Debug().Str("plugin", "lua").Msg("dropped lua work item: runtime closed")
+		return
+	}
+	// The work channel is never closed (Close signals shutdown via ctx), so a
+	// non-blocking send is always safe. If the buffer is full the item is
+	// dropped per the documented backpressure policy.
+	select {
+	case r.work <- fn:
+	default:
+		log.Warn().Str("plugin", "lua").Msg("dropped lua work item: dispatcher queue full")
+	}
+}
+
+// submitSync runs fn on the dispatcher goroutine and waits for it to finish.
+// Panics raised inside fn are recovered and surfaced as errors so the
+// dispatcher goroutine itself never crashes. Returns an error if the runtime
+// is closed before the work item can be enqueued or executed.
+func (r *Runtime) submitSync(fn func(*glua.LState) error) error {
+	if r == nil {
+		return fmt.Errorf("lua runtime is nil")
+	}
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+
+	wrapped := func(state *glua.LState) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				done <- result{err: fmt.Errorf("lua dispatcher panic: %v\n%s", rec, debug.Stack())}
+			}
+		}()
+		done <- result{err: fn(state)}
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("lua runtime is closed")
+	}
+	r.mu.Unlock()
+
+	// Synchronous submissions must not be silently dropped — block until the
+	// dispatcher accepts the item or the runtime shuts down. ctx cancellation
+	// is the abort signal; the channel itself is never closed, so producers
+	// and the dispatcher never race over a closed channel.
+	select {
+	case r.work <- wrapped:
+	case <-r.ctx.Done():
+		return fmt.Errorf("lua runtime is closed")
+	}
+
+	select {
+	case res := <-done:
+		return res.err
+	case <-r.ctx.Done():
+		// The dispatcher may still pick up wrapped from the buffer and run
+		// it; that's fine — wrapped writes to a buffered done channel that
+		// nobody is reading anymore, so it does not block.
+		return fmt.Errorf("lua runtime closed before work completed")
+	}
+}
+
+// LoadEntrypoint executes the plugin entry file on the dispatcher goroutine
+// and returns the function it must yield as its single return value.
 func (r *Runtime) LoadEntrypoint(path string) (*glua.LFunction, error) {
-	base := r.state.GetTop()
-	if err := r.state.DoFile(path); err != nil {
-		return nil, fmt.Errorf("load lua plugin %q: %w", path, err)
-	}
+	var entrypoint *glua.LFunction
+	err := r.submitSync(func(state *glua.LState) error {
+		base := state.GetTop()
+		if err := state.DoFile(path); err != nil {
+			return fmt.Errorf("load lua plugin %q: %w", path, err)
+		}
 
-	returned := r.state.GetTop() - base
-	if returned != 1 {
-		r.state.Pop(returned)
-		return nil, fmt.Errorf("lua plugin %q must return exactly one function", path)
-	}
+		returned := state.GetTop() - base
+		if returned != 1 {
+			state.Pop(returned)
+			return fmt.Errorf("lua plugin %q must return exactly one function", path)
+		}
 
-	entrypoint, ok := r.state.Get(-1).(*glua.LFunction)
-	r.state.Pop(1)
-	if !ok {
-		return nil, fmt.Errorf("lua plugin %q must return a function", path)
-	}
+		fn, ok := state.Get(-1).(*glua.LFunction)
+		state.Pop(1)
+		if !ok {
+			return fmt.Errorf("lua plugin %q must return a function", path)
+		}
 
+		entrypoint = fn
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	return entrypoint, nil
 }
 
-// CallEntrypoint invokes the plugin entry function in protected mode, passing
-// the global `hive` table as its single argument.
+// CallEntrypoint invokes the plugin entry function on the dispatcher goroutine
+// in protected mode, passing the global `hive` table as its single argument.
 func (r *Runtime) CallEntrypoint(entrypoint *glua.LFunction) error {
-	hive, ok := r.state.GetGlobal("hive").(*glua.LTable)
-	if !ok {
-		return fmt.Errorf("internal error: hive table missing from lua runtime")
-	}
-	return r.state.CallByParam(glua.P{
-		Fn:      entrypoint,
-		NRet:    0,
-		Protect: true,
-	}, hive)
+	return r.submitSync(func(state *glua.LState) error {
+		hive, ok := state.GetGlobal("hive").(*glua.LTable)
+		if !ok {
+			return fmt.Errorf("internal error: hive table missing from lua runtime")
+		}
+		return state.CallByParam(glua.P{
+			Fn:      entrypoint,
+			NRet:    0,
+			Protect: true,
+		}, hive)
+	})
 }
 
-// Close releases the underlying Lua state. Safe on a nil receiver and on a
-// runtime that has already been closed.
+// Close stops the dispatcher goroutine, releases the underlying Lua state,
+// and is safe to call from any goroutine. It is idempotent: subsequent calls
+// (and calls on a nil receiver, or a runtime whose constructor failed) are
+// no-ops. After Close returns, Submit calls are silently dropped and any
+// in-flight submitSync callers will see a "runtime is closed" error.
 func (r *Runtime) Close() {
-	if r == nil || r.state == nil {
+	if r == nil {
 		return
 	}
-	r.state.Close()
-	r.state = nil
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	r.mu.Unlock()
+
+	// Cancel so the dispatcher exits after draining the buffer and any
+	// submitSync callers blocked on done unblock with a "closed" error.
+	// The work channel is intentionally not closed: producers may still send
+	// briefly between observing closed=false and the cancel taking effect,
+	// and a closed-channel send would panic. The dispatcher's drain loop
+	// handles those late items gracefully.
+	r.cancel()
+
+	r.wg.Wait()
+
+	if r.state != nil {
+		r.state.Close()
+		r.state = nil
+	}
 }
 
 func openLib(state *glua.LState, name string, fn glua.LGFunction) {

--- a/internal/hive/plugins/lua/runtime.go
+++ b/internal/hive/plugins/lua/runtime.go
@@ -13,18 +13,14 @@ import (
 	glua "github.com/yuin/gopher-lua"
 )
 
-// dispatcherQueueSize is the buffer size of the work-item channel feeding the
-// dispatcher goroutine. It is sized to absorb short bursts of asynchronous
-// callbacks (e.g. ticker fires) without forcing producers to block, while
-// still being small enough that a runaway producer is detected and reported
-// via the drop-and-log overflow policy.
+// dispatcherQueueSize buffers async work (ticker fires, etc.) without
+// blocking producers, but stays small enough that a runaway producer
+// surfaces via drop+log.
 const dispatcherQueueSize = 64
 
-// Runtime owns a sandboxed Lua state for a Hive plugin. The state is private
-// and is touched by exactly one goroutine — the dispatcher started in
-// NewRuntime. Callers schedule work onto that goroutine via Submit or via the
-// higher-level helpers LoadEntrypoint / CallEntrypoint, and tear the runtime
-// down with Close.
+// Runtime owns a sandboxed Lua state. Exactly one goroutine — the
+// dispatcher started in NewRuntime — touches state. Schedule work via
+// Submit, LoadEntrypoint, or CallEntrypoint; tear down with Close.
 type Runtime struct {
 	state *glua.LState
 
@@ -39,9 +35,8 @@ type Runtime struct {
 
 // NewRuntime constructs a sandboxed Lua runtime, configures `require()` to
 // resolve relative to moduleRoot, and registers each HostModule onto the
-// global `hive` table in order. Setup runs synchronously on the calling
-// goroutine; once it returns the dispatcher goroutine is started and is
-// thereafter the sole owner of the underlying LState.
+// global `hive` table. Setup is synchronous; the dispatcher goroutine takes
+// over LState ownership when this returns.
 func NewRuntime(moduleRoot string, modules ...HostModule) (*Runtime, error) {
 	state := glua.NewState(glua.Options{SkipOpenLibs: true})
 
@@ -85,9 +80,8 @@ func NewRuntime(moduleRoot string, modules ...HostModule) (*Runtime, error) {
 	return r, nil
 }
 
-// dispatch drains the work channel on a single goroutine, which is the only
-// goroutine permitted to touch r.state. It returns once the context has been
-// cancelled and the channel has been fully drained.
+// dispatch drains the work channel on the goroutine that owns r.state.
+// Returns once ctx is cancelled and the channel is drained.
 func (r *Runtime) dispatch() {
 	defer r.wg.Done()
 	for {
@@ -97,9 +91,8 @@ func (r *Runtime) dispatch() {
 				fn(r.state)
 			}
 		case <-r.ctx.Done():
-			// Drain any items already in the buffer so synchronous submitters
-			// that won the race against Close still get their result (or, for
-			// items that produced a panic, their error).
+			// Drain so submitSync callers that won the race against
+			// Close still get their result.
 			for {
 				select {
 				case fn := <-r.work:
@@ -114,10 +107,8 @@ func (r *Runtime) dispatch() {
 	}
 }
 
-// Submit enqueues fn to run on the dispatcher goroutine. It is fire-and-forget
-// and never blocks the caller: if the dispatcher queue is full the work item
-// is dropped and a warning is logged. Submit is also safe to call after Close
-// — the call becomes a no-op.
+// Submit schedules fn on the dispatcher. Fire-and-forget, never blocks.
+// Drops and logs if the queue is full or the runtime is closed.
 func (r *Runtime) Submit(fn func(*glua.LState)) {
 	if r == nil || fn == nil {
 		return
@@ -130,9 +121,8 @@ func (r *Runtime) Submit(fn func(*glua.LState)) {
 		log.Debug().Str("plugin", "lua").Msg("dropped lua work item: runtime closed")
 		return
 	}
-	// The work channel is never closed (Close signals shutdown via ctx), so a
-	// non-blocking send is always safe. If the buffer is full the item is
-	// dropped per the documented backpressure policy.
+	// The work channel is never closed (ctx signals shutdown), so a
+	// non-blocking send is always safe.
 	select {
 	case r.work <- fn:
 	default:
@@ -140,10 +130,8 @@ func (r *Runtime) Submit(fn func(*glua.LState)) {
 	}
 }
 
-// submitSync runs fn on the dispatcher goroutine and waits for it to finish.
-// Panics raised inside fn are recovered and surfaced as errors so the
-// dispatcher goroutine itself never crashes. Returns an error if the runtime
-// is closed before the work item can be enqueued or executed.
+// submitSync runs fn on the dispatcher and blocks until it finishes.
+// Panics inside fn surface as errors so the dispatcher cannot crash.
 func (r *Runtime) submitSync(fn func(*glua.LState) error) error {
 	if r == nil {
 		return fmt.Errorf("lua runtime is nil")
@@ -152,6 +140,7 @@ func (r *Runtime) submitSync(fn func(*glua.LState) error) error {
 	type result struct {
 		err error
 	}
+	// Buffered so wrapped completes even if the caller times out below.
 	done := make(chan result, 1)
 
 	wrapped := func(state *glua.LState) {
@@ -170,10 +159,7 @@ func (r *Runtime) submitSync(fn func(*glua.LState) error) error {
 	}
 	r.mu.Unlock()
 
-	// Synchronous submissions must not be silently dropped — block until the
-	// dispatcher accepts the item or the runtime shuts down. ctx cancellation
-	// is the abort signal; the channel itself is never closed, so producers
-	// and the dispatcher never race over a closed channel.
+	// Block (don't drop) until the dispatcher accepts or shutdown wins.
 	select {
 	case r.work <- wrapped:
 	case <-r.ctx.Done():
@@ -184,15 +170,12 @@ func (r *Runtime) submitSync(fn func(*glua.LState) error) error {
 	case res := <-done:
 		return res.err
 	case <-r.ctx.Done():
-		// The dispatcher may still pick up wrapped from the buffer and run
-		// it; that's fine — wrapped writes to a buffered done channel that
-		// nobody is reading anymore, so it does not block.
 		return fmt.Errorf("lua runtime closed before work completed")
 	}
 }
 
-// LoadEntrypoint executes the plugin entry file on the dispatcher goroutine
-// and returns the function it must yield as its single return value.
+// LoadEntrypoint executes the plugin entry file on the dispatcher and
+// returns the function it must yield as its single return value.
 func (r *Runtime) LoadEntrypoint(path string) (*glua.LFunction, error) {
 	var entrypoint *glua.LFunction
 	err := r.submitSync(func(state *glua.LState) error {
@@ -222,8 +205,8 @@ func (r *Runtime) LoadEntrypoint(path string) (*glua.LFunction, error) {
 	return entrypoint, nil
 }
 
-// CallEntrypoint invokes the plugin entry function on the dispatcher goroutine
-// in protected mode, passing the global `hive` table as its single argument.
+// CallEntrypoint invokes the plugin entry function on the dispatcher in
+// protected mode, passing the global `hive` table as its single argument.
 func (r *Runtime) CallEntrypoint(entrypoint *glua.LFunction) error {
 	return r.submitSync(func(state *glua.LState) error {
 		hive, ok := state.GetGlobal("hive").(*glua.LTable)
@@ -238,11 +221,8 @@ func (r *Runtime) CallEntrypoint(entrypoint *glua.LFunction) error {
 	})
 }
 
-// Close stops the dispatcher goroutine, releases the underlying Lua state,
-// and is safe to call from any goroutine. It is idempotent: subsequent calls
-// (and calls on a nil receiver, or a runtime whose constructor failed) are
-// no-ops. After Close returns, Submit calls are silently dropped and any
-// in-flight submitSync callers will see a "runtime is closed" error.
+// Close stops the dispatcher and releases the LState. Idempotent and
+// safe across goroutines.
 func (r *Runtime) Close() {
 	if r == nil {
 		return
@@ -256,12 +236,8 @@ func (r *Runtime) Close() {
 	r.closed = true
 	r.mu.Unlock()
 
-	// Cancel so the dispatcher exits after draining the buffer and any
-	// submitSync callers blocked on done unblock with a "closed" error.
-	// The work channel is intentionally not closed: producers may still send
-	// briefly between observing closed=false and the cancel taking effect,
-	// and a closed-channel send would panic. The dispatcher's drain loop
-	// handles those late items gracefully.
+	// ctx signals shutdown — the work channel is never closed because
+	// late producers can still race a send (see Submit).
 	r.cancel()
 
 	r.wg.Wait()

--- a/internal/hive/plugins/lua/runtime_test.go
+++ b/internal/hive/plugins/lua/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -124,17 +125,18 @@ func TestRuntimeSubmitSerializesConcurrentCalls(t *testing.T) {
 
 func TestRuntimeSubmitAfterCloseIsNoOp(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		rt := newBareRuntime(t)
+		rt.Close()
 
-	rt := newBareRuntime(t)
-	rt.Close()
+		// Twice to exercise the idempotent post-Close fast path.
+		require.NotPanics(t, func() {
+			rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
+			rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
+		})
 
-	// Twice to exercise the idempotent post-Close fast path.
-	require.NotPanics(t, func() {
-		rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
-		rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
+		synctest.Wait()
 	})
-
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestRuntimeSubmitOnNilReceiverIsNoOp(t *testing.T) {

--- a/internal/hive/plugins/lua/runtime_test.go
+++ b/internal/hive/plugins/lua/runtime_test.go
@@ -71,9 +71,7 @@ end
 	assert.Contains(t, help, "is invalid")
 }
 
-// newBareRuntime constructs a Runtime with no host modules attached. Tests that
-// only exercise dispatcher mechanics (Submit, Close, etc.) don't need the full
-// `hive` API surface, and a bare runtime keeps the failure mode obvious.
+// newBareRuntime is a Runtime with no host modules — for dispatcher tests.
 func newBareRuntime(t *testing.T) *Runtime {
 	t.Helper()
 	rt, err := NewRuntime(t.TempDir())
@@ -87,17 +85,14 @@ func TestRuntimeSubmitSerializesConcurrentCalls(t *testing.T) {
 	rt := newBareRuntime(t)
 	t.Cleanup(rt.Close)
 
-	// Each closure increments a plain int. The dispatcher promises to run
-	// closures one at a time on a single goroutine, so a non-atomic increment
-	// is safe — if serialization were broken the race detector would catch
-	// it under `go test -race`.
-	const n = 50 // stays under dispatcherQueueSize (64) so no Submits drop.
+	// Non-atomic increments are safe iff the dispatcher serializes
+	// closures; -race catches a regression.
+	const n = 50 // < dispatcherQueueSize (64), no drops.
 	var counter int
 	var wg sync.WaitGroup
 	wg.Add(n)
 
-	// A barrier ensures all goroutines race to call Submit at roughly the
-	// same instant, maximising the chance of any concurrency bug surfacing.
+	// Barrier so every goroutine races Submit at roughly the same instant.
 	var start sync.WaitGroup
 	start.Add(1)
 
@@ -133,15 +128,12 @@ func TestRuntimeSubmitAfterCloseIsNoOp(t *testing.T) {
 	rt := newBareRuntime(t)
 	rt.Close()
 
-	// Submitting after Close must not panic; the documented behaviour is to
-	// silently drop the work item. We invoke it twice to also exercise the
-	// idempotent fast path inside Submit.
+	// Twice to exercise the idempotent post-Close fast path.
 	require.NotPanics(t, func() {
 		rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
 		rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
 	})
 
-	// Give the dispatcher a moment to confirm nothing fires.
 	time.Sleep(50 * time.Millisecond)
 }
 

--- a/internal/hive/plugins/lua/runtime_test.go
+++ b/internal/hive/plugins/lua/runtime_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
 )
 
 func TestValidateModuleName(t *testing.T) {
@@ -66,6 +69,89 @@ end
 	help := plugin.Commands()["Ok"].Help
 	assert.Contains(t, help, "must use dot notation")
 	assert.Contains(t, help, "is invalid")
+}
+
+// newBareRuntime constructs a Runtime with no host modules attached. Tests that
+// only exercise dispatcher mechanics (Submit, Close, etc.) don't need the full
+// `hive` API surface, and a bare runtime keeps the failure mode obvious.
+func newBareRuntime(t *testing.T) *Runtime {
+	t.Helper()
+	rt, err := NewRuntime(t.TempDir())
+	require.NoError(t, err)
+	return rt
+}
+
+func TestRuntimeSubmitSerializesConcurrentCalls(t *testing.T) {
+	t.Parallel()
+
+	rt := newBareRuntime(t)
+	t.Cleanup(rt.Close)
+
+	// Each closure increments a plain int. The dispatcher promises to run
+	// closures one at a time on a single goroutine, so a non-atomic increment
+	// is safe — if serialization were broken the race detector would catch
+	// it under `go test -race`.
+	const n = 50 // stays under dispatcherQueueSize (64) so no Submits drop.
+	var counter int
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	// A barrier ensures all goroutines race to call Submit at roughly the
+	// same instant, maximising the chance of any concurrency bug surfacing.
+	var start sync.WaitGroup
+	start.Add(1)
+
+	for range n {
+		go func() {
+			start.Wait()
+			rt.Submit(func(_ *glua.LState) {
+				counter++
+				wg.Done()
+			})
+		}()
+	}
+	start.Done()
+
+	doneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("dispatcher did not process all Submits within 2s (counter=%d)", counter)
+	}
+
+	assert.Equal(t, n, counter, "every submitted closure should have run exactly once")
+}
+
+func TestRuntimeSubmitAfterCloseIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rt := newBareRuntime(t)
+	rt.Close()
+
+	// Submitting after Close must not panic; the documented behaviour is to
+	// silently drop the work item. We invoke it twice to also exercise the
+	// idempotent fast path inside Submit.
+	require.NotPanics(t, func() {
+		rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
+		rt.Submit(func(_ *glua.LState) { t.Fatalf("closure must not run after Close") })
+	})
+
+	// Give the dispatcher a moment to confirm nothing fires.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestRuntimeSubmitOnNilReceiverIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var rt *Runtime
+	require.NotPanics(t, func() {
+		rt.Submit(func(_ *glua.LState) {})
+	})
 }
 
 func TestLoadEntrypointRejectsInvalidArity(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `hive.ticker` Lua module exposing `every(duration, fn)` and `after(duration, fn)` with cancellable handles. Plugins can now schedule recurring or delayed callbacks without leaving the sandbox.

Infrastructure changes that make this safe:
- **Runtime work-queue dispatcher** — a single goroutine owns the `LState`; all access funnels through `Submit` (fire-and-forget, drop+log on overflow) or an internal `submitSync` helper used by `LoadEntrypoint`/`CallEntrypoint`. The dispatcher recovers from Lua callback panics so a misbehaving plugin cannot crash the host.
- **Optional `HostModuleCloser` interface** — modules that own background resources (goroutines, timers) implement `Close() error`. `Plugin.Close()` (and partial-init failure paths) iterate every closer in reverse-registration order before tearing down the runtime, so ticker goroutines always stop before the dispatcher does.

Ticker-specific behavior:
- 1-second minimum interval. Sub-second values raise a Lua error rather than silently clamping.
- Callbacks serialize on the dispatcher with the entrypoint and command handlers.
- Backpressure: drop + log when the 64-item dispatcher queue is full (no coalescing).
- Lua callback functions are pinned in a per-instance registry sub-table so they survive Lua GC for the lifetime of the handle; cancellation releases the slot.
- Cancellation via `handle:cancel()` is idempotent.

## Closes

- hc-g3tp53zf (epic) — covers all 7 child tasks: hc-5571fudg, hc-42xz6il9, hc-mpo29tv7, hc-p9iw1m3w, hc-p6ygmx5z, hc-wp6aja8t, hc-l088ilax

## Test plan

- [x] `mise run check` (tidy + lint + test + deadcode) — clean
- [x] `go test -race -count=10 ./internal/hive/plugins/lua/...` — clean
- [x] Unit tests cover: `every` fires repeatedly, `after` fires once, `handle:cancel()` stops fires, callback errors keep ticker alive, `Plugin.Close()` releases ticker goroutines, sub-1s durations rejected, `Submit` serializes concurrent callers, `Submit`-after-Close is a safe no-op.
- [x] Manual smoke test in `mise container`: register a 2s ticker, observe logs at expected cadence; call `handle:cancel()` and confirm logs stop; restart the plugin and confirm clean shutdown without orphaned tick messages.