### PR TITLE
feat(lua): hive.kv module for KV store access

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -219,6 +219,35 @@ Decoding `[]` from JSON produces a marked table, so `decode` followed by `encode
 !!! warning "Cycles raise an error"
     `encode` rejects self-referencing tables with a Lua error. Detect cycles before encoding if your data may contain back-references.
 
+### hive.kv
+
+Persist string values across hive restarts. Backed by the same SQLite store that other Hive plugins use, but every key is automatically prefixed with `lua:` so a Lua plugin cannot read or stomp keys owned by other components.
+
+| Function | Purpose |
+| -------- | ------- |
+| `hive.kv.set(key, value)` | Store `value` under `key`. Both must be strings. |
+| `hive.kv.get(key)` | Return the value for `key`, or `nil` if missing. |
+| `hive.kv.delete(key)` | Remove `key`. No-op if absent. |
+
+```lua
+return function(hive)
+  local last = hive.kv.get("last_run")
+  if last then
+    hive.log.info("previous run: " .. last)
+  end
+  hive.kv.set("last_run", os.date("!%Y-%m-%dT%H:%M:%SZ"))
+end
+```
+
+!!! note "Strings only in v1"
+    Both arguments to `set` go through `CheckString` — Lua numbers are coerced via `tostring`, but tables, booleans, and `nil` are rejected with a Lua error. Use `hive.json.encode` if you need to persist a structured value.
+
+!!! note "Missing keys return `nil`"
+    `get` is the only op that distinguishes missing from present; `set` and `delete` raise a Lua error on store failure but otherwise succeed silently. `delete` on a missing key is a no-op.
+
+!!! warning "Empty keys are rejected"
+    `set("", v)`, `get("")`, and `delete("")` all raise a Lua error. Pick a non-empty key.
+
 ## Tmux Plugin
 
 The tmux plugin provides default commands for session management using bundled scripts (`hive-tmux`, `agent-send`) that are auto-extracted to `$HIVE_DATA_DIR/bin/`.

--- a/internal/hive/plugins/lua/module_kv.go
+++ b/internal/hive/plugins/lua/module_kv.go
@@ -1,0 +1,73 @@
+package lua
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	glua "github.com/yuin/gopher-lua"
+
+	"github.com/colonyops/hive/internal/core/kv"
+)
+
+// KVModule exposes hive.kv.{get,set,delete} backed by a string-typed
+// kv.Scoped store. The scope is applied at construction so the Lua sandbox
+// cannot read or stomp keys outside its namespace.
+type KVModule struct {
+	Store *kv.TypedKV[string]
+}
+
+func (m *KVModule) Register(state *glua.LState, hive *glua.LTable) error {
+	table := state.NewTable()
+	state.SetField(table, "get", state.NewFunction(m.get))
+	state.SetField(table, "set", state.NewFunction(m.set))
+	state.SetField(table, "delete", state.NewFunction(m.delete))
+	state.SetField(hive, "kv", table)
+	return nil
+}
+
+func (m *KVModule) set(state *glua.LState) int {
+	key := state.CheckString(1)
+	value := state.CheckString(2)
+	if key == "" {
+		state.ArgError(1, "key cannot be empty")
+		return 0
+	}
+	if err := m.Store.Set(context.Background(), key, value); err != nil {
+		state.RaiseError("kv set %q: %s", key, err)
+		return 0
+	}
+	return 0
+}
+
+func (m *KVModule) get(state *glua.LState) int {
+	key := state.CheckString(1)
+	if key == "" {
+		state.ArgError(1, "key cannot be empty")
+		return 0
+	}
+	value, err := m.Store.Get(context.Background(), key)
+	if errors.Is(err, sql.ErrNoRows) {
+		state.Push(glua.LNil)
+		return 1
+	}
+	if err != nil {
+		state.RaiseError("kv get %q: %s", key, err)
+		return 0
+	}
+	state.Push(glua.LString(value))
+	return 1
+}
+
+func (m *KVModule) delete(state *glua.LState) int {
+	key := state.CheckString(1)
+	if key == "" {
+		state.ArgError(1, "key cannot be empty")
+		return 0
+	}
+	if err := m.Store.Delete(context.Background(), key); err != nil {
+		state.RaiseError("kv delete %q: %s", key, err)
+		return 0
+	}
+	return 0
+}

--- a/internal/hive/plugins/lua/module_kv_test.go
+++ b/internal/hive/plugins/lua/module_kv_test.go
@@ -1,0 +1,141 @@
+package lua
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/colonyops/hive/internal/core/kv"
+	"github.com/colonyops/hive/internal/data/db"
+	"github.com/colonyops/hive/internal/data/stores"
+)
+
+func newKVHarness(t *testing.T, store kv.KV, script string) {
+	t.Helper()
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: pluginName},
+		&PluginInfoModule{Name: pluginName, Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		&KVModule{Store: kv.Scoped[string](store, pluginName)},
+	)
+	require.NoError(t, err)
+	t.Cleanup(rt.Close)
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+}
+
+func newRealKVStore(t *testing.T) kv.KV {
+	t.Helper()
+	database, err := db.Open(t.TempDir(), db.DefaultOpenOptions())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	return stores.NewKVStore(database)
+}
+
+func TestKVModule_RoundTrip(t *testing.T) {
+	store := newRealKVStore(t)
+	newKVHarness(t, store, `
+return function(hive)
+  hive.kv.set("foo", "bar")
+  assert(hive.kv.get("foo") == "bar", "expected foo=bar")
+end
+`)
+
+	keys, err := store.ListKeys(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, keys, "lua:foo")
+}
+
+func TestKVModule_GetMissingReturnsNil(t *testing.T) {
+	newKVHarness(t, newRealKVStore(t), `
+return function(hive)
+  assert(hive.kv.get("missing") == nil, "expected nil for missing key")
+end
+`)
+}
+
+func TestKVModule_DeleteRemovesKey(t *testing.T) {
+	store := newRealKVStore(t)
+	newKVHarness(t, store, `
+return function(hive)
+  hive.kv.set("foo", "bar")
+  hive.kv.delete("foo")
+  assert(hive.kv.get("foo") == nil, "expected nil after delete")
+end
+`)
+
+	has, err := store.Has(context.Background(), "lua:foo")
+	require.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestKVModule_NamespacingIsolatesPlugins(t *testing.T) {
+	store := newRealKVStore(t)
+	require.NoError(t, store.Set(context.Background(), "other:foo", "v"))
+
+	newKVHarness(t, store, `
+return function(hive)
+  assert(hive.kv.get("foo") == nil, "lua plugin must not see other:foo")
+end
+`)
+}
+
+func TestKVModule_RejectsNonStringValue(t *testing.T) {
+	newKVHarness(t, newRealKVStore(t), `
+return function(hive)
+  local ok = pcall(hive.kv.set, "foo", {1, 2, 3})
+  if ok then
+    error("expected non-string value to be rejected")
+  end
+end
+`)
+}
+
+func TestKVModule_OpsRejectInputs(t *testing.T) {
+	storeErr := &errKV{err: errors.New("disk on fire")}
+	cases := []struct {
+		name   string
+		store  kv.KV
+		script string
+	}{
+		{"set empty key", newRealKVStore(t), `local ok = pcall(hive.kv.set, "", "v"); if ok then error("expected empty key") end`},
+		{"get empty key", newRealKVStore(t), `local ok = pcall(hive.kv.get, ""); if ok then error("expected empty key") end`},
+		{"delete empty key", newRealKVStore(t), `local ok = pcall(hive.kv.delete, ""); if ok then error("expected empty key") end`},
+		{"set store error", storeErr, `local ok, err = pcall(hive.kv.set, "foo", "bar"); if ok or not string.find(tostring(err), "kv set") then error("unexpected: " .. tostring(err)) end`},
+		{"get store error", storeErr, `local ok, err = pcall(hive.kv.get, "foo"); if ok or not string.find(tostring(err), "kv get") then error("unexpected: " .. tostring(err)) end`},
+		{"delete store error", storeErr, `local ok, err = pcall(hive.kv.delete, "foo"); if ok or not string.find(tostring(err), "kv delete") then error("unexpected: " .. tostring(err)) end`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newKVHarness(t, tc.store, "return function(hive) "+tc.script+" end")
+		})
+	}
+}
+
+// errKV is a kv.KV whose every method returns the configured err.
+type errKV struct {
+	err error
+}
+
+func (e *errKV) Get(context.Context, string, any) error                   { return e.err }
+func (e *errKV) Set(context.Context, string, any) error                   { return e.err }
+func (e *errKV) SetTTL(context.Context, string, any, time.Duration) error { return e.err }
+func (e *errKV) Delete(context.Context, string) error                     { return e.err }
+func (e *errKV) Has(context.Context, string) (bool, error)                { return false, e.err }
+func (e *errKV) ListKeys(context.Context) ([]string, error)               { return nil, e.err }
+func (e *errKV) GetRaw(context.Context, string) (kv.Entry, error)         { return kv.Entry{}, e.err }

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -8,23 +8,29 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/colonyops/hive/internal/core/config"
+	"github.com/colonyops/hive/internal/core/kv"
 	"github.com/colonyops/hive/internal/hive/plugins"
 )
+
+// pluginName identifies this plugin to logs, the hive.plugin Lua bindings,
+// and the kv.Scoped namespace shared between production and tests.
+const pluginName = "lua"
 
 // Plugin adapts a Lua entry file to Hive's plugin interface.
 type Plugin struct {
 	cfg      config.LuaPluginConfig
+	kvStore  kv.KV
 	runtime  *Runtime
 	modules  []HostModule
 	commands map[string]config.UserCommand
 }
 
 // New creates a Lua-backed Hive plugin.
-func New(cfg config.LuaPluginConfig) *Plugin {
-	return &Plugin{cfg: cfg}
+func New(cfg config.LuaPluginConfig, kvStore kv.KV) *Plugin {
+	return &Plugin{cfg: cfg, kvStore: kvStore}
 }
 
-func (p *Plugin) Name() string { return "lua" }
+func (p *Plugin) Name() string { return pluginName }
 
 func (p *Plugin) Available() bool {
 	info, err := os.Stat(p.cfg.ResolvedEntry())
@@ -51,6 +57,7 @@ func (p *Plugin) Init(_ context.Context) error {
 		cmdModule,
 		tickerModule,
 		&JSONModule{},
+		&KVModule{Store: kv.Scoped[string](p.kvStore, p.Name())},
 	}
 
 	runtime, err := NewRuntime(p.cfg.ModuleRoot(), modules...)

--- a/internal/hive/plugins/lua/plugin_test.go
+++ b/internal/hive/plugins/lua/plugin_test.go
@@ -2,11 +2,17 @@ package lua
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/colonyops/hive/internal/core/config"
+	"github.com/colonyops/hive/internal/core/kv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,5 +73,79 @@ end
 // NewConfigPlugin builds a Plugin from a single entry file path. Shared by
 // the lifecycle, runtime, and per-module tests in this package.
 func NewConfigPlugin(entry string) *Plugin {
-	return New(config.LuaPluginConfig{Entry: entry})
+	return New(config.LuaPluginConfig{Entry: entry}, newFakeKV())
+}
+
+// fakeKV is an in-memory kv.KV used purely for test wiring. It JSON-encodes
+// values so semantics match the production KVStore: a Set followed by a Get
+// into a string dest works the same way as it would over SQLite.
+type fakeKV struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newFakeKV() *fakeKV {
+	return &fakeKV{data: map[string][]byte{}}
+}
+
+func (f *fakeKV) Get(_ context.Context, key string, dest any) error {
+	f.mu.Lock()
+	raw, ok := f.data[key]
+	f.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("kv get %q: %w", key, sql.ErrNoRows)
+	}
+	if err := json.Unmarshal(raw, dest); err != nil {
+		return fmt.Errorf("kv get %q unmarshal: %w", key, err)
+	}
+	return nil
+}
+
+func (f *fakeKV) Set(_ context.Context, key string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("kv set %q marshal: %w", key, err)
+	}
+	f.mu.Lock()
+	f.data[key] = raw
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeKV) SetTTL(ctx context.Context, key string, value any, _ time.Duration) error {
+	return f.Set(ctx, key, value)
+}
+
+func (f *fakeKV) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	delete(f.data, key)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeKV) Has(_ context.Context, key string) (bool, error) {
+	f.mu.Lock()
+	_, ok := f.data[key]
+	f.mu.Unlock()
+	return ok, nil
+}
+
+func (f *fakeKV) ListKeys(_ context.Context) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keys := make([]string, 0, len(f.data))
+	for k := range f.data {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func (f *fakeKV) GetRaw(_ context.Context, key string) (kv.Entry, error) {
+	f.mu.Lock()
+	raw, ok := f.data[key]
+	f.mu.Unlock()
+	if !ok {
+		return kv.Entry{}, fmt.Errorf("kv get raw %q: %w", key, sql.ErrNoRows)
+	}
+	return kv.Entry{Key: key, Value: raw}, nil
 }

--- a/main.go
+++ b/main.go
@@ -287,7 +287,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				{plugin: contextdir.New(cfg.Plugins.ContextDir, cfg.DataDir), disabled: isDisabled(cfg.Plugins.ContextDir.Enabled)},
 				{plugin: claude.New(cfg.Plugins.Claude, kvStore), disabled: isDisabled(cfg.Plugins.Claude.Enabled)},
 				{plugin: plugintmux.New(cfg.Plugins.Tmux), disabled: isDisabled(cfg.Plugins.Tmux.Enabled)},
-				{plugin: luaplugin.New(cfg.Plugins.Lua), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
+				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
 			}
 
 			pluginInfos := make([]doctor.PluginInfo, len(allPlugins))


### PR DESCRIPTION
Fixes #303

## Purpose

Expose the existing SQLite-backed `kv.KV` store to Lua plugins via a new
`hive.kv.{get,set,delete}` API. Every key is transparently namespaced under
`lua/` so the sandbox cannot read or stomp keys owned by other Hive components.

## Proposed Changes

  - New `KVModule` host module wrapping `kv.KV` with per-plugin key prefixing
  - `luaplugin.New` now takes a `kv.KV`; `main.go` threads through the existing `kvStore`
  - Tests cover round-trip, missing-key (Lua nil), delete, namespace isolation, store-error propagation, and arg validation

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)