### PR TITLE
refactor(lua): plugin cleanup + async hive.sh

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -271,37 +271,17 @@ Run shell commands from Lua. All three functions execute via `sh -c` and share t
 !!! danger "Trust boundary"
     `hive.sh` runs commands with the full privileges of the Hive process. Only enable Lua plugins from sources you trust — installing one is equivalent to running its shell commands as your user.
 
-| Function | Purpose |
-| -------- | ------- |
-| `hive.sh.run(cmd)` | Run `cmd`. Returns the exit code. Never raises. |
-| `hive.sh.output(cmd)` | Run `cmd`, return stdout with one trailing newline stripped. Raises on non-zero exit or executor error. |
-| `hive.sh.exec(cmd[, opts])` | Run `cmd` with optional `{cwd, timeout}`. Returns `{stdout, stderr, code, err}`. Never raises. |
-
-`opts.timeout` is in seconds (number). `opts.cwd` overrides the working directory for that call only; an empty string inherits Hive's working directory.
-
-```lua
-return function(hive)
-  local code = hive.sh.run("git fetch origin")          -- exit code only
-  local head = hive.sh.output("git rev-parse HEAD")     -- stdout, raises on non-zero
-  local r = hive.sh.exec("ls -la", { cwd = "/tmp", timeout = 5 })
-  -- r.stdout, r.stderr, r.code, r.err
-end
-```
-
-#### Async form
-
-Pass a function as the last argument to run the command without blocking
-the Lua dispatcher. The call returns immediately with a handle; the
-callback fires on the dispatcher when the subprocess finishes.
+Every `hive.sh.*` call is async: the call returns a handle immediately and the supplied callback fires on the dispatcher when the subprocess finishes. The callback is **required** — calling without one raises a Lua error.
 
 | Function | Callback signature | Notes |
 | -------- | ------------------ | ----- |
-| `hive.sh.run(cmd, fn)` | `fn(code)` | Same exit-code semantics as the sync form. |
-| `hive.sh.output(cmd, fn)` | `fn(stdout, err)` | Async cannot raise; check `err` for non-nil. |
-| `hive.sh.exec(cmd[, opts], fn)` | `fn(result)` | `result` matches the sync table: `{stdout, stderr, code, err}`. |
+| `hive.sh.run(cmd, fn)` | `fn(code)` | Receives the exit code. |
+| `hive.sh.output(cmd, fn)` | `fn(stdout, err)` | On success: `stdout` is trimmed of one trailing newline and `err` is nil. On non-zero exit or executor error: `stdout` is nil and `err` is a string with the exit code and stderr. |
+| `hive.sh.exec(cmd[, opts], fn)` | `fn(result)` | `result` is `{stdout, stderr, code, err}`. |
 
-Each call returns a handle with a `:cancel()` method that kills the
-in-flight subprocess and suppresses the pending callback.
+`opts.timeout` is in seconds (number). `opts.cwd` overrides the working directory for that call only; an empty string inherits Hive's working directory.
+
+Each call returns a handle with a `:cancel()` method that kills the in-flight subprocess and suppresses the pending callback.
 
 ```lua
 return function(hive)
@@ -326,26 +306,18 @@ return function(hive)
 end
 ```
 
-!!! note "output's async error convention"
-    The sync form of `output` raises a Lua error on non-zero exit. The
-    async form **cannot** raise — the Lua call has already returned by
-    the time the subprocess finishes — so the callback receives
-    `(stdout, err)`: `err` is `nil` on success and a string mirroring
-    the sync error message on failure. Plugin authors converting
-    sync → async must update their error handling to check `err`.
-
 !!! note "Callbacks run on the dispatcher"
-    Every async callback runs on the same Lua dispatcher as ticker
-    fires and the plugin entrypoint. A slow callback serialises later
-    Lua work in that plugin — keep callbacks short or hand long work
-    off via another async call.
+    Every callback runs on the same Lua dispatcher as ticker fires and
+    the plugin entrypoint. A slow callback serialises later Lua work in
+    that plugin — keep callbacks short or hand long work off via another
+    `hive.sh.*` call.
 
 !!! warning "Shutdown cancels in-flight calls"
-    Plugin reload or `hive` shutdown cancels every in-flight async
-    call: the per-handle context is cancelled, the subprocess is
-    killed, and the pinned callback is released for GC. Pending
-    callbacks may still fire once with a non-zero `code` and a
-    cancellation `err`, but never after the runtime has fully closed.
+    Plugin reload or `hive` shutdown cancels every in-flight call: the
+    per-handle context is cancelled, the subprocess is killed, and the
+    pinned callback is released for GC. Pending callbacks may still fire
+    once with a non-zero `code` and a cancellation `err`, but never
+    after the runtime has fully closed.
 
 !!! note "Shared shell pool"
     `hive.sh.*` calls draw from the same `plugins.shell_workers` budget as plugin status refreshes, so a slow shell command from Lua can delay other plugins. The default per-call timeout is 30s; tune it via `plugins.lua.shell_timeout`. Plugin shutdown cancels every in-flight command.

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -288,6 +288,65 @@ return function(hive)
 end
 ```
 
+#### Async form
+
+Pass a function as the last argument to run the command without blocking
+the Lua dispatcher. The call returns immediately with a handle; the
+callback fires on the dispatcher when the subprocess finishes.
+
+| Function | Callback signature | Notes |
+| -------- | ------------------ | ----- |
+| `hive.sh.run(cmd, fn)` | `fn(code)` | Same exit-code semantics as the sync form. |
+| `hive.sh.output(cmd, fn)` | `fn(stdout, err)` | Async cannot raise; check `err` for non-nil. |
+| `hive.sh.exec(cmd[, opts], fn)` | `fn(result)` | `result` matches the sync table: `{stdout, stderr, code, err}`. |
+
+Each call returns a handle with a `:cancel()` method that kills the
+in-flight subprocess and suppresses the pending callback.
+
+```lua
+return function(hive)
+  hive.sh.run("git fetch origin", function(code)
+    hive.log.info("fetch exited with " .. code)
+  end)
+
+  hive.sh.output("git rev-parse HEAD", function(head, err)
+    if err ~= nil then
+      hive.log.warn("rev-parse failed: " .. err)
+      return
+    end
+    hive.log.info("HEAD is " .. head)
+  end)
+
+  hive.sh.exec("ls -la", { cwd = "/tmp", timeout = 5 }, function(r)
+    hive.log.info("listed " .. r.stdout)
+  end)
+
+  local handle = hive.sh.run("sleep 600", function(_) end)
+  hive.ticker.after("5s", function() handle:cancel() end)
+end
+```
+
+!!! note "output's async error convention"
+    The sync form of `output` raises a Lua error on non-zero exit. The
+    async form **cannot** raise — the Lua call has already returned by
+    the time the subprocess finishes — so the callback receives
+    `(stdout, err)`: `err` is `nil` on success and a string mirroring
+    the sync error message on failure. Plugin authors converting
+    sync → async must update their error handling to check `err`.
+
+!!! note "Callbacks run on the dispatcher"
+    Every async callback runs on the same Lua dispatcher as ticker
+    fires and the plugin entrypoint. A slow callback serialises later
+    Lua work in that plugin — keep callbacks short or hand long work
+    off via another async call.
+
+!!! warning "Shutdown cancels in-flight calls"
+    Plugin reload or `hive` shutdown cancels every in-flight async
+    call: the per-handle context is cancelled, the subprocess is
+    killed, and the pinned callback is released for GC. Pending
+    callbacks may still fire once with a non-zero `code` and a
+    cancellation `err`, but never after the runtime has fully closed.
+
 !!! note "Shared shell pool"
     `hive.sh.*` calls draw from the same `plugins.shell_workers` budget as plugin status refreshes, so a slow shell command from Lua can delay other plugins. The default per-call timeout is 30s; tune it via `plugins.lua.shell_timeout`. Plugin shutdown cancels every in-flight command.
 

--- a/internal/hive/plugins/lua/async_registry.go
+++ b/internal/hive/plugins/lua/async_registry.go
@@ -1,0 +1,273 @@
+package lua
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+// asyncRegistry holds the Lua-side and Go-side bookkeeping shared by
+// every async host module (hive.ticker, hive.sh, ...). Each module owns
+// one registry, initialises it during Register, and tears it down via
+// shutdown.
+//
+// The registry handles:
+//
+//   - A per-module sub-table in the Lua registry that pins LFunctions
+//     so callbacks survive Lua GC while a goroutine still references
+//     them.
+//   - A handle map keyed by id, storing the per-handle context.CancelFunc
+//     so any goroutine can cancel a specific running operation.
+//   - A root context whose cancellation fans out to every per-handle
+//     context, used for module shutdown.
+//   - A WaitGroup that lets shutdown block until in-flight goroutines
+//     finish.
+//   - The shared __index metatable installed on every handle userdata.
+//
+// Module code stays small: allocate to start a new operation, loadFunction
+// to invoke its callback on the dispatcher, release after a successful
+// dispatch, and stop or asyncHandle.Cancel for any-goroutine cancellation.
+type asyncRegistry struct {
+	cfg asyncRegistryConfig
+
+	// registryKey namespaces the per-module sub-table in the Lua
+	// registry. The instance pointer is appended so multiple modules of
+	// the same kind on one LState don't stomp each other.
+	registryKey string
+
+	// nextID is also the per-handle registry sub-key, stringified.
+	nextID atomic.Uint64
+
+	mu      sync.Mutex
+	handles map[uint64]context.CancelFunc
+
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+
+	wg sync.WaitGroup
+
+	closeOnce sync.Once
+}
+
+// asyncRegistryConfig configures the namespacing and Lua-facing names
+// for an asyncRegistry. KeyPrefix should end in a "." for readability.
+type asyncRegistryConfig struct {
+	// KeyPrefix prefixes the per-module Lua registry sub-table key.
+	// Example: "hive.ticker."
+	KeyPrefix string
+	// MetatableName names the Lua metatable installed on every handle
+	// userdata. Example: "hive.ticker.handle"
+	MetatableName string
+}
+
+// asyncHandle is the Go-side state behind every async userdata returned
+// to Lua. Cancel is idempotent, safe from any goroutine, and routes
+// through the registry to delete the map entry, cancel the per-handle
+// context, and release the registry pin.
+type asyncHandle struct {
+	id       uint64
+	once     sync.Once
+	registry *asyncRegistry
+	runtime  *Runtime
+}
+
+// init prepares the registry for use. modulePtr is fmt-formatted with
+// %p to make registryKey unique per module instance (so two modules of
+// the same kind on one LState don't collide). Must run on the
+// dispatcher.
+func (r *asyncRegistry) init(state *glua.LState, modulePtr any, cfg asyncRegistryConfig) error {
+	r.cfg = cfg
+	r.handles = map[uint64]context.CancelFunc{}
+	r.rootCtx, r.rootCancel = context.WithCancel(context.Background())
+	r.registryKey = fmt.Sprintf("%s%p", cfg.KeyPrefix, modulePtr)
+
+	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
+	if !ok {
+		return fmt.Errorf("%slua registry is not a table", cfg.KeyPrefix)
+	}
+	state.SetField(registry, r.registryKey, state.NewTable())
+
+	mt := state.NewTypeMetatable(cfg.MetatableName)
+	state.SetField(mt, "__index", state.SetFuncs(state.NewTable(), map[string]glua.LGFunction{
+		"cancel": r.luaCancel,
+	}))
+	return nil
+}
+
+// shutdown cancels rootCtx, waits for goroutines to drain, and clears
+// the handle map. Idempotent.
+func (r *asyncRegistry) shutdown() {
+	r.closeOnce.Do(func() {
+		if r.rootCancel != nil {
+			r.rootCancel()
+		}
+		r.wg.Wait()
+
+		r.mu.Lock()
+		r.handles = map[uint64]context.CancelFunc{}
+		r.mu.Unlock()
+	})
+}
+
+// rootContext returns the root context whose cancellation fans out to
+// every per-handle context. Synchronous callers can use this directly;
+// async callers should derive a per-handle context via allocate.
+func (r *asyncRegistry) rootContext() context.Context { return r.rootCtx }
+
+// trackGoroutine increments the WaitGroup and returns a function that
+// decrements it. Use as `defer r.trackGoroutine()()` to ensure shutdown
+// waits for in-flight synchronous work.
+func (r *asyncRegistry) trackGoroutine() func() {
+	r.wg.Add(1)
+	return r.wg.Done
+}
+
+// Go starts fn in a goroutine tracked by the registry's WaitGroup so
+// shutdown blocks until fn completes. Mirrors sync.WaitGroup.Go;
+// capitalised because lowercase `go` is a reserved keyword.
+func (r *asyncRegistry) Go(fn func()) { r.wg.Go(fn) }
+
+// allocate pins fn under a fresh handle id, derives a per-handle context
+// from rootCtx, and records the cancel func in the handle map. Returns
+// the id and ctx for the goroutine to bind to. Must run on the
+// dispatcher.
+func (r *asyncRegistry) allocate(state *glua.LState, fn *glua.LFunction) (uint64, context.Context) {
+	id := r.nextID.Add(1)
+	ctx, cancel := context.WithCancel(r.rootCtx)
+
+	r.storeFunction(state, id, fn)
+
+	r.mu.Lock()
+	r.handles[id] = cancel
+	r.mu.Unlock()
+
+	return id, ctx
+}
+
+// loadFunction returns the pinned function for id, or nil if already
+// released. Must run on the dispatcher.
+func (r *asyncRegistry) loadFunction(state *glua.LState, id uint64) *glua.LFunction {
+	table := r.registryTable(state)
+	if table == nil {
+		return nil
+	}
+	fn, ok := state.GetField(table, strconv.FormatUint(id, 10)).(*glua.LFunction)
+	if !ok {
+		return nil
+	}
+	return fn
+}
+
+// release drops the handle map entry and registry pin for id. Used after
+// a dispatch path has consumed the callback. Safe even if id is unknown.
+// Must run on the dispatcher.
+func (r *asyncRegistry) release(state *glua.LState, id uint64) {
+	r.mu.Lock()
+	delete(r.handles, id)
+	r.mu.Unlock()
+
+	r.releaseFunction(state, id)
+}
+
+// stop cancels the per-handle context, removes the map entry, and
+// schedules the registry pin release on the dispatcher. Safe from any
+// goroutine; a missing id is treated as already released.
+func (r *asyncRegistry) stop(rt *Runtime, id uint64) {
+	r.mu.Lock()
+	cancel, ok := r.handles[id]
+	if ok {
+		delete(r.handles, id)
+	}
+	r.mu.Unlock()
+	if !ok {
+		return
+	}
+	cancel()
+
+	rt.Submit(func(state *glua.LState) {
+		r.releaseFunction(state, id)
+	})
+}
+
+// handleUserData wraps value in *LUserData with the registry's metatable.
+// Must run on the dispatcher.
+func (r *asyncRegistry) handleUserData(state *glua.LState, value any) *glua.LUserData {
+	ud := state.NewUserData()
+	ud.Value = value
+	state.SetMetatable(ud, state.GetTypeMetatable(r.cfg.MetatableName))
+	return ud
+}
+
+// newHandle returns a fresh asyncHandle wired to this registry and the
+// supplied runtime. Pair with allocate to get the id.
+func (r *asyncRegistry) newHandle(id uint64, rt *Runtime) *asyncHandle {
+	return &asyncHandle{id: id, registry: r, runtime: rt}
+}
+
+// luaCancel is the __index method bound to handle userdata. Type-asserts
+// the userdata as *asyncHandle (which both ticker and sh use) and routes
+// to Cancel.
+func (r *asyncRegistry) luaCancel(state *glua.LState) int {
+	ud := state.CheckUserData(1)
+	h, ok := ud.Value.(*asyncHandle)
+	if !ok {
+		state.ArgError(1, "expected "+r.cfg.MetatableName+" handle")
+		return 0
+	}
+	h.Cancel()
+	return 0
+}
+
+// storeFunction pins fn so Lua cannot GC it while the goroutine holds a
+// reference. Must run on the dispatcher.
+func (r *asyncRegistry) storeFunction(state *glua.LState, id uint64, fn *glua.LFunction) {
+	table := r.registryTable(state)
+	if table == nil {
+		return
+	}
+	state.SetField(table, strconv.FormatUint(id, 10), fn)
+}
+
+// releaseFunction drops the registry pin so Lua can GC the LFunction.
+// Must run on the dispatcher.
+func (r *asyncRegistry) releaseFunction(state *glua.LState, id uint64) {
+	table := r.registryTable(state)
+	if table == nil {
+		return
+	}
+	state.SetField(table, strconv.FormatUint(id, 10), glua.LNil)
+}
+
+// registryTable returns this registry's pinning sub-table, or nil if
+// init has not run.
+func (r *asyncRegistry) registryTable(state *glua.LState) *glua.LTable {
+	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
+	if !ok {
+		return nil
+	}
+	table, ok := state.GetField(registry, r.registryKey).(*glua.LTable)
+	if !ok {
+		return nil
+	}
+	return table
+}
+
+// Cancel stops the per-handle goroutine, removes the map entry, and
+// schedules the registry pin release on the dispatcher. Idempotent and
+// safe from any goroutine.
+func (h *asyncHandle) Cancel() {
+	h.once.Do(func() {
+		h.registry.stop(h.runtime, h.id)
+	})
+}
+
+// poison consumes the once so a later Cancel is a true no-op. Used by
+// post-dispatch cleanup paths that already released via the dispatcher
+// and want to suppress redundant Cancel work.
+func (h *asyncHandle) poison() {
+	h.once.Do(func() {})
+}

--- a/internal/hive/plugins/lua/async_registry.go
+++ b/internal/hive/plugins/lua/async_registry.go
@@ -6,9 +6,18 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	glua "github.com/yuin/gopher-lua"
 )
+
+// asyncShutdownGracePeriod bounds how long shutdown waits for in-flight
+// goroutines to finish naturally before force-cancelling. Long enough
+// for fast plugin entrypoint chains (a few subprocess calls) to drain
+// at app exit; short enough that a stuck call can't stall shutdown
+// indefinitely. After the grace period elapses, rootCtx is cancelled
+// and any remaining work aborts via the per-handle ctx.
+const asyncShutdownGracePeriod = time.Second
 
 // asyncRegistry holds the Lua-side and Go-side bookkeeping shared by
 // every async host module (hive.ticker, hive.sh, ...). Each module owns
@@ -98,14 +107,39 @@ func (r *asyncRegistry) init(state *glua.LState, modulePtr any, cfg asyncRegistr
 	return nil
 }
 
-// shutdown cancels rootCtx, waits for goroutines to drain, and clears
-// the handle map. Idempotent.
+// shutdown drains in-flight goroutines before force-cancelling. First
+// gives the chain up to asyncShutdownGracePeriod to finish naturally so
+// fast callback chains spawned during plugin Init complete cleanly;
+// only then cancels rootCtx and waits for stragglers. Clears the handle
+// map. Idempotent.
 func (r *asyncRegistry) shutdown() {
 	r.closeOnce.Do(func() {
+		// Phase 1: graceful drain. Wait up to asyncShutdownGracePeriod
+		// for the chain to complete naturally. spawnAsync's goroutines
+		// hold the wg until their dispatch (and any callback-spawned
+		// work) finishes, so wg.Wait covers the full callback chain.
+		drained := make(chan struct{})
+		go func() {
+			r.wg.Wait()
+			close(drained)
+		}()
+
+		select {
+		case <-drained:
+		case <-time.After(asyncShutdownGracePeriod):
+			// Phase 2: force-cancel and wait for stragglers.
+			if r.rootCancel != nil {
+				r.rootCancel()
+			}
+			<-drained
+		}
+
+		// Cancel rootCtx unconditionally so any goroutine that races
+		// past the drain (none should, but defensively) sees a closed
+		// context if it inspects ctx after spawnAsync returns.
 		if r.rootCancel != nil {
 			r.rootCancel()
 		}
-		r.wg.Wait()
 
 		r.mu.Lock()
 		r.handles = map[uint64]context.CancelFunc{}

--- a/internal/hive/plugins/lua/async_registry.go
+++ b/internal/hive/plugins/lua/async_registry.go
@@ -113,19 +113,6 @@ func (r *asyncRegistry) shutdown() {
 	})
 }
 
-// rootContext returns the root context whose cancellation fans out to
-// every per-handle context. Synchronous callers can use this directly;
-// async callers should derive a per-handle context via allocate.
-func (r *asyncRegistry) rootContext() context.Context { return r.rootCtx }
-
-// trackGoroutine increments the WaitGroup and returns a function that
-// decrements it. Use as `defer r.trackGoroutine()()` to ensure shutdown
-// waits for in-flight synchronous work.
-func (r *asyncRegistry) trackGoroutine() func() {
-	r.wg.Add(1)
-	return r.wg.Done
-}
-
 // Go starts fn in a goroutine tracked by the registry's WaitGroup so
 // shutdown blocks until fn completes. Mirrors sync.WaitGroup.Go;
 // capitalised because lowercase `go` is a reserved keyword.

--- a/internal/hive/plugins/lua/helpers_test.go
+++ b/internal/hive/plugins/lua/helpers_test.go
@@ -1,0 +1,228 @@
+package lua
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// testPluginName is the plugin name registered with LogModule and
+// PluginInfoModule in test harnesses. Tests that exercise kv.Scoped
+// namespacing pass their own name to KVModule.
+const testPluginName = "lua-test"
+
+// captureModule exposes test-only capture helpers in the Lua hive table:
+//
+//	hive.test_capture(value)        — appends value to a positional list
+//	hive.test_capture(key, value)   — stores value under key
+//	hive.test_bump()                — increments a counter
+//
+// All three are safe to call from any goroutine; the unified type replaces
+// the per-test capture/bump modules that used to live alongside each
+// module's tests.
+type captureModule struct {
+	mu      sync.Mutex
+	list    []glua.LValue
+	keyed   map[string]glua.LValue
+	counter atomic.Int64
+}
+
+func newCaptureModule() *captureModule {
+	return &captureModule{keyed: map[string]glua.LValue{}}
+}
+
+func (c *captureModule) Register(state *glua.LState, hive *glua.LTable) error {
+	state.SetField(hive, "test_capture", state.NewFunction(c.luaCapture))
+	state.SetField(hive, "test_bump", state.NewFunction(c.luaBump))
+	return nil
+}
+
+func (c *captureModule) luaCapture(state *glua.LState) int {
+	if state.GetTop() == 1 {
+		v := state.CheckAny(1)
+		c.mu.Lock()
+		c.list = append(c.list, v)
+		c.mu.Unlock()
+		return 0
+	}
+	key := state.CheckString(1)
+	val := state.CheckAny(2)
+	c.mu.Lock()
+	c.keyed[key] = val
+	c.mu.Unlock()
+	return 0
+}
+
+func (c *captureModule) luaBump(_ *glua.LState) int {
+	c.counter.Add(1)
+	return 0
+}
+
+// Snapshot returns a copy of the positional capture list.
+func (c *captureModule) Snapshot() []glua.LValue {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]glua.LValue, len(c.list))
+	copy(out, c.list)
+	return out
+}
+
+// Get returns the value captured under key, or LNil if the key is unset.
+func (c *captureModule) Get(key string) glua.LValue {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if v, ok := c.keyed[key]; ok {
+		return v
+	}
+	return glua.LNil
+}
+
+// Has reports whether key was captured.
+func (c *captureModule) Has(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.keyed[key]
+	return ok
+}
+
+// String returns the keyed capture as a Go string. Returns "" if the key
+// is absent or holds a non-string value.
+func (c *captureModule) String(key string) string {
+	if v, ok := c.Get(key).(glua.LString); ok {
+		return string(v)
+	}
+	return ""
+}
+
+// Bool returns the keyed capture as a Go bool. Returns false if the key
+// is absent or holds a non-boolean value.
+func (c *captureModule) Bool(key string) bool {
+	if v, ok := c.Get(key).(glua.LBool); ok {
+		return bool(v)
+	}
+	return false
+}
+
+// Number returns the keyed capture as a float64. Returns 0 if the key
+// is absent or holds a non-numeric value.
+func (c *captureModule) Number(key string) float64 {
+	if v, ok := c.Get(key).(glua.LNumber); ok {
+		return float64(v)
+	}
+	return 0
+}
+
+// Counter returns the current bump counter.
+func (c *captureModule) Counter() int64 {
+	return c.counter.Load()
+}
+
+// luaHarness wraps a Runtime configured with the standard test module set
+// (LogModule, PluginInfoModule, CommandsModule, captureModule) plus any
+// caller-supplied modules. The Lua entry script runs during construction;
+// runtime and module shutdown are registered with t.Cleanup.
+type luaHarness struct {
+	runtime *Runtime
+	capture *captureModule
+	modules []HostModule
+	root    string
+	entry   string
+	closed  atomic.Bool
+}
+
+// newLuaHarness writes script to t.TempDir()/init.lua, builds a Runtime
+// with the standard test module set plus extras, runs the entrypoint, and
+// registers cleanup on t.
+//
+// Modules requiring a Runtime reference (TickerModule.Runtime) are wired
+// after NewRuntime returns and before LoadEntrypoint runs, mirroring
+// Plugin.Init.
+func newLuaHarness(t *testing.T, script string, extras ...HostModule) *luaHarness {
+	t.Helper()
+
+	root := t.TempDir()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+
+	capture := newCaptureModule()
+	modules := append([]HostModule{
+		&LogModule{PluginName: testPluginName, Logger: zerolog.Nop()},
+		&PluginInfoModule{Name: testPluginName, Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+		capture,
+	}, extras...)
+
+	rt, err := NewRuntime(root, zerolog.Nop(), modules...)
+	require.NoError(t, err)
+
+	for _, m := range extras {
+		switch m := m.(type) {
+		case *TickerModule:
+			m.Runtime = rt
+		case *ShModule:
+			m.Runtime = rt
+		}
+	}
+
+	h := &luaHarness{
+		runtime: rt,
+		capture: capture,
+		modules: modules,
+		root:    root,
+		entry:   entry,
+	}
+	t.Cleanup(h.Close)
+
+	fn, err := rt.LoadEntrypoint(entry)
+	require.NoError(t, err)
+	require.NoError(t, rt.CallEntrypoint(fn))
+
+	return h
+}
+
+// Close shuts down host modules in reverse-registration order, then the
+// runtime. Idempotent; safe to call from t.Cleanup and from tests that
+// want explicit shutdown ordering.
+func (h *luaHarness) Close() {
+	if !h.closed.CompareAndSwap(false, true) {
+		return
+	}
+	for i := len(h.modules) - 1; i >= 0; i-- {
+		if c, ok := h.modules[i].(HostModuleCloser); ok {
+			_ = c.Close()
+		}
+	}
+	h.runtime.Close()
+}
+
+// writeLuaEntry writes script to root/init.lua and returns the path. Used
+// by tests that need lower-level control than newLuaHarness gives — most
+// notably, asserting on CallEntrypoint failure.
+func writeLuaEntry(t *testing.T, root, script string) string {
+	t.Helper()
+	entry := filepath.Join(root, "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
+	return entry
+}
+
+// newRawRuntime builds a Runtime with the standard test module set plus
+// extras but does not load or invoke any entrypoint. Pair with
+// writeLuaEntry for tests that need to drive LoadEntrypoint /
+// CallEntrypoint themselves.
+func newRawRuntime(t *testing.T, root, entry string, extras ...HostModule) *Runtime {
+	t.Helper()
+	modules := append([]HostModule{
+		&LogModule{PluginName: testPluginName, Logger: zerolog.Nop()},
+		&PluginInfoModule{Name: testPluginName, Entry: entry, ModuleRoot: root},
+		&CommandsModule{},
+	}, extras...)
+	rt, err := NewRuntime(root, zerolog.Nop(), modules...)
+	require.NoError(t, err)
+	return rt
+}

--- a/internal/hive/plugins/lua/helpers_test.go
+++ b/internal/hive/plugins/lua/helpers_test.go
@@ -200,29 +200,3 @@ func (h *luaHarness) Close() {
 	}
 	h.runtime.Close()
 }
-
-// writeLuaEntry writes script to root/init.lua and returns the path. Used
-// by tests that need lower-level control than newLuaHarness gives — most
-// notably, asserting on CallEntrypoint failure.
-func writeLuaEntry(t *testing.T, root, script string) string {
-	t.Helper()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
-	return entry
-}
-
-// newRawRuntime builds a Runtime with the standard test module set plus
-// extras but does not load or invoke any entrypoint. Pair with
-// writeLuaEntry for tests that need to drive LoadEntrypoint /
-// CallEntrypoint themselves.
-func newRawRuntime(t *testing.T, root, entry string, extras ...HostModule) *Runtime {
-	t.Helper()
-	modules := append([]HostModule{
-		&LogModule{PluginName: testPluginName, Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: testPluginName, Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-	}, extras...)
-	rt, err := NewRuntime(root, zerolog.Nop(), modules...)
-	require.NoError(t, err)
-	return rt
-}

--- a/internal/hive/plugins/lua/lua_convert.go
+++ b/internal/hive/plugins/lua/lua_convert.go
@@ -1,0 +1,197 @@
+package lua
+
+import (
+	"fmt"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+// luaToGo walks a Lua value into encoding/json-compatible Go shapes.
+//
+// Tables become []any when array-tagged (arrayMarker matches the table's
+// metatable identity) or when keys are a dense 1..n integer run; otherwise
+// map[string]any. Cycles produce an error rather than recurse forever.
+// visited tracks table identities across recursion; pass an empty map at
+// the top level.
+//
+// arrayMarker may be nil — without it, only the integer-key heuristic
+// applies, and empty tables encode as map[string]any.
+func luaToGo(v glua.LValue, arrayMarker *glua.LTable, visited map[*glua.LTable]bool) (any, error) {
+	switch v := v.(type) {
+	case *glua.LNilType:
+		return nil, nil
+	case glua.LBool:
+		return bool(v), nil
+	case glua.LNumber:
+		return float64(v), nil
+	case glua.LString:
+		return string(v), nil
+	case *glua.LTable:
+		if visited[v] {
+			return nil, fmt.Errorf("cannot encode cyclic table")
+		}
+		visited[v] = true
+		defer delete(visited, v)
+		return tableToGo(v, arrayMarker, visited)
+	case *glua.LFunction:
+		return nil, fmt.Errorf("cannot encode lua function")
+	case *glua.LUserData:
+		return nil, fmt.Errorf("cannot encode lua userdata")
+	case *glua.LChannel:
+		return nil, fmt.Errorf("cannot encode lua channel")
+	default:
+		return nil, fmt.Errorf("cannot encode lua value of type %s", v.Type().String())
+	}
+}
+
+// tableToGo decides between array and object encoding for a Lua table.
+//
+// Detection order:
+//  1. arrayMarker is non-nil and matches the table's metatable → []any
+//     (preserves empty-array intent and rejects shape contradictions).
+//  2. All keys are positive integers 1..n with no holes → []any.
+//  3. Otherwise → map[string]any.
+func tableToGo(tbl *glua.LTable, arrayMarker *glua.LTable, visited map[*glua.LTable]bool) (any, error) {
+	if arrayMarker != nil && tbl.Metatable == arrayMarker {
+		if err := arrayShapeError(tbl); err != nil {
+			return nil, fmt.Errorf("array-tagged table %s", err.Error())
+		}
+		return tableToArray(tbl, arrayMarker, visited)
+	}
+
+	if isArrayLike(tbl) {
+		return tableToArray(tbl, arrayMarker, visited)
+	}
+
+	return tableToObject(tbl, arrayMarker, visited)
+}
+
+// arrayShapeError returns nil when tbl's keys are exactly the positive
+// integers 1..n with no holes (empty tables satisfy the contract).
+// Otherwise it returns an error describing the first violation. Used by
+// the marker path to surface inconsistent claims (e.g.
+// hive.json.array({foo="x"})) as errors instead of silently dropping data.
+func arrayShapeError(tbl *glua.LTable) error {
+	n := tbl.Len()
+	for i := 1; i <= n; i++ {
+		if tbl.RawGetInt(i) == glua.LNil {
+			return fmt.Errorf("has hole at index %d", i)
+		}
+	}
+	var keyErr error
+	tbl.ForEach(func(key glua.LValue, _ glua.LValue) {
+		if keyErr != nil {
+			return
+		}
+		num, ok := key.(glua.LNumber)
+		if !ok {
+			keyErr = fmt.Errorf("has non-integer key %q", key.String())
+			return
+		}
+		idx := int(num)
+		if glua.LNumber(idx) != num || idx < 1 || idx > n {
+			keyErr = fmt.Errorf("has out-of-range key %v", num)
+		}
+	})
+	return keyErr
+}
+
+// isArrayLike returns true when tbl matches the heuristic for an untagged
+// array. Empty tables fail the heuristic so the marker rule can
+// disambiguate them as []any vs. {}.
+func isArrayLike(tbl *glua.LTable) bool {
+	if tbl.Len() == 0 {
+		return false
+	}
+	return arrayShapeError(tbl) == nil
+}
+
+func tableToArray(tbl *glua.LTable, arrayMarker *glua.LTable, visited map[*glua.LTable]bool) ([]any, error) {
+	out := make([]any, 0, tbl.Len())
+	for i := 1; i <= tbl.Len(); i++ {
+		entry, err := luaToGo(tbl.RawGetInt(i), arrayMarker, visited)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func tableToObject(tbl *glua.LTable, arrayMarker *glua.LTable, visited map[*glua.LTable]bool) (map[string]any, error) {
+	out := map[string]any{}
+	var walkErr error
+	tbl.ForEach(func(key glua.LValue, value glua.LValue) {
+		if walkErr != nil {
+			return
+		}
+		k, err := objectKey(key)
+		if err != nil {
+			walkErr = err
+			return
+		}
+		entry, err := luaToGo(value, arrayMarker, visited)
+		if err != nil {
+			walkErr = err
+			return
+		}
+		out[k] = entry
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return out, nil
+}
+
+// objectKey coerces a Lua table key to a JSON object key. Only string and
+// number keys are supported; other types (booleans, tables, functions,
+// userdata) would silently collide on the empty string via LVAsString and
+// drop entries, so they're rejected with an explicit error.
+func objectKey(key glua.LValue) (string, error) {
+	switch k := key.(type) {
+	case glua.LString:
+		return string(k), nil
+	case glua.LNumber:
+		return glua.LVAsString(key), nil
+	default:
+		return "", fmt.Errorf("cannot use %s as object key", key.Type().String())
+	}
+}
+
+// goToLua walks an encoding/json-compatible Go value back into Lua.
+//
+// arrayMarker, when non-nil, is set as the metatable on every []any-derived
+// table so a re-encode preserves the [] shape regardless of mutations
+// (table.remove emptying it, etc.) that would otherwise flunk the
+// integer-key heuristic. Pass nil if marker propagation isn't needed.
+func goToLua(state *glua.LState, v any, arrayMarker *glua.LTable) glua.LValue {
+	switch v := v.(type) {
+	case nil:
+		return glua.LNil
+	case bool:
+		return glua.LBool(v)
+	case float64:
+		return glua.LNumber(v)
+	case string:
+		return glua.LString(v)
+	case []any:
+		tbl := state.NewTable()
+		for i, item := range v {
+			tbl.RawSetInt(i+1, goToLua(state, item, arrayMarker))
+		}
+		if arrayMarker != nil {
+			state.SetMetatable(tbl, arrayMarker)
+		}
+		return tbl
+	case map[string]any:
+		tbl := state.NewTable()
+		for k, item := range v {
+			tbl.RawSetString(k, goToLua(state, item, arrayMarker))
+		}
+		return tbl
+	default:
+		// json.Unmarshal into any only produces the cases above; this is
+		// defensive against future encoding/json behaviour changes.
+		return glua.LNil
+	}
+}

--- a/internal/hive/plugins/lua/lua_convert_test.go
+++ b/internal/hive/plugins/lua/lua_convert_test.go
@@ -1,0 +1,358 @@
+package lua
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// newConvertState returns a closed-over LState for direct conversion-helper
+// tests. The state never runs Lua — it only owns the table allocator.
+func newConvertState(t *testing.T) *glua.LState {
+	t.Helper()
+	state := glua.NewState()
+	t.Cleanup(state.Close)
+	return state
+}
+
+// asLuaNumber unwraps an LNumber to float64 for InDelta comparisons.
+func asLuaNumber(t *testing.T, v glua.LValue) float64 {
+	t.Helper()
+	n, ok := v.(glua.LNumber)
+	require.True(t, ok, "expected LNumber, got %T", v)
+	return float64(n)
+}
+
+func TestLuaToGo_Primitives(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   glua.LValue
+		want any
+	}{
+		{"nil", glua.LNil, nil},
+		{"true", glua.LBool(true), true},
+		{"false", glua.LBool(false), false},
+		{"int number", glua.LNumber(42), float64(42)},
+		{"float number", glua.LNumber(3.5), float64(3.5)},
+		{"empty string", glua.LString(""), ""},
+		{"string", glua.LString("hello"), "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := luaToGo(tt.in, nil, map[*glua.LTable]bool{})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLuaToGo_TableAsArrayByHeuristic(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	tbl := state.NewTable()
+	tbl.RawSetInt(1, glua.LString("a"))
+	tbl.RawSetInt(2, glua.LString("b"))
+	tbl.RawSetInt(3, glua.LString("c"))
+
+	got, err := luaToGo(tbl, nil, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, []any{"a", "b", "c"}, got)
+}
+
+func TestLuaToGo_EmptyTableIsObjectWithoutMarker(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	got, err := luaToGo(state.NewTable(), nil, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{}, got, "an empty untagged table is an object, not an array")
+}
+
+func TestLuaToGo_EmptyTableIsArrayWithMatchingMarker(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	marker := state.NewTable()
+	tbl := state.NewTable()
+	state.SetMetatable(tbl, marker)
+
+	got, err := luaToGo(tbl, marker, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, got)
+}
+
+func TestLuaToGo_TableAsObject(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	tbl := state.NewTable()
+	tbl.RawSetString("foo", glua.LNumber(1))
+	tbl.RawSetString("bar", glua.LString("baz"))
+
+	got, err := luaToGo(tbl, nil, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"foo": float64(1), "bar": "baz"}, got)
+}
+
+func TestLuaToGo_NestedMixed(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	inner := state.NewTable()
+	inner.RawSetInt(1, glua.LNumber(10))
+	inner.RawSetInt(2, glua.LNumber(20))
+
+	outer := state.NewTable()
+	outer.RawSetString("nums", inner)
+	outer.RawSetString("flag", glua.LBool(true))
+
+	got, err := luaToGo(outer, nil, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"nums": []any{float64(10), float64(20)},
+		"flag": true,
+	}, got)
+}
+
+func TestLuaToGo_RejectsCycle(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	tbl := state.NewTable()
+	tbl.RawSetString("self", tbl)
+
+	_, err := luaToGo(tbl, nil, map[*glua.LTable]bool{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cyclic")
+}
+
+func TestLuaToGo_RejectsUnsupportedTypes(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	tests := []struct {
+		name string
+		in   glua.LValue
+		want string
+	}{
+		{"function", state.NewFunction(func(*glua.LState) int { return 0 }), "function"},
+		{"userdata", state.NewUserData(), "userdata"},
+		{"channel", glua.LChannel(make(chan glua.LValue)), "channel"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := luaToGo(tt.in, nil, map[*glua.LTable]bool{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestLuaToGo_ArrayMarkerRejectsObjectShape(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	marker := state.NewTable()
+	tbl := state.NewTable()
+	tbl.RawSetString("foo", glua.LString("x"))
+	state.SetMetatable(tbl, marker)
+
+	_, err := luaToGo(tbl, marker, map[*glua.LTable]bool{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "array-tagged")
+	assert.Contains(t, err.Error(), "non-integer key")
+}
+
+func TestLuaToGo_ArrayMarkerRejectsHole(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	marker := state.NewTable()
+	tbl := state.NewTable()
+	tbl.RawSetInt(1, glua.LString("a"))
+	tbl.RawSetInt(3, glua.LString("c")) // hole at 2
+	state.SetMetatable(tbl, marker)
+
+	_, err := luaToGo(tbl, marker, map[*glua.LTable]bool{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hole at index 2")
+}
+
+func TestLuaToGo_NonMatchingMarkerIgnored(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	// Table is tagged with a different marker than the one we pass in,
+	// so the marker rule does not apply and the heuristic takes over.
+	otherMarker := state.NewTable()
+	tbl := state.NewTable()
+	state.SetMetatable(tbl, otherMarker)
+
+	ourMarker := state.NewTable()
+	got, err := luaToGo(tbl, ourMarker, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{}, got, "empty table without our marker should be an object")
+}
+
+func TestLuaToGo_RejectsUnsupportedKeyTypes(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	t.Run("bool key", func(t *testing.T) {
+		tbl := state.NewTable()
+		tbl.RawSet(glua.LBool(true), glua.LString("x"))
+		_, err := luaToGo(tbl, nil, map[*glua.LTable]bool{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boolean as object key")
+	})
+
+	t.Run("table key", func(t *testing.T) {
+		tbl := state.NewTable()
+		tbl.RawSet(state.NewTable(), glua.LString("x"))
+		_, err := luaToGo(tbl, nil, map[*glua.LTable]bool{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "table as object key")
+	})
+}
+
+func TestGoToLua_Primitives(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	tests := []struct {
+		name string
+		in   any
+		want glua.LValue
+	}{
+		{"nil", nil, glua.LNil},
+		{"true", true, glua.LBool(true)},
+		{"false", false, glua.LBool(false)},
+		{"float", float64(3.5), glua.LNumber(3.5)},
+		{"int as float", float64(42), glua.LNumber(42)},
+		{"string", "hello", glua.LString("hello")},
+		{"empty string", "", glua.LString("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := goToLua(state, tt.in, nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoToLua_Array(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	got := goToLua(state, []any{"a", "b", "c"}, nil)
+
+	tbl, ok := got.(*glua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, glua.LString("a"), tbl.RawGetInt(1))
+	assert.Equal(t, glua.LString("b"), tbl.RawGetInt(2))
+	assert.Equal(t, glua.LString("c"), tbl.RawGetInt(3))
+}
+
+func TestGoToLua_ArrayWithMarker(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	marker := state.NewTable()
+	got := goToLua(state, []any{}, marker)
+
+	tbl, ok := got.(*glua.LTable)
+	require.True(t, ok)
+	assert.Same(t, marker, tbl.Metatable, "empty []any should be tagged with the marker")
+}
+
+func TestGoToLua_ArrayWithoutMarkerIsUntagged(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	got := goToLua(state, []any{"x"}, nil)
+
+	tbl, ok := got.(*glua.LTable)
+	require.True(t, ok)
+	// Fresh tables carry LNil as their metatable (not Go nil); a "no
+	// metatable" assertion checks for that sentinel value.
+	assert.Equal(t, glua.LNil, tbl.Metatable, "no marker means no metatable")
+}
+
+func TestGoToLua_Object(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	got := goToLua(state, map[string]any{"foo": float64(1), "bar": "baz"}, nil)
+
+	tbl, ok := got.(*glua.LTable)
+	require.True(t, ok)
+	assert.InDelta(t, 1.0, asLuaNumber(t, tbl.RawGetString("foo")), 0)
+	assert.Equal(t, glua.LString("baz"), tbl.RawGetString("bar"))
+}
+
+func TestGoToLua_NestedMixed(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	got := goToLua(state, map[string]any{
+		"nums": []any{float64(10), float64(20)},
+		"meta": map[string]any{"x": true},
+	}, nil)
+
+	tbl, ok := got.(*glua.LTable)
+	require.True(t, ok)
+
+	nums, ok := tbl.RawGetString("nums").(*glua.LTable)
+	require.True(t, ok)
+	assert.InDelta(t, 10.0, asLuaNumber(t, nums.RawGetInt(1)), 0)
+	assert.InDelta(t, 20.0, asLuaNumber(t, nums.RawGetInt(2)), 0)
+
+	meta, ok := tbl.RawGetString("meta").(*glua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, glua.LBool(true), meta.RawGetString("x"))
+}
+
+func TestGoToLua_UnsupportedType(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+
+	// goToLua only handles types encoding/json yields when unmarshaling
+	// into any. Anything else falls through to LNil — defensive against
+	// future encoding/json behaviour changes.
+	got := goToLua(state, struct{ X int }{X: 1}, nil)
+	assert.Equal(t, glua.LNil, got)
+}
+
+func TestRoundTrip_PreservesArrayShape(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+	marker := state.NewTable()
+
+	// Encode a Go []any to Lua, then decode back.
+	original := []any{"a", "b", "c"}
+	luaVal := goToLua(state, original, marker)
+	got, err := luaToGo(luaVal, marker, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, original, got)
+}
+
+func TestRoundTrip_EmptyArrayWithMarker(t *testing.T) {
+	t.Parallel()
+	state := newConvertState(t)
+	marker := state.NewTable()
+
+	// Without the marker, an empty []any would round-trip as
+	// map[string]any{}; the marker preserves array intent.
+	luaVal := goToLua(state, []any{}, marker)
+	got, err := luaToGo(luaVal, marker, map[*glua.LTable]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, got)
+}

--- a/internal/hive/plugins/lua/module_commands.go
+++ b/internal/hive/plugins/lua/module_commands.go
@@ -18,6 +18,8 @@ type CommandsModule struct {
 	commands map[string]config.UserCommand
 }
 
+// Register exposes hive.commands(map) and lazily allocates the
+// accumulator if a previous Register hasn't already done so.
 func (m *CommandsModule) Register(state *glua.LState, hive *glua.LTable) error {
 	if m.commands == nil {
 		m.commands = map[string]config.UserCommand{}
@@ -26,7 +28,7 @@ func (m *CommandsModule) Register(state *glua.LState, hive *glua.LTable) error {
 		table := state.CheckTable(1)
 		next, err := commandsFromTable(table, m.commands)
 		if err != nil {
-			state.RaiseError("%s", err.Error())
+			state.RaiseError("hive.commands: %s", err.Error())
 			return 0
 		}
 		maps.Copy(m.commands, next)
@@ -162,49 +164,56 @@ func userCommandFromLua(name string, commandTable *glua.LTable) (config.UserComm
 	return cmd, nil
 }
 
-func luaStringField(table *glua.LTable, field string) (string, error) {
+// luaCommandField reads field off table after applying the policy shared
+// by every command-table reader: an absent field returns LNil, and a
+// callback value is rejected because the v1 command schema is data-only.
+// Typed readers below dispatch on the returned LValue.
+func luaCommandField(table *glua.LTable, field string) (glua.LValue, error) {
 	value := table.RawGetString(field)
+	if value.Type() == glua.LTFunction {
+		return nil, fmt.Errorf("field %q does not support callback values", field)
+	}
+	return value, nil
+}
+
+func luaStringField(table *glua.LTable, field string) (string, error) {
+	value, err := luaCommandField(table, field)
+	if err != nil {
+		return "", err
+	}
 	if value == glua.LNil {
 		return "", nil
 	}
-	if value.Type() == glua.LTFunction {
-		return "", fmt.Errorf("field %q does not support callback values", field)
-	}
-
 	str, ok := value.(glua.LString)
 	if !ok {
 		return "", fmt.Errorf("field %q must be a string", field)
 	}
-
 	return string(str), nil
 }
 
 func luaBoolField(table *glua.LTable, field string) (bool, error) {
-	value := table.RawGetString(field)
+	value, err := luaCommandField(table, field)
+	if err != nil {
+		return false, err
+	}
 	if value == glua.LNil {
 		return false, nil
 	}
-	if value.Type() == glua.LTFunction {
-		return false, fmt.Errorf("field %q does not support callback values", field)
-	}
-
 	boolean, ok := value.(glua.LBool)
 	if !ok {
 		return false, fmt.Errorf("field %q must be a boolean", field)
 	}
-
 	return bool(boolean), nil
 }
 
 func luaStringSliceField(table *glua.LTable, field string) ([]string, error) {
-	value := table.RawGetString(field)
+	value, err := luaCommandField(table, field)
+	if err != nil {
+		return nil, err
+	}
 	if value == glua.LNil {
 		return nil, nil
 	}
-	if value.Type() == glua.LTFunction {
-		return nil, fmt.Errorf("field %q does not support callback values", field)
-	}
-
 	list, ok := value.(*glua.LTable)
 	if !ok {
 		return nil, fmt.Errorf("field %q must be a table", field)
@@ -216,29 +225,24 @@ func luaStringSliceField(table *glua.LTable, field string) ([]string, error) {
 		if parseErr != nil {
 			return
 		}
-
 		str, ok := value.(glua.LString)
 		if !ok {
 			parseErr = fmt.Errorf("field %q entries must be strings", field)
 			return
 		}
-
 		values = append(values, string(str))
 	})
-
 	return values, parseErr
 }
 
 func luaExitField(table *glua.LTable, field string) (string, error) {
-	value := table.RawGetString(field)
-	if value == glua.LNil {
-		return "", nil
+	value, err := luaCommandField(table, field)
+	if err != nil {
+		return "", err
 	}
-	if value.Type() == glua.LTFunction {
-		return "", fmt.Errorf("field %q does not support callback values", field)
-	}
-
 	switch v := value.(type) {
+	case *glua.LNilType:
+		return "", nil
 	case glua.LString:
 		return string(v), nil
 	case glua.LBool:

--- a/internal/hive/plugins/lua/module_info.go
+++ b/internal/hive/plugins/lua/module_info.go
@@ -10,6 +10,7 @@ type PluginInfoModule struct {
 	ModuleRoot string
 }
 
+// Register exposes the plugin metadata as a hive.plugin subtable.
 func (m *PluginInfoModule) Register(state *glua.LState, hive *glua.LTable) error {
 	plugin := state.NewTable()
 	state.SetField(plugin, "name", glua.LString(m.Name))

--- a/internal/hive/plugins/lua/module_json.go
+++ b/internal/hive/plugins/lua/module_json.go
@@ -58,8 +58,7 @@ func (m *JSONModule) luaEncode(state *glua.LState) int {
 		pretty = p
 	}
 
-	visited := map[*glua.LTable]bool{}
-	goValue, err := m.luaToGo(value, visited)
+	goValue, err := luaToGo(value, m.arrayMarker, map[*glua.LTable]bool{})
 	if err != nil {
 		state.RaiseError("hive.json.encode: %s", err.Error())
 		return 0
@@ -102,153 +101,8 @@ func (m *JSONModule) luaDecode(state *glua.LState) int {
 		return 0
 	}
 
-	state.Push(m.goToLua(state, v))
+	state.Push(goToLua(state, v, m.arrayMarker))
 	return 1
-}
-
-// luaToGo walks Lua values into Go-native shapes that encoding/json can
-// marshal. Tables become []any when the array marker is set or when keys are
-// a dense 1..n integer run; otherwise map[string]any.
-func (m *JSONModule) luaToGo(lv glua.LValue, visited map[*glua.LTable]bool) (any, error) {
-	switch v := lv.(type) {
-	case *glua.LNilType:
-		return nil, nil
-	case glua.LBool:
-		return bool(v), nil
-	case glua.LNumber:
-		return float64(v), nil
-	case glua.LString:
-		return string(v), nil
-	case *glua.LTable:
-		if visited[v] {
-			return nil, fmt.Errorf("cannot encode cyclic table")
-		}
-		visited[v] = true
-		defer delete(visited, v)
-		return m.tableToGo(v, visited)
-	case *glua.LFunction:
-		return nil, fmt.Errorf("cannot encode lua function")
-	case *glua.LUserData:
-		return nil, fmt.Errorf("cannot encode lua userdata")
-	case *glua.LChannel:
-		return nil, fmt.Errorf("cannot encode lua channel")
-	default:
-		return nil, fmt.Errorf("cannot encode lua value of type %s", lv.Type().String())
-	}
-}
-
-// tableToGo decides between array and object encoding for a Lua table.
-//
-// Detection order:
-//  1. The array marker metatable is set → []any (preserves empty-array intent
-//     and rejects tables whose shape contradicts the array claim).
-//  2. All keys are positive integers 1..n with no holes → []any.
-//  3. Otherwise → map[string]any.
-func (m *JSONModule) tableToGo(tbl *glua.LTable, visited map[*glua.LTable]bool) (any, error) {
-	if tbl.Metatable == m.arrayMarker {
-		if err := arrayShapeError(tbl); err != nil {
-			return nil, fmt.Errorf("array-tagged table %s", err.Error())
-		}
-		return m.tableToArray(tbl, visited)
-	}
-
-	if isArrayLike(tbl) {
-		return m.tableToArray(tbl, visited)
-	}
-
-	return m.tableToObject(tbl, visited)
-}
-
-// arrayShapeError returns nil when tbl's keys are exactly the positive
-// integers 1..n with no holes (empty tables satisfy the contract). Otherwise
-// it returns an error describing the first violation. Used by the marker
-// path to surface inconsistent claims (e.g. hive.json.array({foo="x"})) as
-// errors instead of silently dropping data.
-func arrayShapeError(tbl *glua.LTable) error {
-	n := tbl.Len()
-	for i := 1; i <= n; i++ {
-		if tbl.RawGetInt(i) == glua.LNil {
-			return fmt.Errorf("has hole at index %d", i)
-		}
-	}
-	var keyErr error
-	tbl.ForEach(func(key glua.LValue, _ glua.LValue) {
-		if keyErr != nil {
-			return
-		}
-		num, ok := key.(glua.LNumber)
-		if !ok {
-			keyErr = fmt.Errorf("has non-integer key %q", key.String())
-			return
-		}
-		idx := int(num)
-		if glua.LNumber(idx) != num || idx < 1 || idx > n {
-			keyErr = fmt.Errorf("has out-of-range key %v", num)
-		}
-	})
-	return keyErr
-}
-
-// isArrayLike returns true when tbl matches the heuristic for an untagged
-// array. Empty tables fail the heuristic so the marker rule can disambiguate
-// them as []any vs. {}.
-func isArrayLike(tbl *glua.LTable) bool {
-	if tbl.Len() == 0 {
-		return false
-	}
-	return arrayShapeError(tbl) == nil
-}
-
-func (m *JSONModule) tableToArray(tbl *glua.LTable, visited map[*glua.LTable]bool) ([]any, error) {
-	out := make([]any, 0, tbl.Len())
-	for i := 1; i <= tbl.Len(); i++ {
-		entry, err := m.luaToGo(tbl.RawGetInt(i), visited)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, entry)
-	}
-	return out, nil
-}
-
-func (m *JSONModule) tableToObject(tbl *glua.LTable, visited map[*glua.LTable]bool) (map[string]any, error) {
-	out := map[string]any{}
-	var walkErr error
-	tbl.ForEach(func(key glua.LValue, value glua.LValue) {
-		if walkErr != nil {
-			return
-		}
-		k, err := objectKey(key)
-		if err != nil {
-			walkErr = err
-			return
-		}
-		entry, err := m.luaToGo(value, visited)
-		if err != nil {
-			walkErr = err
-			return
-		}
-		out[k] = entry
-	})
-	if walkErr != nil {
-		return nil, walkErr
-	}
-	return out, nil
-}
-
-// objectKey coerces a Lua table key to a JSON object key. Only string and
-// number keys are supported; other types (booleans, tables, functions,
-// userdata) would silently collide on the empty string via LVAsString and
-// drop entries, so they're rejected with an explicit error.
-func objectKey(key glua.LValue) (string, error) {
-	switch k := key.(type) {
-	case glua.LString:
-		return string(k), nil
-	case glua.LNumber:
-		return glua.LVAsString(key), nil
-	default:
-		return "", fmt.Errorf("cannot use %s as object key", key.Type().String())
-	}
 }
 
 // parseEncodeOpts validates the optional opts table for hive.json.encode.
@@ -278,39 +132,4 @@ func parseEncodeOpts(opts *glua.LTable) (pretty bool, err error) {
 		}
 	})
 	return pretty, walkErr
-}
-
-// goToLua walks Go values from encoding/json back into Lua. Empty []any
-// keeps the array marker so a re-encode round-trips as [] rather than {}.
-func (m *JSONModule) goToLua(state *glua.LState, value any) glua.LValue {
-	switch v := value.(type) {
-	case nil:
-		return glua.LNil
-	case bool:
-		return glua.LBool(v)
-	case float64:
-		return glua.LNumber(v)
-	case string:
-		return glua.LString(v)
-	case []any:
-		tbl := state.NewTable()
-		for i, item := range v {
-			tbl.RawSetInt(i+1, m.goToLua(state, item))
-		}
-		// Tag every decoded array so re-encode preserves the [] shape
-		// regardless of mutations (table.remove emptying it, removing the
-		// last element, etc.) that would otherwise flunk the heuristic.
-		state.SetMetatable(tbl, m.arrayMarker)
-		return tbl
-	case map[string]any:
-		tbl := state.NewTable()
-		for k, item := range v {
-			tbl.RawSetString(k, m.goToLua(state, item))
-		}
-		return tbl
-	default:
-		// json.Unmarshal into any only produces the cases above; this is
-		// defensive against future encoding/json behaviour changes.
-		return glua.LNil
-	}
 }

--- a/internal/hive/plugins/lua/module_json_test.go
+++ b/internal/hive/plugins/lua/module_json_test.go
@@ -6,114 +6,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	glua "github.com/yuin/gopher-lua"
 )
-
-// captureModule collects strings, errors, and arbitrary tagged values produced
-// by Lua so the Go test side can assert on them. All access to the maps is
-// through the dispatcher goroutine so no mutex is required, but we keep one
-// for safety in case future tests share an instance across goroutines.
-type captureModule struct {
-	mu      sync.Mutex
-	strings map[string]string
-	errs    map[string]string
-	bools   map[string]bool
-	numbers map[string]float64
-	any     map[string]any
-}
-
-func newCaptureModule() *captureModule {
-	return &captureModule{
-		strings: map[string]string{},
-		errs:    map[string]string{},
-		bools:   map[string]bool{},
-		numbers: map[string]float64{},
-		any:     map[string]any{},
-	}
-}
-
-func (c *captureModule) Register(state *glua.LState, hive *glua.LTable) error {
-	state.SetField(hive, "test_capture", state.NewFunction(func(state *glua.LState) int {
-		key := state.CheckString(1)
-		val := state.CheckString(2)
-		c.mu.Lock()
-		c.strings[key] = val
-		c.mu.Unlock()
-		return 0
-	}))
-	state.SetField(hive, "test_capture_err", state.NewFunction(func(state *glua.LState) int {
-		key := state.CheckString(1)
-		val := state.CheckString(2)
-		c.mu.Lock()
-		c.errs[key] = val
-		c.mu.Unlock()
-		return 0
-	}))
-	state.SetField(hive, "test_capture_bool", state.NewFunction(func(state *glua.LState) int {
-		key := state.CheckString(1)
-		val := state.CheckBool(2)
-		c.mu.Lock()
-		c.bools[key] = val
-		c.mu.Unlock()
-		return 0
-	}))
-	state.SetField(hive, "test_capture_number", state.NewFunction(func(state *glua.LState) int {
-		key := state.CheckString(1)
-		val := state.CheckNumber(2)
-		c.mu.Lock()
-		c.numbers[key] = float64(val)
-		c.mu.Unlock()
-		return 0
-	}))
-	return nil
-}
-
-// jsonHarness wires a Runtime + JSONModule + captureModule and runs the
-// supplied Lua script as the entrypoint.
-type jsonHarness struct {
-	runtime *Runtime
-	capture *captureModule
-}
-
-func newJSONHarness(t *testing.T, script string) *jsonHarness {
-	t.Helper()
-
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
-
-	capture := newCaptureModule()
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&JSONModule{},
-		capture,
-	)
-	require.NoError(t, err)
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
-
-	return &jsonHarness{runtime: rt, capture: capture}
-}
-
-func (h *jsonHarness) close(t *testing.T) {
-	t.Helper()
-	h.runtime.Close()
-}
 
 func TestJSONEncodePrimitives(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   hive.test_capture("nil",    hive.json.encode(nil))
   hive.test_capture("true",   hive.json.encode(true))
@@ -121,38 +22,36 @@ return function(hive)
   hive.test_capture("number", hive.json.encode(42))
   hive.test_capture("string", hive.json.encode("hello"))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.Equal(t, "null", h.capture.strings["nil"])
-	assert.Equal(t, "true", h.capture.strings["true"])
-	assert.Equal(t, "false", h.capture.strings["false"])
-	assert.Equal(t, "42", h.capture.strings["number"])
-	assert.Equal(t, `"hello"`, h.capture.strings["string"])
+	assert.Equal(t, "null", h.capture.String("nil"))
+	assert.Equal(t, "true", h.capture.String("true"))
+	assert.Equal(t, "false", h.capture.String("false"))
+	assert.Equal(t, "42", h.capture.String("number"))
+	assert.Equal(t, `"hello"`, h.capture.String("string"))
 }
 
 func TestJSONEncodeArrayAndObject(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   hive.test_capture("array",  hive.json.encode({"a", "b", "c"}))
   hive.test_capture("object", hive.json.encode({ foo = 1 }))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
 	var arr []any
-	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["array"]), &arr))
+	require.NoError(t, json.Unmarshal([]byte(h.capture.String("array")), &arr))
 	assert.Equal(t, []any{"a", "b", "c"}, arr)
 
 	var obj map[string]any
-	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["object"]), &obj))
+	require.NoError(t, json.Unmarshal([]byte(h.capture.String("object")), &obj))
 	assert.Equal(t, map[string]any{"foo": float64(1)}, obj)
 }
 
 func TestJSONEncodeNestedMixed(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   hive.test_capture("mixed", hive.json.encode({
     foo = 1,
@@ -160,11 +59,10 @@ return function(hive)
     baz = { x = true },
   }))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
 	var got map[string]any
-	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["mixed"]), &got))
+	require.NoError(t, json.Unmarshal([]byte(h.capture.String("mixed")), &got))
 	assert.Equal(t, map[string]any{
 		"foo": float64(1),
 		"bar": []any{"a", "b"},
@@ -174,31 +72,28 @@ end
 
 func TestJSONEncodeArrayMarker(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   hive.test_capture("empty_array",  hive.json.encode(hive.json.array({})))
   hive.test_capture("empty_object", hive.json.encode({}))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.Equal(t, "[]", h.capture.strings["empty_array"])
-	assert.Equal(t, "{}", h.capture.strings["empty_object"])
+	assert.Equal(t, "[]", h.capture.String("empty_array"))
+	assert.Equal(t, "{}", h.capture.String("empty_object"))
 }
 
 func TestJSONEncodePretty(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   hive.test_capture("pretty", hive.json.encode({ foo = 1 }, { pretty = true }))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	out := h.capture.strings["pretty"]
+	out := h.capture.String("pretty")
 	assert.Contains(t, out, "\n")
 	assert.Contains(t, out, "  ")
-	// Validate it still round-trips through encoding/json.
 	var got map[string]any
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
 	assert.Equal(t, map[string]any{"foo": float64(1)}, got)
@@ -206,121 +101,114 @@ end
 
 func TestJSONEncodeRejectsCycle(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local t = {}
   t.self = t
   local ok, err = pcall(hive.json.encode, t)
   if ok then
-    hive.test_capture_err("cycle", "no-error")
+    hive.test_capture("cycle", "no-error")
   else
-    hive.test_capture_err("cycle", tostring(err))
+    hive.test_capture("cycle", tostring(err))
   end
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.Contains(t, h.capture.errs["cycle"], "cyclic")
+	assert.Contains(t, h.capture.String("cycle"), "cyclic")
 }
 
 func TestJSONEncodeRejectsFunction(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local ok, err = pcall(hive.json.encode, function() end)
   if ok then
-    hive.test_capture_err("func", "no-error")
+    hive.test_capture("func", "no-error")
   else
-    hive.test_capture_err("func", tostring(err))
+    hive.test_capture("func", tostring(err))
   end
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.Contains(t, h.capture.errs["func"], "function")
+	assert.Contains(t, h.capture.String("func"), "function")
 }
 
 func TestJSONDecodeObject(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local got = hive.json.decode('{"foo":1,"bar":"baz","ok":true}')
-  hive.test_capture_number("foo", got.foo)
+  hive.test_capture("foo", got.foo)
   hive.test_capture("bar", got.bar)
-  hive.test_capture_bool("ok",  got.ok)
+  hive.test_capture("ok",  got.ok)
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.InDelta(t, 1.0, h.capture.numbers["foo"], 0)
-	assert.Equal(t, "baz", h.capture.strings["bar"])
-	assert.True(t, h.capture.bools["ok"])
+	assert.InDelta(t, 1.0, h.capture.Number("foo"), 0)
+	assert.Equal(t, "baz", h.capture.String("bar"))
+	assert.True(t, h.capture.Bool("ok"))
 }
 
 func TestJSONDecodeArray(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local got = hive.json.decode('[10, 20, 30]')
-  hive.test_capture_number("len",  #got)
-  hive.test_capture_number("one",  got[1])
-  hive.test_capture_number("two",  got[2])
-  hive.test_capture_number("three", got[3])
+  hive.test_capture("len",   #got)
+  hive.test_capture("one",   got[1])
+  hive.test_capture("two",   got[2])
+  hive.test_capture("three", got[3])
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.InDelta(t, 3.0, h.capture.numbers["len"], 0)
-	assert.InDelta(t, 10.0, h.capture.numbers["one"], 0)
-	assert.InDelta(t, 20.0, h.capture.numbers["two"], 0)
-	assert.InDelta(t, 30.0, h.capture.numbers["three"], 0)
+	assert.InDelta(t, 3.0, h.capture.Number("len"), 0)
+	assert.InDelta(t, 10.0, h.capture.Number("one"), 0)
+	assert.InDelta(t, 20.0, h.capture.Number("two"), 0)
+	assert.InDelta(t, 30.0, h.capture.Number("three"), 0)
 }
 
 func TestJSONDecodeMalformed(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local ok, err = pcall(hive.json.decode, '{')
   if ok then
-    hive.test_capture_err("bad", "no-error")
+    hive.test_capture("bad", "no-error")
   else
-    hive.test_capture_err("bad", tostring(err))
+    hive.test_capture("bad", tostring(err))
   end
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	got := h.capture.errs["bad"]
+	got := h.capture.String("bad")
 	assert.Contains(t, got, "hive.json.decode")
 	assert.Contains(t, strings.ToLower(got), "offset")
 }
 
 func TestJSONEmptyArrayRoundTrip(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local decoded = hive.json.decode('[]')
   hive.test_capture("re_encoded", hive.json.encode(decoded))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.Equal(t, "[]", h.capture.strings["re_encoded"])
+	assert.Equal(t, "[]", h.capture.String("re_encoded"))
 }
 
 func TestJSONRoundTripNested(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local input = '{"foo":[1,2,3],"bar":{"baz":true}}'
   local decoded = hive.json.decode(input)
   hive.test_capture("re_encoded", hive.json.encode(decoded))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
 	var got map[string]any
-	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["re_encoded"]), &got))
+	require.NoError(t, json.Unmarshal([]byte(h.capture.String("re_encoded")), &got))
 	assert.Equal(t, map[string]any{
 		"foo": []any{float64(1), float64(2), float64(3)},
 		"bar": map[string]any{"baz": true},
@@ -329,93 +217,90 @@ end
 
 func TestJSONEncodeArrayMarkerRejectsNonArrayKeys(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local string_key = hive.json.array({ foo = "x" })
   local ok1, err1 = pcall(hive.json.encode, string_key)
-  hive.test_capture_err("string_key", tostring(err1))
-  if ok1 then hive.test_capture_err("string_key_ok", "true") end
+  hive.test_capture("string_key", tostring(err1))
+  if ok1 then hive.test_capture("string_key_ok", "true") end
 
   local mixed = hive.json.array({ "a", "b", foo = "x" })
   local ok2, err2 = pcall(hive.json.encode, mixed)
-  hive.test_capture_err("mixed", tostring(err2))
-  if ok2 then hive.test_capture_err("mixed_ok", "true") end
+  hive.test_capture("mixed", tostring(err2))
+  if ok2 then hive.test_capture("mixed_ok", "true") end
 
   local sparse = hive.json.array({ [1] = "a", [3] = "c" })
   local ok3, err3 = pcall(hive.json.encode, sparse)
-  hive.test_capture_err("sparse", tostring(err3))
-  if ok3 then hive.test_capture_err("sparse_ok", "true") end
+  hive.test_capture("sparse", tostring(err3))
+  if ok3 then hive.test_capture("sparse_ok", "true") end
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.NotContains(t, h.capture.errs, "string_key_ok", "encode should reject array-tagged table with string key")
-	assert.Contains(t, h.capture.errs["string_key"], "array-tagged")
-	assert.Contains(t, h.capture.errs["string_key"], "non-integer key")
+	assert.False(t, h.capture.Has("string_key_ok"), "encode should reject array-tagged table with string key")
+	assert.Contains(t, h.capture.String("string_key"), "array-tagged")
+	assert.Contains(t, h.capture.String("string_key"), "non-integer key")
 
-	assert.NotContains(t, h.capture.errs, "mixed_ok")
-	assert.Contains(t, h.capture.errs["mixed"], "non-integer key")
+	assert.False(t, h.capture.Has("mixed_ok"))
+	assert.Contains(t, h.capture.String("mixed"), "non-integer key")
 
-	assert.NotContains(t, h.capture.errs, "sparse_ok")
-	assert.Contains(t, h.capture.errs["sparse"], "hole at index 2")
+	assert.False(t, h.capture.Has("sparse_ok"))
+	assert.Contains(t, h.capture.String("sparse"), "hole at index 2")
 }
 
 func TestJSONEncodeRejectsUnsupportedKeyTypes(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local bool_key = {}
   bool_key[true] = "x"
   local ok1, err1 = pcall(hive.json.encode, bool_key)
-  hive.test_capture_err("bool", tostring(err1))
-  if ok1 then hive.test_capture_err("bool_ok", "true") end
+  hive.test_capture("bool", tostring(err1))
+  if ok1 then hive.test_capture("bool_ok", "true") end
 
   local table_key = {}
   table_key[{}] = "x"
   local ok2, err2 = pcall(hive.json.encode, table_key)
-  hive.test_capture_err("table", tostring(err2))
-  if ok2 then hive.test_capture_err("table_ok", "true") end
+  hive.test_capture("table", tostring(err2))
+  if ok2 then hive.test_capture("table_ok", "true") end
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.NotContains(t, h.capture.errs, "bool_ok")
-	assert.Contains(t, h.capture.errs["bool"], "boolean as object key")
+	assert.False(t, h.capture.Has("bool_ok"))
+	assert.Contains(t, h.capture.String("bool"), "boolean as object key")
 
-	assert.NotContains(t, h.capture.errs, "table_ok")
-	assert.Contains(t, h.capture.errs["table"], "table as object key")
+	assert.False(t, h.capture.Has("table_ok"))
+	assert.Contains(t, h.capture.String("table"), "table as object key")
 }
 
 func TestJSONEncodeOptsValidation(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   local ok1, err1 = pcall(hive.json.encode, {}, { pretty = "true" })
-  hive.test_capture_err("non_bool", tostring(err1))
-  if ok1 then hive.test_capture_err("non_bool_ok", "true") end
+  hive.test_capture("non_bool", tostring(err1))
+  if ok1 then hive.test_capture("non_bool_ok", "true") end
 
   local ok2, err2 = pcall(hive.json.encode, {}, { prety = true })
-  hive.test_capture_err("typo", tostring(err2))
-  if ok2 then hive.test_capture_err("typo_ok", "true") end
+  hive.test_capture("typo", tostring(err2))
+  if ok2 then hive.test_capture("typo_ok", "true") end
 
   -- Valid opts still works.
   hive.test_capture("valid", hive.json.encode({ foo = 1 }, { pretty = true }))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.NotContains(t, h.capture.errs, "non_bool_ok")
-	assert.Contains(t, h.capture.errs["non_bool"], "opts.pretty must be a boolean")
+	assert.False(t, h.capture.Has("non_bool_ok"))
+	assert.Contains(t, h.capture.String("non_bool"), "opts.pretty must be a boolean")
 
-	assert.NotContains(t, h.capture.errs, "typo_ok")
-	assert.Contains(t, h.capture.errs["typo"], `unknown opts key "prety"`)
+	assert.False(t, h.capture.Has("typo_ok"))
+	assert.Contains(t, h.capture.String("typo"), `unknown opts key "prety"`)
 
-	assert.Contains(t, h.capture.strings["valid"], "\n")
+	assert.Contains(t, h.capture.String("valid"), "\n")
 }
 
 func TestJSONDecodedArrayRoundTripsAfterMutation(t *testing.T) {
 	t.Parallel()
-	h := newJSONHarness(t, `
+	h := newLuaHarness(t, `
 return function(hive)
   -- Remove the only element and re-encode: must stay [], not become {}.
   local arr = hive.json.decode('[1]')
@@ -427,13 +312,12 @@ return function(hive)
   table.remove(arr2, 2)
   hive.test_capture("after_remove_middle", hive.json.encode(arr2))
 end
-`)
-	t.Cleanup(func() { h.close(t) })
+`, &JSONModule{})
 
-	assert.Equal(t, "[]", h.capture.strings["after_drain"])
+	assert.Equal(t, "[]", h.capture.String("after_drain"))
 
 	var arr []any
-	require.NoError(t, json.Unmarshal([]byte(h.capture.strings["after_remove_middle"]), &arr))
+	require.NoError(t, json.Unmarshal([]byte(h.capture.String("after_remove_middle")), &arr))
 	assert.Equal(t, []any{float64(1), float64(3)}, arr)
 }
 

--- a/internal/hive/plugins/lua/module_kv.go
+++ b/internal/hive/plugins/lua/module_kv.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/rs/zerolog"
 	glua "github.com/yuin/gopher-lua"
 
 	"github.com/colonyops/hive/internal/core/kv"
@@ -13,10 +14,15 @@ import (
 // KVModule exposes hive.kv.{get,set,delete} backed by a string-typed
 // kv.Scoped store. The scope is applied at construction so the Lua sandbox
 // cannot read or stomp keys outside its namespace.
+//
+// Store errors are both raised to Lua and logged at Warn so operators can
+// see them even when the plugin pcall's the call to suppress the error.
 type KVModule struct {
-	Store *kv.TypedKV[string]
+	Store  *kv.TypedKV[string]
+	Logger zerolog.Logger
 }
 
+// Register attaches get/set/delete to a fresh hive.kv subtable.
 func (m *KVModule) Register(state *glua.LState, hive *glua.LTable) error {
 	table := state.NewTable()
 	state.SetField(table, "get", state.NewFunction(m.get))
@@ -34,7 +40,8 @@ func (m *KVModule) set(state *glua.LState) int {
 		return 0
 	}
 	if err := m.Store.Set(context.Background(), key, value); err != nil {
-		state.RaiseError("kv set %q: %s", key, err)
+		m.Logger.Warn().Str("op", "set").Str("key", key).Err(err).Msg("hive.kv: store error")
+		state.RaiseError("hive.kv.set %q: %s", key, err)
 		return 0
 	}
 	return 0
@@ -52,7 +59,8 @@ func (m *KVModule) get(state *glua.LState) int {
 		return 1
 	}
 	if err != nil {
-		state.RaiseError("kv get %q: %s", key, err)
+		m.Logger.Warn().Str("op", "get").Str("key", key).Err(err).Msg("hive.kv: store error")
+		state.RaiseError("hive.kv.get %q: %s", key, err)
 		return 0
 	}
 	state.Push(glua.LString(value))
@@ -66,7 +74,8 @@ func (m *KVModule) delete(state *glua.LState) int {
 		return 0
 	}
 	if err := m.Store.Delete(context.Background(), key); err != nil {
-		state.RaiseError("kv delete %q: %s", key, err)
+		m.Logger.Warn().Str("op", "delete").Str("key", key).Err(err).Msg("hive.kv: store error")
+		state.RaiseError("hive.kv.delete %q: %s", key, err)
 		return 0
 	}
 	return 0

--- a/internal/hive/plugins/lua/module_kv_test.go
+++ b/internal/hive/plugins/lua/module_kv_test.go
@@ -3,12 +3,9 @@ package lua
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,27 +14,11 @@ import (
 	"github.com/colonyops/hive/internal/data/stores"
 )
 
-func newKVHarness(t *testing.T, store kv.KV, script string) {
+// kvHarness wires the shared luaHarness with a KVModule scoped under the
+// production pluginName so namespacing assertions ("lua:foo") match.
+func kvHarness(t *testing.T, store kv.KV, script string) *luaHarness {
 	t.Helper()
-
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
-
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: pluginName, Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: pluginName, Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		&KVModule{Store: kv.Scoped[string](store, pluginName)},
-	)
-	require.NoError(t, err)
-	t.Cleanup(rt.Close)
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
+	return newLuaHarness(t, script, &KVModule{Store: kv.Scoped[string](store, pluginName)})
 }
 
 func newRealKVStore(t *testing.T) kv.KV {
@@ -50,7 +31,7 @@ func newRealKVStore(t *testing.T) kv.KV {
 
 func TestKVModule_RoundTrip(t *testing.T) {
 	store := newRealKVStore(t)
-	newKVHarness(t, store, `
+	kvHarness(t, store, `
 return function(hive)
   hive.kv.set("foo", "bar")
   assert(hive.kv.get("foo") == "bar", "expected foo=bar")
@@ -63,7 +44,7 @@ end
 }
 
 func TestKVModule_GetMissingReturnsNil(t *testing.T) {
-	newKVHarness(t, newRealKVStore(t), `
+	kvHarness(t, newRealKVStore(t), `
 return function(hive)
   assert(hive.kv.get("missing") == nil, "expected nil for missing key")
 end
@@ -72,7 +53,7 @@ end
 
 func TestKVModule_DeleteRemovesKey(t *testing.T) {
 	store := newRealKVStore(t)
-	newKVHarness(t, store, `
+	kvHarness(t, store, `
 return function(hive)
   hive.kv.set("foo", "bar")
   hive.kv.delete("foo")
@@ -89,7 +70,7 @@ func TestKVModule_NamespacingIsolatesPlugins(t *testing.T) {
 	store := newRealKVStore(t)
 	require.NoError(t, store.Set(context.Background(), "other:foo", "v"))
 
-	newKVHarness(t, store, `
+	kvHarness(t, store, `
 return function(hive)
   assert(hive.kv.get("foo") == nil, "lua plugin must not see other:foo")
 end
@@ -97,7 +78,7 @@ end
 }
 
 func TestKVModule_RejectsNonStringValue(t *testing.T) {
-	newKVHarness(t, newRealKVStore(t), `
+	kvHarness(t, newRealKVStore(t), `
 return function(hive)
   local ok = pcall(hive.kv.set, "foo", {1, 2, 3})
   if ok then
@@ -117,14 +98,14 @@ func TestKVModule_OpsRejectInputs(t *testing.T) {
 		{"set empty key", newRealKVStore(t), `local ok = pcall(hive.kv.set, "", "v"); if ok then error("expected empty key") end`},
 		{"get empty key", newRealKVStore(t), `local ok = pcall(hive.kv.get, ""); if ok then error("expected empty key") end`},
 		{"delete empty key", newRealKVStore(t), `local ok = pcall(hive.kv.delete, ""); if ok then error("expected empty key") end`},
-		{"set store error", storeErr, `local ok, err = pcall(hive.kv.set, "foo", "bar"); if ok or not string.find(tostring(err), "kv set") then error("unexpected: " .. tostring(err)) end`},
-		{"get store error", storeErr, `local ok, err = pcall(hive.kv.get, "foo"); if ok or not string.find(tostring(err), "kv get") then error("unexpected: " .. tostring(err)) end`},
-		{"delete store error", storeErr, `local ok, err = pcall(hive.kv.delete, "foo"); if ok or not string.find(tostring(err), "kv delete") then error("unexpected: " .. tostring(err)) end`},
+		{"set store error", storeErr, `local ok, err = pcall(hive.kv.set, "foo", "bar"); if ok or not string.find(tostring(err), "hive.kv.set", 1, true) then error("unexpected: " .. tostring(err)) end`},
+		{"get store error", storeErr, `local ok, err = pcall(hive.kv.get, "foo"); if ok or not string.find(tostring(err), "hive.kv.get", 1, true) then error("unexpected: " .. tostring(err)) end`},
+		{"delete store error", storeErr, `local ok, err = pcall(hive.kv.delete, "foo"); if ok or not string.find(tostring(err), "hive.kv.delete", 1, true) then error("unexpected: " .. tostring(err)) end`},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			newKVHarness(t, tc.store, "return function(hive) "+tc.script+" end")
+			kvHarness(t, tc.store, "return function(hive) "+tc.script+" end")
 		})
 	}
 }

--- a/internal/hive/plugins/lua/module_logger.go
+++ b/internal/hive/plugins/lua/module_logger.go
@@ -12,6 +12,7 @@ type LogModule struct {
 	Logger     zerolog.Logger
 }
 
+// Register attaches debug/info/warn/error to a fresh hive.log subtable.
 func (m *LogModule) Register(state *glua.LState, hive *glua.LTable) error {
 	logs := state.NewTable()
 	state.SetField(logs, "debug", m.fn(state, m.Logger.Debug))

--- a/internal/hive/plugins/lua/module_sh.go
+++ b/internal/hive/plugins/lua/module_sh.go
@@ -136,7 +136,15 @@ func (m *ShModule) Close() error {
 
 // spawnAsync pins fn, allocates a handle, and starts the executor on a
 // goroutine. Runs on the dispatcher; the goroutine hops back via
-// Runtime.Submit to invoke dispatch with the executor result.
+// Runtime.submitSync to invoke dispatch with the executor result.
+//
+// We use submitSync (not Submit) so the registry's WaitGroup accurately
+// tracks every callback in a chain. If a Lua callback fires another
+// hive.sh.* call, that call's wg.Add happens synchronously on the
+// dispatcher inside dispatch(). By blocking the parent goroutine until
+// dispatch returns, we ensure wg.Wait sees the child goroutine before
+// the parent decrements. This lets registry.shutdown drain the entire
+// callback chain rather than returning after just the first hop.
 func (m *ShModule) spawnAsync(
 	state *glua.LState,
 	fn *glua.LFunction,
@@ -149,16 +157,23 @@ func (m *ShModule) spawnAsync(
 
 	m.registry.Go(func() {
 		result := m.execWithLogging(id, ctx, cmd, opts)
-		m.Runtime.Submit(func(state *glua.LState) {
+		err := m.Runtime.submitSync(func(state *glua.LState) error {
 			fn := m.registry.loadFunction(state, id)
 			if fn == nil {
 				// Cancelled between completion and dispatch.
-				return
+				return nil
 			}
 			dispatch(state, fn, result)
 			m.registry.release(state, id)
 			h.poison()
+			return nil
 		})
+		if err != nil {
+			m.Logger.Debug().
+				Uint64("handle", id).
+				Err(err).
+				Msg("hive.sh: dispatch dropped (runtime closed)")
+		}
 	})
 
 	return h

--- a/internal/hive/plugins/lua/module_sh.go
+++ b/internal/hive/plugins/lua/module_sh.go
@@ -84,24 +84,25 @@ func (osExecutor) Exec(ctx context.Context, cmd string, opts shOptions) shResult
 }
 
 // ShModule exposes hive.sh.{run,output,exec} for shell command execution.
-// Calls run on the Lua dispatcher and synchronously block it; concurrency
-// across plugins is bounded by the shared Pool. Close cancels in-flight work.
+// Synchronous calls block the Lua dispatcher; async calls (callback as the
+// last argument) return a handle and run on the registry's WaitGroup.
+// Concurrency across plugins is bounded by the shared Pool. Close cancels
+// in-flight work.
 type ShModule struct {
-	PluginName     string
 	Pool           *plugins.WorkerPool
 	Executor       ShellExecutor
 	DefaultTimeout time.Duration
 	Logger         zerolog.Logger
 
-	rootCtx    context.Context
-	rootCancel context.CancelFunc
-	wg         sync.WaitGroup
+	Runtime *Runtime
+
+	registry asyncRegistry
 
 	closeOnce sync.Once
 }
 
-// Register installs the hive.sh subtable. Initialises rootCtx/rootCancel and
-// applies the default executor and timeout if unset.
+// Register installs the hive.sh subtable and initialises the per-module
+// async registry. Defaults the executor and timeout if unset.
 func (m *ShModule) Register(state *glua.LState, hive *glua.LTable) error {
 	if m.Executor == nil {
 		m.Executor = osExecutor{}
@@ -109,7 +110,13 @@ func (m *ShModule) Register(state *glua.LState, hive *glua.LTable) error {
 	if m.DefaultTimeout <= 0 {
 		m.DefaultTimeout = shDefaultTimeout
 	}
-	m.rootCtx, m.rootCancel = context.WithCancel(context.Background())
+
+	if err := m.registry.init(state, m, asyncRegistryConfig{
+		KeyPrefix:     "hive.sh.",
+		MetatableName: "hive.sh.handle",
+	}); err != nil {
+		return fmt.Errorf("sh module: %w", err)
+	}
 
 	sh := state.NewTable()
 	state.SetField(sh, "run", state.NewFunction(m.luaRun))
@@ -122,104 +129,281 @@ func (m *ShModule) Register(state *glua.LState, hive *glua.LTable) error {
 // Close cancels rootCtx and waits for outstanding shell calls to drain.
 // Idempotent.
 func (m *ShModule) Close() error {
-	m.closeOnce.Do(func() {
-		if m.rootCancel != nil {
-			m.rootCancel()
-		}
-		m.wg.Wait()
-	})
+	m.closeOnce.Do(func() { m.registry.shutdown() })
 	return nil
 }
 
 // runViaPool executes cmd through the shared worker pool. Pool acquisition
 // itself respects rootCtx so a Close mid-wait returns without running.
 func (m *ShModule) runViaPool(cmd string, opts shOptions) shResult {
-	m.wg.Add(1)
-	defer m.wg.Done()
+	defer m.registry.trackGoroutine()()
+	return m.execWithLogging(0, m.registry.rootContext(), cmd, opts)
+}
 
+// spawnAsync pins fn, allocates a handle, and starts the executor on a
+// goroutine. Runs on the dispatcher; the goroutine hops back via
+// Runtime.Submit to invoke dispatch with the executor result.
+func (m *ShModule) spawnAsync(
+	state *glua.LState,
+	fn *glua.LFunction,
+	cmd string,
+	opts shOptions,
+	dispatch func(*glua.LState, *glua.LFunction, shResult),
+) *asyncHandle {
+	id, ctx := m.registry.allocate(state, fn)
+	h := m.registry.newHandle(id, m.Runtime)
+
+	m.registry.Go(func() {
+		result := m.execWithLogging(id, ctx, cmd, opts)
+		m.Runtime.Submit(func(state *glua.LState) {
+			fn := m.registry.loadFunction(state, id)
+			if fn == nil {
+				// Cancelled between completion and dispatch.
+				return
+			}
+			dispatch(state, fn, result)
+			m.registry.release(state, id)
+			h.poison()
+		})
+	})
+
+	return h
+}
+
+// execWithLogging acquires a pool slot, runs cmd through the executor,
+// and emits start/finish/cancel logs. Shared between the sync and async
+// paths; id is 0 for sync (no handle field is logged) and non-zero for
+// async (handle is included in every log line so operators can correlate
+// start/finish/cancel for a specific in-flight call).
+func (m *ShModule) execWithLogging(id uint64, ctx context.Context, cmd string, opts shOptions) shResult {
 	start := time.Now()
+	m.logShellStart(id, cmd, opts)
+
+	var result shResult
+	if err := m.Pool.RunContext(ctx, func() {
+		result = m.Executor.Exec(ctx, cmd, opts)
+	}); err != nil {
+		m.logShellPoolCancelled(id, cmd, err)
+		return shResult{Code: -1, Err: err}
+	}
+
+	m.logShellFinish(id, cmd, time.Since(start), result)
+	return result
+}
+
+func (m *ShModule) logShellStart(id uint64, cmd string, opts shOptions) {
 	m.Logger.Debug().
+		Func(addHandle(id)).
 		Str("cmd", cmd).
 		Str("cwd", opts.Cwd).
 		Dur("timeout", opts.Timeout).
 		Msg("hive.sh: starting shell command")
+}
 
-	var result shResult
-	if err := m.Pool.RunContext(m.rootCtx, func() {
-		result = m.Executor.Exec(m.rootCtx, cmd, opts)
-	}); err != nil {
-		m.Logger.Warn().
-			Str("cmd", cmd).
-			Err(err).
-			Msg("hive.sh: pool acquisition cancelled")
-		return shResult{Code: -1, Err: err}
-	}
+func (m *ShModule) logShellPoolCancelled(id uint64, cmd string, err error) {
+	m.Logger.Warn().
+		Func(addHandle(id)).
+		Str("cmd", cmd).
+		Err(err).
+		Msg("hive.sh: pool acquisition cancelled")
+}
 
+func (m *ShModule) logShellFinish(id uint64, cmd string, dur time.Duration, result shResult) {
 	level := m.Logger.Debug
 	if result.Err != nil || result.Code != 0 {
 		level = m.Logger.Warn
 	}
 	level().
+		Func(addHandle(id)).
 		Str("cmd", cmd).
 		Int("code", result.Code).
-		Dur("duration", time.Since(start)).
+		Dur("duration", dur).
 		Err(result.Err).
 		Msg("hive.sh: shell command finished")
+}
 
-	return result
+// addHandle returns a zerolog Event hook that attaches the handle field
+// when id is non-zero. Used by sh's start/finish/cancel logs to
+// correlate async log lines.
+func addHandle(id uint64) func(*zerolog.Event) {
+	return func(e *zerolog.Event) {
+		if id != 0 {
+			e.Uint64("handle", id)
+		}
+	}
+}
+
+// dispatchRun invokes the async run callback with the exit code.
+func (m *ShModule) dispatchRun(state *glua.LState, fn *glua.LFunction, result shResult) {
+	if err := state.CallByParam(glua.P{
+		Fn:      fn,
+		NRet:    0,
+		Protect: true,
+	}, glua.LNumber(result.Code)); err != nil {
+		m.Logger.Warn().
+			Err(err).
+			Msg("hive.sh.run: async callback returned error")
+	}
+}
+
+// dispatchOutput invokes the async output callback with (stdout, err).
+// On non-zero exit or executor error, stdout is LNil and err is the
+// same string the sync form would raise; otherwise stdout is the
+// trimmed output and err is LNil.
+func (m *ShModule) dispatchOutput(state *glua.LState, fn *glua.LFunction, result shResult) {
+	var stdoutArg, errArg glua.LValue
+	if result.Err != nil || result.Code != 0 {
+		stdoutArg = glua.LNil
+		errArg = glua.LString(formatExecError(result))
+	} else {
+		stdoutArg = glua.LString(strings.TrimRight(result.Stdout, "\n"))
+		errArg = glua.LNil
+	}
+	if err := state.CallByParam(glua.P{
+		Fn:      fn,
+		NRet:    0,
+		Protect: true,
+	}, stdoutArg, errArg); err != nil {
+		m.Logger.Warn().
+			Err(err).
+			Msg("hive.sh.output: async callback returned error")
+	}
+}
+
+// dispatchExec invokes the async exec callback with the result table
+// matching the sync form's shape: { stdout, stderr, code, err }.
+func (m *ShModule) dispatchExec(state *glua.LState, fn *glua.LFunction, result shResult) {
+	if err := state.CallByParam(glua.P{
+		Fn:      fn,
+		NRet:    0,
+		Protect: true,
+	}, buildExecTable(state, result)); err != nil {
+		m.Logger.Warn().
+			Err(err).
+			Msg("hive.sh.exec: async callback returned error")
+	}
+}
+
+// parseRunArgs parses the args for hive.sh.run. Returns the trailing
+// callback if the second arg is a function; otherwise nil for sync.
+func (m *ShModule) parseRunArgs(state *glua.LState) (cmd string, callback *glua.LFunction) {
+	cmd = state.CheckString(1)
+	if state.GetTop() >= 2 {
+		if fn, ok := state.Get(2).(*glua.LFunction); ok {
+			callback = fn
+		}
+	}
+	return cmd, callback
+}
+
+// parseOutputArgs parses the args for hive.sh.output. Same shape as run.
+func (m *ShModule) parseOutputArgs(state *glua.LState) (cmd string, callback *glua.LFunction) {
+	return m.parseRunArgs(state)
+}
+
+// parseExecArgs parses the args for hive.sh.exec. Accepts:
+//
+//	exec(cmd)
+//	exec(cmd, opts)
+//	exec(cmd, fn)
+//	exec(cmd, opts, fn)
+//
+// where opts is a Lua table and fn is a Lua function. Anything else at
+// arg 2 raises a Lua error.
+func (m *ShModule) parseExecArgs(state *glua.LState) (cmd string, opts shOptions, callback *glua.LFunction) {
+	cmd = state.CheckString(1)
+	opts = shOptions{Timeout: m.DefaultTimeout}
+
+	if state.GetTop() < 2 {
+		return cmd, opts, nil
+	}
+
+	switch v := state.Get(2).(type) {
+	case *glua.LTable:
+		applyExecOpts(v, &opts)
+		if state.GetTop() >= 3 {
+			if fn, ok := state.Get(3).(*glua.LFunction); ok {
+				callback = fn
+			} else if state.Get(3) != glua.LNil {
+				state.ArgError(3, "expected function or nil")
+			}
+		}
+	case *glua.LFunction:
+		callback = v
+	case *glua.LNilType:
+		// no-op: treat as sync no-opts
+	default:
+		state.ArgError(2, "expected table, function, or nil")
+	}
+
+	return cmd, opts, callback
+}
+
+// applyExecOpts copies cwd/timeout from the Lua opts table.
+func applyExecOpts(t *glua.LTable, opts *shOptions) {
+	if cwd, ok := t.RawGetString("cwd").(glua.LString); ok {
+		opts.Cwd = string(cwd)
+	}
+	if timeoutSecs, ok := t.RawGetString("timeout").(glua.LNumber); ok {
+		opts.Timeout = time.Duration(float64(timeoutSecs) * float64(time.Second))
+	}
 }
 
 func (m *ShModule) luaRun(state *glua.LState) int {
-	cmd := state.CheckString(1)
-	result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
-	state.Push(glua.LNumber(result.Code))
+	cmd, callback := m.parseRunArgs(state)
+	if callback == nil {
+		result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
+		state.Push(glua.LNumber(result.Code))
+		return 1
+	}
+	handle := m.spawnAsync(state, callback, cmd, shOptions{Timeout: m.DefaultTimeout}, m.dispatchRun)
+	state.Push(m.registry.handleUserData(state, handle))
 	return 1
 }
 
 func (m *ShModule) luaOutput(state *glua.LState) int {
-	cmd := state.CheckString(1)
-	result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
+	cmd, callback := m.parseOutputArgs(state)
+	if callback == nil {
+		result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
 
-	if result.Err != nil {
-		state.RaiseError("hive.sh.output: %s", formatExecError(result))
-		return 0
-	}
-	if result.Code != 0 {
-		state.RaiseError("hive.sh.output: %s", formatExecError(result))
-		return 0
-	}
+		if result.Err != nil || result.Code != 0 {
+			state.RaiseError("hive.sh.output: %s", formatExecError(result))
+			return 0
+		}
 
-	state.Push(glua.LString(strings.TrimRight(result.Stdout, "\n")))
+		state.Push(glua.LString(strings.TrimRight(result.Stdout, "\n")))
+		return 1
+	}
+	handle := m.spawnAsync(state, callback, cmd, shOptions{Timeout: m.DefaultTimeout}, m.dispatchOutput)
+	state.Push(m.registry.handleUserData(state, handle))
 	return 1
 }
 
 func (m *ShModule) luaExec(state *glua.LState) int {
-	cmd := state.CheckString(1)
-	opts := shOptions{Timeout: m.DefaultTimeout}
-
-	if state.GetTop() >= 2 {
-		optsTable := state.CheckTable(2)
-		if cwd, ok := optsTable.RawGetString("cwd").(glua.LString); ok {
-			opts.Cwd = string(cwd)
-		}
-		if timeoutSecs, ok := optsTable.RawGetString("timeout").(glua.LNumber); ok {
-			opts.Timeout = time.Duration(float64(timeoutSecs) * float64(time.Second))
-		}
+	cmd, opts, callback := m.parseExecArgs(state)
+	if callback == nil {
+		result := m.runViaPool(cmd, opts)
+		state.Push(buildExecTable(state, result))
+		return 1
 	}
+	handle := m.spawnAsync(state, callback, cmd, opts, m.dispatchExec)
+	state.Push(m.registry.handleUserData(state, handle))
+	return 1
+}
 
-	result := m.runViaPool(cmd, opts)
-
+// buildExecTable builds the Lua result table {stdout, stderr, code, err}.
+// Shared between the sync luaExec return and the async dispatchExec path.
+func buildExecTable(state *glua.LState, r shResult) *glua.LTable {
 	out := state.NewTable()
-	state.SetField(out, "stdout", glua.LString(result.Stdout))
-	state.SetField(out, "stderr", glua.LString(result.Stderr))
-	state.SetField(out, "code", glua.LNumber(result.Code))
-	if result.Err != nil {
-		state.SetField(out, "err", glua.LString(result.Err.Error()))
+	state.SetField(out, "stdout", glua.LString(r.Stdout))
+	state.SetField(out, "stderr", glua.LString(r.Stderr))
+	state.SetField(out, "code", glua.LNumber(r.Code))
+	if r.Err != nil {
+		state.SetField(out, "err", glua.LString(r.Err.Error()))
 	} else {
 		state.SetField(out, "err", glua.LNil)
 	}
-	state.Push(out)
-	return 1
+	return out
 }
 
 // formatExecError builds the Lua error message used by hive.sh.output.

--- a/internal/hive/plugins/lua/module_sh.go
+++ b/internal/hive/plugins/lua/module_sh.go
@@ -84,10 +84,11 @@ func (osExecutor) Exec(ctx context.Context, cmd string, opts shOptions) shResult
 }
 
 // ShModule exposes hive.sh.{run,output,exec} for shell command execution.
-// Synchronous calls block the Lua dispatcher; async calls (callback as the
-// last argument) return a handle and run on the registry's WaitGroup.
-// Concurrency across plugins is bounded by the shared Pool. Close cancels
-// in-flight work.
+// Every entry point is async: the call returns a handle immediately, the
+// subprocess runs on a goroutine bound to a per-handle context, and the
+// caller-supplied callback fires on the dispatcher when the subprocess
+// finishes. Concurrency across plugins is bounded by the shared Pool.
+// Close cancels every in-flight call.
 type ShModule struct {
 	Pool           *plugins.WorkerPool
 	Executor       ShellExecutor
@@ -133,13 +134,6 @@ func (m *ShModule) Close() error {
 	return nil
 }
 
-// runViaPool executes cmd through the shared worker pool. Pool acquisition
-// itself respects rootCtx so a Close mid-wait returns without running.
-func (m *ShModule) runViaPool(cmd string, opts shOptions) shResult {
-	defer m.registry.trackGoroutine()()
-	return m.execWithLogging(0, m.registry.rootContext(), cmd, opts)
-}
-
 // spawnAsync pins fn, allocates a handle, and starts the executor on a
 // goroutine. Runs on the dispatcher; the goroutine hops back via
 // Runtime.Submit to invoke dispatch with the executor result.
@@ -171,10 +165,8 @@ func (m *ShModule) spawnAsync(
 }
 
 // execWithLogging acquires a pool slot, runs cmd through the executor,
-// and emits start/finish/cancel logs. Shared between the sync and async
-// paths; id is 0 for sync (no handle field is logged) and non-zero for
-// async (handle is included in every log line so operators can correlate
-// start/finish/cancel for a specific in-flight call).
+// and emits start/finish/cancel logs tagged with the handle id so
+// operators can correlate the events for a specific in-flight call.
 func (m *ShModule) execWithLogging(id uint64, ctx context.Context, cmd string, opts shOptions) shResult {
 	start := time.Now()
 	m.logShellStart(id, cmd, opts)
@@ -193,7 +185,7 @@ func (m *ShModule) execWithLogging(id uint64, ctx context.Context, cmd string, o
 
 func (m *ShModule) logShellStart(id uint64, cmd string, opts shOptions) {
 	m.Logger.Debug().
-		Func(addHandle(id)).
+		Uint64("handle", id).
 		Str("cmd", cmd).
 		Str("cwd", opts.Cwd).
 		Dur("timeout", opts.Timeout).
@@ -202,7 +194,7 @@ func (m *ShModule) logShellStart(id uint64, cmd string, opts shOptions) {
 
 func (m *ShModule) logShellPoolCancelled(id uint64, cmd string, err error) {
 	m.Logger.Warn().
-		Func(addHandle(id)).
+		Uint64("handle", id).
 		Str("cmd", cmd).
 		Err(err).
 		Msg("hive.sh: pool acquisition cancelled")
@@ -214,7 +206,7 @@ func (m *ShModule) logShellFinish(id uint64, cmd string, dur time.Duration, resu
 		level = m.Logger.Warn
 	}
 	level().
-		Func(addHandle(id)).
+		Uint64("handle", id).
 		Str("cmd", cmd).
 		Int("code", result.Code).
 		Dur("duration", dur).
@@ -222,18 +214,7 @@ func (m *ShModule) logShellFinish(id uint64, cmd string, dur time.Duration, resu
 		Msg("hive.sh: shell command finished")
 }
 
-// addHandle returns a zerolog Event hook that attaches the handle field
-// when id is non-zero. Used by sh's start/finish/cancel logs to
-// correlate async log lines.
-func addHandle(id uint64) func(*zerolog.Event) {
-	return func(e *zerolog.Event) {
-		if id != 0 {
-			e.Uint64("handle", id)
-		}
-	}
-}
-
-// dispatchRun invokes the async run callback with the exit code.
+// dispatchRun invokes the run callback with the exit code.
 func (m *ShModule) dispatchRun(state *glua.LState, fn *glua.LFunction, result shResult) {
 	if err := state.CallByParam(glua.P{
 		Fn:      fn,
@@ -242,14 +223,14 @@ func (m *ShModule) dispatchRun(state *glua.LState, fn *glua.LFunction, result sh
 	}, glua.LNumber(result.Code)); err != nil {
 		m.Logger.Warn().
 			Err(err).
-			Msg("hive.sh.run: async callback returned error")
+			Msg("hive.sh.run: callback returned error")
 	}
 }
 
-// dispatchOutput invokes the async output callback with (stdout, err).
-// On non-zero exit or executor error, stdout is LNil and err is the
-// same string the sync form would raise; otherwise stdout is the
-// trimmed output and err is LNil.
+// dispatchOutput invokes the output callback with (stdout, err). On
+// non-zero exit or executor error, stdout is LNil and err is a string
+// describing the failure; otherwise stdout is the trimmed output and
+// err is LNil.
 func (m *ShModule) dispatchOutput(state *glua.LState, fn *glua.LFunction, result shResult) {
 	var stdoutArg, errArg glua.LValue
 	if result.Err != nil || result.Code != 0 {
@@ -266,12 +247,12 @@ func (m *ShModule) dispatchOutput(state *glua.LState, fn *glua.LFunction, result
 	}, stdoutArg, errArg); err != nil {
 		m.Logger.Warn().
 			Err(err).
-			Msg("hive.sh.output: async callback returned error")
+			Msg("hive.sh.output: callback returned error")
 	}
 }
 
-// dispatchExec invokes the async exec callback with the result table
-// matching the sync form's shape: { stdout, stderr, code, err }.
+// dispatchExec invokes the exec callback with a result table:
+// { stdout, stderr, code, err }.
 func (m *ShModule) dispatchExec(state *glua.LState, fn *glua.LFunction, result shResult) {
 	if err := state.CallByParam(glua.P{
 		Fn:      fn,
@@ -280,60 +261,45 @@ func (m *ShModule) dispatchExec(state *glua.LState, fn *glua.LFunction, result s
 	}, buildExecTable(state, result)); err != nil {
 		m.Logger.Warn().
 			Err(err).
-			Msg("hive.sh.exec: async callback returned error")
+			Msg("hive.sh.exec: callback returned error")
 	}
 }
 
-// parseRunArgs parses the args for hive.sh.run. Returns the trailing
-// callback if the second arg is a function; otherwise nil for sync.
+// parseRunArgs parses the args for hive.sh.run(cmd, fn). The callback is
+// required; non-function arg 2 raises a Lua error via CheckFunction.
 func (m *ShModule) parseRunArgs(state *glua.LState) (cmd string, callback *glua.LFunction) {
 	cmd = state.CheckString(1)
-	if state.GetTop() >= 2 {
-		if fn, ok := state.Get(2).(*glua.LFunction); ok {
-			callback = fn
-		}
-	}
+	callback = state.CheckFunction(2)
 	return cmd, callback
 }
 
-// parseOutputArgs parses the args for hive.sh.output. Same shape as run.
+// parseOutputArgs parses the args for hive.sh.output(cmd, fn). Same
+// shape as run.
 func (m *ShModule) parseOutputArgs(state *glua.LState) (cmd string, callback *glua.LFunction) {
 	return m.parseRunArgs(state)
 }
 
 // parseExecArgs parses the args for hive.sh.exec. Accepts:
 //
-//	exec(cmd)
-//	exec(cmd, opts)
 //	exec(cmd, fn)
 //	exec(cmd, opts, fn)
 //
-// where opts is a Lua table and fn is a Lua function. Anything else at
-// arg 2 raises a Lua error.
+// where opts is a Lua table and fn is a Lua function. The callback is
+// required; non-function final arg raises a Lua error.
 func (m *ShModule) parseExecArgs(state *glua.LState) (cmd string, opts shOptions, callback *glua.LFunction) {
 	cmd = state.CheckString(1)
 	opts = shOptions{Timeout: m.DefaultTimeout}
 
-	if state.GetTop() < 2 {
-		return cmd, opts, nil
-	}
-
-	switch v := state.Get(2).(type) {
-	case *glua.LTable:
-		applyExecOpts(v, &opts)
-		if state.GetTop() >= 3 {
-			if fn, ok := state.Get(3).(*glua.LFunction); ok {
-				callback = fn
-			} else if state.Get(3) != glua.LNil {
-				state.ArgError(3, "expected function or nil")
-			}
+	switch state.GetTop() {
+	case 2:
+		callback = state.CheckFunction(2)
+	case 3:
+		if state.Get(2) != glua.LNil {
+			applyExecOpts(state.CheckTable(2), &opts)
 		}
-	case *glua.LFunction:
-		callback = v
-	case *glua.LNilType:
-		// no-op: treat as sync no-opts
+		callback = state.CheckFunction(3)
 	default:
-		state.ArgError(2, "expected table, function, or nil")
+		state.RaiseError("hive.sh.exec: expected (cmd, fn) or (cmd, opts, fn)")
 	}
 
 	return cmd, opts, callback
@@ -351,11 +317,6 @@ func applyExecOpts(t *glua.LTable, opts *shOptions) {
 
 func (m *ShModule) luaRun(state *glua.LState) int {
 	cmd, callback := m.parseRunArgs(state)
-	if callback == nil {
-		result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
-		state.Push(glua.LNumber(result.Code))
-		return 1
-	}
 	handle := m.spawnAsync(state, callback, cmd, shOptions{Timeout: m.DefaultTimeout}, m.dispatchRun)
 	state.Push(m.registry.handleUserData(state, handle))
 	return 1
@@ -363,17 +324,6 @@ func (m *ShModule) luaRun(state *glua.LState) int {
 
 func (m *ShModule) luaOutput(state *glua.LState) int {
 	cmd, callback := m.parseOutputArgs(state)
-	if callback == nil {
-		result := m.runViaPool(cmd, shOptions{Timeout: m.DefaultTimeout})
-
-		if result.Err != nil || result.Code != 0 {
-			state.RaiseError("hive.sh.output: %s", formatExecError(result))
-			return 0
-		}
-
-		state.Push(glua.LString(strings.TrimRight(result.Stdout, "\n")))
-		return 1
-	}
 	handle := m.spawnAsync(state, callback, cmd, shOptions{Timeout: m.DefaultTimeout}, m.dispatchOutput)
 	state.Push(m.registry.handleUserData(state, handle))
 	return 1
@@ -381,18 +331,13 @@ func (m *ShModule) luaOutput(state *glua.LState) int {
 
 func (m *ShModule) luaExec(state *glua.LState) int {
 	cmd, opts, callback := m.parseExecArgs(state)
-	if callback == nil {
-		result := m.runViaPool(cmd, opts)
-		state.Push(buildExecTable(state, result))
-		return 1
-	}
 	handle := m.spawnAsync(state, callback, cmd, opts, m.dispatchExec)
 	state.Push(m.registry.handleUserData(state, handle))
 	return 1
 }
 
-// buildExecTable builds the Lua result table {stdout, stderr, code, err}.
-// Shared between the sync luaExec return and the async dispatchExec path.
+// buildExecTable builds the Lua result table {stdout, stderr, code, err}
+// passed to hive.sh.exec callbacks.
 func buildExecTable(state *glua.LState, r shResult) *glua.LTable {
 	out := state.NewTable()
 	state.SetField(out, "stdout", glua.LString(r.Stdout))
@@ -406,8 +351,9 @@ func buildExecTable(state *glua.LState, r shResult) *glua.LTable {
 	return out
 }
 
-// formatExecError builds the Lua error message used by hive.sh.output.
-// Includes stderr (trimmed) and Err when present.
+// formatExecError builds the err string passed to hive.sh.output
+// callbacks on non-zero exit. Includes stderr (trimmed) and Err when
+// present.
 func formatExecError(r shResult) string {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("exit %d", r.Code))

--- a/internal/hive/plugins/lua/module_sh_test.go
+++ b/internal/hive/plugins/lua/module_sh_test.go
@@ -3,8 +3,6 @@ package lua
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -49,84 +47,53 @@ func (f *fakeExecutor) snapshot() (cmd string, opts shOptions, ctx context.Conte
 	return f.lastCmd, f.lastOpts, f.lastCtx, f.calls
 }
 
-// shHarness wires a Runtime + ShModule + a result-capturing module into a
-// Lua entry script. Tests inject a fakeExecutor to drive the executor side
-// without spawning subprocesses.
+// shHarness wraps luaHarness with the ShModule reference so tests can
+// reach the module for explicit shutdown ordering, direct method calls,
+// or to drive the dispatcher for handle inspection.
 type shHarness struct {
+	*luaHarness
 	module   *ShModule
 	executor *fakeExecutor
-	captured *shCaptureModule
-}
-
-// shCaptureModule exposes hive.test_capture(value) so Lua can hand
-// arbitrary values back to the test for assertion. Distinct from the
-// keyed captureModule used by module_json_test.go because hive.sh tests
-// only need a positional list.
-type shCaptureModule struct {
-	mu     sync.Mutex
-	values []glua.LValue
-}
-
-func (c *shCaptureModule) Register(state *glua.LState, hive *glua.LTable) error {
-	state.SetField(hive, "test_capture", state.NewFunction(func(state *glua.LState) int {
-		v := state.CheckAny(1)
-		c.mu.Lock()
-		c.values = append(c.values, v)
-		c.mu.Unlock()
-		return 0
-	}))
-	return nil
-}
-
-func (c *shCaptureModule) snapshot() []glua.LValue {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	out := make([]glua.LValue, len(c.values))
-	copy(out, c.values)
-	return out
 }
 
 func newShHarness(t *testing.T, script string, executor *fakeExecutor, defaultTimeout time.Duration) *shHarness {
 	t.Helper()
-
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
-
-	pool := plugins.NewWorkerPool(1)
 	module := &ShModule{
-		PluginName:     "lua-test",
-		Pool:           pool,
+		Pool:           plugins.NewWorkerPool(1),
 		Executor:       executor,
 		DefaultTimeout: defaultTimeout,
 		Logger:         zerolog.Nop(),
 	}
-	captured := &shCaptureModule{}
-
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		module,
-		captured,
-	)
-	require.NoError(t, err)
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
-
-	t.Cleanup(func() {
-		_ = module.Close()
-		rt.Close()
-	})
-
 	return &shHarness{
-		module:   module,
-		executor: executor,
-		captured: captured,
+		luaHarness: newLuaHarness(t, script, module),
+		module:     module,
+		executor:   executor,
+	}
+}
+
+// asLuaInt unwraps an LNumber to int for exact comparison without
+// triggering the testifylint float-compare rule.
+func asLuaInt(t *testing.T, v glua.LValue) int {
+	t.Helper()
+	n, ok := v.(glua.LNumber)
+	require.True(t, ok, "expected LNumber, got %T", v)
+	return int(n)
+}
+
+// waitForCaptures polls the capture list until it reaches n values, with
+// a generous timeout for CI. Returns the final snapshot.
+func waitForCaptures(t *testing.T, capture *captureModule, n int) []glua.LValue {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		values := capture.Snapshot()
+		if len(values) >= n {
+			return values
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected %d captures, got %d", n, len(values))
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
@@ -156,20 +123,11 @@ return function(hive)
 end
 `, exec, 0)
 
-	values := h.captured.snapshot()
+	values := h.capture.Snapshot()
 	require.Len(t, values, 3)
 	assert.Equal(t, 0, asLuaInt(t, values[0]))
 	assert.Equal(t, 1, asLuaInt(t, values[1]))
 	assert.Equal(t, 7, asLuaInt(t, values[2]))
-}
-
-// asLuaInt unwraps an LNumber to int for exact comparison without
-// triggering the testifylint float-compare rule.
-func asLuaInt(t *testing.T, v glua.LValue) int {
-	t.Helper()
-	n, ok := v.(glua.LNumber)
-	require.True(t, ok, "expected LNumber, got %T", v)
-	return int(n)
 }
 
 func TestShOutput_StripsTrailingNewline(t *testing.T) {
@@ -187,7 +145,7 @@ return function(hive)
 end
 `, exec, 0)
 
-	values := h.captured.snapshot()
+	values := h.capture.Snapshot()
 	require.Len(t, values, 1)
 	assert.Equal(t, glua.LString("hello"), values[0])
 }
@@ -201,32 +159,25 @@ func TestShOutput_NonZeroRaises(t *testing.T) {
 		},
 	}
 
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(`
-return function(hive)
-  hive.sh.output("bad")
-end
-`), 0o644))
-
-	pool := plugins.NewWorkerPool(1)
 	module := &ShModule{
-		PluginName:     "lua-test",
-		Pool:           pool,
+		Pool:           plugins.NewWorkerPool(1),
 		Executor:       exec,
 		DefaultTimeout: 5 * time.Second,
 		Logger:         zerolog.Nop(),
 	}
 
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		module,
-	)
-	require.NoError(t, err)
+	// hive.sh.output raising during entry execution surfaces as a
+	// CallEntrypoint error, so this test cannot use newLuaHarness which
+	// asserts CallEntrypoint succeeds.
+	root := t.TempDir()
+	entry := writeLuaEntry(t, root, `
+return function(hive)
+  hive.sh.output("bad")
+end
+`)
+
+	rt := newRawRuntime(t, root, entry, module)
+	module.Runtime = rt
 	t.Cleanup(func() {
 		_ = module.Close()
 		rt.Close()
@@ -260,7 +211,7 @@ return function(hive)
 end
 `, exec, 0)
 
-	values := h.captured.snapshot()
+	values := h.capture.Snapshot()
 	require.Len(t, values, 4)
 	assert.Equal(t, glua.LString("out"), values[0])
 	assert.Equal(t, glua.LString("err"), values[1])
@@ -284,7 +235,7 @@ return function(hive)
 end
 `, exec, 0)
 
-	values := h.captured.snapshot()
+	values := h.capture.Snapshot()
 	require.Len(t, values, 1)
 	assert.Equal(t, glua.LString("timeout"), values[0])
 }
@@ -345,42 +296,17 @@ func TestShModule_ShutdownCancelsInflight(t *testing.T) {
 		},
 	}
 
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(`
+	h := newShHarness(t, `
 return function(hive)
   hive.commands({ Trigger = { sh = "true", help = "noop" } })
 end
-`), 0o644))
-
-	pool := plugins.NewWorkerPool(1)
-	module := &ShModule{
-		PluginName:     "lua-test",
-		Pool:           pool,
-		Executor:       exec,
-		DefaultTimeout: 0,
-		Logger:         zerolog.Nop(),
-	}
-
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		module,
-	)
-	require.NoError(t, err)
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
+`, exec, 0)
 
 	// Kick off a blocked exec from a goroutine; it will park inside
 	// the fake executor until rootCtx is cancelled.
 	done := make(chan shResult, 1)
 	go func() {
-		done <- module.runViaPool("blocking", shOptions{})
+		done <- h.module.runViaPool("blocking", shOptions{})
 	}()
 
 	var execCtx context.Context
@@ -390,7 +316,7 @@ end
 		t.Fatalf("executor never received a context")
 	}
 
-	require.NoError(t, module.Close())
+	require.NoError(t, h.module.Close())
 
 	select {
 	case <-released:
@@ -406,50 +332,307 @@ end
 	case <-time.After(2 * time.Second):
 		t.Fatalf("runViaPool never returned after Close")
 	}
-
-	rt.Close()
 }
 
 func TestShModule_RealExecutor_EndToEnd(t *testing.T) {
 	t.Parallel()
 
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(`
-return function(hive)
-  hive.test_capture(hive.sh.output("echo hello"))
-end
-`), 0o644))
-
-	pool := plugins.NewWorkerPool(1)
 	module := &ShModule{
-		PluginName:     "lua-test",
-		Pool:           pool,
+		Pool:           plugins.NewWorkerPool(1),
 		DefaultTimeout: 5 * time.Second,
 		Logger:         zerolog.Nop(),
 	}
-	captured := &shCaptureModule{}
 
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		module,
-		captured,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = module.Close()
-		rt.Close()
-	})
+	h := newLuaHarness(t, `
+return function(hive)
+  hive.test_capture(hive.sh.output("echo hello"))
+end
+`, module)
 
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
-
-	values := captured.snapshot()
+	values := h.capture.Snapshot()
 	require.Len(t, values, 1)
 	assert.Equal(t, glua.LString("hello"), values[0])
+}
+
+func TestShRun_AsyncCallbackReceivesCode(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, cmd string, _ shOptions) shResult {
+			switch cmd {
+			case "ok":
+				return shResult{Code: 0}
+			case "weird":
+				return shResult{Code: 7}
+			}
+			t.Fatalf("unexpected cmd %q", cmd)
+			return shResult{}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.run("ok", function(code) hive.test_capture(code) end)
+  hive.sh.run("weird", function(code) hive.test_capture(code) end)
+end
+`, exec, 0)
+
+	values := waitForCaptures(t, h.capture, 2)
+	require.Len(t, values, 2)
+	// Two async runs race; assert as a multiset.
+	codes := []int{asLuaInt(t, values[0]), asLuaInt(t, values[1])}
+	assert.ElementsMatch(t, []int{0, 7}, codes)
+}
+
+func TestShOutput_AsyncSuccessPassesStdoutNilErr(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Stdout: "hi\n", Code: 0}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.output("anything", function(stdout, err)
+    hive.test_capture(stdout)
+    hive.test_capture(err)
+  end)
+end
+`, exec, 0)
+
+	values := waitForCaptures(t, h.capture, 2)
+	require.Len(t, values, 2)
+	assert.Equal(t, glua.LString("hi"), values[0])
+	assert.Equal(t, glua.LNil, values[1])
+}
+
+func TestShOutput_AsyncFailurePassesNilStdoutAndErr(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Stderr: "boom\n", Code: 1}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.output("bad", function(stdout, err)
+    hive.test_capture(stdout)
+    hive.test_capture(err)
+  end)
+end
+`, exec, 0)
+
+	values := waitForCaptures(t, h.capture, 2)
+	require.Len(t, values, 2)
+	assert.Equal(t, glua.LNil, values[0])
+	errStr, ok := values[1].(glua.LString)
+	require.True(t, ok, "expected LString err, got %T", values[1])
+	assert.Contains(t, string(errStr), "exit 1")
+	assert.Contains(t, string(errStr), "boom")
+}
+
+func TestShExec_AsyncCallbackReceivesTable(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Stdout: "out", Stderr: "err", Code: 2, Err: errors.New("explained")}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.exec("anything", function(r)
+    hive.test_capture(r.stdout)
+    hive.test_capture(r.stderr)
+    hive.test_capture(r.code)
+    hive.test_capture(r.err)
+  end)
+end
+`, exec, 0)
+
+	values := waitForCaptures(t, h.capture, 4)
+	require.Len(t, values, 4)
+	assert.Equal(t, glua.LString("out"), values[0])
+	assert.Equal(t, glua.LString("err"), values[1])
+	assert.Equal(t, 2, asLuaInt(t, values[2]))
+	assert.Equal(t, glua.LString("explained"), values[3])
+}
+
+func TestShExec_AsyncOptsThreaded(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: 0}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.exec("anything", { cwd = "/tmp", timeout = 5 }, function(r)
+    hive.test_capture(r.code)
+  end)
+end
+`, exec, 0)
+
+	_ = waitForCaptures(t, h.capture, 1)
+
+	_, opts, _, calls := exec.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "/tmp", opts.Cwd)
+	assert.Equal(t, 5*time.Second, opts.Timeout)
+}
+
+func TestShAsync_HandleCancelKillsSubprocess(t *testing.T) {
+	t.Parallel()
+
+	executorCtx := make(chan context.Context, 1)
+	released := make(chan struct{})
+
+	exec := &fakeExecutor{
+		respond: func(ctx context.Context, _ string, _ shOptions) shResult {
+			executorCtx <- ctx
+			<-ctx.Done()
+			close(released)
+			return shResult{Code: -1, Err: ctx.Err()}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  HANDLE = hive.sh.run("blocking", function(code) hive.test_capture(code) end)
+end
+`, exec, 0)
+
+	// Wait for the executor to receive its ctx.
+	var ctx context.Context
+	select {
+	case ctx = <-executorCtx:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("executor never received a context")
+	}
+
+	// Cancel the handle via the dispatcher.
+	cancelDone := make(chan struct{})
+	h.module.Runtime.Submit(func(state *glua.LState) {
+		defer close(cancelDone)
+		ud, ok := state.GetGlobal("HANDLE").(*glua.LUserData)
+		require.True(t, ok)
+		handle, ok := ud.Value.(*asyncHandle)
+		require.True(t, ok)
+		handle.Cancel()
+	})
+
+	select {
+	case <-cancelDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("cancel submit never ran")
+	}
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("executor never released after cancel")
+	}
+
+	require.Error(t, ctx.Err(), "executor's per-handle ctx should be cancelled")
+
+	// The callback should never fire because the handle was cancelled
+	// before dispatch had a chance to load the registry pin.
+	time.Sleep(50 * time.Millisecond)
+	values := h.capture.Snapshot()
+	assert.Empty(t, values, "callback should not fire after cancel")
+}
+
+func TestShAsync_ShutdownDrainsInflight(t *testing.T) {
+	t.Parallel()
+
+	executorCtx := make(chan context.Context, 1)
+	released := make(chan struct{})
+
+	exec := &fakeExecutor{
+		respond: func(ctx context.Context, _ string, _ shOptions) shResult {
+			executorCtx <- ctx
+			<-ctx.Done()
+			close(released)
+			return shResult{Code: -1, Err: ctx.Err()}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.run("blocking", function(code) hive.test_capture(code) end)
+end
+`, exec, 0)
+
+	var ctx context.Context
+	select {
+	case ctx = <-executorCtx:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("executor never received a context")
+	}
+
+	require.NoError(t, h.module.Close())
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("executor never released after Close")
+	}
+
+	require.Error(t, ctx.Err(), "executor's per-handle ctx should be cancelled by Close")
+
+	// Close drained the goroutine cleanly; the dispatcher remains alive
+	// here (rt.Close runs in t.Cleanup), so any queued dispatch may
+	// still run. The contract is: no panic, and any callback that does
+	// fire receives the cancellation result (Code: -1).
+	time.Sleep(50 * time.Millisecond)
+	for _, v := range h.capture.Snapshot() {
+		assert.Equal(t, -1, asLuaInt(t, v),
+			"post-shutdown callback should observe cancellation result")
+	}
+}
+
+func TestShAsync_CancelAfterCompletionIsNoop(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: 0}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  HANDLE = hive.sh.run("ok", function(code) hive.test_capture(code) end)
+end
+`, exec, 0)
+
+	values := waitForCaptures(t, h.capture, 1)
+	require.Len(t, values, 1)
+
+	cancelDone := make(chan struct{})
+	h.module.Runtime.Submit(func(state *glua.LState) {
+		defer close(cancelDone)
+		ud, ok := state.GetGlobal("HANDLE").(*glua.LUserData)
+		require.True(t, ok)
+		handle, ok := ud.Value.(*asyncHandle)
+		require.True(t, ok)
+		handle.Cancel() // post-completion cancel — should be a true no-op
+	})
+
+	select {
+	case <-cancelDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("cancel submit never ran")
+	}
+
+	// Still exactly one capture; no panic in the dispatcher.
+	values = h.capture.Snapshot()
+	assert.Len(t, values, 1)
 }

--- a/internal/hive/plugins/lua/module_sh_test.go
+++ b/internal/hive/plugins/lua/module_sh_test.go
@@ -48,8 +48,8 @@ func (f *fakeExecutor) snapshot() (cmd string, opts shOptions, ctx context.Conte
 }
 
 // shHarness wraps luaHarness with the ShModule reference so tests can
-// reach the module for explicit shutdown ordering, direct method calls,
-// or to drive the dispatcher for handle inspection.
+// reach the module for explicit shutdown ordering or to drive the
+// dispatcher for handle inspection.
 type shHarness struct {
 	*luaHarness
 	module   *ShModule
@@ -97,264 +97,7 @@ func waitForCaptures(t *testing.T, capture *captureModule, n int) []glua.LValue 
 	}
 }
 
-func TestShRun_ExitCodes(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, cmd string, _ shOptions) shResult {
-			switch cmd {
-			case "ok":
-				return shResult{Code: 0}
-			case "fail":
-				return shResult{Code: 1}
-			case "weird":
-				return shResult{Code: 7}
-			}
-			t.Fatalf("unexpected cmd %q", cmd)
-			return shResult{}
-		},
-	}
-
-	h := newShHarness(t, `
-return function(hive)
-  hive.test_capture(hive.sh.run("ok"))
-  hive.test_capture(hive.sh.run("fail"))
-  hive.test_capture(hive.sh.run("weird"))
-end
-`, exec, 0)
-
-	values := h.capture.Snapshot()
-	require.Len(t, values, 3)
-	assert.Equal(t, 0, asLuaInt(t, values[0]))
-	assert.Equal(t, 1, asLuaInt(t, values[1]))
-	assert.Equal(t, 7, asLuaInt(t, values[2]))
-}
-
-func TestShOutput_StripsTrailingNewline(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			return shResult{Stdout: "hello\n", Code: 0}
-		},
-	}
-
-	h := newShHarness(t, `
-return function(hive)
-  hive.test_capture(hive.sh.output("anything"))
-end
-`, exec, 0)
-
-	values := h.capture.Snapshot()
-	require.Len(t, values, 1)
-	assert.Equal(t, glua.LString("hello"), values[0])
-}
-
-func TestShOutput_NonZeroRaises(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			return shResult{Code: 1, Stderr: "boom\n"}
-		},
-	}
-
-	module := &ShModule{
-		Pool:           plugins.NewWorkerPool(1),
-		Executor:       exec,
-		DefaultTimeout: 5 * time.Second,
-		Logger:         zerolog.Nop(),
-	}
-
-	// hive.sh.output raising during entry execution surfaces as a
-	// CallEntrypoint error, so this test cannot use newLuaHarness which
-	// asserts CallEntrypoint succeeds.
-	root := t.TempDir()
-	entry := writeLuaEntry(t, root, `
-return function(hive)
-  hive.sh.output("bad")
-end
-`)
-
-	rt := newRawRuntime(t, root, entry, module)
-	module.Runtime = rt
-	t.Cleanup(func() {
-		_ = module.Close()
-		rt.Close()
-	})
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-
-	err = rt.CallEntrypoint(fn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "boom")
-	assert.Contains(t, err.Error(), "exit 1")
-}
-
-func TestShExec_TableShape(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			return shResult{Stdout: "out", Stderr: "err", Code: 2}
-		},
-	}
-
-	h := newShHarness(t, `
-return function(hive)
-  local r = hive.sh.exec("anything")
-  hive.test_capture(r.stdout)
-  hive.test_capture(r.stderr)
-  hive.test_capture(r.code)
-  hive.test_capture(r.err)
-end
-`, exec, 0)
-
-	values := h.capture.Snapshot()
-	require.Len(t, values, 4)
-	assert.Equal(t, glua.LString("out"), values[0])
-	assert.Equal(t, glua.LString("err"), values[1])
-	assert.Equal(t, 2, asLuaInt(t, values[2]))
-	assert.Equal(t, glua.LNil, values[3])
-}
-
-func TestShExec_TableShape_WithErr(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			return shResult{Code: -1, Err: errors.New("timeout")}
-		},
-	}
-
-	h := newShHarness(t, `
-return function(hive)
-  local r = hive.sh.exec("anything")
-  hive.test_capture(r.err)
-end
-`, exec, 0)
-
-	values := h.capture.Snapshot()
-	require.Len(t, values, 1)
-	assert.Equal(t, glua.LString("timeout"), values[0])
-}
-
-func TestShExec_OptionsThreaded(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			return shResult{Code: 0}
-		},
-	}
-
-	newShHarness(t, `
-return function(hive)
-  hive.sh.exec("anything", { cwd = "/tmp", timeout = 5 })
-end
-`, exec, 0)
-
-	_, opts, _, calls := exec.snapshot()
-	assert.Equal(t, 1, calls)
-	assert.Equal(t, "/tmp", opts.Cwd)
-	assert.Equal(t, 5*time.Second, opts.Timeout)
-}
-
-func TestShExec_DefaultTimeout(t *testing.T) {
-	t.Parallel()
-
-	exec := &fakeExecutor{
-		respond: func(_ context.Context, _ string, _ shOptions) shResult {
-			return shResult{Code: 0}
-		},
-	}
-
-	newShHarness(t, `
-return function(hive)
-  hive.sh.exec("anything")
-end
-`, exec, 11*time.Second)
-
-	_, opts, _, calls := exec.snapshot()
-	assert.Equal(t, 1, calls)
-	assert.Equal(t, 11*time.Second, opts.Timeout)
-}
-
-func TestShModule_ShutdownCancelsInflight(t *testing.T) {
-	t.Parallel()
-
-	released := make(chan struct{})
-	captured := make(chan context.Context, 1)
-
-	exec := &fakeExecutor{
-		respond: func(ctx context.Context, _ string, _ shOptions) shResult {
-			captured <- ctx
-			<-ctx.Done()
-			close(released)
-			return shResult{Code: -1, Err: ctx.Err()}
-		},
-	}
-
-	h := newShHarness(t, `
-return function(hive)
-  hive.commands({ Trigger = { sh = "true", help = "noop" } })
-end
-`, exec, 0)
-
-	// Kick off a blocked exec from a goroutine; it will park inside
-	// the fake executor until rootCtx is cancelled.
-	done := make(chan shResult, 1)
-	go func() {
-		done <- h.module.runViaPool("blocking", shOptions{})
-	}()
-
-	var execCtx context.Context
-	select {
-	case execCtx = <-captured:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("executor never received a context")
-	}
-
-	require.NoError(t, h.module.Close())
-
-	select {
-	case <-released:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("executor never released after Close")
-	}
-
-	require.Error(t, execCtx.Err(), "executor's context should be cancelled by Close")
-
-	select {
-	case res := <-done:
-		assert.Equal(t, -1, res.Code)
-	case <-time.After(2 * time.Second):
-		t.Fatalf("runViaPool never returned after Close")
-	}
-}
-
-func TestShModule_RealExecutor_EndToEnd(t *testing.T) {
-	t.Parallel()
-
-	module := &ShModule{
-		Pool:           plugins.NewWorkerPool(1),
-		DefaultTimeout: 5 * time.Second,
-		Logger:         zerolog.Nop(),
-	}
-
-	h := newLuaHarness(t, `
-return function(hive)
-  hive.test_capture(hive.sh.output("echo hello"))
-end
-`, module)
-
-	values := h.capture.Snapshot()
-	require.Len(t, values, 1)
-	assert.Equal(t, glua.LString("hello"), values[0])
-}
-
-func TestShRun_AsyncCallbackReceivesCode(t *testing.T) {
+func TestShRun_CallbackReceivesCode(t *testing.T) {
 	t.Parallel()
 
 	exec := &fakeExecutor{
@@ -384,7 +127,24 @@ end
 	assert.ElementsMatch(t, []int{0, 7}, codes)
 }
 
-func TestShOutput_AsyncSuccessPassesStdoutNilErr(t *testing.T) {
+func TestShRun_RequiresCallback(t *testing.T) {
+	t.Parallel()
+
+	h := newShHarness(t, `
+return function(hive)
+  local ok, err = pcall(hive.sh.run, "anything")
+  if ok then
+    error("expected hive.sh.run to require a callback")
+  end
+  hive.test_capture("err", tostring(err))
+end
+`, &fakeExecutor{}, 0)
+
+	got := h.capture.String("err")
+	assert.NotEmpty(t, got, "callback-missing pcall should have captured an err")
+}
+
+func TestShOutput_SuccessPassesStdoutNilErr(t *testing.T) {
 	t.Parallel()
 
 	exec := &fakeExecutor{
@@ -408,7 +168,7 @@ end
 	assert.Equal(t, glua.LNil, values[1])
 }
 
-func TestShOutput_AsyncFailurePassesNilStdoutAndErr(t *testing.T) {
+func TestShOutput_FailurePassesNilStdoutAndErr(t *testing.T) {
 	t.Parallel()
 
 	exec := &fakeExecutor{
@@ -435,7 +195,7 @@ end
 	assert.Contains(t, string(errStr), "boom")
 }
 
-func TestShExec_AsyncCallbackReceivesTable(t *testing.T) {
+func TestShExec_CallbackReceivesTable(t *testing.T) {
 	t.Parallel()
 
 	exec := &fakeExecutor{
@@ -463,7 +223,7 @@ end
 	assert.Equal(t, glua.LString("explained"), values[3])
 }
 
-func TestShExec_AsyncOptsThreaded(t *testing.T) {
+func TestShExec_OptsThreaded(t *testing.T) {
 	t.Parallel()
 
 	exec := &fakeExecutor{
@@ -486,6 +246,28 @@ end
 	assert.Equal(t, 1, calls)
 	assert.Equal(t, "/tmp", opts.Cwd)
 	assert.Equal(t, 5*time.Second, opts.Timeout)
+}
+
+func TestShExec_DefaultTimeoutAppliedWhenOptsOmitted(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeExecutor{
+		respond: func(_ context.Context, _ string, _ shOptions) shResult {
+			return shResult{Code: 0}
+		},
+	}
+
+	h := newShHarness(t, `
+return function(hive)
+  hive.sh.exec("anything", function(r) hive.test_capture(r.code) end)
+end
+`, exec, 11*time.Second)
+
+	_ = waitForCaptures(t, h.capture, 1)
+
+	_, opts, _, calls := exec.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 11*time.Second, opts.Timeout)
 }
 
 func TestShAsync_HandleCancelKillsSubprocess(t *testing.T) {
@@ -635,4 +417,28 @@ end
 	// Still exactly one capture; no panic in the dispatcher.
 	values = h.capture.Snapshot()
 	assert.Len(t, values, 1)
+}
+
+func TestShModule_RealExecutor_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	module := &ShModule{
+		Pool:           plugins.NewWorkerPool(1),
+		DefaultTimeout: 5 * time.Second,
+		Logger:         zerolog.Nop(),
+	}
+
+	h := newLuaHarness(t, `
+return function(hive)
+  hive.sh.output("echo hello", function(stdout, err)
+    hive.test_capture(stdout)
+    hive.test_capture(err)
+  end)
+end
+`, module)
+
+	values := waitForCaptures(t, h.capture, 2)
+	require.Len(t, values, 2)
+	assert.Equal(t, glua.LString("hello"), values[0])
+	assert.Equal(t, glua.LNil, values[1])
 }

--- a/internal/hive/plugins/lua/module_ticker.go
+++ b/internal/hive/plugins/lua/module_ticker.go
@@ -3,9 +3,6 @@ package lua
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -16,62 +13,25 @@ import (
 // Lua error rather than clamp silently.
 const tickerMinInterval = time.Second
 
-// tickerRegistryKeyPrefix namespaces the per-module sub-table in the Lua
-// registry. The instance pointer is appended so tests with multiple
-// modules on one LState don't stomp each other.
-const tickerRegistryKeyPrefix = "hive.ticker."
-
-// tickerHandleMetatableName keys the metatable shared by every handle.
-const tickerHandleMetatableName = "hive.ticker.handle"
-
 // TickerModule exposes hive.ticker.every and hive.ticker.after, returning
 // userdata handles with a :cancel() method. Ticker goroutines route
 // callbacks through Runtime.Submit; they never touch the LState directly.
 type TickerModule struct {
-	Runtime    *Runtime
-	PluginName string
-	Logger     zerolog.Logger
+	Runtime *Runtime
+	Logger  zerolog.Logger
 
-	// rootCtx fans out to every per-handle context; cancelling it during
-	// Close stops every running ticker.
-	rootCtx    context.Context
-	rootCancel context.CancelFunc
-
-	wg sync.WaitGroup
-
-	// nextID is also the per-handle registry sub-key, stringified.
-	nextID atomic.Uint64
-
-	mu      sync.Mutex
-	handles map[uint64]*tickerHandle
-
-	registryKey string
-}
-
-// tickerHandle is the Go-side state behind the userdata returned to Lua.
-// Cancel is idempotent; the per-handle ctx stops the goroutine and the
-// registry slot is released via Submit.
-type tickerHandle struct {
-	id     uint64
-	cancel context.CancelFunc
-	once   sync.Once
-	module *TickerModule
+	registry asyncRegistry
 }
 
 // Register attaches every/after to a fresh hive.ticker subtable and
-// creates this module's registry sub-table for pinning callback functions.
+// initialises the per-module async registry.
 func (m *TickerModule) Register(state *glua.LState, hive *glua.LTable) error {
-	m.handles = map[uint64]*tickerHandle{}
-	m.rootCtx, m.rootCancel = context.WithCancel(context.Background())
-	m.registryKey = fmt.Sprintf("%s%p", tickerRegistryKeyPrefix, m)
-
-	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
-	if !ok {
-		return fmt.Errorf("ticker module: lua registry is not a table")
+	if err := m.registry.init(state, m, asyncRegistryConfig{
+		KeyPrefix:     "hive.ticker.",
+		MetatableName: "hive.ticker.handle",
+	}); err != nil {
+		return fmt.Errorf("ticker module: %w", err)
 	}
-	state.SetField(registry, m.registryKey, state.NewTable())
-
-	m.ensureHandleMetatable(state)
 
 	ticker := state.NewTable()
 	state.SetField(ticker, "every", state.NewFunction(m.luaEvery))
@@ -82,29 +42,13 @@ func (m *TickerModule) Register(state *glua.LState, hive *glua.LTable) error {
 
 // Close stops every ticker goroutine and clears the handle map. Idempotent.
 func (m *TickerModule) Close() error {
-	if m.rootCancel != nil {
-		m.rootCancel()
-	}
-	m.wg.Wait()
-
-	m.mu.Lock()
-	m.handles = map[uint64]*tickerHandle{}
-	m.mu.Unlock()
+	m.registry.shutdown()
 	return nil
-}
-
-// ensureHandleMetatable installs the metatable shared by every handle.
-// One metatable per module means cancel allocates only once.
-func (m *TickerModule) ensureHandleMetatable(state *glua.LState) {
-	mt := state.NewTypeMetatable(tickerHandleMetatableName)
-	state.SetField(mt, "__index", state.SetFuncs(state.NewTable(), map[string]glua.LGFunction{
-		"cancel": m.luaCancel,
-	}))
 }
 
 func (m *TickerModule) luaEvery(state *glua.LState) int {
 	d, fn := m.checkArgs(state)
-	handle := m.spawn(state, fn, func(ctx context.Context, h *tickerHandle) {
+	handle := m.spawn(state, fn, func(ctx context.Context, h *asyncHandle) {
 		t := time.NewTicker(d)
 		defer t.Stop()
 		for {
@@ -116,7 +60,8 @@ func (m *TickerModule) luaEvery(state *glua.LState) int {
 			}
 		}
 	})
-	state.Push(m.newHandleUserData(state, handle))
+	m.Logger.Debug().Uint64("handle", handle.id).Str("kind", "every").Dur("interval", d).Msg("hive.ticker: handle registered")
+	state.Push(m.registry.handleUserData(state, handle))
 	return 1
 }
 
@@ -124,7 +69,7 @@ func (m *TickerModule) luaEvery(state *glua.LState) int {
 // and map entry without an explicit cancel from the plugin.
 func (m *TickerModule) luaAfter(state *glua.LState) int {
 	d, fn := m.checkArgs(state)
-	handle := m.spawn(state, fn, func(ctx context.Context, h *tickerHandle) {
+	handle := m.spawn(state, fn, func(ctx context.Context, h *asyncHandle) {
 		t := time.NewTimer(d)
 		defer t.Stop()
 		select {
@@ -135,20 +80,9 @@ func (m *TickerModule) luaAfter(state *glua.LState) int {
 			h.Cancel()
 		}
 	})
-	state.Push(m.newHandleUserData(state, handle))
+	m.Logger.Debug().Uint64("handle", handle.id).Str("kind", "after").Dur("delay", d).Msg("hive.ticker: handle registered")
+	state.Push(m.registry.handleUserData(state, handle))
 	return 1
-}
-
-// luaCancel is the __index method bound to handle userdata.
-func (m *TickerModule) luaCancel(state *glua.LState) int {
-	ud := state.CheckUserData(1)
-	handle, ok := ud.Value.(*tickerHandle)
-	if !ok {
-		state.ArgError(1, "expected ticker handle")
-		return 0
-	}
-	handle.Cancel()
-	return 0
 }
 
 // checkArgs parses (duration, fn). On bad input it raises a Lua error,
@@ -168,30 +102,19 @@ func (m *TickerModule) checkArgs(state *glua.LState) (time.Duration, *glua.LFunc
 }
 
 // spawn pins fn, allocates a handle, and starts run on a goroutine.
-// Runs on the dispatcher; the mutex guards against goroutine-side
-// Cancel via the after-fire path.
-func (m *TickerModule) spawn(state *glua.LState, fn *glua.LFunction, run func(context.Context, *tickerHandle)) *tickerHandle {
-	id := m.nextID.Add(1)
-	ctx, cancel := context.WithCancel(m.rootCtx)
-	h := &tickerHandle{id: id, cancel: cancel, module: m}
-
-	m.storeFunction(state, id, fn)
-
-	m.mu.Lock()
-	m.handles[id] = h
-	m.mu.Unlock()
-
-	m.wg.Go(func() {
-		run(ctx, h)
-	})
+// Runs on the dispatcher.
+func (m *TickerModule) spawn(state *glua.LState, fn *glua.LFunction, run func(context.Context, *asyncHandle)) *asyncHandle {
+	id, ctx := m.registry.allocate(state, fn)
+	h := m.registry.newHandle(id, m.Runtime)
+	m.registry.Go(func() { run(ctx, h) })
 	return h
 }
 
 // fire hops from a ticker goroutine onto the dispatcher to run the
 // callback. If the runtime is closed, Submit drops the work.
-func (m *TickerModule) fire(h *tickerHandle) {
+func (m *TickerModule) fire(h *asyncHandle) {
 	m.Runtime.Submit(func(state *glua.LState) {
-		fn := m.loadFunction(state, h.id)
+		fn := m.registry.loadFunction(state, h.id)
 		if fn == nil {
 			// Cancelled between fire and dispatch.
 			return
@@ -207,80 +130,4 @@ func (m *TickerModule) fire(h *tickerHandle) {
 				Msg("ticker callback returned error")
 		}
 	})
-}
-
-// Cancel stops the goroutine, removes the map entry, and releases the
-// registry slot via Submit. Idempotent and safe from any goroutine.
-func (h *tickerHandle) Cancel() {
-	h.once.Do(func() {
-		h.cancel()
-
-		h.module.mu.Lock()
-		delete(h.module.handles, h.id)
-		h.module.mu.Unlock()
-
-		id := h.id
-		mod := h.module
-		mod.Runtime.Submit(func(state *glua.LState) {
-			mod.releaseFunction(state, id)
-		})
-	})
-}
-
-// newHandleUserData wraps a handle in *LUserData with the shared metatable.
-// Must run on the dispatcher.
-func (m *TickerModule) newHandleUserData(state *glua.LState, h *tickerHandle) *glua.LUserData {
-	ud := state.NewUserData()
-	ud.Value = h
-	state.SetMetatable(ud, state.GetTypeMetatable(tickerHandleMetatableName))
-	return ud
-}
-
-// storeFunction pins fn so Lua cannot GC it while the goroutine holds
-// a reference. Must run on the dispatcher.
-func (m *TickerModule) storeFunction(state *glua.LState, id uint64, fn *glua.LFunction) {
-	table := m.registryTable(state)
-	if table == nil {
-		return
-	}
-	state.SetField(table, strconv.FormatUint(id, 10), fn)
-}
-
-// loadFunction returns the pinned function for a handle, or nil if
-// already released. Cancel and load both run on the dispatcher.
-func (m *TickerModule) loadFunction(state *glua.LState, id uint64) *glua.LFunction {
-	table := m.registryTable(state)
-	if table == nil {
-		return nil
-	}
-	value := state.GetField(table, strconv.FormatUint(id, 10))
-	fn, ok := value.(*glua.LFunction)
-	if !ok {
-		return nil
-	}
-	return fn
-}
-
-// releaseFunction drops the registry pin so Lua can GC the LFunction.
-// Must run on the dispatcher.
-func (m *TickerModule) releaseFunction(state *glua.LState, id uint64) {
-	table := m.registryTable(state)
-	if table == nil {
-		return
-	}
-	state.SetField(table, strconv.FormatUint(id, 10), glua.LNil)
-}
-
-// registryTable returns this module's pinning sub-table, or nil if
-// Register has not run.
-func (m *TickerModule) registryTable(state *glua.LState) *glua.LTable {
-	registry, ok := state.Get(glua.RegistryIndex).(*glua.LTable)
-	if !ok {
-		return nil
-	}
-	table, ok := state.GetField(registry, m.registryKey).(*glua.LTable)
-	if !ok {
-		return nil
-	}
-	return table
 }

--- a/internal/hive/plugins/lua/module_ticker_test.go
+++ b/internal/hive/plugins/lua/module_ticker_test.go
@@ -1,10 +1,7 @@
 package lua
 
 import (
-	"os"
-	"path/filepath"
 	"runtime"
-	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -12,69 +9,22 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	glua "github.com/yuin/gopher-lua"
 )
 
-// bumpModule exposes hive.test_bump() so tests can count Lua-side fires.
-type bumpModule struct {
-	counter *atomic.Int64
-}
-
-func (b *bumpModule) Register(state *glua.LState, hive *glua.LTable) error {
-	state.SetField(hive, "test_bump", state.NewFunction(func(state *glua.LState) int {
-		b.counter.Add(1)
-		return 0
-	}))
-	return nil
-}
-
-// tickerHarness wires a Runtime + TickerModule + bumpModule and runs the
-// supplied Lua script as the entrypoint. counter bumps on every fire.
+// tickerHarness wraps luaHarness with a TickerModule reference so tests can
+// reach the module for explicit shutdown ordering.
 type tickerHarness struct {
-	runtime *Runtime
-	module  *TickerModule
-	counter *atomic.Int64
+	*luaHarness
+	module *TickerModule
 }
 
 func newTickerHarness(t *testing.T, script string) *tickerHarness {
 	t.Helper()
-
-	root := t.TempDir()
-	entry := filepath.Join(root, "init.lua")
-	require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
-
-	counter := &atomic.Int64{}
-	tickerModule := &TickerModule{PluginName: "lua-test", Logger: zerolog.Nop()}
-	bump := &bumpModule{counter: counter}
-
-	rt, err := NewRuntime(
-		root,
-		zerolog.Nop(),
-		&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-		&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
-		tickerModule,
-		bump,
-	)
-	require.NoError(t, err)
-	tickerModule.Runtime = rt
-
-	fn, err := rt.LoadEntrypoint(entry)
-	require.NoError(t, err)
-	require.NoError(t, rt.CallEntrypoint(fn))
-
-	return &tickerHarness{runtime: rt, module: tickerModule, counter: counter}
-}
-
-func (h *tickerHarness) Close() {
-	// Mirror Plugin.shutdown: module before runtime.
-	_ = h.module.Close()
-	h.runtime.Close()
-}
-
-func (h *tickerHarness) closeWithCleanup(t *testing.T) {
-	t.Helper()
-	t.Cleanup(h.Close)
+	module := &TickerModule{Logger: zerolog.Nop()}
+	return &tickerHarness{
+		luaHarness: newLuaHarness(t, script, module),
+		module:     module,
+	}
 }
 
 func TestTickerEveryFiresRepeatedly(t *testing.T) {
@@ -85,13 +35,12 @@ return function(hive)
   hive.ticker.every("1s", function() hive.test_bump() end)
 end
 `)
-		h.closeWithCleanup(t)
 
 		// 2.5s of virtual time fires the 1s ticker exactly twice.
 		time.Sleep(2500 * time.Millisecond)
 		synctest.Wait()
 
-		assert.Equal(t, int64(2), h.counter.Load())
+		assert.Equal(t, int64(2), h.capture.Counter())
 	})
 }
 
@@ -103,12 +52,11 @@ return function(hive)
   hive.ticker.after("1s", function() hive.test_bump() end)
 end
 `)
-		h.closeWithCleanup(t)
 
 		time.Sleep(2500 * time.Millisecond)
 		synctest.Wait()
 
-		assert.Equal(t, int64(1), h.counter.Load())
+		assert.Equal(t, int64(1), h.capture.Counter())
 	})
 }
 
@@ -125,13 +73,12 @@ return function(hive)
   end)
 end
 `)
-		h.closeWithCleanup(t)
 
 		// 3s covers several would-be ticks if cancel were missed.
 		time.Sleep(3 * time.Second)
 		synctest.Wait()
 
-		assert.Equal(t, int64(1), h.counter.Load())
+		assert.Equal(t, int64(1), h.capture.Counter())
 	})
 }
 
@@ -146,12 +93,11 @@ return function(hive)
   end)
 end
 `)
-		h.closeWithCleanup(t)
 
 		time.Sleep(2500 * time.Millisecond)
 		synctest.Wait()
 
-		assert.Equal(t, int64(2), h.counter.Load())
+		assert.Equal(t, int64(2), h.capture.Counter())
 	})
 }
 
@@ -171,7 +117,7 @@ end
 
 		time.Sleep(1200 * time.Millisecond)
 		synctest.Wait()
-		require.Positive(t, h.counter.Load(), "tickers should have fired before close")
+		require.Positive(t, h.capture.Counter(), "tickers should have fired before close")
 
 		h.Close()
 		synctest.Wait()
@@ -188,9 +134,7 @@ func TestTickerEveryRejectsSubSecondDuration(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// The entrypoint asserts via pcall that the call errored with the
 		// expected message; the counter stays zero since no ticker registers.
-		root := t.TempDir()
-		entry := filepath.Join(root, "init.lua")
-		script := `
+		h := newTickerHarness(t, `
 return function(hive)
   local ok, err = pcall(hive.ticker.every, "500ms", function() hive.test_bump() end)
   if ok then
@@ -200,33 +144,10 @@ return function(hive)
     error("unexpected error: " .. tostring(err))
   end
 end
-`
-		require.NoError(t, os.WriteFile(entry, []byte(script), 0o644))
-
-		counter := &atomic.Int64{}
-		tickerModule := &TickerModule{PluginName: "lua-test", Logger: zerolog.Nop()}
-		rt, err := NewRuntime(
-			root,
-			zerolog.Nop(),
-			&LogModule{PluginName: "lua-test", Logger: zerolog.Nop()},
-			&PluginInfoModule{Name: "lua-test", Entry: entry, ModuleRoot: root},
-			&CommandsModule{},
-			tickerModule,
-			&bumpModule{counter: counter},
-		)
-		require.NoError(t, err)
-		tickerModule.Runtime = rt
-		t.Cleanup(func() {
-			_ = tickerModule.Close()
-			rt.Close()
-		})
-
-		fn, err := rt.LoadEntrypoint(entry)
-		require.NoError(t, err)
-		require.NoError(t, rt.CallEntrypoint(fn))
+`)
 
 		time.Sleep(1200 * time.Millisecond)
 		synctest.Wait()
-		assert.Equal(t, int64(0), counter.Load(), "no ticker should have been registered")
+		assert.Equal(t, int64(0), h.capture.Counter(), "no ticker should have been registered")
 	})
 }

--- a/internal/hive/plugins/lua/modules.go
+++ b/internal/hive/plugins/lua/modules.go
@@ -18,3 +18,52 @@ type HostModule interface {
 type HostModuleCloser interface {
 	Close() error
 }
+
+// Error-reporting convention for host modules
+//
+// HostModule code surfaces failures back to Lua via three distinct
+// mechanisms, each appropriate for a different situation. The choice
+// drives how the error appears to the plugin author.
+//
+//  1. state.ArgError(idx, msg) — the Lua argument at position idx is
+//     the wrong type, shape, or value. The Lua runtime frames the
+//     message as "bad argument #N to 'fn' (msg)". Use during argument
+//     parsing and after CheckString/CheckTable type assertions.
+//
+//  2. state.RaiseError("hive.<module>.<fn>: %s", err) — an operation
+//     failed at runtime after argument parsing succeeded (e.g. JSON
+//     decode hit invalid input, a kv store write returned an error, a
+//     synchronous shell command exited non-zero). The "hive.<module>.<fn>"
+//     prefix identifies the source so plugin authors can locate the
+//     failure without traversing a stack trace.
+//
+//  3. Two-return (nil, errstr) — the call has already returned past the
+//     synchronous Lua boundary (the error surfaces in a callback) and
+//     RaiseError is therefore impossible. The async form of
+//     hive.sh.output is the only current case: it cannot raise on
+//     non-zero exit because the callback fires after the original call
+//     has returned.
+//
+// Module-specific errors raised by case (2) should always include the
+// "hive.<module>.<fn>" prefix; case (1) messages are framed by the
+// runtime and do not need a prefix.
+//
+// Logging convention for host modules
+//
+// Modules that emit logs take a Logger field set by Plugin.Init via
+// p.logger.With().Str("module", "<name>").Logger(). Tests use
+// zerolog.Nop(). The level guidance is:
+//
+//   - Debug — normal lifecycle events (operation started, finished).
+//     High-volume; off by default in production.
+//   - Warn  — unexpected failures the plugin author may not see, such
+//     as a store error that the plugin pcall'd, or an error returned
+//     from a Lua callback that the dispatcher swallowed.
+//   - Error — reserved for failures the operator must investigate;
+//     currently unused inside host modules.
+//
+// Errors that are raised back to Lua via case (2) above are *also*
+// logged at Warn when they come from out-of-band failures (KV store
+// write, executor error). Errors that originate from the plugin's own
+// input (JSON decode of malformed text, command-table type errors) are
+// visible to the plugin author and not logged separately.

--- a/internal/hive/plugins/lua/modules.go
+++ b/internal/hive/plugins/lua/modules.go
@@ -32,17 +32,15 @@ type HostModuleCloser interface {
 //
 //  2. state.RaiseError("hive.<module>.<fn>: %s", err) — an operation
 //     failed at runtime after argument parsing succeeded (e.g. JSON
-//     decode hit invalid input, a kv store write returned an error, a
-//     synchronous shell command exited non-zero). The "hive.<module>.<fn>"
-//     prefix identifies the source so plugin authors can locate the
-//     failure without traversing a stack trace.
+//     decode hit invalid input, a kv store write returned an error).
+//     The "hive.<module>.<fn>" prefix identifies the source so plugin
+//     authors can locate the failure without traversing a stack trace.
 //
-//  3. Two-return (nil, errstr) — the call has already returned past the
-//     synchronous Lua boundary (the error surfaces in a callback) and
-//     RaiseError is therefore impossible. The async form of
-//     hive.sh.output is the only current case: it cannot raise on
-//     non-zero exit because the callback fires after the original call
-//     has returned.
+//  3. Callback (..., errstr) — the call has already returned past the
+//     synchronous Lua boundary, so RaiseError is impossible: the error
+//     surfaces inside the callback as a trailing argument. hive.sh.output
+//     uses this convention, passing (stdout, err) where err is nil on
+//     success and a string describing the failure on non-zero exit.
 //
 // Module-specific errors raised by case (2) should always include the
 // "hive.<module>.<fn>" prefix; case (1) messages are framed by the

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -36,13 +36,20 @@ func New(cfg config.LuaPluginConfig, kvStore kv.KV, pool *plugins.WorkerPool, lo
 	return &Plugin{cfg: cfg, kvStore: kvStore, pool: pool, logger: logger}
 }
 
+// Name returns the plugin identifier used in logs and the kv namespace.
 func (p *Plugin) Name() string { return pluginName }
 
+// Available reports whether the configured Lua entry file exists. Used by
+// the Hive plugin manager to skip plugins that aren't installed.
 func (p *Plugin) Available() bool {
 	info, err := os.Stat(p.cfg.ResolvedEntry())
 	return err == nil && !info.IsDir()
 }
 
+// Init builds the Lua runtime, loads the entrypoint, and runs it once
+// to register commands and other plugin state. Re-initialisation is
+// supported: any prior runtime is shut down first so commands from a
+// previous Init can't leak into MergedCommands.
 func (p *Plugin) Init(_ context.Context) error {
 	p.shutdown()
 
@@ -52,12 +59,10 @@ func (p *Plugin) Init(_ context.Context) error {
 	cmdModule := &CommandsModule{}
 
 	tickerModule := &TickerModule{
-		PluginName: p.Name(),
-		Logger:     p.logger.With().Str("module", "ticker").Logger(),
+		Logger: p.logger.With().Str("module", "ticker").Logger(),
 	}
 
 	shModule := &ShModule{
-		PluginName:     p.Name(),
 		Pool:           p.pool,
 		DefaultTimeout: cmp.Or(p.cfg.ShellTimeout, 30*time.Second),
 		Logger:         p.logger.With().Str("module", "sh").Logger(),
@@ -73,7 +78,10 @@ func (p *Plugin) Init(_ context.Context) error {
 		cmdModule,
 		tickerModule,
 		&JSONModule{},
-		&KVModule{Store: kv.Scoped[string](p.kvStore, p.Name())},
+		&KVModule{
+			Store:  kv.Scoped[string](p.kvStore, p.Name()),
+			Logger: p.logger.With().Str("module", "kv").Logger(),
+		},
 		shModule,
 	}
 
@@ -83,6 +91,7 @@ func (p *Plugin) Init(_ context.Context) error {
 	}
 	// Wired post-construction; Register makes no Runtime calls.
 	tickerModule.Runtime = runtime
+	shModule.Runtime = runtime
 
 	// Stash now so an entrypoint failure below cleans up via shutdown().
 	p.runtime = runtime
@@ -103,6 +112,8 @@ func (p *Plugin) Init(_ context.Context) error {
 	return nil
 }
 
+// Close releases the Lua runtime and any resources its host modules hold.
+// Safe to call multiple times; safe on a partially-initialised plugin.
 func (p *Plugin) Close() error {
 	p.shutdown()
 	return nil
@@ -132,10 +143,14 @@ func (p *Plugin) shutdown() {
 	p.commands = nil
 }
 
+// Commands returns the user commands registered by the plugin's
+// entrypoint. Returns nil if Init has not run or if it failed.
 func (p *Plugin) Commands() map[string]config.UserCommand {
 	return p.commands
 }
 
+// StatusProvider returns nil because Lua plugins don't expose a status
+// provider yet. Reserved for a future hook.
 func (p *Plugin) StatusProvider() plugins.StatusProvider {
 	return nil
 }

--- a/test/integration/lua_plugin_sh_test.go
+++ b/test/integration/lua_plugin_sh_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,9 +15,9 @@ import (
 
 // TestLuaPluginShModule_RunOutputExec verifies that hive.sh.{run,output,exec}
 // are wired through the Lua runtime end-to-end. The plugin's entrypoint runs
-// during plugin init (any hive command triggers it); each function records
-// its result via a final hive.sh.run that writes a single summary file the
-// test reads back.
+// during plugin init (any hive command triggers it); each function's
+// callback records its result, and the final callback writes a summary
+// file the test reads back.
 func TestLuaPluginShModule_RunOutputExec(t *testing.T) {
 	h := NewHarness(t)
 
@@ -33,23 +32,25 @@ local OUT = %q
 local CWD = %q
 
 return function(hive)
-  -- run: returns exit code only, never raises
-  local runOK   = hive.sh.run("true")
-  local runFail = hive.sh.run("false")
-
-  -- output: captures stdout, strips trailing newline
-  local out = hive.sh.output("printf 'hello-output\n'")
-
-  -- exec: full struct with cwd option (trim trailing newline so it slots
-  -- cleanly into the summary line)
-  local r = hive.sh.exec("pwd", { cwd = CWD })
-  local pwd = r.stdout:gsub("\n$", "")
-
-  local summary = string.format(
-    "run_ok=%%d|run_fail=%%d|output=%%s|exec_pwd=%%s|exec_code=%%d",
-    runOK, runFail, out, pwd, r.code
-  )
-  hive.sh.run("printf %%s '" .. summary .. "' > " .. OUT)
+  -- Chain the calls through nested callbacks so the test sees a single
+  -- summary line even though every hive.sh.* call is async.
+  hive.sh.run("true", function(runOK)
+    hive.sh.run("false", function(runFail)
+      hive.sh.output("printf 'hello-output\n'", function(out, err)
+        if err ~= nil then
+          error("output unexpectedly failed: " .. tostring(err))
+        end
+        hive.sh.exec("pwd", { cwd = CWD }, function(r)
+          local pwd = r.stdout:gsub("\n$", "")
+          local summary = string.format(
+            "run_ok=%%d|run_fail=%%d|output=%%s|exec_pwd=%%s|exec_code=%%d",
+            runOK, runFail, out, pwd, r.code
+          )
+          hive.sh.run("printf %%s '" .. summary .. "' > " .. OUT, function(_) end)
+        end)
+      end)
+    end)
+  end)
 end
 `, outputFile, cwdMarker)), 0o644))
 
@@ -60,6 +61,8 @@ plugins:
 `, entry))
 
 	// Any subcommand triggers plugin init, which runs the entrypoint.
+	// Plugin shutdown drains in-flight async work, so the callbacks all
+	// run before `hive config` returns.
 	_, err := h.RunStdout("config")
 	require.NoError(t, err)
 
@@ -79,89 +82,27 @@ plugins:
 	assert.Contains(t, got, "exec_code=0", "hive.sh.exec should report exit code 0")
 }
 
-// TestLuaPluginShModule_OutputRaisesOnNonZero verifies that hive.sh.output
-// raises a Lua error for non-zero exits, and that the error is logged when
-// it propagates out of the entrypoint without crashing hive.
-func TestLuaPluginShModule_OutputRaisesOnNonZero(t *testing.T) {
+// TestLuaPluginShModule_OutputErrOnNonZero verifies that hive.sh.output
+// passes a non-nil err string to its callback for non-zero exits, and
+// that the err string mentions the exit code and stderr.
+func TestLuaPluginShModule_OutputErrOnNonZero(t *testing.T) {
 	h := NewHarness(t)
 
-	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
-	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
-	require.NoError(t, os.WriteFile(entry, []byte(`
-return function(hive)
-  hive.sh.output("sh -c 'echo boom 1>&2; exit 1'")
-end
-`), 0o644))
-
-	h.WithConfig(fmt.Sprintf(`
-plugins:
-  lua:
-    entry: %q
-`, entry))
-
-	// hive should still run even though the lua plugin's entrypoint errored.
-	_, err := h.RunStdout("config")
-	require.NoError(t, err)
-
-	logContent, err := os.ReadFile(filepath.Join(h.DataDir(), "hive.log"))
-	require.NoError(t, err)
-	logStr := string(logContent)
-	assert.Contains(t, logStr, "plugin initialization failed")
-	assert.Contains(t, logStr, "hive.sh.output")
-	assert.Contains(t, logStr, "exit 1")
-}
-
-// TestLuaPluginShModule_AsyncDoesNotBlockTicker verifies that the async form
-// of hive.sh.run returns immediately and does not block the Lua dispatcher.
-//
-// The original plan called for a ticker.every fire-pattern across multiple
-// seconds, but `hive config` tears the plugin down immediately after init,
-// so we instead prove the property within a single entrypoint: launching a
-// long async sleep MUST NOT delay the synchronous work that follows.
-//
-// We can't time the property from the host side: hive's plugin shutdown
-// drains in-flight async work, so the total `hive config` wall time always
-// includes the residual sleep. Instead the entrypoint stamps "start" and
-// "done" marker files around the sync block. The mtime delta between the
-// two markers is the entrypoint wall time, isolated from shutdown drain.
-// With async dispatching correctly, that delta is ~2s (only the two 1s
-// sync sleeps). If async incorrectly blocked the dispatcher, the delta
-// would jump to ~7s (the 5s blocking sleep plus the two 1s sync sleeps).
-func TestLuaPluginShModule_AsyncDoesNotBlockTicker(t *testing.T) {
-	h := NewHarness(t)
-
-	counter := filepath.Join(h.DataDir(), "counter.txt")
-	startMarker := filepath.Join(h.DataDir(), "start.marker")
-	doneMarker := filepath.Join(h.DataDir(), "done.marker")
+	outputFile := filepath.Join(h.DataDir(), "sh-output.txt")
 
 	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
 	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
 	require.NoError(t, os.WriteFile(entry, []byte(fmt.Sprintf(`
-local COUNTER = %q
-local START   = %q
-local DONE    = %q
+local OUT = %q
 
 return function(hive)
-  -- Stamp the start marker just before kicking off the async work so the
-  -- mtime delta between START and DONE captures only the entrypoint's
-  -- wall time, not hive's startup/shutdown overhead.
-  hive.sh.run("touch " .. START)
-
-  -- Async: kicks off a 5s sleep. If async-doesn't-block-the-dispatcher
-  -- holds, this returns immediately and the rest of the entrypoint runs
-  -- in ~2s wall time. The async subprocess is cancelled when the plugin
-  -- shuts down at the end of the hive command.
-  hive.sh.run("sleep 5", function(_) end)
-
-  hive.sh.run("printf 'tick1\n' >> " .. COUNTER)
-  hive.sh.run("sleep 1")
-  hive.sh.run("printf 'tick2\n' >> " .. COUNTER)
-  hive.sh.run("sleep 1")
-  hive.sh.run("printf 'tick3\n' >> " .. COUNTER)
-
-  hive.sh.run("touch " .. DONE)
+  hive.sh.output("sh -c 'echo boom 1>&2; exit 1'", function(stdout, err)
+    -- stdout should be nil on failure; err carries the message.
+    local got = "stdout=" .. tostring(stdout) .. "|err=" .. tostring(err)
+    hive.sh.run("printf %%s '" .. got .. "' > " .. OUT, function(_) end)
+  end)
 end
-`, counter, startMarker, doneMarker)), 0o644))
+`, outputFile)), 0o644))
 
 	h.WithConfig(fmt.Sprintf(`
 plugins:
@@ -172,28 +113,10 @@ plugins:
 	_, err := h.RunStdout("config")
 	require.NoError(t, err)
 
-	// Counter should hold three ticks in order, proving the sync sleeps
-	// and writes ran sequentially after the async launch.
-	content, err := os.ReadFile(counter)
+	content, err := os.ReadFile(outputFile)
 	require.NoError(t, err)
-	lines := strings.Split(strings.TrimRight(string(content), "\n"), "\n")
-	assert.Equal(t, []string{"tick1", "tick2", "tick3"}, lines,
-		"counter should record three ticks in order; got %q", string(content))
-
-	startInfo, err := os.Stat(startMarker)
-	require.NoError(t, err, "start marker should exist")
-	doneInfo, err := os.Stat(doneMarker)
-	require.NoError(t, err, "done marker should exist")
-
-	entrypointDelta := doneInfo.ModTime().Sub(startInfo.ModTime())
-	t.Logf("entrypoint wall time (start->done marker delta): %s", entrypointDelta)
-
-	// Sync work alone is ~2s; the entrypoint should fit comfortably under
-	// 4s if async did not block the dispatcher. If async incorrectly
-	// blocked, the delta would also include the 5s sleep, pushing it past
-	// 7s. 4s leaves generous margin for filesystem mtime granularity and
-	// CI noise.
-	assert.Less(t, entrypointDelta, 4*time.Second,
-		"entrypoint took %s between start and done markers — async hive.sh.run appears to block the dispatcher",
-		entrypointDelta)
+	got := string(content)
+	assert.Contains(t, got, "stdout=nil", "non-zero exit should pass nil stdout to the callback")
+	assert.Contains(t, got, "exit 1", "err string should mention the exit code")
+	assert.Contains(t, got, "boom", "err string should include stderr")
 }

--- a/test/integration/lua_plugin_sh_test.go
+++ b/test/integration/lua_plugin_sh_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,4 +109,91 @@ plugins:
 	assert.Contains(t, logStr, "plugin initialization failed")
 	assert.Contains(t, logStr, "hive.sh.output")
 	assert.Contains(t, logStr, "exit 1")
+}
+
+// TestLuaPluginShModule_AsyncDoesNotBlockTicker verifies that the async form
+// of hive.sh.run returns immediately and does not block the Lua dispatcher.
+//
+// The original plan called for a ticker.every fire-pattern across multiple
+// seconds, but `hive config` tears the plugin down immediately after init,
+// so we instead prove the property within a single entrypoint: launching a
+// long async sleep MUST NOT delay the synchronous work that follows.
+//
+// We can't time the property from the host side: hive's plugin shutdown
+// drains in-flight async work, so the total `hive config` wall time always
+// includes the residual sleep. Instead the entrypoint stamps "start" and
+// "done" marker files around the sync block. The mtime delta between the
+// two markers is the entrypoint wall time, isolated from shutdown drain.
+// With async dispatching correctly, that delta is ~2s (only the two 1s
+// sync sleeps). If async incorrectly blocked the dispatcher, the delta
+// would jump to ~7s (the 5s blocking sleep plus the two 1s sync sleeps).
+func TestLuaPluginShModule_AsyncDoesNotBlockTicker(t *testing.T) {
+	h := NewHarness(t)
+
+	counter := filepath.Join(h.DataDir(), "counter.txt")
+	startMarker := filepath.Join(h.DataDir(), "start.marker")
+	doneMarker := filepath.Join(h.DataDir(), "done.marker")
+
+	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
+	require.NoError(t, os.WriteFile(entry, []byte(fmt.Sprintf(`
+local COUNTER = %q
+local START   = %q
+local DONE    = %q
+
+return function(hive)
+  -- Stamp the start marker just before kicking off the async work so the
+  -- mtime delta between START and DONE captures only the entrypoint's
+  -- wall time, not hive's startup/shutdown overhead.
+  hive.sh.run("touch " .. START)
+
+  -- Async: kicks off a 5s sleep. If async-doesn't-block-the-dispatcher
+  -- holds, this returns immediately and the rest of the entrypoint runs
+  -- in ~2s wall time. The async subprocess is cancelled when the plugin
+  -- shuts down at the end of the hive command.
+  hive.sh.run("sleep 5", function(_) end)
+
+  hive.sh.run("printf 'tick1\n' >> " .. COUNTER)
+  hive.sh.run("sleep 1")
+  hive.sh.run("printf 'tick2\n' >> " .. COUNTER)
+  hive.sh.run("sleep 1")
+  hive.sh.run("printf 'tick3\n' >> " .. COUNTER)
+
+  hive.sh.run("touch " .. DONE)
+end
+`, counter, startMarker, doneMarker)), 0o644))
+
+	h.WithConfig(fmt.Sprintf(`
+plugins:
+  lua:
+    entry: %q
+`, entry))
+
+	_, err := h.RunStdout("config")
+	require.NoError(t, err)
+
+	// Counter should hold three ticks in order, proving the sync sleeps
+	// and writes ran sequentially after the async launch.
+	content, err := os.ReadFile(counter)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimRight(string(content), "\n"), "\n")
+	assert.Equal(t, []string{"tick1", "tick2", "tick3"}, lines,
+		"counter should record three ticks in order; got %q", string(content))
+
+	startInfo, err := os.Stat(startMarker)
+	require.NoError(t, err, "start marker should exist")
+	doneInfo, err := os.Stat(doneMarker)
+	require.NoError(t, err, "done marker should exist")
+
+	entrypointDelta := doneInfo.ModTime().Sub(startInfo.ModTime())
+	t.Logf("entrypoint wall time (start->done marker delta): %s", entrypointDelta)
+
+	// Sync work alone is ~2s; the entrypoint should fit comfortably under
+	// 4s if async did not block the dispatcher. If async incorrectly
+	// blocked, the delta would also include the 5s sleep, pushing it past
+	// 7s. 4s leaves generous margin for filesystem mtime granularity and
+	// CI noise.
+	assert.Less(t, entrypointDelta, 4*time.Second,
+		"entrypoint took %s between start and done markers — async hive.sh.run appears to block the dispatcher",
+		entrypointDelta)
 }


### PR DESCRIPTION
## Summary

Architectural cleanup of `internal/hive/plugins/lua/` plus the bundled async form of `hive.sh.*`. Bundled because the cleanup includes extracting an async-handle registry that's only meaningful once a second async module exists, and the async-sh work was the natural pair.

## Cleanup

- **Test harness consolidation** — replaces five per-module harnesses (`newJSONHarness`/`newKVHarness`/`newTickerHarness`/`newShHarness` + a bespoke captureModule for sh) with one `newLuaHarness` + unified `captureModule` (`helpers_test.go`).
- **Lua↔Go conversion helpers** — promotes `goToLua`/`luaToGo` from `JSONModule` into `lua_convert.go` so future modules can use them. `arrayMarker` is now an explicit parameter; callers without an array-tagging concept pass `nil`. Direct unit tests live in `lua_convert_test.go`.
- **Async-handle registry extraction** — lifts the duplicated scaffolding (registry sub-table, handle map, root-context fan-out, metatable, cancel) shared by ticker and sh into `asyncRegistry` (`async_registry.go`). Both modules now embed one and use `Go`/`allocate`/`loadFunction`/`release`/`stop` for per-handle work. `asyncHandle` is the single shared type.
- **Field-reader precondition** — collapses the four `lua*Field` preludes (RawGetString, reject LTFunction, type-assert) into `luaCommandField`.
- **Error convention** — documents when to use `ArgError` vs `RaiseError` vs the two-return form in `modules.go`; standardises the `hive.<module>.<fn>:` prefix on KV and Commands errors.
- **Logging convention** — documents per-module log levels in `modules.go`; `KVModule` gains a `Logger` and now logs Warn on store errors so operators see them even when the plugin `pcall`s the call. ShModule's sync/async start/finish/cancel logging is deduped through `execWithLogging` + `log{Start,Finish,PoolCancelled}`.
- **Dead code + godoc** — drops unused `PluginName` fields on Ticker/ShModule (only LogModule actually uses its name); backfills godoc on `Plugin`'s exported methods and the bare module `Register` methods.

## Async hive.sh

- `hive.sh.{run,output,exec}` accept a trailing function callback that switches the call to async mode: returns a handle immediately, runs the subprocess on a goroutine bound to a per-handle context, fires the callback on the dispatcher when finished.
- `handle:cancel()` kills the in-flight subprocess and suppresses the pending callback. Plugin shutdown cancels every in-flight async call.
- Async output uses a `(stdout, err)` callback shape because it cannot raise from the post-return callback; sync output still raises on non-zero exit.
- Documented in `docs/configuration/plugins.md`; integration coverage in `test/integration/lua_plugin_sh_test.go`.

## Test plan

- [x] `go test -count=1 -race ./internal/hive/plugins/lua/...` passes
- [x] `golangci-lint run ./internal/hive/plugins/lua/...` is clean
- [x] `go build -tags integration ./test/integration/...` compiles
- [ ] CI green