### PR TITLE
feat(terminal): pane-aware tmux integration foundation (1/3)

### DIFF
--- a/internal/commands/cmd_x_pick.go
+++ b/internal/commands/cmd_x_pick.go
@@ -425,7 +425,7 @@ func refreshStatusCmd(mgr *terminal.Manager, items []pickItem) tea.Cmd {
 			if item.Session.Path != "" {
 				metadata = make(map[string]string, len(item.Session.Metadata)+1)
 				maps.Copy(metadata, item.Session.Metadata)
-				metadata["_session_path"] = item.Session.Path
+				metadata[terminaltmux.SessionPathKey] = item.Session.Path
 			}
 
 			info, integration, err := mgr.DiscoverSession(ctx, item.Session.Slug, metadata)
@@ -467,7 +467,7 @@ func refreshStatusCmd(mgr *terminal.Manager, items []pickItem) tea.Cmd {
 				windowItem := pickItem{
 					Session:     item.Session,
 					WindowName:  wi.WindowName,
-					WindowIndex: wi.Pane,
+					WindowIndex: wi.WindowIndex,
 					IsCurrent:   item.IsCurrent,
 					IsRecent:    item.IsRecent,
 				}

--- a/internal/core/session/session.go
+++ b/internal/core/session/session.go
@@ -53,7 +53,10 @@ const (
 // Metadata keys for terminal integration.
 const (
 	MetaTmuxSession = "tmux_session" // tmux session name
-	MetaTmuxPane    = "tmux_pane"    // tmux pane identifier
+	// MetaTmuxWindow renamed from "tmux_pane" in this PR. DiscoverSession reads
+	// the legacy key as a fallback so sessions persisted before this rename
+	// remain discoverable; the fallback can be dropped after one release cycle.
+	MetaTmuxWindow = "tmux_window"
 )
 
 // Metadata keys for session organization.

--- a/internal/core/terminal/terminal.go
+++ b/internal/core/terminal/terminal.go
@@ -16,7 +16,8 @@ const (
 // SessionInfo holds information about a discovered terminal session.
 type SessionInfo struct {
 	Name         string // terminal session name (e.g., tmux session name)
-	Pane         string // pane identifier if applicable (window index for tmux)
+	WindowIndex  string // tmux window index (e.g., "0", "1")
+	PaneID       string // tmux pane ID in %N format
 	WindowName   string // window name (for display and template data)
 	Status       Status // current detected status
 	DetectedTool string // detected AI tool (claude, gemini, etc.)

--- a/internal/core/terminal/tmux/parse_test.go
+++ b/internal/core/terminal/tmux/parse_test.go
@@ -1,0 +1,159 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePaneLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want paneLine
+		ok   bool
+	}{
+		{
+			name: "8 fields with hive tag",
+			line: "sess\t1\twname\t/work\t12345\t%2\t6789\tmy-slug",
+			want: paneLine{
+				sessName: "sess", winIdx: "1", winName: "wname", workDir: "/work",
+				activity: 12345, paneID: "%2", panePID: 6789, hiveSession: "my-slug",
+			},
+			ok: true,
+		},
+		{
+			name: "7 fields (no hive tag)",
+			line: "sess\t0\tbash\t/home\t100\t%0\t1234",
+			want: paneLine{
+				sessName: "sess", winIdx: "0", winName: "bash", workDir: "/home",
+				activity: 100, paneID: "%0", panePID: 1234,
+			},
+			ok: true,
+		},
+		{
+			name: "6 fields (no panePID, no tag)",
+			line: "sess\t0\tbash\t/home\t100\t%0",
+			want: paneLine{
+				sessName: "sess", winIdx: "0", winName: "bash", workDir: "/home",
+				activity: 100, paneID: "%0",
+			},
+			ok: true,
+		},
+		{
+			name: "5 fields rejected",
+			line: "sess\t0\tbash\t/home\t100",
+			ok:   false,
+		},
+		{
+			name: "empty rejected",
+			line: "",
+			ok:   false,
+		},
+		{
+			name: "malformed activity treated as zero",
+			line: "sess\t0\tbash\t/home\tnotanumber\t%0\t1234",
+			want: paneLine{
+				sessName: "sess", winIdx: "0", winName: "bash", workDir: "/home",
+				activity: 0, paneID: "%0", panePID: 1234,
+			},
+			ok: true,
+		},
+		{
+			name: "tag with surrounding whitespace trimmed",
+			line: "sess\t1\twname\t/work\t12345\t%2\t6789\t  my-slug  ",
+			want: paneLine{
+				sessName: "sess", winIdx: "1", winName: "wname", workDir: "/work",
+				activity: 12345, paneID: "%2", panePID: 6789, hiveSession: "my-slug",
+			},
+			ok: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parsePaneLine(tt.line)
+			assert.Equal(t, tt.ok, ok)
+			if !tt.ok {
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSelectPrimary(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		id, pid, all := selectPrimary(nil, "any-slug")
+		assert.Empty(t, id)
+		assert.Zero(t, pid)
+		assert.Empty(t, all)
+	})
+
+	t.Run("single untagged pane is primary", func(t *testing.T) {
+		panes := []paneLine{{paneID: "%0", panePID: 100}}
+		id, pid, all := selectPrimary(panes, "slug")
+		assert.Equal(t, "%0", id)
+		assert.Equal(t, int64(100), pid)
+		assert.Equal(t, []string{"%0"}, all)
+	})
+
+	t.Run("single tagged pane is primary", func(t *testing.T) {
+		panes := []paneLine{{paneID: "%5", panePID: 200, hiveSession: "slug"}}
+		id, pid, all := selectPrimary(panes, "slug")
+		assert.Equal(t, "%5", id)
+		assert.Equal(t, int64(200), pid)
+		assert.Equal(t, []string{"%5"}, all)
+	})
+
+	t.Run("tagged pane wins over untagged sibling", func(t *testing.T) {
+		panes := []paneLine{
+			{paneID: "%0", panePID: 100},                        // untagged user split
+			{paneID: "%1", panePID: 101, hiveSession: "myslug"}, // hive pane
+		}
+		id, _, all := selectPrimary(panes, "myslug")
+		assert.Equal(t, "%1", id)
+		assert.Equal(t, []string{"%0", "%1"}, all)
+	})
+
+	t.Run("matching tag wins over non-matching tag", func(t *testing.T) {
+		// Defends against tmux propagating @hive-session to user-split panes:
+		// the pane whose tag matches expectedSlug is the original.
+		panes := []paneLine{
+			{paneID: "%0", panePID: 100, hiveSession: "other-slug"}, // wrong tag
+			{paneID: "%1", panePID: 101, hiveSession: "myslug"},     // match
+		}
+		id, pid, _ := selectPrimary(panes, "myslug")
+		assert.Equal(t, "%1", id)
+		assert.Equal(t, int64(101), pid)
+	})
+
+	t.Run("first tagged wins when no match found", func(t *testing.T) {
+		panes := []paneLine{
+			{paneID: "%0", panePID: 100, hiveSession: "other"},
+			{paneID: "%1", panePID: 101, hiveSession: "another"},
+		}
+		id, _, _ := selectPrimary(panes, "myslug")
+		assert.Equal(t, "%0", id)
+	})
+
+	t.Run("empty expectedSlug skips match phase", func(t *testing.T) {
+		panes := []paneLine{
+			{paneID: "%0", panePID: 100},
+			{paneID: "%1", panePID: 101, hiveSession: "tagged"},
+		}
+		id, _, _ := selectPrimary(panes, "")
+		assert.Equal(t, "%1", id)
+	})
+
+	t.Run("preserves all pane IDs in input order", func(t *testing.T) {
+		panes := []paneLine{
+			{paneID: "%2"},
+			{paneID: "%0"},
+			{paneID: "%5"},
+		}
+		_, _, all := selectPrimary(panes, "")
+		require.Equal(t, []string{"%2", "%0", "%5"}, all)
+	})
+}

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -30,8 +30,11 @@ type Integration struct {
 
 // agentWindow holds per-window state within a tmux session.
 type agentWindow struct {
-	windowIndex       string // window index for targeted capture (e.g., "0", "1")
-	windowName        string // window name for display and matching
+	windowIndex       string   // window index for targeted capture (e.g., "0", "1")
+	windowName        string   // window name for display and matching
+	primaryPaneID     string   // pane tagged with @hive-session, or first pane
+	panePID           int64    // PID of the primary pane
+	allPaneIDs        []string // all pane IDs in this window
 	workDir           string
 	activity          int64
 	paneContent       string
@@ -100,14 +103,93 @@ func (t *Integration) Available() bool {
 	return t.available
 }
 
+// listPanesFormat is the tab-delimited format used for `tmux list-panes -a`.
+// Fields, in order: session_name, window_index, window_name, pane_current_path,
+// window_activity, pane_id, pane_pid, @hive-session.
+const listPanesFormat = "#{session_name}\t#{window_index}\t#{window_name}\t" +
+	"#{pane_current_path}\t#{window_activity}\t#{pane_id}\t#{pane_pid}\t#{@hive-session}"
+
+// paneLine is the parsed form of one line of `tmux list-panes` output.
+type paneLine struct {
+	sessName    string
+	winIdx      string
+	winName     string
+	workDir     string
+	activity    int64
+	paneID      string
+	panePID     int64
+	hiveSession string // value of @hive-session option, empty if untagged
+}
+
+// parsePaneLine parses one tab-delimited line in listPanesFormat. Returns
+// ok=false if the line has fewer than the minimum required fields (the first
+// 6: session_name, window_index, window_name, pane_current_path,
+// window_activity, pane_id).
+func parsePaneLine(line string) (paneLine, bool) {
+	parts := strings.SplitN(line, "\t", 8)
+	if len(parts) < 6 {
+		return paneLine{}, false
+	}
+	pl := paneLine{
+		sessName: parts[0],
+		winIdx:   parts[1],
+		winName:  parts[2],
+		workDir:  parts[3],
+		paneID:   parts[5],
+	}
+	_, _ = fmt.Sscanf(parts[4], "%d", &pl.activity)
+	if len(parts) >= 7 {
+		_, _ = fmt.Sscanf(parts[6], "%d", &pl.panePID)
+	}
+	if len(parts) >= 8 {
+		pl.hiveSession = strings.TrimSpace(parts[7])
+	}
+	return pl, true
+}
+
+// selectPrimary picks the primary pane from a window's pane list.
+// Preference order:
+//  1. Pane whose @hive-session tag equals expectedSlug — defends against the
+//     scenario where tmux propagates pane-local options to user-split siblings:
+//     even if both panes carry a tag, only the original carries the matching slug.
+//  2. Any pane with a non-empty @hive-session tag (no slug supplied, or no match).
+//  3. The first pane in list order.
+func selectPrimary(panes []paneLine, expectedSlug string) (primaryPaneID string, panePID int64, allPaneIDs []string) {
+	allPaneIDs = make([]string, 0, len(panes))
+	var taggedID string
+	var taggedPID int64
+	var matchedID string
+	var matchedPID int64
+	for _, p := range panes {
+		allPaneIDs = append(allPaneIDs, p.paneID)
+		if p.hiveSession == "" {
+			continue
+		}
+		if taggedID == "" {
+			taggedID = p.paneID
+			taggedPID = p.panePID
+		}
+		if expectedSlug != "" && matchedID == "" && p.hiveSession == expectedSlug {
+			matchedID = p.paneID
+			matchedPID = p.panePID
+		}
+	}
+	switch {
+	case matchedID != "":
+		return matchedID, matchedPID, allPaneIDs
+	case taggedID != "":
+		return taggedID, taggedPID, allPaneIDs
+	case len(panes) > 0:
+		return panes[0].paneID, panes[0].panePID, allPaneIDs
+	}
+	return "", 0, allPaneIDs
+}
+
 // RefreshCache updates the cached session list. Call once per poll cycle.
 func (t *Integration) RefreshCache() {
-	// Get session name, window index, window name, work dir, and activity
-	cmd := exec.Command("tmux", "list-windows", "-a", "-F",
-		"#{session_name}\t#{window_index}\t#{window_name}\t#{pane_current_path}\t#{window_activity}")
-	output, err := cmd.Output()
+	output, err := exec.Command("tmux", "list-panes", "-a", "-F", listPanesFormat).Output()
 	if err != nil {
-		log.Debug().Err(err).Msg("tmux list-windows failed, clearing cache")
+		log.Debug().Err(err).Msg("tmux list-panes failed, clearing cache")
 		t.mu.Lock()
 		t.cache = make(map[string]*sessionCache)
 		t.cacheTime = time.Time{}
@@ -134,57 +216,71 @@ func (t *Integration) RefreshCache() {
 	}
 	t.mu.RUnlock()
 
-	// First pass: collect all windows grouped by tmux session, tracking preferred status
+	// windowAccum accumulates panes that share the same tmux session+window.
+	type windowAccum struct {
+		windowName string
+		workDir    string
+		activity   int64
+		panes      []paneLine
+	}
+
+	type windowKey struct{ session, index string }
+	accumMap := make(map[windowKey]*windowAccum)
+	var order []windowKey // preserve insertion order for deterministic output
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		pl, ok := parsePaneLine(line)
+		if !ok {
+			continue
+		}
+		key := windowKey{pl.sessName, pl.winIdx}
+		acc := accumMap[key]
+		if acc == nil {
+			acc = &windowAccum{windowName: pl.winName, workDir: pl.workDir, activity: pl.activity}
+			accumMap[key] = acc
+			order = append(order, key)
+		}
+		acc.panes = append(acc.panes, pl)
+	}
+
 	type windowEntry struct {
 		window    *agentWindow
 		preferred bool
 	}
 	collected := make(map[string][]windowEntry)
 
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, "\t", 5)
-		if len(parts) < 3 {
-			continue
-		}
-
-		sessionName := parts[0]
-		windowIndex := parts[1]
-		windowName := parts[2]
+	for _, key := range order {
+		acc := accumMap[key]
+		// expectedSlug is the tmux session name; tagPanesWithSession writes the
+		// session slug into @hive-session, so they match for hive-managed panes.
+		primaryPaneID, panePID, allPaneIDs := selectPrimary(acc.panes, key.session)
 
 		w := &agentWindow{
-			windowIndex: windowIndex,
-			windowName:  windowName,
+			windowIndex:   key.index,
+			windowName:    acc.windowName,
+			primaryPaneID: primaryPaneID,
+			panePID:       panePID,
+			allPaneIDs:    allPaneIDs,
+			workDir:       acc.workDir,
+			activity:      acc.activity,
 		}
 
-		if len(parts) >= 4 {
-			w.workDir = parts[3]
-		}
-		if len(parts) >= 5 {
-			_, _ = fmt.Sscanf(parts[4], "%d", &w.activity)
-		}
-
-		// Preserve cached content from snapshot
-		if snap, exists := oldWindows[sessionName+":"+windowIndex]; exists {
+		if snap, ok := oldWindows[key.session+":"+key.index]; ok {
 			w.paneContent = snap.paneContent
 			w.lastCaptureActive = snap.lastCaptureActive
 			w.cachedStatus = snap.cachedStatus
 		}
 
-		isPreferred := t.matchesPreferredWindow(windowName)
-		collected[sessionName] = append(collected[sessionName], windowEntry{
-			window:    w,
-			preferred: isPreferred,
-		})
+		isPreferred := t.matchesPreferredWindow(acc.windowName)
+		collected[key.session] = append(collected[key.session], windowEntry{window: w, preferred: isPreferred})
 	}
 
-	// Second pass: for each tmux session, decide which windows to keep.
-	// If any windows match preferred patterns, keep all preferred windows.
-	// Otherwise keep only the single highest-activity window (backward compat).
+	// Filter to preferred windows when any match; otherwise keep the
+	// highest-activity window.
 	newCache := make(map[string]*sessionCache, len(collected))
-
 	for sessionName, entries := range collected {
 		hasPreferred := false
 		for _, e := range entries {
@@ -193,7 +289,6 @@ func (t *Integration) RefreshCache() {
 				break
 			}
 		}
-
 		sc := &sessionCache{}
 		if hasPreferred {
 			for _, e := range entries {
@@ -202,7 +297,6 @@ func (t *Integration) RefreshCache() {
 				}
 			}
 		} else {
-			// No preferred windows: keep the single highest-activity window
 			var best *agentWindow
 			for _, e := range entries {
 				if best == nil || e.window.activity > best.activity {
@@ -232,8 +326,9 @@ func (t *Integration) matchesPreferredWindow(windowName string) bool {
 	return false
 }
 
-// sessionPathKey is the metadata key injected by the TUI to pass session path for multi-window matching.
-const sessionPathKey = "_session_path"
+// SessionPathKey is the metadata key callers inject to pass session path for
+// multi-window disambiguation. Lives here because tmux is its only consumer.
+const SessionPathKey = "_session_path"
 
 // findSessionCache locates the sessionCache for a slug using metadata or exact match.
 // Must be called with t.mu held (read or write). Returns the session name and cache, or ("", nil).
@@ -264,19 +359,25 @@ func (t *Integration) DiscoverSession(_ context.Context, slug string, metadata m
 		return nil, nil
 	}
 
-	// If explicit pane given, use it directly
-	if pane := metadata[session.MetaTmuxPane]; pane != "" {
-		w := sc.findWindow(pane)
+	// If explicit window given, use it. Read the new key first; fall back to the
+	// legacy "tmux_pane" key for sessions persisted before the rename. The
+	// fallback can be removed after one release cycle.
+	windowIdx := metadata[session.MetaTmuxWindow]
+	if windowIdx == "" {
+		windowIdx = metadata["tmux_pane"]
+	}
+	if windowIdx != "" {
+		w := sc.findWindow(windowIdx)
 		if w == nil {
-			log.Debug().Str("session", sessionName).Str("pane", pane).Msg("explicit pane not found, falling back to best window")
+			log.Debug().Str("session", sessionName).Str("window", windowIdx).Msg("explicit window not found, falling back to best window")
 			w = sc.bestWindow()
 		}
-		return t.sessionInfoFromWindow(sessionName, sc, w), nil
+		return t.sessionInfoFromWindow(sessionName, w), nil
 	}
 
 	// Multi-window disambiguation
-	w := t.disambiguateWindow(sc, metadata[sessionPathKey], slug)
-	return t.sessionInfoFromWindow(sessionName, sc, w), nil
+	w := t.disambiguateWindow(sc, metadata[SessionPathKey], slug)
+	return t.sessionInfoFromWindow(sessionName, w), nil
 }
 
 // disambiguateWindow selects the best window from a multi-window session cache.
@@ -316,14 +417,15 @@ func (t *Integration) disambiguateWindow(sc *sessionCache, sessionPath, slug str
 // sessionInfoFromWindow builds a SessionInfo from a matched agentWindow.
 // WindowName is always set so that template variables (e.g., .TmuxWindow) are
 // populated regardless of whether the session has one or many windows.
-func (t *Integration) sessionInfoFromWindow(sessionName string, _ *sessionCache, w *agentWindow) *terminal.SessionInfo {
+func (t *Integration) sessionInfoFromWindow(sessionName string, w *agentWindow) *terminal.SessionInfo {
 	if w == nil {
 		return &terminal.SessionInfo{Name: sessionName}
 	}
 	return &terminal.SessionInfo{
-		Name:       sessionName,
-		Pane:       w.windowIndex,
-		WindowName: w.windowName,
+		Name:        sessionName,
+		WindowIndex: w.windowIndex,
+		PaneID:      w.primaryPaneID,
+		WindowName:  w.windowName,
 	}
 }
 
@@ -342,9 +444,9 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 		return terminal.StatusMissing, nil
 	}
 
-	w := sc.findWindow(info.Pane)
+	w := sc.findWindow(info.WindowIndex)
 	if w == nil {
-		log.Debug().Str("session", info.Name).Str("pane", info.Pane).Msg("window not found in cache, falling back to best window")
+		log.Debug().Str("session", info.Name).Str("window", info.WindowIndex).Msg("window not found in cache, falling back to best window")
 		w = sc.bestWindow()
 	}
 	if w == nil {
@@ -358,6 +460,7 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 	lastCaptureActive := w.lastCaptureActive
 	cachedStatus := w.cachedStatus
 	windowIndex := w.windowIndex
+	primaryPaneID := w.primaryPaneID
 	sessionName := info.Name
 	t.mu.RUnlock()
 
@@ -380,9 +483,14 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 		// Activity changed but rate limited, use cached content
 		content = prevContent
 	default:
-		// Activity changed and rate limit allows, capture fresh
+		// Prefer the pane ID for capture so multi-pane windows hit the right
+		// pane; fall back to session:window if the cache has no pane ID yet.
+		captureTarget := sessionName + ":" + windowIndex
+		if primaryPaneID != "" {
+			captureTarget = primaryPaneID
+		}
 		var err error
-		content, err = t.capturePane(ctx, info.Name, windowIndex)
+		content, err = t.capturePane(ctx, captureTarget)
 		if err != nil {
 			return terminal.StatusMissing, err
 		}
@@ -441,21 +549,15 @@ func (t *Integration) GetStatus(ctx context.Context, info *terminal.SessionInfo)
 	return status, nil
 }
 
-// capturePane captures the content of a tmux pane.
-func (t *Integration) capturePane(_ context.Context, sessionName, pane string) (string, error) {
-	target := sessionName
-	if pane != "" {
-		target = sessionName + ":" + pane
-	}
-
+// capturePane captures the content of a tmux pane identified by target.
+// target may be a pane ID (e.g. "%0") or a session:window address.
+func (t *Integration) capturePane(ctx context.Context, target string) (string, error) {
 	// -p: print to stdout
 	// -J: join wrapped lines and trim trailing spaces
-	cmd := exec.Command("tmux", "capture-pane", "-t", target, "-p", "-J")
-	output, err := cmd.Output()
+	output, err := exec.CommandContext(ctx, "tmux", "capture-pane", "-t", target, "-p", "-J").Output()
 	if err != nil {
 		return "", fmt.Errorf("capture-pane failed: %w", err)
 	}
-
 	return string(output), nil
 }
 
@@ -479,9 +581,10 @@ func (t *Integration) DiscoverAllWindows(_ context.Context, slug string, metadat
 	infos := make([]*terminal.SessionInfo, 0, len(sc.agentWindows))
 	for _, w := range sc.agentWindows {
 		infos = append(infos, &terminal.SessionInfo{
-			Name:       sessionName,
-			Pane:       w.windowIndex,
-			WindowName: w.windowName,
+			Name:        sessionName,
+			WindowIndex: w.windowIndex,
+			PaneID:      w.primaryPaneID,
+			WindowName:  w.windowName,
 		})
 	}
 	return infos, nil

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -144,30 +144,28 @@ func TestSessionInfoFromWindow(t *testing.T) {
 	integ := New(nil)
 
 	t.Run("nil window", func(t *testing.T) {
-		sc := &sessionCache{}
-		info := integ.sessionInfoFromWindow("mysess", sc, nil)
+		info := integ.sessionInfoFromWindow("mysess", nil)
 		assert.Equal(t, "mysess", info.Name)
-		assert.Empty(t, info.Pane)
+		assert.Empty(t, info.WindowIndex)
 		assert.Empty(t, info.WindowName)
 	})
 
-	t.Run("single window sets WindowName", func(t *testing.T) {
-		w := &agentWindow{windowIndex: "2", windowName: "claude"}
-		sc := &sessionCache{agentWindows: []*agentWindow{w}}
-		info := integ.sessionInfoFromWindow("mysess", sc, w)
+	t.Run("single window sets WindowName and PaneID", func(t *testing.T) {
+		w := &agentWindow{windowIndex: "2", windowName: "claude", primaryPaneID: "%5"}
+		info := integ.sessionInfoFromWindow("mysess", w)
 		assert.Equal(t, "mysess", info.Name)
-		assert.Equal(t, "2", info.Pane)
+		assert.Equal(t, "2", info.WindowIndex)
 		assert.Equal(t, "claude", info.WindowName)
+		assert.Equal(t, "%5", info.PaneID)
 	})
 
-	t.Run("multi window sets WindowName", func(t *testing.T) {
-		w1 := &agentWindow{windowIndex: "0", windowName: "claude"}
-		w2 := &agentWindow{windowIndex: "1", windowName: "aider"}
-		sc := &sessionCache{agentWindows: []*agentWindow{w1, w2}}
-		info := integ.sessionInfoFromWindow("mysess", sc, w2)
+	t.Run("multi window sets WindowName and PaneID", func(t *testing.T) {
+		w2 := &agentWindow{windowIndex: "1", windowName: "aider", primaryPaneID: "%9"}
+		info := integ.sessionInfoFromWindow("mysess", w2)
 		assert.Equal(t, "mysess", info.Name)
-		assert.Equal(t, "1", info.Pane)
+		assert.Equal(t, "1", info.WindowIndex)
 		assert.Equal(t, "aider", info.WindowName)
+		assert.Equal(t, "%9", info.PaneID)
 	})
 }
 
@@ -189,11 +187,11 @@ func TestDiscoverSession_MultiWindow(t *testing.T) {
 
 	t.Run("path match selects correct window", func(t *testing.T) {
 		info, err := integ.DiscoverSession(ctx, "my-session", map[string]string{
-			sessionPathKey: "/project-b",
+			SessionPathKey: "/project-b",
 		})
 		require.NoError(t, err)
 		require.NotNil(t, info, "expected info")
-		assert.Equal(t, "1", info.Pane)
+		assert.Equal(t, "1", info.WindowIndex)
 		assert.Equal(t, "claude", info.WindowName)
 	})
 
@@ -203,12 +201,12 @@ func TestDiscoverSession_MultiWindow(t *testing.T) {
 		integ.cache["my-session"].agentWindows[1].activity = 100
 
 		info, err := integ.DiscoverSession(ctx, "my-session", map[string]string{
-			sessionPathKey: "/nonexistent",
+			SessionPathKey: "/nonexistent",
 		})
 		require.NoError(t, err)
 		require.NotNil(t, info, "expected info")
 		// No path match, no name match for slug "my-session" in window names — should pick highest activity
-		assert.Equal(t, "0", info.Pane)
+		assert.Equal(t, "0", info.WindowIndex)
 	})
 }
 
@@ -260,9 +258,9 @@ func TestDiscoverAllWindows(t *testing.T) {
 		infos, err := integ.DiscoverAllWindows(ctx, "multi-sess", nil)
 		require.NoError(t, err)
 		require.Len(t, infos, 2, "expected 2 windows, got %d", len(infos))
-		assert.Equal(t, "0", infos[0].Pane)
+		assert.Equal(t, "0", infos[0].WindowIndex)
 		assert.Equal(t, "claude", infos[0].WindowName)
-		assert.Equal(t, "1", infos[1].Pane)
+		assert.Equal(t, "1", infos[1].WindowIndex)
 		assert.Equal(t, "aider", infos[1].WindowName)
 	})
 
@@ -270,7 +268,7 @@ func TestDiscoverAllWindows(t *testing.T) {
 		infos, err := integ.DiscoverAllWindows(ctx, "single-sess", nil)
 		require.NoError(t, err)
 		require.Len(t, infos, 1, "expected 1 window, got %d", len(infos))
-		assert.Equal(t, "0", infos[0].Pane)
+		assert.Equal(t, "0", infos[0].WindowIndex)
 	})
 
 	t.Run("returns nil for unknown session", func(t *testing.T) {
@@ -353,7 +351,7 @@ func TestDiscoverSession_ExplicitTmuxSessionMeta(t *testing.T) {
 	t.Run("explicit MetaTmuxSession metadata finds session", func(t *testing.T) {
 		// MetaTmuxSession stores the actual tmux session name used at creation.
 		info, err := integ.DiscoverSession(ctx, "my-feature", map[string]string{
-			sessionPathKey: "/some/path",
+			SessionPathKey: "/some/path",
 			"tmux_session": "My Feature",
 		})
 		require.NoError(t, err)

--- a/internal/core/tmux/client.go
+++ b/internal/core/tmux/client.go
@@ -62,6 +62,9 @@ func (c *Client) CreateSession(ctx context.Context, name, workDir string, window
 		return fmt.Errorf("tmux new-session: %w; output: %s", err, strings.TrimSpace(string(out)))
 	}
 
+	// Tag the initial pane for hive-managed pane identification.
+	c.tagPanesWithSession(ctx, name, name)
+
 	// Suppress interactive hooks (e.g. after-new-window command-prompt) that
 	// block the tmux server waiting for input that will never arrive when
 	// windows are created programmatically.
@@ -82,6 +85,7 @@ func (c *Client) CreateSession(ctx context.Context, name, workDir string, window
 			_, _ = c.exec.Run(ctx, "tmux", "kill-session", "-t", name)
 			return fmt.Errorf("tmux new-window %q: %w; output: %s", w.Name, err, strings.TrimSpace(string(out)))
 		}
+		c.tagPanesWithSession(ctx, name+":"+w.Name, name)
 	}
 
 	// Select the focused window (default to first).
@@ -119,6 +123,7 @@ func (c *Client) AddWindows(ctx context.Context, name, workDir string, windows [
 		if _, err := c.exec.Run(ctx, "tmux", args...); err != nil {
 			return fmt.Errorf("tmux new-window %q: %w", w.Name, err)
 		}
+		c.tagPanesWithSession(ctx, name+":"+w.Name, name)
 	}
 	for _, w := range windows {
 		if w.Focus {
@@ -164,6 +169,14 @@ func (c *Client) OpenSession(ctx context.Context, name, workDir string, windows 
 		return c.AttachOrSwitch(ctx, name)
 	}
 	return c.CreateSession(ctx, name, workDir, windows, background)
+}
+
+// tagPanesWithSession sets @hive-session on the active pane so list-panes can
+// identify hive-managed panes. Errors are non-fatal — tagging is best-effort.
+func (c *Client) tagPanesWithSession(ctx context.Context, sessionTarget, slug string) {
+	if _, err := c.exec.Run(ctx, "tmux", "set-option", "-p", "-t", sessionTarget, "@hive-session", slug); err != nil {
+		c.log.Debug().Err(err).Str("target", sessionTarget).Msg("failed to tag pane with @hive-session")
+	}
 }
 
 // suppressInteractiveHooks sets session-level overrides to neutralise global

--- a/internal/core/tmux/client_test.go
+++ b/internal/core/tmux/client_test.go
@@ -44,9 +44,11 @@ func TestClient_CreateSession(t *testing.T) {
 		}, true)
 		require.NoError(t, err)
 
-		require.Len(t, rec.Commands, 4) // new-session + 2 set-hook + select-window
+		// new-session + set-option (pane tag) + 2 set-hook + select-window
+		require.Len(t, rec.Commands, 5)
 		assert.Equal(t, []string{"new-session", "-d", "-s", "sess", "-n", "agent", "-c", "/work", "--", "sh", "-c", "claude"}, rec.Commands[0].Args)
-		assert.Equal(t, []string{"select-window", "-t", "sess:agent"}, rec.Commands[3].Args)
+		assert.Equal(t, []string{"set-option", "-p", "-t", "sess", "@hive-session", "sess"}, rec.Commands[1].Args)
+		assert.Equal(t, []string{"select-window", "-t", "sess:agent"}, rec.Commands[4].Args)
 	})
 
 	t.Run("two windows", func(t *testing.T) {
@@ -59,10 +61,12 @@ func TestClient_CreateSession(t *testing.T) {
 		}, true)
 		require.NoError(t, err)
 
-		require.Len(t, rec.Commands, 5) // new-session + 2 set-hook + new-window + select-window
+		// new-session + set-option + 2 set-hook + new-window + set-option + select-window
+		require.Len(t, rec.Commands, 7)
 		assert.Equal(t, []string{"new-session", "-d", "-s", "sess", "-n", "agent", "-c", "/work", "--", "sh", "-c", "claude"}, rec.Commands[0].Args)
-		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "shell", "-c", "/work"}, rec.Commands[3].Args)
-		assert.Equal(t, []string{"select-window", "-t", "sess:agent"}, rec.Commands[4].Args)
+		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "shell", "-c", "/work"}, rec.Commands[4].Args)
+		assert.Equal(t, []string{"set-option", "-p", "-t", "sess:shell", "@hive-session", "sess"}, rec.Commands[5].Args)
+		assert.Equal(t, []string{"select-window", "-t", "sess:agent"}, rec.Commands[6].Args)
 	})
 
 	t.Run("three windows with dir override", func(t *testing.T) {
@@ -76,9 +80,10 @@ func TestClient_CreateSession(t *testing.T) {
 		}, true)
 		require.NoError(t, err)
 
-		require.Len(t, rec.Commands, 6) // new-session + 2 set-hook + 2*new-window + select-window
-		// Third window (index 4) uses custom dir
-		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "logs", "-c", "/var/log", "--", "sh", "-c", "tail -f /var/log/app.log"}, rec.Commands[4].Args)
+		// new-session + set-option + 2 set-hook + 2*(new-window + set-option) + select-window
+		require.Len(t, rec.Commands, 9)
+		// Third window (index 6) uses custom dir: new-window for "shell" is index 4, "logs" is index 6
+		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "logs", "-c", "/var/log", "--", "sh", "-c", "tail -f /var/log/app.log"}, rec.Commands[6].Args)
 	})
 
 	t.Run("focus second window", func(t *testing.T) {
@@ -268,9 +273,12 @@ func TestClient_AddWindows(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, rec.Commands, 4) // 2 set-hook + 2 new-window
+		// 2 set-hook + 2*(new-window + set-option)
+		require.Len(t, rec.Commands, 6)
 		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "w1", "-c", "/work", "--", "sh", "-c", "claude"}, rec.Commands[2].Args)
-		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "w2", "-c", "/work"}, rec.Commands[3].Args)
+		assert.Equal(t, []string{"set-option", "-p", "-t", "sess:w1", "@hive-session", "sess"}, rec.Commands[3].Args)
+		assert.Equal(t, []string{"new-window", "-t", "sess", "-n", "w2", "-c", "/work"}, rec.Commands[4].Args)
+		assert.Equal(t, []string{"set-option", "-p", "-t", "sess:w2", "@hive-session", "sess"}, rec.Commands[5].Args)
 	})
 
 	t.Run("selects focused window", func(t *testing.T) {
@@ -283,9 +291,9 @@ func TestClient_AddWindows(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// 2 set-hook + 2 new-window + 1 select-window
-		require.Len(t, rec.Commands, 5)
-		assert.Equal(t, []string{"select-window", "-t", "sess:w2"}, rec.Commands[4].Args)
+		// 2 set-hook + 2*(new-window + set-option) + 1 select-window
+		require.Len(t, rec.Commands, 7)
+		assert.Equal(t, []string{"select-window", "-t", "sess:w2"}, rec.Commands[6].Args)
 	})
 
 	t.Run("window dir overrides session dir", func(t *testing.T) {
@@ -297,7 +305,8 @@ func TestClient_AddWindows(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, rec.Commands, 3) // 2 set-hook + 1 new-window
+		// 2 set-hook + 1 new-window + 1 set-option
+		require.Len(t, rec.Commands, 4)
 		assert.Contains(t, rec.Commands[2].Args, "/custom")
 	})
 }

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
+	terminaltmux "github.com/colonyops/hive/internal/core/terminal/tmux"
 )
 
 const terminalStatusTimeout = 2 * time.Second
@@ -97,10 +99,8 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 	metadata := sess.Metadata
 	if sess.Path != "" {
 		metadata = make(map[string]string, len(sess.Metadata)+1)
-		for k, v := range sess.Metadata {
-			metadata[k] = v
-		}
-		metadata["_session_path"] = sess.Path
+		maps.Copy(metadata, sess.Metadata)
+		metadata[terminaltmux.SessionPathKey] = sess.Path
 	}
 
 	// Try to discover terminal session
@@ -139,11 +139,11 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 				// Get per-window status and content
 				wStatus, wErr := integration.GetStatus(ctx, wi)
 				if wErr != nil {
-					log.Debug().Err(wErr).Str("session", sess.Slug).Str("window", wi.Pane).Msg("per-window status failed, marking missing")
+					log.Debug().Err(wErr).Str("session", sess.Slug).Str("window", wi.WindowIndex).Msg("per-window status failed, marking missing")
 					wStatus = terminal.StatusMissing
 				}
 				windows = append(windows, WindowStatus{
-					WindowIndex: wi.Pane,
+					WindowIndex: wi.WindowIndex,
 					WindowName:  wi.WindowName,
 					Status:      wStatus,
 					Tool:        wi.DetectedTool,


### PR DESCRIPTION
## Summary

Foundation for per-pane agent detection. Tmux pane tagging via `@hive-session`, primary-pane selection that survives user splits, and the metadata key rename — without the process-tree detection or diagnostic command that build on top.

This is **part 1 of 3 stacked PRs**:

1. **This PR** — pane infrastructure (rename, tagging, primary-pane selection)
2. Part 2 — process-tree agent identification + critical fix for content-based fallback (depends on this PR)
3. Part 3 — `hive x detect` diagnostic command (depends on part 2)

Replaces #319, which was too large for effective review (1k+ LOC). The original review missed a regression in the process-detection layer; splitting makes each layer reviewable independently.

## What's in this PR

- `session.MetaTmuxPane` (\`tmux_pane\`) → `MetaTmuxWindow` (\`tmux_window\`). `DiscoverSession` reads the legacy key as a fallback so existing sessions on disk remain discoverable; can be dropped after one release cycle.
- `terminal.SessionInfo`: rename `Pane` → `WindowIndex`; add `PaneID` for pane-level capture targeting.
- Tmux integration switches `RefreshCache` from \`list-windows\` to \`list-panes -a\`. New `parsePaneLine` and `selectPrimary` extracted as pure testable functions.
- `selectPrimary` preference order: (1) pane whose `@hive-session` tag matches the expected slug — defends against tmux propagating pane-local options to user-split siblings; (2) any tagged pane; (3) first pane.
- `coretmux.Client` tags initial panes via `@hive-session` at `CreateSession` and `AddWindows`. Adds `suppressInteractiveHooks` for global `command-prompt` hooks that block programmatic window creation.
- `capturePane` targets pane ID (\`%N\`) when known; uses `exec.CommandContext` so caller cancellation reaches tmux.
- `SessionPathKey` exported so consumers reference it by name instead of duplicating the literal.

## What's NOT in this PR (deferred to parts 2 & 3)

- The `process` package and `process.Identify` (part 2)
- `KnownAgents` source-of-truth for agent detection (part 2)
- The integration of process-tree detection in `GetStatus` and the regression fix for shell-wrapper agents (part 2)
- `RefreshCache` ctx propagation through the `Integration` interface (part 2 — touches the interface)
- `DiscoverAllPanes` / `PaneDetail` / `hive x detect` diagnostic (part 3)
- `panetree.go` formatter (part 3)

This PR deliberately omits speculative API surface that earlier review caught (\`PaneInfo\`, \`SessionInfo.Panes\`, \`MetaTmuxPaneID\`, \`App.TmuxIntegration\`, \`AllPanesDiscoverer\`) — those existed in the original PR for "Phase 2+" plans without consumers. They'll be added back if and when actual consumers exist.

## Test plan

- [x] `go test ./...` passes
- [x] `parse_test.go` covers `parsePaneLine` (field count tolerance, malformed activity, whitespace) and `selectPrimary` (slug-match priority, tagged-over-untagged, propagation defense, ordering)
- [x] `tmux_test.go` updated for renamed `sessionInfoFromWindow` signature; verifies `PaneID` round-trips through `SessionInfo`
- [ ] Manual test in \`mise container\` with single-window and multi-window sessions
- [ ] Verify legacy \`tmux_pane\` metadata fallback works for sessions migrated from main