### PR TITLE
feat(lua): hive.json encode/decode module

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -169,6 +169,56 @@ end
 !!! note "Shutdown cancels everything"
     When hive shuts down or the plugin is reloaded, every outstanding ticker is cancelled and its callback is released for GC.
 
+### hive.json
+
+Encode and decode JSON values for IPC, config files, or HTTP integrations.
+
+| Function | Purpose |
+| -------- | ------- |
+| `hive.json.encode(value, opts?)` | Encode a Lua value to a JSON string. |
+| `hive.json.decode(string)` | Decode a JSON string to a Lua value. |
+| `hive.json.array(table)` | Tag a Lua table so it always encodes as a JSON array. |
+
+`opts` is an optional table. Set `pretty = true` to pretty-print the output with two-space indentation.
+
+```lua
+return function(hive)
+  local payload = hive.json.encode({
+    sessions = { "alpha", "beta" },
+    count    = 2,
+  }, { pretty = true })
+  hive.log.info(payload)
+
+  local decoded = hive.json.decode('{"foo":[1,2,3]}')
+  hive.log.info("first item: " .. tostring(decoded.foo[1]))
+end
+```
+
+#### Array vs object detection
+
+A Lua table encodes as a JSON array when:
+
+1. It was passed through `hive.json.array(...)`, **or**
+2. Every key is a positive integer `1..n` with no holes.
+
+Otherwise it encodes as a JSON object. Empty unmarked tables encode as `{}` because Lua cannot distinguish "empty array" from "empty object" without a hint:
+
+```lua
+hive.json.encode({})                      -- "{}"
+hive.json.encode(hive.json.array({}))     -- "[]"
+```
+
+Decoding `[]` from JSON produces a marked table, so `decode` followed by `encode` round-trips empty arrays as `[]` rather than `{}`.
+
+!!! warning "Number precision"
+    All Lua numbers are 64-bit floats, so integer values larger than 2^53 (≈ 9 × 10^15) lose precision on the round-trip. If you need full-width integer fidelity, encode such values as strings.
+
+!!! note "JSON null becomes Lua nil"
+    JSON `null` decodes to `nil`, which Lua treats as "field absent". A re-encode of a decoded object will therefore omit any field that was originally `null`. There is no `hive.json.null` sentinel in this release.
+
+!!! warning "Cycles raise an error"
+    `encode` rejects self-referencing tables with a Lua error. Detect cycles before encoding if your data may contain back-references.
+
 ## Tmux Plugin
 
 The tmux plugin provides default commands for session management using bundled scripts (`hive-tmux`, `agent-send`) that are auto-extracted to `$HIVE_DATA_DIR/bin/`.

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -35,8 +35,8 @@ Hive can load user commands from a local Lua entry file.
 ```yaml
 plugins:
   lua:
-    enabled: true                              # nil = auto-detect, false to disable
-    entry: ~/.config/hive/plugins/init.lua     # omit to use the default discovery path
+    enabled: true # nil = auto-detect, false to disable
+    entry: ~/.config/hive/plugins/init.lua # omit to use the default discovery path
 ```
 
 When `entry` is omitted, Hive checks `~/.config/hive/plugins/init.lua` automatically; a missing file there is silently ignored. When `entry` is set explicitly, the file must exist. Set `enabled: false` to keep the entry file on disk but skip loading it.
@@ -59,14 +59,14 @@ Hive loads helper modules relative to that entry file, so `require("commands.hel
 
 Supported command fields:
 
-| Field     | Type                  | Meaning |
-| --------- | --------------------- | ------- |
-| `sh`      | `string`              | Shell command template to execute. This is required. |
-| `help`    | `string`              | Help text shown in the command palette. |
+| Field     | Type                  | Meaning                                                                |
+| --------- | --------------------- | ---------------------------------------------------------------------- |
+| `sh`      | `string`              | Shell command template to execute. This is required.                   |
+| `help`    | `string`              | Help text shown in the command palette.                                |
 | `scope`   | `string[]`            | Views where the command is available. Omit it for global availability. |
-| `confirm` | `string`              | Confirmation prompt shown before execution. |
-| `silent`  | `boolean`             | Skip the loading popup for fast commands. |
-| `exit`    | `boolean` or `string` | Exit condition, using the same rules as normal user commands. |
+| `confirm` | `string`              | Confirmation prompt shown before execution.                            |
+| `silent`  | `boolean`             | Skip the loading popup for fast commands.                              |
+| `exit`    | `boolean` or `string` | Exit condition, using the same rules as normal user commands.          |
 
 Lua-backed commands are intentionally limited to shell-backed command registration. Fields such as `action`, `windows`, `options`, and `form` are not supported here.
 
@@ -136,11 +136,11 @@ Open the command palette with `:`, run `LuaHello`, and confirm that `.lua-plugin
 
 Schedule callbacks to run repeatedly or after a delay.
 
-| Function | Purpose |
-| -------- | ------- |
-| `hive.ticker.every(duration, fn)` | Run `fn` every `duration`. Returns a handle. |
+| Function                          | Purpose                                           |
+| --------------------------------- | ------------------------------------------------- |
+| `hive.ticker.every(duration, fn)` | Run `fn` every `duration`. Returns a handle.      |
 | `hive.ticker.after(duration, fn)` | Run `fn` once after `duration`. Returns a handle. |
-| `handle:cancel()` | Cancel the ticker. Idempotent. |
+| `handle:cancel()`                 | Cancel the ticker. Idempotent.                    |
 
 `duration` accepts any Go duration string (e.g. `"5s"`, `"1m30s"`).
 
@@ -173,11 +173,11 @@ end
 
 Encode and decode JSON values for IPC, config files, or HTTP integrations.
 
-| Function | Purpose |
-| -------- | ------- |
-| `hive.json.encode(value, opts?)` | Encode a Lua value to a JSON string. |
-| `hive.json.decode(string)` | Decode a JSON string to a Lua value. |
-| `hive.json.array(table)` | Tag a Lua table so it always encodes as a JSON array. |
+| Function                         | Purpose                                               |
+| -------------------------------- | ----------------------------------------------------- |
+| `hive.json.encode(value, opts?)` | Encode a Lua value to a JSON string.                  |
+| `hive.json.decode(string)`       | Decode a JSON string to a Lua value.                  |
+| `hive.json.array(table)`         | Tag a Lua table so it always encodes as a JSON array. |
 
 `opts` is an optional table. Set `pretty = true` to pretty-print the output with two-space indentation.
 
@@ -247,18 +247,18 @@ The Claude plugin provides integration with Claude Code sessions — forking ses
 ```yaml
 plugins:
   claude:
-    enabled: true        # auto-detected (requires `claude` CLI)
-    cache_ttl: 30s       # status cache duration
+    enabled: true # auto-detected (requires `claude` CLI)
+    cache_ttl: 30s # status cache duration
     yellow_threshold: 60 # yellow warning above this % (default: 60)
-    red_threshold: 80    # red warning above this % (default: 80)
-    model_limit: 200000  # context token limit (default: 200000)
+    red_threshold: 80 # red warning above this % (default: 80)
+    model_limit: 200000 # context token limit (default: 200000)
 ```
 
 ### Commands Provided
 
-| Command      | Description                      | Default Key |
-| ------------ | -------------------------------- | ----------- |
-| `ClaudeFork` | Fork Claude session in new window | —          |
+| Command      | Description                       | Default Key |
+| ------------ | --------------------------------- | ----------- |
+| `ClaudeFork` | Fork Claude session in new window | —           |
 
 ### Context Analytics
 
@@ -290,8 +290,8 @@ The GitHub plugin provides PR status display and GitHub CLI commands. Auto-detec
 ```yaml
 plugins:
   github:
-    enabled: true      # auto-detected (requires `gh` CLI)
-    results_cache: 8m  # how often to refresh PR status (default: 8m)
+    enabled: true # auto-detected (requires `gh` CLI)
+    results_cache: 8m # how often to refresh PR status (default: 8m)
 ```
 
 ### Commands Provided
@@ -307,12 +307,12 @@ plugins:
 
 Sessions with an associated PR show a status indicator:
 
-| Label    | Color   | Meaning          |
-| -------- | ------- | ---------------- |
-| `PR open`   | Green   | PR is open       |
-| `PR draft`  | Muted   | PR is a draft    |
-| `PR merged` | Primary | PR was merged    |
-| `PR closed` | Muted   | PR was closed    |
+| Label       | Color   | Meaning       |
+| ----------- | ------- | ------------- |
+| `PR open`   | Green   | PR is open    |
+| `PR draft`  | Muted   | PR is a draft |
+| `PR merged` | Primary | PR was merged |
+| `PR closed` | Muted   | PR was closed |
 
 ## Beads Plugin
 
@@ -321,8 +321,8 @@ The Beads plugin provides issue tracking integration with the `bd` (beads) CLI. 
 ```yaml
 plugins:
   beads:
-    enabled: true        # auto-detected (requires `bd` CLI)
-    results_cache: 30s   # how often to refresh issue counts (default: 30s)
+    enabled: true # auto-detected (requires `bd` CLI)
+    results_cache: 30s # how often to refresh issue counts (default: 30s)
 ```
 
 ### Commands Provided
@@ -339,10 +339,10 @@ plugins:
 
 Sessions with a `.beads` directory show issue progress:
 
-| Display  | Color   | Meaning                    |
-| -------- | ------- | -------------------------- |
-| `BD 3/5` | Primary | 3 of 5 issues closed       |
-| `BD 5/5` | Green   | All issues closed          |
+| Display  | Color   | Meaning              |
+| -------- | ------- | -------------------- |
+| `BD 3/5` | Primary | 3 of 5 issues closed |
+| `BD 5/5` | Green   | All issues closed    |
 
 ## LazyGit Plugin
 
@@ -351,15 +351,15 @@ The lazygit plugin provides commands to open lazygit in a tmux popup. Auto-detec
 ```yaml
 plugins:
   lazygit:
-    enabled: true  # auto-detected (requires `lazygit`)
+    enabled: true # auto-detected (requires `lazygit`)
 ```
 
 ### Commands Provided
 
-| Command          | Description                 | Default Key |
-| ---------------- | --------------------------- | ----------- |
-| `LazyGitOpen`    | Open lazygit (full popup)   | —           |
-| `LazyGitCommits` | Open lazygit commit log     | —           |
+| Command          | Description               | Default Key |
+| ---------------- | ------------------------- | ----------- |
+| `LazyGitOpen`    | Open lazygit (full popup) | —           |
+| `LazyGitCommits` | Open lazygit commit log   | —           |
 
 ## Neovim Plugin
 
@@ -368,14 +368,14 @@ The neovim plugin provides a command to open neovim in the session's tmux sessio
 ```yaml
 plugins:
   neovim:
-    enabled: true  # auto-detected (requires `nvim`)
+    enabled: true # auto-detected (requires `nvim`)
 ```
 
 ### Commands Provided
 
-| Command      | Description                          | Default Key |
-| ------------ | ------------------------------------ | ----------- |
-| `NeovimOpen` | Open neovim in new tmux window       | —           |
+| Command      | Description                    | Default Key |
+| ------------ | ------------------------------ | ----------- |
+| `NeovimOpen` | Open neovim in new tmux window | —           |
 
 ## Context Directory Plugin
 
@@ -384,7 +384,7 @@ The context directory plugin provides commands to open context directories in th
 ```yaml
 plugins:
   contextdir:
-    enabled: true  # always available on macOS/Linux
+    enabled: true # always available on macOS/Linux
 ```
 
 ### Commands Provided

--- a/internal/hive/plugins/lua/module_json.go
+++ b/internal/hive/plugins/lua/module_json.go
@@ -50,9 +50,12 @@ func (m *JSONModule) luaEncode(state *glua.LState) int {
 	pretty := false
 	if state.GetTop() >= 2 {
 		opts := state.CheckTable(2)
-		if v, ok := opts.RawGetString("pretty").(glua.LBool); ok {
-			pretty = bool(v)
+		p, err := parseEncodeOpts(opts)
+		if err != nil {
+			state.RaiseError("hive.json.encode: %s", err.Error())
+			return 0
 		}
+		pretty = p
 	}
 
 	visited := map[*glua.LTable]bool{}
@@ -137,14 +140,15 @@ func (m *JSONModule) luaToGo(lv glua.LValue, visited map[*glua.LTable]bool) (any
 // tableToGo decides between array and object encoding for a Lua table.
 //
 // Detection order:
-//  1. The array marker metatable is set → []any (preserves empty-array intent).
+//  1. The array marker metatable is set → []any (preserves empty-array intent
+//     and rejects tables whose shape contradicts the array claim).
 //  2. All keys are positive integers 1..n with no holes → []any.
 //  3. Otherwise → map[string]any.
-//
-// We index sequentially via RawGetInt because ForEach iteration order is
-// undefined; relying on it would race with table layout changes.
 func (m *JSONModule) tableToGo(tbl *glua.LTable, visited map[*glua.LTable]bool) (any, error) {
 	if tbl.Metatable == m.arrayMarker {
+		if err := arrayShapeError(tbl); err != nil {
+			return nil, fmt.Errorf("array-tagged table %s", err.Error())
+		}
 		return m.tableToArray(tbl, visited)
 	}
 
@@ -155,37 +159,44 @@ func (m *JSONModule) tableToGo(tbl *glua.LTable, visited map[*glua.LTable]bool) 
 	return m.tableToObject(tbl, visited)
 }
 
-// isArrayLike returns true when every key in tbl is a positive integer 1..n
-// with no holes and no extra non-array keys. Empty tables are NOT array-like;
-// callers must apply the marker rule first to disambiguate them as []any.
-func isArrayLike(tbl *glua.LTable) bool {
+// arrayShapeError returns nil when tbl's keys are exactly the positive
+// integers 1..n with no holes (empty tables satisfy the contract). Otherwise
+// it returns an error describing the first violation. Used by the marker
+// path to surface inconsistent claims (e.g. hive.json.array({foo="x"})) as
+// errors instead of silently dropping data.
+func arrayShapeError(tbl *glua.LTable) error {
 	n := tbl.Len()
-	if n == 0 {
-		return false
-	}
 	for i := 1; i <= n; i++ {
 		if tbl.RawGetInt(i) == glua.LNil {
-			return false
+			return fmt.Errorf("has hole at index %d", i)
 		}
 	}
-
-	// Confirm there are no non-integer or out-of-range keys.
-	extra := false
+	var keyErr error
 	tbl.ForEach(func(key glua.LValue, _ glua.LValue) {
-		if extra {
+		if keyErr != nil {
 			return
 		}
 		num, ok := key.(glua.LNumber)
 		if !ok {
-			extra = true
+			keyErr = fmt.Errorf("has non-integer key %q", key.String())
 			return
 		}
 		idx := int(num)
 		if glua.LNumber(idx) != num || idx < 1 || idx > n {
-			extra = true
+			keyErr = fmt.Errorf("has out-of-range key %v", num)
 		}
 	})
-	return !extra
+	return keyErr
+}
+
+// isArrayLike returns true when tbl matches the heuristic for an untagged
+// array. Empty tables fail the heuristic so the marker rule can disambiguate
+// them as []any vs. {}.
+func isArrayLike(tbl *glua.LTable) bool {
+	if tbl.Len() == 0 {
+		return false
+	}
+	return arrayShapeError(tbl) == nil
 }
 
 func (m *JSONModule) tableToArray(tbl *glua.LTable, visited map[*glua.LTable]bool) ([]any, error) {
@@ -207,7 +218,11 @@ func (m *JSONModule) tableToObject(tbl *glua.LTable, visited map[*glua.LTable]bo
 		if walkErr != nil {
 			return
 		}
-		k := glua.LVAsString(key)
+		k, err := objectKey(key)
+		if err != nil {
+			walkErr = err
+			return
+		}
 		entry, err := m.luaToGo(value, visited)
 		if err != nil {
 			walkErr = err
@@ -219,6 +234,50 @@ func (m *JSONModule) tableToObject(tbl *glua.LTable, visited map[*glua.LTable]bo
 		return nil, walkErr
 	}
 	return out, nil
+}
+
+// objectKey coerces a Lua table key to a JSON object key. Only string and
+// number keys are supported; other types (booleans, tables, functions,
+// userdata) would silently collide on the empty string via LVAsString and
+// drop entries, so they're rejected with an explicit error.
+func objectKey(key glua.LValue) (string, error) {
+	switch k := key.(type) {
+	case glua.LString:
+		return string(k), nil
+	case glua.LNumber:
+		return glua.LVAsString(key), nil
+	default:
+		return "", fmt.Errorf("cannot use %s as object key", key.Type().String())
+	}
+}
+
+// parseEncodeOpts validates the optional opts table for hive.json.encode.
+// Unknown keys and non-bool values for known keys are rejected so typos
+// surface immediately rather than silently producing the wrong output.
+func parseEncodeOpts(opts *glua.LTable) (pretty bool, err error) {
+	var walkErr error
+	opts.ForEach(func(key glua.LValue, value glua.LValue) {
+		if walkErr != nil {
+			return
+		}
+		name, ok := key.(glua.LString)
+		if !ok {
+			walkErr = fmt.Errorf("opts key must be a string")
+			return
+		}
+		switch string(name) {
+		case "pretty":
+			b, ok := value.(glua.LBool)
+			if !ok {
+				walkErr = fmt.Errorf("opts.pretty must be a boolean")
+				return
+			}
+			pretty = bool(b)
+		default:
+			walkErr = fmt.Errorf("unknown opts key %q", string(name))
+		}
+	})
+	return pretty, walkErr
 }
 
 // goToLua walks Go values from encoding/json back into Lua. Empty []any
@@ -238,11 +297,10 @@ func (m *JSONModule) goToLua(state *glua.LState, value any) glua.LValue {
 		for i, item := range v {
 			tbl.RawSetInt(i+1, m.goToLua(state, item))
 		}
-		// Empty arrays would otherwise round-trip to {}; tag them so a
-		// follow-up encode preserves the [] shape.
-		if len(v) == 0 {
-			state.SetMetatable(tbl, m.arrayMarker)
-		}
+		// Tag every decoded array so re-encode preserves the [] shape
+		// regardless of mutations (table.remove emptying it, removing the
+		// last element, etc.) that would otherwise flunk the heuristic.
+		state.SetMetatable(tbl, m.arrayMarker)
 		return tbl
 	case map[string]any:
 		tbl := state.NewTable()

--- a/internal/hive/plugins/lua/module_json.go
+++ b/internal/hive/plugins/lua/module_json.go
@@ -1,0 +1,258 @@
+package lua
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+// JSONModule exposes hive.json.encode, hive.json.decode, and hive.json.array.
+//
+// The array marker is a per-Register *LTable used as a metatable. Its identity
+// (pointer) tags Lua tables that should be encoded as JSON arrays even when
+// they are empty or otherwise look like objects to the heuristic walker.
+type JSONModule struct {
+	// arrayMarker is the metatable installed on tables passed through array().
+	// Identity is by pointer; we never read fields off it.
+	arrayMarker *glua.LTable
+}
+
+// Register attaches encode/decode/array to a fresh hive.json subtable.
+func (m *JSONModule) Register(state *glua.LState, hive *glua.LTable) error {
+	m.arrayMarker = state.NewTable()
+
+	json := state.NewTable()
+	state.SetField(json, "encode", state.NewFunction(m.luaEncode))
+	state.SetField(json, "decode", state.NewFunction(m.luaDecode))
+	state.SetField(json, "array", state.NewFunction(m.luaArray))
+	state.SetField(hive, "json", json)
+	return nil
+}
+
+// luaArray tags the given table with the array marker and returns it. The
+// same table is mutated, so callers can chain or assign as they please.
+func (m *JSONModule) luaArray(state *glua.LState) int {
+	table := state.CheckTable(1)
+	state.SetMetatable(table, m.arrayMarker)
+	state.Push(table)
+	return 1
+}
+
+// luaEncode implements hive.json.encode(value, opts?).
+//
+// opts is an optional table with a "pretty" boolean. When pretty is true the
+// output uses two-space indentation via json.MarshalIndent.
+func (m *JSONModule) luaEncode(state *glua.LState) int {
+	value := state.CheckAny(1)
+
+	pretty := false
+	if state.GetTop() >= 2 {
+		opts := state.CheckTable(2)
+		if v, ok := opts.RawGetString("pretty").(glua.LBool); ok {
+			pretty = bool(v)
+		}
+	}
+
+	visited := map[*glua.LTable]bool{}
+	goValue, err := m.luaToGo(value, visited)
+	if err != nil {
+		state.RaiseError("hive.json.encode: %s", err.Error())
+		return 0
+	}
+
+	var (
+		bytes []byte
+		mErr  error
+	)
+	if pretty {
+		bytes, mErr = json.MarshalIndent(goValue, "", "  ")
+	} else {
+		bytes, mErr = json.Marshal(goValue)
+	}
+	if mErr != nil {
+		state.RaiseError("hive.json.encode: %s", mErr.Error())
+		return 0
+	}
+
+	state.Push(glua.LString(bytes))
+	return 1
+}
+
+// luaDecode implements hive.json.decode(string).
+func (m *JSONModule) luaDecode(state *glua.LState) int {
+	input := state.CheckString(1)
+
+	var v any
+	if err := json.Unmarshal([]byte(input), &v); err != nil {
+		var syntaxErr *json.SyntaxError
+		var typeErr *json.UnmarshalTypeError
+		switch {
+		case errors.As(err, &syntaxErr):
+			state.RaiseError("hive.json.decode: %s at offset %d", syntaxErr.Error(), syntaxErr.Offset)
+		case errors.As(err, &typeErr):
+			state.RaiseError("hive.json.decode: %s at offset %d", typeErr.Error(), typeErr.Offset)
+		default:
+			state.RaiseError("hive.json.decode: %s", err.Error())
+		}
+		return 0
+	}
+
+	state.Push(m.goToLua(state, v))
+	return 1
+}
+
+// luaToGo walks Lua values into Go-native shapes that encoding/json can
+// marshal. Tables become []any when the array marker is set or when keys are
+// a dense 1..n integer run; otherwise map[string]any.
+func (m *JSONModule) luaToGo(lv glua.LValue, visited map[*glua.LTable]bool) (any, error) {
+	switch v := lv.(type) {
+	case *glua.LNilType:
+		return nil, nil
+	case glua.LBool:
+		return bool(v), nil
+	case glua.LNumber:
+		return float64(v), nil
+	case glua.LString:
+		return string(v), nil
+	case *glua.LTable:
+		if visited[v] {
+			return nil, fmt.Errorf("cannot encode cyclic table")
+		}
+		visited[v] = true
+		defer delete(visited, v)
+		return m.tableToGo(v, visited)
+	case *glua.LFunction:
+		return nil, fmt.Errorf("cannot encode lua function")
+	case *glua.LUserData:
+		return nil, fmt.Errorf("cannot encode lua userdata")
+	case *glua.LChannel:
+		return nil, fmt.Errorf("cannot encode lua channel")
+	default:
+		return nil, fmt.Errorf("cannot encode lua value of type %s", lv.Type().String())
+	}
+}
+
+// tableToGo decides between array and object encoding for a Lua table.
+//
+// Detection order:
+//  1. The array marker metatable is set → []any (preserves empty-array intent).
+//  2. All keys are positive integers 1..n with no holes → []any.
+//  3. Otherwise → map[string]any.
+//
+// We index sequentially via RawGetInt because ForEach iteration order is
+// undefined; relying on it would race with table layout changes.
+func (m *JSONModule) tableToGo(tbl *glua.LTable, visited map[*glua.LTable]bool) (any, error) {
+	if tbl.Metatable == m.arrayMarker {
+		return m.tableToArray(tbl, visited)
+	}
+
+	if isArrayLike(tbl) {
+		return m.tableToArray(tbl, visited)
+	}
+
+	return m.tableToObject(tbl, visited)
+}
+
+// isArrayLike returns true when every key in tbl is a positive integer 1..n
+// with no holes and no extra non-array keys. Empty tables are NOT array-like;
+// callers must apply the marker rule first to disambiguate them as []any.
+func isArrayLike(tbl *glua.LTable) bool {
+	n := tbl.Len()
+	if n == 0 {
+		return false
+	}
+	for i := 1; i <= n; i++ {
+		if tbl.RawGetInt(i) == glua.LNil {
+			return false
+		}
+	}
+
+	// Confirm there are no non-integer or out-of-range keys.
+	extra := false
+	tbl.ForEach(func(key glua.LValue, _ glua.LValue) {
+		if extra {
+			return
+		}
+		num, ok := key.(glua.LNumber)
+		if !ok {
+			extra = true
+			return
+		}
+		idx := int(num)
+		if glua.LNumber(idx) != num || idx < 1 || idx > n {
+			extra = true
+		}
+	})
+	return !extra
+}
+
+func (m *JSONModule) tableToArray(tbl *glua.LTable, visited map[*glua.LTable]bool) ([]any, error) {
+	out := make([]any, 0, tbl.Len())
+	for i := 1; i <= tbl.Len(); i++ {
+		entry, err := m.luaToGo(tbl.RawGetInt(i), visited)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func (m *JSONModule) tableToObject(tbl *glua.LTable, visited map[*glua.LTable]bool) (map[string]any, error) {
+	out := map[string]any{}
+	var walkErr error
+	tbl.ForEach(func(key glua.LValue, value glua.LValue) {
+		if walkErr != nil {
+			return
+		}
+		k := glua.LVAsString(key)
+		entry, err := m.luaToGo(value, visited)
+		if err != nil {
+			walkErr = err
+			return
+		}
+		out[k] = entry
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return out, nil
+}
+
+// goToLua walks Go values from encoding/json back into Lua. Empty []any
+// keeps the array marker so a re-encode round-trips as [] rather than {}.
+func (m *JSONModule) goToLua(state *glua.LState, value any) glua.LValue {
+	switch v := value.(type) {
+	case nil:
+		return glua.LNil
+	case bool:
+		return glua.LBool(v)
+	case float64:
+		return glua.LNumber(v)
+	case string:
+		return glua.LString(v)
+	case []any:
+		tbl := state.NewTable()
+		for i, item := range v {
+			tbl.RawSetInt(i+1, m.goToLua(state, item))
+		}
+		// Empty arrays would otherwise round-trip to {}; tag them so a
+		// follow-up encode preserves the [] shape.
+		if len(v) == 0 {
+			state.SetMetatable(tbl, m.arrayMarker)
+		}
+		return tbl
+	case map[string]any:
+		tbl := state.NewTable()
+		for k, item := range v {
+			tbl.RawSetString(k, m.goToLua(state, item))
+		}
+		return tbl
+	default:
+		// json.Unmarshal into any only produces the cases above; this is
+		// defensive against future encoding/json behaviour changes.
+		return glua.LNil
+	}
+}

--- a/internal/hive/plugins/lua/module_json_test.go
+++ b/internal/hive/plugins/lua/module_json_test.go
@@ -1,0 +1,343 @@
+package lua
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// captureModule collects strings, errors, and arbitrary tagged values produced
+// by Lua so the Go test side can assert on them. All access to the maps is
+// through the dispatcher goroutine so no mutex is required, but we keep one
+// for safety in case future tests share an instance across goroutines.
+type captureModule struct {
+	mu      sync.Mutex
+	strings map[string]string
+	errs    map[string]string
+	bools   map[string]bool
+	numbers map[string]float64
+	any     map[string]any
+}
+
+func newCaptureModule() *captureModule {
+	return &captureModule{
+		strings: map[string]string{},
+		errs:    map[string]string{},
+		bools:   map[string]bool{},
+		numbers: map[string]float64{},
+		any:     map[string]any{},
+	}
+}
+
+func (c *captureModule) Register(state *glua.LState, hive *glua.LTable) error {
+	state.SetField(hive, "test_capture", state.NewFunction(func(state *glua.LState) int {
+		key := state.CheckString(1)
+		val := state.CheckString(2)
+		c.mu.Lock()
+		c.strings[key] = val
+		c.mu.Unlock()
+		return 0
+	}))
+	state.SetField(hive, "test_capture_err", state.NewFunction(func(state *glua.LState) int {
+		key := state.CheckString(1)
+		val := state.CheckString(2)
+		c.mu.Lock()
+		c.errs[key] = val
+		c.mu.Unlock()
+		return 0
+	}))
+	state.SetField(hive, "test_capture_bool", state.NewFunction(func(state *glua.LState) int {
+		key := state.CheckString(1)
+		val := state.CheckBool(2)
+		c.mu.Lock()
+		c.bools[key] = val
+		c.mu.Unlock()
+		return 0
+	}))
+	state.SetField(hive, "test_capture_number", state.NewFunction(func(state *glua.LState) int {
+		key := state.CheckString(1)
+		val := state.CheckNumber(2)
+		c.mu.Lock()
+		c.numbers[key] = float64(val)
+		c.mu.Unlock()
+		return 0
+	}))
+	return nil
+}
+
+// jsonHarness wires a Runtime + JSONModule + captureModule and runs the
+// supplied Lua script as the entrypoint.
+type jsonHarness struct {
+	runtime *Runtime
+	capture *captureModule
+}
+
+func newJSONHarness(t *testing.T, script string) *jsonHarness {
+	t.Helper()
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+
+	capture := newCaptureModule()
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&JSONModule{},
+		capture,
+	)
+	require.NoError(t, err)
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	return &jsonHarness{runtime: rt, capture: capture}
+}
+
+func (h *jsonHarness) close(t *testing.T) {
+	t.Helper()
+	h.runtime.Close()
+}
+
+func TestJSONEncodePrimitives(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  hive.test_capture("nil",    hive.json.encode(nil))
+  hive.test_capture("true",   hive.json.encode(true))
+  hive.test_capture("false",  hive.json.encode(false))
+  hive.test_capture("number", hive.json.encode(42))
+  hive.test_capture("string", hive.json.encode("hello"))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.Equal(t, "null", h.capture.strings["nil"])
+	assert.Equal(t, "true", h.capture.strings["true"])
+	assert.Equal(t, "false", h.capture.strings["false"])
+	assert.Equal(t, "42", h.capture.strings["number"])
+	assert.Equal(t, `"hello"`, h.capture.strings["string"])
+}
+
+func TestJSONEncodeArrayAndObject(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  hive.test_capture("array",  hive.json.encode({"a", "b", "c"}))
+  hive.test_capture("object", hive.json.encode({ foo = 1 }))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	var arr []any
+	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["array"]), &arr))
+	assert.Equal(t, []any{"a", "b", "c"}, arr)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["object"]), &obj))
+	assert.Equal(t, map[string]any{"foo": float64(1)}, obj)
+}
+
+func TestJSONEncodeNestedMixed(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  hive.test_capture("mixed", hive.json.encode({
+    foo = 1,
+    bar = { "a", "b" },
+    baz = { x = true },
+  }))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["mixed"]), &got))
+	assert.Equal(t, map[string]any{
+		"foo": float64(1),
+		"bar": []any{"a", "b"},
+		"baz": map[string]any{"x": true},
+	}, got)
+}
+
+func TestJSONEncodeArrayMarker(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  hive.test_capture("empty_array",  hive.json.encode(hive.json.array({})))
+  hive.test_capture("empty_object", hive.json.encode({}))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.Equal(t, "[]", h.capture.strings["empty_array"])
+	assert.Equal(t, "{}", h.capture.strings["empty_object"])
+}
+
+func TestJSONEncodePretty(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  hive.test_capture("pretty", hive.json.encode({ foo = 1 }, { pretty = true }))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	out := h.capture.strings["pretty"]
+	assert.Contains(t, out, "\n")
+	assert.Contains(t, out, "  ")
+	// Validate it still round-trips through encoding/json.
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, map[string]any{"foo": float64(1)}, got)
+}
+
+func TestJSONEncodeRejectsCycle(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local t = {}
+  t.self = t
+  local ok, err = pcall(hive.json.encode, t)
+  if ok then
+    hive.test_capture_err("cycle", "no-error")
+  else
+    hive.test_capture_err("cycle", tostring(err))
+  end
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.Contains(t, h.capture.errs["cycle"], "cyclic")
+}
+
+func TestJSONEncodeRejectsFunction(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local ok, err = pcall(hive.json.encode, function() end)
+  if ok then
+    hive.test_capture_err("func", "no-error")
+  else
+    hive.test_capture_err("func", tostring(err))
+  end
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.Contains(t, h.capture.errs["func"], "function")
+}
+
+func TestJSONDecodeObject(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local got = hive.json.decode('{"foo":1,"bar":"baz","ok":true}')
+  hive.test_capture_number("foo", got.foo)
+  hive.test_capture("bar", got.bar)
+  hive.test_capture_bool("ok",  got.ok)
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.InDelta(t, 1.0, h.capture.numbers["foo"], 0)
+	assert.Equal(t, "baz", h.capture.strings["bar"])
+	assert.True(t, h.capture.bools["ok"])
+}
+
+func TestJSONDecodeArray(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local got = hive.json.decode('[10, 20, 30]')
+  hive.test_capture_number("len",  #got)
+  hive.test_capture_number("one",  got[1])
+  hive.test_capture_number("two",  got[2])
+  hive.test_capture_number("three", got[3])
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.InDelta(t, 3.0, h.capture.numbers["len"], 0)
+	assert.InDelta(t, 10.0, h.capture.numbers["one"], 0)
+	assert.InDelta(t, 20.0, h.capture.numbers["two"], 0)
+	assert.InDelta(t, 30.0, h.capture.numbers["three"], 0)
+}
+
+func TestJSONDecodeMalformed(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local ok, err = pcall(hive.json.decode, '{')
+  if ok then
+    hive.test_capture_err("bad", "no-error")
+  else
+    hive.test_capture_err("bad", tostring(err))
+  end
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	got := h.capture.errs["bad"]
+	assert.Contains(t, got, "hive.json.decode")
+	assert.Contains(t, strings.ToLower(got), "offset")
+}
+
+func TestJSONEmptyArrayRoundTrip(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local decoded = hive.json.decode('[]')
+  hive.test_capture("re_encoded", hive.json.encode(decoded))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.Equal(t, "[]", h.capture.strings["re_encoded"])
+}
+
+func TestJSONRoundTripNested(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local input = '{"foo":[1,2,3],"bar":{"baz":true}}'
+  local decoded = hive.json.decode(input)
+  hive.test_capture("re_encoded", hive.json.encode(decoded))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["re_encoded"]), &got))
+	assert.Equal(t, map[string]any{
+		"foo": []any{float64(1), float64(2), float64(3)},
+		"bar": map[string]any{"baz": true},
+	}, got)
+}
+
+func TestJSONModuleRegistersInPlugin(t *testing.T) {
+	t.Parallel()
+	entry := filepath.Join(t.TempDir(), "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  if type(hive.json)        ~= "table"    then error("hive.json missing")        end
+  if type(hive.json.encode) ~= "function" then error("hive.json.encode missing") end
+  if type(hive.json.decode) ~= "function" then error("hive.json.decode missing") end
+  if type(hive.json.array)  ~= "function" then error("hive.json.array missing")  end
+end
+`), 0o644))
+
+	plugin := NewConfigPlugin(entry)
+	require.NoError(t, plugin.Init(context.Background()))
+	t.Cleanup(func() { require.NoError(t, plugin.Close()) })
+}

--- a/internal/hive/plugins/lua/module_json_test.go
+++ b/internal/hive/plugins/lua/module_json_test.go
@@ -325,6 +325,116 @@ end
 	}, got)
 }
 
+func TestJSONEncodeArrayMarkerRejectsNonArrayKeys(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local string_key = hive.json.array({ foo = "x" })
+  local ok1, err1 = pcall(hive.json.encode, string_key)
+  hive.test_capture_err("string_key", tostring(err1))
+  if ok1 then hive.test_capture_err("string_key_ok", "true") end
+
+  local mixed = hive.json.array({ "a", "b", foo = "x" })
+  local ok2, err2 = pcall(hive.json.encode, mixed)
+  hive.test_capture_err("mixed", tostring(err2))
+  if ok2 then hive.test_capture_err("mixed_ok", "true") end
+
+  local sparse = hive.json.array({ [1] = "a", [3] = "c" })
+  local ok3, err3 = pcall(hive.json.encode, sparse)
+  hive.test_capture_err("sparse", tostring(err3))
+  if ok3 then hive.test_capture_err("sparse_ok", "true") end
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.NotContains(t, h.capture.errs, "string_key_ok", "encode should reject array-tagged table with string key")
+	assert.Contains(t, h.capture.errs["string_key"], "array-tagged")
+	assert.Contains(t, h.capture.errs["string_key"], "non-integer key")
+
+	assert.NotContains(t, h.capture.errs, "mixed_ok")
+	assert.Contains(t, h.capture.errs["mixed"], "non-integer key")
+
+	assert.NotContains(t, h.capture.errs, "sparse_ok")
+	assert.Contains(t, h.capture.errs["sparse"], "hole at index 2")
+}
+
+func TestJSONEncodeRejectsUnsupportedKeyTypes(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local bool_key = {}
+  bool_key[true] = "x"
+  local ok1, err1 = pcall(hive.json.encode, bool_key)
+  hive.test_capture_err("bool", tostring(err1))
+  if ok1 then hive.test_capture_err("bool_ok", "true") end
+
+  local table_key = {}
+  table_key[{}] = "x"
+  local ok2, err2 = pcall(hive.json.encode, table_key)
+  hive.test_capture_err("table", tostring(err2))
+  if ok2 then hive.test_capture_err("table_ok", "true") end
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.NotContains(t, h.capture.errs, "bool_ok")
+	assert.Contains(t, h.capture.errs["bool"], "boolean as object key")
+
+	assert.NotContains(t, h.capture.errs, "table_ok")
+	assert.Contains(t, h.capture.errs["table"], "table as object key")
+}
+
+func TestJSONEncodeOptsValidation(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  local ok1, err1 = pcall(hive.json.encode, {}, { pretty = "true" })
+  hive.test_capture_err("non_bool", tostring(err1))
+  if ok1 then hive.test_capture_err("non_bool_ok", "true") end
+
+  local ok2, err2 = pcall(hive.json.encode, {}, { prety = true })
+  hive.test_capture_err("typo", tostring(err2))
+  if ok2 then hive.test_capture_err("typo_ok", "true") end
+
+  -- Valid opts still works.
+  hive.test_capture("valid", hive.json.encode({ foo = 1 }, { pretty = true }))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.NotContains(t, h.capture.errs, "non_bool_ok")
+	assert.Contains(t, h.capture.errs["non_bool"], "opts.pretty must be a boolean")
+
+	assert.NotContains(t, h.capture.errs, "typo_ok")
+	assert.Contains(t, h.capture.errs["typo"], `unknown opts key "prety"`)
+
+	assert.Contains(t, h.capture.strings["valid"], "\n")
+}
+
+func TestJSONDecodedArrayRoundTripsAfterMutation(t *testing.T) {
+	t.Parallel()
+	h := newJSONHarness(t, `
+return function(hive)
+  -- Remove the only element and re-encode: must stay [], not become {}.
+  local arr = hive.json.decode('[1]')
+  table.remove(arr, 1)
+  hive.test_capture("after_drain", hive.json.encode(arr))
+
+  -- Remove a middle element from a longer array; result is still 1..n.
+  local arr2 = hive.json.decode('[1,2,3]')
+  table.remove(arr2, 2)
+  hive.test_capture("after_remove_middle", hive.json.encode(arr2))
+end
+`)
+	t.Cleanup(func() { h.close(t) })
+
+	assert.Equal(t, "[]", h.capture.strings["after_drain"])
+
+	var arr []any
+	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["after_remove_middle"]), &arr))
+	assert.Equal(t, []any{float64(1), float64(3)}, arr)
+}
+
 func TestJSONModuleRegistersInPlugin(t *testing.T) {
 	t.Parallel()
 	entry := filepath.Join(t.TempDir(), "init.lua")

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -50,6 +50,7 @@ func (p *Plugin) Init(_ context.Context) error {
 		},
 		cmdModule,
 		tickerModule,
+		&JSONModule{},
 	}
 
 	runtime, err := NewRuntime(p.cfg.ModuleRoot(), modules...)


### PR DESCRIPTION
Fixes #308

## Purpose

Plugins had no way to round-trip JSON; this adds `hive.json.encode`/`decode`/`array` alongside the existing `log`/`info`/`commands`/`ticker` modules.

## Proposed Changes

  - New `JSONModule` wrapping `encoding/json` with cycle detection, an `array(t)` sentinel for empty-array disambiguation, and `{pretty=true}` opts
  - Strict validation: array-tagged tables with non-array keys, unsupported object key types, and unknown opts keys all raise Lua errors instead of silently dropping data
  - Decoded arrays are always tagged so re-encode preserves \`[]\` shape across mutations
  - Documentation in \`docs/configuration/plugins.md\` covering API, detection rules, number precision, and JSON-null asymmetry

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)