### PR TITLE
feat(lua): add hive.sh HostModule

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -264,6 +264,40 @@ end
 !!! warning "Empty keys are rejected"
     `set("", v)`, `get("")`, and `delete("")` all raise a Lua error. Pick a non-empty key.
 
+### hive.sh
+
+Run shell commands from Lua. All three functions execute via `sh -c` and share the same per-call timeout (default 30s) and shared worker pool used by status refreshes.
+
+!!! danger "Trust boundary"
+    `hive.sh` runs commands with the full privileges of the Hive process. Only enable Lua plugins from sources you trust — installing one is equivalent to running its shell commands as your user.
+
+| Function | Purpose |
+| -------- | ------- |
+| `hive.sh.run(cmd)` | Run `cmd`. Returns the exit code. Never raises. |
+| `hive.sh.output(cmd)` | Run `cmd`, return stdout with one trailing newline stripped. Raises on non-zero exit or executor error. |
+| `hive.sh.exec(cmd[, opts])` | Run `cmd` with optional `{cwd, timeout}`. Returns `{stdout, stderr, code, err}`. Never raises. |
+
+`opts.timeout` is in seconds (number). `opts.cwd` overrides the working directory for that call only; an empty string inherits Hive's working directory.
+
+```lua
+return function(hive)
+  local code = hive.sh.run("git fetch origin")          -- exit code only
+  local head = hive.sh.output("git rev-parse HEAD")     -- stdout, raises on non-zero
+  local r = hive.sh.exec("ls -la", { cwd = "/tmp", timeout = 5 })
+  -- r.stdout, r.stderr, r.code, r.err
+end
+```
+
+!!! note "Shared shell pool"
+    `hive.sh.*` calls draw from the same `plugins.shell_workers` budget as plugin status refreshes, so a slow shell command from Lua can delay other plugins. The default per-call timeout is 30s; tune it via `plugins.lua.shell_timeout`. Plugin shutdown cancels every in-flight command.
+
+```yaml
+plugins:
+  lua:
+    enabled: true
+    shell_timeout: 30s   # per-call timeout for hive.sh.* (default: 30s)
+```
+
 ## Tmux Plugin
 
 The tmux plugin provides default commands for session management using bundled scripts (`hive-tmux`, `agent-send`) that are auto-extracted to `$HIVE_DATA_DIR/bin/`.

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -505,8 +505,9 @@ type TmuxPluginConfig struct {
 // distinguishing "user did not configure this" from "user explicitly chose the
 // default path" relies on Entry == "" being preserved as the unset signal.
 type LuaPluginConfig struct {
-	Enabled *bool  `json:"enabled" yaml:"enabled"` // nil = auto-detect, true/false = override
-	Entry   string `json:"entry"   yaml:"entry"`
+	Enabled      *bool         `json:"enabled"       yaml:"enabled"` // nil = auto-detect, true/false = override
+	Entry        string        `json:"entry"         yaml:"entry"`
+	ShellTimeout time.Duration `json:"shell_timeout" yaml:"shell_timeout"` // per-call timeout for hive.sh.* (default: 30s)
 }
 
 // ResolvedEntry returns the configured Lua entry path or the default discovery path.

--- a/internal/hive/plugins/lua/module_json_test.go
+++ b/internal/hive/plugins/lua/module_json_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	glua "github.com/yuin/gopher-lua"
@@ -90,7 +91,8 @@ func newJSONHarness(t *testing.T, script string) *jsonHarness {
 	capture := newCaptureModule()
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: "lua-test"},
+		zerolog.Nop(),
+		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 		&JSONModule{},
 		capture,

--- a/internal/hive/plugins/lua/module_kv_test.go
+++ b/internal/hive/plugins/lua/module_kv_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +26,8 @@ func newKVHarness(t *testing.T, store kv.KV, script string) {
 
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: pluginName},
+		zerolog.Nop(),
+		&LogModule{PluginName: pluginName, Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: pluginName, Entry: entry, ModuleRoot: root},
 		&CommandsModule{},
 		&KVModule{Store: kv.Scoped[string](store, pluginName)},

--- a/internal/hive/plugins/lua/module_logger.go
+++ b/internal/hive/plugins/lua/module_logger.go
@@ -2,22 +2,22 @@ package lua
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	glua "github.com/yuin/gopher-lua"
 )
 
 // LogModule exposes `hive.log.{debug,info,warn,error}` functions that emit to
-// the standard Hive log with a "plugin" field tagged with PluginName.
+// the injected logger with a "plugin" field tagged with PluginName.
 type LogModule struct {
 	PluginName string
+	Logger     zerolog.Logger
 }
 
 func (m *LogModule) Register(state *glua.LState, hive *glua.LTable) error {
 	logs := state.NewTable()
-	state.SetField(logs, "debug", m.fn(state, log.Debug))
-	state.SetField(logs, "info", m.fn(state, log.Info))
-	state.SetField(logs, "warn", m.fn(state, log.Warn))
-	state.SetField(logs, "error", m.fn(state, log.Error))
+	state.SetField(logs, "debug", m.fn(state, m.Logger.Debug))
+	state.SetField(logs, "info", m.fn(state, m.Logger.Info))
+	state.SetField(logs, "warn", m.fn(state, m.Logger.Warn))
+	state.SetField(logs, "error", m.fn(state, m.Logger.Error))
 	state.SetField(hive, "log", logs)
 	return nil
 }

--- a/internal/hive/plugins/lua/module_sh.go
+++ b/internal/hive/plugins/lua/module_sh.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	glua "github.com/yuin/gopher-lua"
 
 	"github.com/colonyops/hive/internal/hive/plugins"
@@ -90,6 +91,7 @@ type ShModule struct {
 	Pool           *plugins.WorkerPool
 	Executor       ShellExecutor
 	DefaultTimeout time.Duration
+	Logger         zerolog.Logger
 
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
@@ -135,16 +137,35 @@ func (m *ShModule) runViaPool(cmd string, opts shOptions) shResult {
 	m.wg.Add(1)
 	defer m.wg.Done()
 
-	if m.Pool == nil {
-		return m.Executor.Exec(m.rootCtx, cmd, opts)
-	}
+	start := time.Now()
+	m.Logger.Debug().
+		Str("cmd", cmd).
+		Str("cwd", opts.Cwd).
+		Dur("timeout", opts.Timeout).
+		Msg("hive.sh: starting shell command")
 
 	var result shResult
 	if err := m.Pool.RunContext(m.rootCtx, func() {
 		result = m.Executor.Exec(m.rootCtx, cmd, opts)
 	}); err != nil {
+		m.Logger.Warn().
+			Str("cmd", cmd).
+			Err(err).
+			Msg("hive.sh: pool acquisition cancelled")
 		return shResult{Code: -1, Err: err}
 	}
+
+	level := m.Logger.Debug
+	if result.Err != nil || result.Code != 0 {
+		level = m.Logger.Warn
+	}
+	level().
+		Str("cmd", cmd).
+		Int("code", result.Code).
+		Dur("duration", time.Since(start)).
+		Err(result.Err).
+		Msg("hive.sh: shell command finished")
+
 	return result
 }
 

--- a/internal/hive/plugins/lua/module_sh.go
+++ b/internal/hive/plugins/lua/module_sh.go
@@ -1,0 +1,216 @@
+package lua
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	glua "github.com/yuin/gopher-lua"
+
+	"github.com/colonyops/hive/internal/hive/plugins"
+)
+
+// shDefaultTimeout is used when ShModule.DefaultTimeout is zero.
+const shDefaultTimeout = 30 * time.Second
+
+// shOptions captures per-call execution settings parsed from the Lua side.
+type shOptions struct {
+	Cwd     string
+	Timeout time.Duration
+}
+
+// shResult is the executor's complete return value. Exec never returns an
+// error separately; non-exit failures go in Err.
+type shResult struct {
+	Stdout string
+	Stderr string
+	Code   int
+	Err    error
+}
+
+// ShellExecutor runs a shell command and reports the outcome. The default
+// implementation (osExecutor) shells out via "sh -c"; tests inject fakes.
+type ShellExecutor interface {
+	Exec(ctx context.Context, cmd string, opts shOptions) shResult
+}
+
+// osExecutor runs commands through "sh -c" with separate stdout/stderr buffers
+// and applies opts.Cwd / opts.Timeout. Returns -1 on signal/timeout.
+type osExecutor struct{}
+
+func (osExecutor) Exec(ctx context.Context, cmd string, opts shOptions) shResult {
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	c := exec.CommandContext(ctx, "sh", "-c", cmd)
+	if opts.Cwd != "" {
+		c.Dir = opts.Cwd
+	}
+
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+
+	err := c.Run()
+
+	result := shResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+		Code:   0,
+	}
+
+	if err == nil {
+		return result
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		result.Code = exitErr.ExitCode()
+		return result
+	}
+
+	result.Code = -1
+	result.Err = err
+	return result
+}
+
+// ShModule exposes hive.sh.{run,output,exec} for shell command execution.
+// Calls run on the Lua dispatcher and synchronously block it; concurrency
+// across plugins is bounded by the shared Pool. Close cancels in-flight work.
+type ShModule struct {
+	PluginName     string
+	Pool           *plugins.WorkerPool
+	Executor       ShellExecutor
+	DefaultTimeout time.Duration
+
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+	wg         sync.WaitGroup
+
+	closeOnce sync.Once
+}
+
+// Register installs the hive.sh subtable. Initialises rootCtx/rootCancel and
+// applies the default executor and timeout if unset.
+func (m *ShModule) Register(state *glua.LState, hive *glua.LTable) error {
+	if m.Executor == nil {
+		m.Executor = osExecutor{}
+	}
+	if m.DefaultTimeout <= 0 {
+		m.DefaultTimeout = shDefaultTimeout
+	}
+	m.rootCtx, m.rootCancel = context.WithCancel(context.Background())
+
+	sh := state.NewTable()
+	state.SetField(sh, "run", state.NewFunction(m.luaRun))
+	state.SetField(sh, "output", state.NewFunction(m.luaOutput))
+	state.SetField(sh, "exec", state.NewFunction(m.luaExec))
+	state.SetField(hive, "sh", sh)
+	return nil
+}
+
+// Close cancels rootCtx and waits for outstanding shell calls to drain.
+// Idempotent.
+func (m *ShModule) Close() error {
+	m.closeOnce.Do(func() {
+		if m.rootCancel != nil {
+			m.rootCancel()
+		}
+		m.wg.Wait()
+	})
+	return nil
+}
+
+// runViaPool executes cmd through the shared worker pool. Pool acquisition
+// itself respects rootCtx so a Close mid-wait returns without running.
+func (m *ShModule) runViaPool(cmd string, opts shOptions) shResult {
+	m.wg.Add(1)
+	defer m.wg.Done()
+
+	if m.Pool == nil {
+		return m.Executor.Exec(m.rootCtx, cmd, opts)
+	}
+
+	var result shResult
+	if err := m.Pool.RunContext(m.rootCtx, func() {
+		result = m.Executor.Exec(m.rootCtx, cmd, opts)
+	}); err != nil {
+		return shResult{Code: -1, Err: err}
+	}
+	return result
+}
+
+func (m *ShModule) luaRun(state *glua.LState) int {
+	cmd := state.CheckString(1)
+	result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
+	state.Push(glua.LNumber(result.Code))
+	return 1
+}
+
+func (m *ShModule) luaOutput(state *glua.LState) int {
+	cmd := state.CheckString(1)
+	result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
+
+	if result.Err != nil {
+		state.RaiseError("hive.sh.output: %s", formatExecError(result))
+		return 0
+	}
+	if result.Code != 0 {
+		state.RaiseError("hive.sh.output: %s", formatExecError(result))
+		return 0
+	}
+
+	state.Push(glua.LString(strings.TrimRight(result.Stdout, "\n")))
+	return 1
+}
+
+func (m *ShModule) luaExec(state *glua.LState) int {
+	cmd := state.CheckString(1)
+	opts := shOptions{Timeout: m.DefaultTimeout}
+
+	if state.GetTop() >= 2 {
+		optsTable := state.CheckTable(2)
+		if cwd, ok := optsTable.RawGetString("cwd").(glua.LString); ok {
+			opts.Cwd = string(cwd)
+		}
+		if timeoutSecs, ok := optsTable.RawGetString("timeout").(glua.LNumber); ok {
+			opts.Timeout = time.Duration(float64(timeoutSecs) * float64(time.Second))
+		}
+	}
+
+	result := m.runViaPool(cmd, opts)
+
+	out := state.NewTable()
+	state.SetField(out, "stdout", glua.LString(result.Stdout))
+	state.SetField(out, "stderr", glua.LString(result.Stderr))
+	state.SetField(out, "code", glua.LNumber(result.Code))
+	if result.Err != nil {
+		state.SetField(out, "err", glua.LString(result.Err.Error()))
+	} else {
+		state.SetField(out, "err", glua.LNil)
+	}
+	state.Push(out)
+	return 1
+}
+
+// formatExecError builds the Lua error message used by hive.sh.output.
+// Includes stderr (trimmed) and Err when present.
+func formatExecError(r shResult) string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("exit %d", r.Code))
+	if r.Err != nil {
+		parts = append(parts, r.Err.Error())
+	}
+	if msg := strings.TrimRight(r.Stderr, "\n"); msg != "" {
+		parts = append(parts, msg)
+	}
+	return strings.Join(parts, ": ")
+}

--- a/internal/hive/plugins/lua/module_sh_test.go
+++ b/internal/hive/plugins/lua/module_sh_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	glua "github.com/yuin/gopher-lua"
@@ -99,12 +99,14 @@ func newShHarness(t *testing.T, script string, executor *fakeExecutor, defaultTi
 		Pool:           pool,
 		Executor:       executor,
 		DefaultTimeout: defaultTimeout,
+		Logger:         zerolog.Nop(),
 	}
 	captured := &shCaptureModule{}
 
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: "lua-test"},
+		zerolog.Nop(),
+		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 		&CommandsModule{},
 		module,
@@ -213,11 +215,13 @@ end
 		Pool:           pool,
 		Executor:       exec,
 		DefaultTimeout: 5 * time.Second,
+		Logger:         zerolog.Nop(),
 	}
 
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: "lua-test"},
+		zerolog.Nop(),
+		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 		&CommandsModule{},
 		module,
@@ -355,11 +359,13 @@ end
 		Pool:           pool,
 		Executor:       exec,
 		DefaultTimeout: 0,
+		Logger:         zerolog.Nop(),
 	}
 
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: "lua-test"},
+		zerolog.Nop(),
+		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 		&CommandsModule{},
 		module,
@@ -420,12 +426,14 @@ end
 		PluginName:     "lua-test",
 		Pool:           pool,
 		DefaultTimeout: 5 * time.Second,
+		Logger:         zerolog.Nop(),
 	}
 	captured := &shCaptureModule{}
 
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: "lua-test"},
+		zerolog.Nop(),
+		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 		&CommandsModule{},
 		module,
@@ -444,52 +452,4 @@ end
 	values := captured.snapshot()
 	require.Len(t, values, 1)
 	assert.Equal(t, glua.LString("hello"), values[0])
-}
-
-// TestShModule_NilPoolRunsInline guards against a nil Pool panic so the
-// module remains usable in tests that don't care about pool semantics.
-func TestShModule_NilPoolRunsInline(t *testing.T) {
-	t.Parallel()
-
-	var calls atomic.Int32
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			calls.Add(1)
-			return shResult{Code: 0}
-		},
-	}
-
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(`
-return function(hive)
-  hive.sh.run("anything")
-end
-`), 0o644))
-
-	module := &ShModule{
-		PluginName:     "lua-test",
-		Pool:           nil,
-		Executor:       exec,
-		DefaultTimeout: time.Second,
-	}
-
-	rt, err := NewRuntime(
-		root,
-		&LogModule{PluginName: "lua-test"},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		module,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = module.Close()
-		rt.Close()
-	})
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
-
-	assert.Equal(t, int32(1), calls.Load())
 }

--- a/internal/hive/plugins/lua/module_sh_test.go
+++ b/internal/hive/plugins/lua/module_sh_test.go
@@ -1,0 +1,495 @@
+package lua
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+
+	"github.com/colonyops/hive/internal/hive/plugins"
+)
+
+// fakeExecutor implements ShellExecutor with caller-provided behaviour.
+type fakeExecutor struct {
+	mu sync.Mutex
+
+	respond func(ctx context.Context, cmd string, opts shOptions) shResult
+
+	lastCmd  string
+	lastOpts shOptions
+	lastCtx  context.Context
+	calls    int
+}
+
+func (f *fakeExecutor) Exec(ctx context.Context, cmd string, opts shOptions) shResult {
+	respond := f.respond
+	f.mu.Lock()
+	f.lastCmd = cmd
+	f.lastOpts = opts
+	f.lastCtx = ctx
+	f.calls++
+	f.mu.Unlock()
+	if respond == nil {
+		return shResult{}
+	}
+	return respond(ctx, cmd, opts)
+}
+
+func (f *fakeExecutor) snapshot() (cmd string, opts shOptions, ctx context.Context, calls int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastCmd, f.lastOpts, f.lastCtx, f.calls
+}
+
+// shHarness wires a Runtime + ShModule + a result-capturing module into a
+// Lua entry script. Tests inject a fakeExecutor to drive the executor side
+// without spawning subprocesses.
+type shHarness struct {
+	module   *ShModule
+	executor *fakeExecutor
+	captured *shCaptureModule
+}
+
+// shCaptureModule exposes hive.test_capture(value) so Lua can hand
+// arbitrary values back to the test for assertion. Distinct from the
+// keyed captureModule used by module_json_test.go because hive.sh tests
+// only need a positional list.
+type shCaptureModule struct {
+	mu     sync.Mutex
+	values []glua.LValue
+}
+
+func (c *shCaptureModule) Register(state *glua.LState, hive *glua.LTable) error {
+	state.SetField(hive, "test_capture", state.NewFunction(func(state *glua.LState) int {
+		v := state.CheckAny(1)
+		c.mu.Lock()
+		c.values = append(c.values, v)
+		c.mu.Unlock()
+		return 0
+	}))
+	return nil
+}
+
+func (c *shCaptureModule) snapshot() []glua.LValue {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]glua.LValue, len(c.values))
+	copy(out, c.values)
+	return out
+}
+
+func newShHarness(t *testing.T, script string, executor *fakeExecutor, defaultTimeout time.Duration) *shHarness {
+	t.Helper()
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+
+	pool := plugins.NewWorkerPool(1)
+	module := &ShModule{
+		PluginName:     "lua-test",
+		Pool:           pool,
+		Executor:       executor,
+		DefaultTimeout: defaultTimeout,
+	}
+	captured := &shCaptureModule{}
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		module,
+		captured,
+	)
+	require.NoError(t, err)
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	t.Cleanup(func() {
+		_ = module.Close()
+		rt.Close()
+	})
+
+	return &shHarness{
+		module:   module,
+		executor: executor,
+		captured: captured,
+	}
+}
+
+func TestShRun_ExitCodes(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, cmd string, _ shOptions) shResult {
+			switch cmd {
+			case "ok":
+				return shResult{Code: 0}
+			case "fail":
+				return shResult{Code: 1}
+			case "weird":
+				return shResult{Code: 7}
+			}
+			t.Fatalf("unexpected cmd %q", cmd)
+			return shResult{}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.test_capture(hive.sh.run("ok"))
+  hive.test_capture(hive.sh.run("fail"))
+  hive.test_capture(hive.sh.run("weird"))
+end
+`, exec, 0)
+
+	values := h.captured.snapshot()
+	require.Len(t, values, 3)
+	assert.Equal(t, 0, asLuaInt(t, values[0]))
+	assert.Equal(t, 1, asLuaInt(t, values[1]))
+	assert.Equal(t, 7, asLuaInt(t, values[2]))
+}
+
+// asLuaInt unwraps an LNumber to int for exact comparison without
+// triggering the testifylint float-compare rule.
+func asLuaInt(t *testing.T, v glua.LValue) int {
+	t.Helper()
+	n, ok := v.(glua.LNumber)
+	require.True(t, ok, "expected LNumber, got %T", v)
+	return int(n)
+}
+
+func TestShOutput_StripsTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Stdout: "hello\n", Code: 0}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.test_capture(hive.sh.output("anything"))
+end
+`, exec, 0)
+
+	values := h.captured.snapshot()
+	require.Len(t, values, 1)
+	assert.Equal(t, glua.LString("hello"), values[0])
+}
+
+func TestShOutput_NonZeroRaises(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: 1, Stderr: "boom\n"}
+		},
+	}
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.sh.output("bad")
+end
+`), 0o644))
+
+	pool := plugins.NewWorkerPool(1)
+	module := &ShModule{
+		PluginName:     "lua-test",
+		Pool:           pool,
+		Executor:       exec,
+		DefaultTimeout: 5 * time.Second,
+	}
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		module,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = module.Close()
+		rt.Close()
+	})
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+
+	err = rt.CallEntrypoint(fn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+	assert.Contains(t, err.Error(), "exit 1")
+}
+
+func TestShExec_TableShape(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Stdout: "out", Stderr: "err", Code: 2}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  local r = hive.sh.exec("anything")
+  hive.test_capture(r.stdout)
+  hive.test_capture(r.stderr)
+  hive.test_capture(r.code)
+  hive.test_capture(r.err)
+end
+`, exec, 0)
+
+	values := h.captured.snapshot()
+	require.Len(t, values, 4)
+	assert.Equal(t, glua.LString("out"), values[0])
+	assert.Equal(t, glua.LString("err"), values[1])
+	assert.Equal(t, 2, asLuaInt(t, values[2]))
+	assert.Equal(t, glua.LNil, values[3])
+}
+
+func TestShExec_TableShape_WithErr(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: -1, Err: errors.New("timeout")}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  local r = hive.sh.exec("anything")
+  hive.test_capture(r.err)
+end
+`, exec, 0)
+
+	values := h.captured.snapshot()
+	require.Len(t, values, 1)
+	assert.Equal(t, glua.LString("timeout"), values[0])
+}
+
+func TestShExec_OptionsThreaded(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: 0}
+		},
+	}
+
+	newShHarness(t, `
+return function(hive)
+  hive.sh.exec("anything", { cwd = "/tmp", timeout = 5 })
+end
+`, exec, 0)
+
+	_, opts, _, calls := exec.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "/tmp", opts.Cwd)
+	assert.Equal(t, 5*time.Second, opts.Timeout)
+}
+
+func TestShExec_DefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: 0}
+		},
+	}
+
+	newShHarness(t, `
+return function(hive)
+  hive.sh.exec("anything")
+end
+`, exec, 11*time.Second)
+
+	_, opts, _, calls := exec.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 11*time.Second, opts.Timeout)
+}
+
+func TestShModule_ShutdownCancelsInflight(t *testing.T) {
+	t.Parallel()
+
+	released := make(chan struct{})
+	captured := make(chan context.Context, 1)
+
+	exec := &fakeExecutor{
+		respond: func(ctx context.Context, _ string, _ shOptions) shResult {
+			captured <- ctx
+			<-ctx.Done()
+			close(released)
+			return shResult{Code: -1, Err: ctx.Err()}
+		},
+	}
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.commands({ Trigger = { sh = "true", help = "noop" } })
+end
+`), 0o644))
+
+	pool := plugins.NewWorkerPool(1)
+	module := &ShModule{
+		PluginName:     "lua-test",
+		Pool:           pool,
+		Executor:       exec,
+		DefaultTimeout: 0,
+	}
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		module,
+	)
+	require.NoError(t, err)
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	// Kick off a blocked exec from a goroutine; it will park inside
+	// the fake executor until rootCtx is cancelled.
+	done := make(chan shResult, 1)
+	go func() {
+		done <- module.runViaPool("blocking", shOptions{})
+	}()
+
+	var execCtx context.Context
+	select {
+	case execCtx = <-captured:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("executor never received a context")
+	}
+
+	require.NoError(t, module.Close())
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("executor never released after Close")
+	}
+
+	require.Error(t, execCtx.Err(), "executor's context should be cancelled by Close")
+
+	select {
+	case res := <-done:
+		assert.Equal(t, -1, res.Code)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runViaPool never returned after Close")
+	}
+
+	rt.Close()
+}
+
+func TestShModule_RealExecutor_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.test_capture(hive.sh.output("echo hello"))
+end
+`), 0o644))
+
+	pool := plugins.NewWorkerPool(1)
+	module := &ShModule{
+		PluginName:     "lua-test",
+		Pool:           pool,
+		DefaultTimeout: 5 * time.Second,
+	}
+	captured := &shCaptureModule{}
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		module,
+		captured,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = module.Close()
+		rt.Close()
+	})
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	values := captured.snapshot()
+	require.Len(t, values, 1)
+	assert.Equal(t, glua.LString("hello"), values[0])
+}
+
+// TestShModule_NilPoolRunsInline guards against a nil Pool panic so the
+// module remains usable in tests that don't care about pool semantics.
+func TestShModule_NilPoolRunsInline(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			calls.Add(1)
+			return shResult{Code: 0}
+		},
+	}
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.sh.run("anything")
+end
+`), 0o644))
+
+	module := &ShModule{
+		PluginName:     "lua-test",
+		Pool:           nil,
+		Executor:       exec,
+		DefaultTimeout: time.Second,
+	}
+
+	rt, err := NewRuntime(
+		root,
+		&LogModule{PluginName: "lua-test"},
+		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		module,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = module.Close()
+		rt.Close()
+	})
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	assert.Equal(t, int32(1), calls.Load())
+}

--- a/internal/hive/plugins/lua/module_ticker.go
+++ b/internal/hive/plugins/lua/module_ticker.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	glua "github.com/yuin/gopher-lua"
 )
 
@@ -30,6 +30,7 @@ const tickerHandleMetatableName = "hive.ticker.handle"
 type TickerModule struct {
 	Runtime    *Runtime
 	PluginName string
+	Logger     zerolog.Logger
 
 	// rootCtx fans out to every per-handle context; cancelling it during
 	// Close stops every running ticker.
@@ -200,8 +201,7 @@ func (m *TickerModule) fire(h *tickerHandle) {
 			NRet:    0,
 			Protect: true,
 		}); err != nil {
-			log.Warn().
-				Str("plugin", m.PluginName).
+			m.Logger.Warn().
 				Uint64("handle", h.id).
 				Err(err).
 				Msg("ticker callback returned error")

--- a/internal/hive/plugins/lua/module_ticker_test.go
+++ b/internal/hive/plugins/lua/module_ticker_test.go
@@ -9,6 +9,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	glua "github.com/yuin/gopher-lua"
@@ -43,12 +44,13 @@ func newTickerHarness(t *testing.T, script string) *tickerHarness {
 	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
 
 	counter := &atomic.Int64{}
-	tickerModule := &TickerModule{PluginName: "lua-test"}
+	tickerModule := &TickerModule{PluginName: "lua-test", Logger: zerolog.Nop()}
 	bump := &bumpModule{counter: counter}
 
 	rt, err := NewRuntime(
 		root,
-		&LogModule{PluginName: "lua-test"},
+		zerolog.Nop(),
+		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 		&CommandsModule{},
 		tickerModule,
@@ -202,10 +204,11 @@ end
 		require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
 
 		counter := &atomic.Int64{}
-		tickerModule := &TickerModule{PluginName: "lua-test"}
+		tickerModule := &TickerModule{PluginName: "lua-test", Logger: zerolog.Nop()}
 		rt, err := NewRuntime(
 			root,
-			&LogModule{PluginName: "lua-test"},
+			zerolog.Nop(),
+			&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
 			&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
 			&CommandsModule{},
 			tickerModule,

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -1,12 +1,13 @@
 package lua
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
 	"time"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/kv"
@@ -22,6 +23,7 @@ type Plugin struct {
 	cfg      config.LuaPluginConfig
 	kvStore  kv.KV
 	pool     *plugins.WorkerPool
+	logger   zerolog.Logger
 	runtime  *Runtime
 	modules  []HostModule
 	commands map[string]config.UserCommand
@@ -30,8 +32,8 @@ type Plugin struct {
 // New creates a Lua-backed Hive plugin. The shared worker pool throttles
 // hive.sh.* shell execution; pass nil only in tests that don't exercise the
 // shell module.
-func New(cfg config.LuaPluginConfig, kvStore kv.KV, pool *plugins.WorkerPool) *Plugin {
-	return &Plugin{cfg: cfg, kvStore: kvStore, pool: pool}
+func New(cfg config.LuaPluginConfig, kvStore kv.KV, pool *plugins.WorkerPool, logger zerolog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, kvStore: kvStore, pool: pool, logger: logger}
 }
 
 func (p *Plugin) Name() string { return pluginName }
@@ -49,16 +51,20 @@ func (p *Plugin) Init(_ context.Context) error {
 	// commands reachable from MergedCommands.
 	cmdModule := &CommandsModule{}
 
-	tickerModule := &TickerModule{PluginName: p.Name()}
+	tickerModule := &TickerModule{
+		PluginName: p.Name(),
+		Logger:     p.logger.With().Str("module", "ticker").Logger(),
+	}
 
 	shModule := &ShModule{
 		PluginName:     p.Name(),
 		Pool:           p.pool,
-		DefaultTimeout: defaultDuration(p.cfg.ShellTimeout, 30*time.Second),
+		DefaultTimeout: cmp.Or(p.cfg.ShellTimeout, 30*time.Second),
+		Logger:         p.logger.With().Str("module", "sh").Logger(),
 	}
 
 	modules := []HostModule{
-		&LogModule{PluginName: p.Name()},
+		&LogModule{PluginName: p.Name(), Logger: p.logger},
 		&PluginInfoModule{
 			Name:       p.Name(),
 			Entry:      p.cfg.ResolvedEntry(),
@@ -71,7 +77,7 @@ func (p *Plugin) Init(_ context.Context) error {
 		shModule,
 	}
 
-	runtime, err := NewRuntime(p.cfg.ModuleRoot(), modules...)
+	runtime, err := NewRuntime(p.cfg.ModuleRoot(), p.logger, modules...)
 	if err != nil {
 		return err
 	}
@@ -112,8 +118,7 @@ func (p *Plugin) shutdown() {
 			continue
 		}
 		if err := closer.Close(); err != nil {
-			log.Warn().
-				Str("plugin", p.Name()).
+			p.logger.Warn().
 				Err(err).
 				Msg("host module close failed")
 		}
@@ -133,12 +138,4 @@ func (p *Plugin) Commands() map[string]config.UserCommand {
 
 func (p *Plugin) StatusProvider() plugins.StatusProvider {
 	return nil
-}
-
-// defaultDuration returns d when positive, otherwise fallback.
-func defaultDuration(d, fallback time.Duration) time.Duration {
-	if d > 0 {
-		return d
-	}
-	return fallback
 }

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -20,14 +21,17 @@ const pluginName = "lua"
 type Plugin struct {
 	cfg      config.LuaPluginConfig
 	kvStore  kv.KV
+	pool     *plugins.WorkerPool
 	runtime  *Runtime
 	modules  []HostModule
 	commands map[string]config.UserCommand
 }
 
-// New creates a Lua-backed Hive plugin.
-func New(cfg config.LuaPluginConfig, kvStore kv.KV) *Plugin {
-	return &Plugin{cfg: cfg, kvStore: kvStore}
+// New creates a Lua-backed Hive plugin. The shared worker pool throttles
+// hive.sh.* shell execution; pass nil only in tests that don't exercise the
+// shell module.
+func New(cfg config.LuaPluginConfig, kvStore kv.KV, pool *plugins.WorkerPool) *Plugin {
+	return &Plugin{cfg: cfg, kvStore: kvStore, pool: pool}
 }
 
 func (p *Plugin) Name() string { return pluginName }
@@ -47,6 +51,12 @@ func (p *Plugin) Init(_ context.Context) error {
 
 	tickerModule := &TickerModule{PluginName: p.Name()}
 
+	shModule := &ShModule{
+		PluginName:     p.Name(),
+		Pool:           p.pool,
+		DefaultTimeout: defaultDuration(p.cfg.ShellTimeout, 30*time.Second),
+	}
+
 	modules := []HostModule{
 		&LogModule{PluginName: p.Name()},
 		&PluginInfoModule{
@@ -58,6 +68,7 @@ func (p *Plugin) Init(_ context.Context) error {
 		tickerModule,
 		&JSONModule{},
 		&KVModule{Store: kv.Scoped[string](p.kvStore, p.Name())},
+		shModule,
 	}
 
 	runtime, err := NewRuntime(p.cfg.ModuleRoot(), modules...)
@@ -122,4 +133,12 @@ func (p *Plugin) Commands() map[string]config.UserCommand {
 
 func (p *Plugin) StatusProvider() plugins.StatusProvider {
 	return nil
+}
+
+// defaultDuration returns d when positive, otherwise fallback.
+func defaultDuration(d, fallback time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return fallback
 }

--- a/internal/hive/plugins/lua/plugin_test.go
+++ b/internal/hive/plugins/lua/plugin_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/kv"
+	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +74,7 @@ end
 // NewConfigPlugin builds a Plugin from a single entry file path. Shared by
 // the lifecycle, runtime, and per-module tests in this package.
 func NewConfigPlugin(entry string) *Plugin {
-	return New(config.LuaPluginConfig{Entry: entry}, newFakeKV())
+	return New(config.LuaPluginConfig{Entry: entry}, newFakeKV(), plugins.NewWorkerPool(1))
 }
 
 // fakeKV is an in-memory kv.KV used purely for test wiring. It JSON-encodes

--- a/internal/hive/plugins/lua/plugin_test.go
+++ b/internal/hive/plugins/lua/plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/kv"
 	"github.com/colonyops/hive/internal/hive/plugins"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +75,7 @@ end
 // NewConfigPlugin builds a Plugin from a single entry file path. Shared by
 // the lifecycle, runtime, and per-module tests in this package.
 func NewConfigPlugin(entry string) *Plugin {
-	return New(config.LuaPluginConfig{Entry: entry}, newFakeKV(), plugins.NewWorkerPool(1))
+	return New(config.LuaPluginConfig{Entry: entry}, newFakeKV(), plugins.NewWorkerPool(1), zerolog.Nop())
 }
 
 // fakeKV is an in-memory kv.KV used purely for test wiring. It JSON-encodes

--- a/internal/hive/plugins/lua/runtime.go
+++ b/internal/hive/plugins/lua/runtime.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	glua "github.com/yuin/gopher-lua"
 )
 
@@ -22,7 +22,8 @@ const dispatcherQueueSize = 64
 // dispatcher started in NewRuntime — touches state. Schedule work via
 // Submit, LoadEntrypoint, or CallEntrypoint; tear down with Close.
 type Runtime struct {
-	state *glua.LState
+	state  *glua.LState
+	logger zerolog.Logger
 
 	work   chan func(*glua.LState)
 	ctx    context.Context
@@ -37,7 +38,7 @@ type Runtime struct {
 // resolve relative to moduleRoot, and registers each HostModule onto the
 // global `hive` table. Setup is synchronous; the dispatcher goroutine takes
 // over LState ownership when this returns.
-func NewRuntime(moduleRoot string, modules ...HostModule) (*Runtime, error) {
+func NewRuntime(moduleRoot string, logger zerolog.Logger, modules ...HostModule) (*Runtime, error) {
 	state := glua.NewState(glua.Options{SkipOpenLibs: true})
 
 	// Opt-in standard libraries: omit io/os/debug so plugins cannot touch the
@@ -69,6 +70,7 @@ func NewRuntime(moduleRoot string, modules ...HostModule) (*Runtime, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &Runtime{
 		state:  state,
+		logger: logger,
 		work:   make(chan func(*glua.LState), dispatcherQueueSize),
 		ctx:    ctx,
 		cancel: cancel,
@@ -118,7 +120,7 @@ func (r *Runtime) Submit(fn func(*glua.LState)) {
 	closed := r.closed
 	r.mu.Unlock()
 	if closed {
-		log.Debug().Str("plugin", "lua").Msg("dropped lua work item: runtime closed")
+		r.logger.Debug().Msg("dropped lua work item: runtime closed")
 		return
 	}
 	// The work channel is never closed (ctx signals shutdown), so a
@@ -126,7 +128,7 @@ func (r *Runtime) Submit(fn func(*glua.LState)) {
 	select {
 	case r.work <- fn:
 	default:
-		log.Warn().Str("plugin", "lua").Msg("dropped lua work item: dispatcher queue full")
+		r.logger.Warn().Msg("dropped lua work item: dispatcher queue full")
 	}
 }
 

--- a/internal/hive/plugins/lua/runtime_test.go
+++ b/internal/hive/plugins/lua/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	glua "github.com/yuin/gopher-lua"
@@ -75,7 +76,7 @@ end
 // newBareRuntime is a Runtime with no host modules — for dispatcher tests.
 func newBareRuntime(t *testing.T) *Runtime {
 	t.Helper()
-	rt, err := NewRuntime(t.TempDir())
+	rt, err := NewRuntime(t.TempDir(), zerolog.Nop())
 	require.NoError(t, err)
 	return rt
 }

--- a/internal/hive/plugins/manager.go
+++ b/internal/hive/plugins/manager.go
@@ -42,11 +42,13 @@ type Manager struct {
 	refreshTrigger chan struct{}
 }
 
-// NewManager creates a new plugin manager with a shared worker pool.
-func NewManager(cfg config.PluginsConfig) *Manager {
+// NewManager creates a new plugin manager. The pool is injected so it can be
+// shared with plugins (e.g. the Lua hive.sh module) that draw from the same
+// concurrency budget as status refreshes.
+func NewManager(_ config.PluginsConfig, pool *WorkerPool) *Manager {
 	return &Manager{
 		plugins:        make(map[string]Plugin),
-		pool:           NewWorkerPool(cfg.ShellWorkers),
+		pool:           pool,
 		collector:      NewStatusCollector(),
 		jobs:           make(chan Job, defaultJobBufferSize),
 		results:        make(chan Result, defaultResultBufferSize),

--- a/internal/hive/plugins/manager.go
+++ b/internal/hive/plugins/manager.go
@@ -45,7 +45,7 @@ type Manager struct {
 // NewManager creates a new plugin manager. The pool is injected so it can be
 // shared with plugins (e.g. the Lua hive.sh module) that draw from the same
 // concurrency budget as status refreshes.
-func NewManager(_ config.PluginsConfig, pool *WorkerPool) *Manager {
+func NewManager(pool *WorkerPool) *Manager {
 	return &Manager{
 		plugins:        make(map[string]Plugin),
 		pool:           pool,

--- a/internal/hive/plugins/manager_test.go
+++ b/internal/hive/plugins/manager_test.go
@@ -79,7 +79,7 @@ func TestSessionsChanged(t *testing.T) {
 }
 
 func TestMergedCommandsPriority(t *testing.T) {
-	mgr := NewManager(config.PluginsConfig{})
+	mgr := NewManager(config.PluginsConfig{}, NewWorkerPool(0))
 	mgr.Register(&mockPlugin{
 		name: "plugin",
 		commands: map[string]config.UserCommand{

--- a/internal/hive/plugins/manager_test.go
+++ b/internal/hive/plugins/manager_test.go
@@ -79,7 +79,7 @@ func TestSessionsChanged(t *testing.T) {
 }
 
 func TestMergedCommandsPriority(t *testing.T) {
-	mgr := NewManager(config.PluginsConfig{}, NewWorkerPool(0))
+	mgr := NewManager(NewWorkerPool(0))
 	mgr.Register(&mockPlugin{
 		name: "plugin",
 		commands: map[string]config.UserCommand{

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -105,7 +105,7 @@ func newMouseTestSessionsView(t *testing.T) *sessions.View {
 	cfg := &config.Config{}
 	handler := NewKeybindingResolver(nil, nil, testRenderer)
 	mgr := terminal.NewManager(nil)
-	pm := plugins.NewManager(config.PluginsConfig{}, plugins.NewWorkerPool(0))
+	pm := plugins.NewManager(plugins.NewWorkerPool(0))
 	return sessions.New(sessions.ViewOpts{
 		Cfg:             cfg,
 		Service:         svc,

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -105,7 +105,7 @@ func newMouseTestSessionsView(t *testing.T) *sessions.View {
 	cfg := &config.Config{}
 	handler := NewKeybindingResolver(nil, nil, testRenderer)
 	mgr := terminal.NewManager(nil)
-	pm := plugins.NewManager(config.PluginsConfig{})
+	pm := plugins.NewManager(config.PluginsConfig{}, plugins.NewWorkerPool(0))
 	return sessions.New(sessions.ViewOpts{
 		Cfg:             cfg,
 		Service:         svc,

--- a/main.go
+++ b/main.go
@@ -279,6 +279,8 @@ Run 'hive new' to create a new session from the current repository.`,
 				return flag != nil && !*flag
 			}
 
+			shellPool := plugins.NewWorkerPool(cfg.Plugins.ShellWorkers)
+
 			allPlugins := []configuredPlugin{
 				{plugin: github.New(cfg.Plugins.GitHub, kvStore), disabled: isDisabled(cfg.Plugins.GitHub.Enabled)},
 				{plugin: beads.New(cfg.Plugins.Beads, kvStore), disabled: isDisabled(cfg.Plugins.Beads.Enabled)},
@@ -287,7 +289,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				{plugin: contextdir.New(cfg.Plugins.ContextDir, cfg.DataDir), disabled: isDisabled(cfg.Plugins.ContextDir.Enabled)},
 				{plugin: claude.New(cfg.Plugins.Claude, kvStore), disabled: isDisabled(cfg.Plugins.Claude.Enabled)},
 				{plugin: plugintmux.New(cfg.Plugins.Tmux), disabled: isDisabled(cfg.Plugins.Tmux.Enabled)},
-				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
+				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore, shellPool), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
 			}
 
 			pluginInfos := make([]doctor.PluginInfo, len(allPlugins))
@@ -300,7 +302,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				}
 			}
 
-			pluginMgr = plugins.NewManager(cfg.Plugins)
+			pluginMgr = plugins.NewManager(cfg.Plugins, shellPool)
 			for _, candidate := range allPlugins {
 				pluginMgr.Register(candidate.plugin)
 			}

--- a/main.go
+++ b/main.go
@@ -289,7 +289,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				{plugin: contextdir.New(cfg.Plugins.ContextDir, cfg.DataDir), disabled: isDisabled(cfg.Plugins.ContextDir.Enabled)},
 				{plugin: claude.New(cfg.Plugins.Claude, kvStore), disabled: isDisabled(cfg.Plugins.Claude.Enabled)},
 				{plugin: plugintmux.New(cfg.Plugins.Tmux), disabled: isDisabled(cfg.Plugins.Tmux.Enabled)},
-				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore, shellPool), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
+				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore, shellPool, log.With().Str("component", "lua").Logger()), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
 			}
 
 			pluginInfos := make([]doctor.PluginInfo, len(allPlugins))
@@ -302,7 +302,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				}
 			}
 
-			pluginMgr = plugins.NewManager(cfg.Plugins, shellPool)
+			pluginMgr = plugins.NewManager(shellPool)
 			for _, candidate := range allPlugins {
 				pluginMgr.Register(candidate.plugin)
 			}

--- a/test/integration/lua_plugin_sh_test.go
+++ b/test/integration/lua_plugin_sh_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLuaPluginShModule_RunOutputExec verifies that hive.sh.{run,output,exec}
+// are wired through the Lua runtime end-to-end. The plugin's entrypoint runs
+// during plugin init (any hive command triggers it); each function records
+// its result via a final hive.sh.run that writes a single summary file the
+// test reads back.
+func TestLuaPluginShModule_RunOutputExec(t *testing.T) {
+	h := NewHarness(t)
+
+	outputFile := filepath.Join(h.DataDir(), "sh-output.txt")
+	cwdMarker := filepath.Join(h.DataDir(), "sh-cwd-marker")
+	require.NoError(t, os.MkdirAll(cwdMarker, 0o755))
+
+	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
+	require.NoError(t, os.WriteFile(entry, []byte(fmt.Sprintf(`
+local OUT = %q
+local CWD = %q
+
+return function(hive)
+  -- run: returns exit code only, never raises
+  local runOK   = hive.sh.run("true")
+  local runFail = hive.sh.run("false")
+
+  -- output: captures stdout, strips trailing newline
+  local out = hive.sh.output("printf 'hello-output\n'")
+
+  -- exec: full struct with cwd option (trim trailing newline so it slots
+  -- cleanly into the summary line)
+  local r = hive.sh.exec("pwd", { cwd = CWD })
+  local pwd = r.stdout:gsub("\n$", "")
+
+  local summary = string.format(
+    "run_ok=%%d|run_fail=%%d|output=%%s|exec_pwd=%%s|exec_code=%%d",
+    runOK, runFail, out, pwd, r.code
+  )
+  hive.sh.run("printf %%s '" .. summary .. "' > " .. OUT)
+end
+`, outputFile, cwdMarker)), 0o644))
+
+	h.WithConfig(fmt.Sprintf(`
+plugins:
+  lua:
+    entry: %q
+`, entry))
+
+	// Any subcommand triggers plugin init, which runs the entrypoint.
+	_, err := h.RunStdout("config")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outputFile)
+	require.NoError(t, err, "summary file should be created by the lua plugin entrypoint")
+
+	got := string(content)
+	assert.Contains(t, got, "run_ok=0", "hive.sh.run should report exit code 0 for 'true'")
+	assert.Contains(t, got, "run_fail=1", "hive.sh.run should report exit code 1 for 'false'")
+	assert.Contains(t, got, "output=hello-output", "hive.sh.output should capture stdout and strip trailing newline")
+	// pwd from exec should resolve to CWD (or its symlink-resolved form on macOS).
+	resolvedCWD, err := filepath.EvalSymlinks(cwdMarker)
+	require.NoError(t, err)
+	assert.True(t,
+		strings.Contains(got, cwdMarker) || strings.Contains(got, resolvedCWD),
+		"exec_pwd should reflect opts.cwd; got: %s", got)
+	assert.Contains(t, got, "exec_code=0", "hive.sh.exec should report exit code 0")
+}
+
+// TestLuaPluginShModule_OutputRaisesOnNonZero verifies that hive.sh.output
+// raises a Lua error for non-zero exits, and that the error is logged when
+// it propagates out of the entrypoint without crashing hive.
+func TestLuaPluginShModule_OutputRaisesOnNonZero(t *testing.T) {
+	h := NewHarness(t)
+
+	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.sh.output("sh -c 'echo boom 1>&2; exit 1'")
+end
+`), 0o644))
+
+	h.WithConfig(fmt.Sprintf(`
+plugins:
+  lua:
+    entry: %q
+`, entry))
+
+	// hive should still run even though the lua plugin's entrypoint errored.
+	_, err := h.RunStdout("config")
+	require.NoError(t, err)
+
+	logContent, err := os.ReadFile(filepath.Join(h.DataDir(), "hive.log"))
+	require.NoError(t, err)
+	logStr := string(logContent)
+	assert.Contains(t, logStr, "plugin initialization failed")
+	assert.Contains(t, logStr, "hive.sh.output")
+	assert.Contains(t, logStr, "exit 1")
+}


### PR DESCRIPTION
## Summary
- Adds `hive.sh.run`, `hive.sh.output`, and `hive.sh.exec` to the Lua plugin API for shell command execution from Lua plugins. Backed by a `ShellExecutor` interface so tests can swap in a fake; the default `osExecutor` shells out via `sh -c` with separate stdout/stderr buffers.
- Hoists the shell `WorkerPool` to `main.go` so plugin status refreshes and `hive.sh.*` calls share one `plugins.shell_workers` budget. `plugins.NewManager` now accepts the pool by injection instead of constructing its own.
- Threads an injected `zerolog.Logger` from `main.go` through `Plugin` → `Runtime` → host modules (`LogModule`, `TickerModule`, `ShModule`), replacing the global logger calls inside the lua package. Adds structured logs around shell execution.
- Closes #306.

## What it looks like from Lua
\`\`\`lua
return function(hive)
  local code = hive.sh.run("git fetch origin")          -- exit code only
  local head = hive.sh.output("git rev-parse HEAD")     -- stdout, raises on non-zero
  local r = hive.sh.exec("ls -la", { cwd = "/tmp", timeout = 5 })
  -- r.stdout, r.stderr, r.code, r.err
end
\`\`\`

Defaults: 30s per-call timeout (configurable via \`plugins.lua.shell_timeout\`); \`opts.cwd\` defaults to Hive's working directory; \`opts.timeout\` is in seconds.

## Trust boundary
Documented prominently in \`docs/configuration/plugins.md\`: \`hive.sh\` runs commands with the full privileges of the Hive process. Only enable Lua plugins from sources you trust.

## Test plan
- [x] Unit tests for \`run\`/\`output\`/\`exec\` exit codes, trailing-newline stripping, options threading, default timeout, shutdown cancellation, and an end-to-end \`echo hello\` round-trip with the real \`osExecutor\`
- [x] \`mi test\` passes (full suite)
- [x] \`mi lint\` shows no new issues (pre-existing 50 \`goconst\` on main are unchanged)
- [ ] \`mise container\` smoke test: write a Lua plugin calling each of \`hive.sh.run\`/\`output\`/\`exec\`, including \`exec("sleep 5", { timeout = 1 })\` and a \`cwd\` override
- [ ] Reload plugin while a long-running \`hive.sh.exec("sleep 60")\` is in flight; confirm the subprocess is killed (no orphan \`sleep\`)
- [ ] Eyeball the docs site preview for the new \`### hive.sh\` section