### PR TITLE
feat(lua): hive.http client for outbound HTTP requests

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -329,6 +329,74 @@ plugins:
     shell_timeout: 30s   # per-call timeout for hive.sh.* (default: 30s)
 ```
 
+### hive.http
+
+Make outbound HTTP requests from Lua. Like `hive.sh`, every call is async: the call returns a handle immediately and the supplied callback fires on the dispatcher when the response (or error) is in. The callback is **required** — calling without one raises a Lua error.
+
+| Function | Notes |
+| -------- | ----- |
+| `hive.http.get(url[, opts], fn)` | GET request. `opts` is optional. |
+| `hive.http.post(url[, opts], fn)` | POST request. Pass `opts.body` as a string (use `hive.json.encode` for JSON). |
+| `hive.http.put(url[, opts], fn)` | PUT request. |
+| `hive.http.delete(url[, opts], fn)` | DELETE request. |
+| `hive.http.request(opts, fn)` | Full control. `opts.method` defaults to `"GET"`; `opts.url` is required. |
+
+Callback signature: `fn(response, err)`.
+
+- On success, `response` is `{ status, body, headers }` and `err` is `nil`. Non-2xx HTTP responses are still successes — branch on `response.status`.
+- On network/protocol failure (DNS, connection refused, timeout, response too large), `response` is `nil` and `err` is a string.
+
+`opts` fields:
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `headers` | `{ [name] = string }` | Request headers. Numeric values are coerced via `tostring`. |
+| `query` | `{ [key] = string\|number\|boolean }` | Merged into the URL's query string. Existing query params are preserved. |
+| `body` | `string` | Request body (raw). Use `hive.json.encode` for JSON. |
+| `timeout` | `number` (seconds) | Per-call timeout. Defaults to `plugins.lua.http_timeout`. |
+| `max_bytes` | `number` | Response body cap. Defaults to `plugins.lua.http_max_bytes`. Exceeding the cap surfaces as an error to the callback. |
+
+Each call returns a handle with a `:cancel()` method that aborts the in-flight request and suppresses the pending callback.
+
+```lua
+return function(hive)
+  hive.http.get("https://api.github.com/repos/colonyops/hive", {
+    headers = { Authorization = "token " .. (hive.kv.get("gh_token") or "") },
+    timeout = 10,
+  }, function(res, err)
+    if err ~= nil then
+      hive.log.warn("github fetch failed: " .. err)
+      return
+    end
+    if res.status >= 400 then
+      hive.log.warn("github returned " .. res.status)
+      return
+    end
+    local data = hive.json.decode(res.body)
+    hive.log.info("stars: " .. tostring(data.stargazers_count))
+  end)
+
+  hive.http.post("https://example.com/api", {
+    headers = { ["Content-Type"] = "application/json" },
+    body = hive.json.encode({ foo = 1 }),
+  }, function(res, err) end)
+end
+```
+
+!!! warning "Trust boundary"
+    `hive.http` issues requests with the network access the Hive process has. Only enable Lua plugins from sources you trust.
+
+!!! note "Shutdown cancels in-flight calls"
+    Plugin reload or `hive` shutdown cancels every in-flight request. Pending callbacks may still fire once with a non-nil `err` describing the cancellation, but never after the runtime has fully closed.
+
+```yaml
+plugins:
+  lua:
+    enabled: true
+    http_timeout: 30s         # per-call timeout for hive.http.* (default: 30s)
+    http_max_bytes: 10485760  # response body cap in bytes (default: 10 MiB)
+```
+
 ## Tmux Plugin
 
 The tmux plugin provides default commands for session management using bundled scripts (`hive-tmux`, `agent-send`) that are auto-extracted to `$HIVE_DATA_DIR/bin/`.

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -343,8 +343,12 @@ Make outbound HTTP requests from Lua. Like `hive.sh`, every call is async: the c
 
 Callback signature: `fn(response, err)`.
 
-- On success, `response` is `{ status, body, headers }` and `err` is `nil`. Non-2xx HTTP responses are still successes — branch on `response.status`.
+- On success, `response` is `{ status, body, headers, cookies }` and `err` is `nil`. Non-2xx HTTP responses are still successes — branch on `response.status`.
 - On network/protocol failure (DNS, connection refused, timeout, response too large), `response` is `nil` and `err` is a string.
+
+`response.headers` is keyed by net/http's canonical MIME case (e.g. `Content-Type`, `X-Echo`), not the raw casing the server sent. Multi-value headers are joined with `", "`.
+
+`response.cookies` is a 1-indexed array of raw `Set-Cookie` header strings, in the order the server sent them. `Set-Cookie` is split off from `headers` because cookie values legitimately contain commas (e.g. `Expires` dates) and would be corrupted by the join above. The array is empty (not `nil`) when no cookies were set.
 
 `opts` fields:
 

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -505,9 +505,11 @@ type TmuxPluginConfig struct {
 // distinguishing "user did not configure this" from "user explicitly chose the
 // default path" relies on Entry == "" being preserved as the unset signal.
 type LuaPluginConfig struct {
-	Enabled      *bool         `json:"enabled"       yaml:"enabled"` // nil = auto-detect, true/false = override
-	Entry        string        `json:"entry"         yaml:"entry"`
-	ShellTimeout time.Duration `json:"shell_timeout" yaml:"shell_timeout"` // per-call timeout for hive.sh.* (default: 30s)
+	Enabled      *bool         `json:"enabled"        yaml:"enabled"` // nil = auto-detect, true/false = override
+	Entry        string        `json:"entry"          yaml:"entry"`
+	ShellTimeout time.Duration `json:"shell_timeout"  yaml:"shell_timeout"`  // per-call timeout for hive.sh.* (default: 30s)
+	HTTPTimeout  time.Duration `json:"http_timeout"   yaml:"http_timeout"`   // per-call timeout for hive.http.* (default: 30s)
+	HTTPMaxBytes int64         `json:"http_max_bytes" yaml:"http_max_bytes"` // response body cap for hive.http.* (default: 10 MiB)
 }
 
 // ResolvedEntry returns the configured Lua entry path or the default discovery path.

--- a/internal/hive/plugins/lua/helpers_test.go
+++ b/internal/hive/plugins/lua/helpers_test.go
@@ -167,6 +167,8 @@ func newLuaHarness(t *testing.T, script string, extras ...HostModule) *luaHarnes
 			m.Runtime = rt
 		case *ShModule:
 			m.Runtime = rt
+		case *HTTPModule:
+			m.Runtime = rt
 		}
 	}
 

--- a/internal/hive/plugins/lua/helpers_test.go
+++ b/internal/hive/plugins/lua/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -25,16 +26,31 @@ const testPluginName = "lua-test"
 //
 // All three are safe to call from any goroutine; the unified type replaces
 // the per-test capture/bump modules that used to live alongside each
-// module's tests.
+// module's tests. The notify channel signals every state change so tests
+// can wait without polling.
 type captureModule struct {
 	mu      sync.Mutex
 	list    []glua.LValue
 	keyed   map[string]glua.LValue
 	counter atomic.Int64
+	notify  chan struct{}
 }
 
 func newCaptureModule() *captureModule {
-	return &captureModule{keyed: map[string]glua.LValue{}}
+	return &captureModule{
+		keyed:  map[string]glua.LValue{},
+		notify: make(chan struct{}, 1),
+	}
+}
+
+// signal nudges the notify channel without blocking. Tests use a buffered
+// receive in WaitForKey/WaitForCaptures, so dropped signals don't matter
+// — once the buffered slot is full, any pending waiter will read it.
+func (c *captureModule) signal() {
+	select {
+	case c.notify <- struct{}{}:
+	default:
+	}
 }
 
 func (c *captureModule) Register(state *glua.LState, hive *glua.LTable) error {
@@ -49,6 +65,7 @@ func (c *captureModule) luaCapture(state *glua.LState) int {
 		c.mu.Lock()
 		c.list = append(c.list, v)
 		c.mu.Unlock()
+		c.signal()
 		return 0
 	}
 	key := state.CheckString(1)
@@ -56,11 +73,13 @@ func (c *captureModule) luaCapture(state *glua.LState) int {
 	c.mu.Lock()
 	c.keyed[key] = val
 	c.mu.Unlock()
+	c.signal()
 	return 0
 }
 
 func (c *captureModule) luaBump(_ *glua.LState) int {
 	c.counter.Add(1)
+	c.signal()
 	return 0
 }
 
@@ -121,6 +140,66 @@ func (c *captureModule) Number(key string) float64 {
 // Counter returns the current bump counter.
 func (c *captureModule) Counter() int64 {
 	return c.counter.Load()
+}
+
+// captureWaitTimeout bounds how long the wait helpers below block. Long
+// enough to absorb CI scheduling variance, short enough that a deadlocked
+// callback fails the test instead of hanging the whole suite.
+const captureWaitTimeout = 2 * time.Second
+
+// WaitForKey blocks until key has been captured or captureWaitTimeout
+// elapses. Failure here means the callback never wrote the key — it
+// did not race the deadline.
+func (c *captureModule) WaitForKey(t *testing.T, key string) {
+	t.Helper()
+	deadline := time.NewTimer(captureWaitTimeout)
+	defer deadline.Stop()
+	for {
+		if c.Has(key) {
+			return
+		}
+		select {
+		case <-c.notify:
+		case <-deadline.C:
+			t.Fatalf("expected capture key %q within %s", key, captureWaitTimeout)
+		}
+	}
+}
+
+// WaitForCaptures blocks until the positional list has at least n
+// entries, then returns the snapshot.
+func (c *captureModule) WaitForCaptures(t *testing.T, n int) []glua.LValue {
+	t.Helper()
+	deadline := time.NewTimer(captureWaitTimeout)
+	defer deadline.Stop()
+	for {
+		values := c.Snapshot()
+		if len(values) >= n {
+			return values
+		}
+		select {
+		case <-c.notify:
+		case <-deadline.C:
+			t.Fatalf("expected %d captures within %s, got %d", n, captureWaitTimeout, len(values))
+		}
+	}
+}
+
+// WaitForCounter blocks until the bump counter has reached at least n.
+func (c *captureModule) WaitForCounter(t *testing.T, n int64) {
+	t.Helper()
+	deadline := time.NewTimer(captureWaitTimeout)
+	defer deadline.Stop()
+	for {
+		if c.counter.Load() >= n {
+			return
+		}
+		select {
+		case <-c.notify:
+		case <-deadline.C:
+			t.Fatalf("expected counter >= %d within %s, got %d", n, captureWaitTimeout, c.counter.Load())
+		}
+	}
 }
 
 // luaHarness wraps a Runtime configured with the standard test module set

--- a/internal/hive/plugins/lua/module_http.go
+++ b/internal/hive/plugins/lua/module_http.go
@@ -14,13 +14,10 @@ import (
 	glua "github.com/yuin/gopher-lua"
 )
 
-// httpDefaultTimeout is used when HTTPModule.DefaultTimeout is zero.
-const httpDefaultTimeout = 30 * time.Second
-
-// httpDefaultMaxBytes caps response bodies so a runaway download cannot
-// OOM the process. Plugins that legitimately need more must opt in
-// per-call via opts.max_bytes.
-const httpDefaultMaxBytes = int64(10 * 1024 * 1024)
+const (
+	httpDefaultTimeout  = 30 * time.Second
+	httpDefaultMaxBytes = int64(10 * 1024 * 1024)
+)
 
 // httpClient is the subset of *http.Client the module uses; tests
 // inject a fake to avoid hitting the network.
@@ -28,9 +25,6 @@ type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// httpRequest captures the resolved per-call inputs for an HTTP call.
-// Built from the Lua opts table by applyHTTPOpts so the executor stays
-// independent of glua types.
 type httpRequest struct {
 	Method   string
 	URL      string
@@ -40,26 +34,24 @@ type httpRequest struct {
 	MaxBytes int64
 }
 
-// httpResult is the executor's complete return value. Network/protocol
-// failures populate Err; non-2xx status codes are not failures and live
-// alongside Body+Headers.
+// httpResult is the executor's return value. Network/protocol failures
+// populate Err; non-2xx status codes are not failures and live alongside
+// Body+Headers. Cookies preserves Set-Cookie verbatim because cookie
+// values can contain commas (Expires dates), which would corrupt every
+// cookie after the first if joined into Headers.
 type httpResult struct {
 	Status  int
 	Body    string
 	Headers map[string]string
-	// Cookies preserves Set-Cookie verbatim and in order. Set-Cookie
-	// cannot be safely flattened into Headers because cookie values
-	// legitimately contain commas (Expires dates), so a comma-joined
-	// string corrupts every cookie after the first.
 	Cookies []string
 	Err     error
 }
 
-// HTTPModule exposes hive.http.{get,post,put,delete,request} for outbound
-// HTTP requests. Every entry point is async: the call returns a handle
-// immediately, the request runs on a goroutine bound to a per-handle
-// context, and the caller-supplied callback fires on the dispatcher when
-// the response (or error) is in. Close cancels every in-flight call.
+// HTTPModule exposes hive.http.{get,post,put,delete,request}. Every
+// entry point is async: the call returns a handle immediately, the
+// request runs on a goroutine bound to a per-handle context, and the
+// callback fires on the dispatcher when the response (or error) is in.
+// Close cancels every in-flight call.
 type HTTPModule struct {
 	Client          httpClient
 	DefaultTimeout  time.Duration
@@ -68,13 +60,10 @@ type HTTPModule struct {
 
 	Runtime *Runtime
 
-	registry asyncRegistry
-
+	registry  asyncRegistry
 	closeOnce sync.Once
 }
 
-// Register installs the hive.http subtable and initialises the per-module
-// async registry. Defaults the client, timeout, and max-bytes if unset.
 func (m *HTTPModule) Register(state *glua.LState, hive *glua.LTable) error {
 	if m.Client == nil {
 		m.Client = &http.Client{}
@@ -103,114 +92,88 @@ func (m *HTTPModule) Register(state *glua.LState, hive *glua.LTable) error {
 	return nil
 }
 
-// Close cancels every in-flight request and waits for the workers to
-// drain. Idempotent.
 func (m *HTTPModule) Close() error {
 	m.closeOnce.Do(func() { m.registry.shutdown() })
 	return nil
 }
 
-// luaVerb returns the Lua handler for a verb where the URL is the first
-// positional argument. Accepts (url, fn) or (url, opts, fn).
+// luaVerb handles `hive.http.<verb>(url, fn)` and `(url, opts, fn)`.
 func (m *HTTPModule) luaVerb(method string) glua.LGFunction {
 	return func(state *glua.LState) int {
-		req, callback, err := m.parseVerbArgs(state, method)
-		if err != nil {
-			state.RaiseError("hive.http.%s: %s", strings.ToLower(method), err.Error())
+		rawURL := state.CheckString(1)
+
+		var optsTable *glua.LTable
+		var callback *glua.LFunction
+		switch state.GetTop() {
+		case 2:
+			callback = state.CheckFunction(2)
+		case 3:
+			if state.Get(2) != glua.LNil {
+				optsTable = state.CheckTable(2)
+			}
+			callback = state.CheckFunction(3)
+		default:
+			state.RaiseError("hive.http.%s: expected (url, fn) or (url, opts, fn)", strings.ToLower(method))
 			return 0
 		}
-		handle := m.spawnAsync(state, callback, req)
-		state.Push(m.registry.handleUserData(state, handle))
+
+		req := httpRequest{
+			Method:   method,
+			URL:      rawURL,
+			Headers:  http.Header{},
+			Timeout:  m.DefaultTimeout,
+			MaxBytes: m.DefaultMaxBytes,
+		}
+		if optsTable != nil {
+			if err := applyHTTPOpts(optsTable, &req); err != nil {
+				state.RaiseError("hive.http.%s: %s", strings.ToLower(method), err.Error())
+				return 0
+			}
+		}
+		if req.URL == "" {
+			state.RaiseError("hive.http.%s: url must be a non-empty string", strings.ToLower(method))
+			return 0
+		}
+
+		state.Push(m.registry.handleUserData(state, m.spawnAsync(state, callback, req)))
 		return 1
 	}
 }
 
-// luaRequest is hive.http.request(opts, fn). opts.method defaults to GET
-// and opts.url is required.
+// luaRequest handles `hive.http.request(opts, fn)`. opts.method defaults
+// to GET; opts.url is required.
 func (m *HTTPModule) luaRequest(state *glua.LState) int {
 	opts := state.CheckTable(1)
 	callback := state.CheckFunction(2)
 
-	req, err := m.parseRequestTable(opts)
-	if err != nil {
-		state.RaiseError("hive.http.request: %s", err.Error())
-		return 0
-	}
-	handle := m.spawnAsync(state, callback, req)
-	state.Push(m.registry.handleUserData(state, handle))
-	return 1
-}
-
-// parseVerbArgs handles the (url, fn) and (url, opts, fn) shapes shared
-// by get/post/put/delete.
-func (m *HTTPModule) parseVerbArgs(state *glua.LState, method string) (httpRequest, *glua.LFunction, error) {
-	rawURL := state.CheckString(1)
-
-	var (
-		optsTable *glua.LTable
-		callback  *glua.LFunction
-	)
-	switch state.GetTop() {
-	case 2:
-		callback = state.CheckFunction(2)
-	case 3:
-		if state.Get(2) != glua.LNil {
-			optsTable = state.CheckTable(2)
-		}
-		callback = state.CheckFunction(3)
-	default:
-		return httpRequest{}, nil, fmt.Errorf("expected (url, fn) or (url, opts, fn)")
-	}
-
-	req := m.defaultRequest()
-	req.Method = method
-	req.URL = rawURL
-	if optsTable != nil {
-		if err := applyHTTPOpts(optsTable, &req); err != nil {
-			return httpRequest{}, nil, err
-		}
-	}
-	if err := finaliseRequest(&req); err != nil {
-		return httpRequest{}, nil, err
-	}
-	return req, callback, nil
-}
-
-// parseRequestTable handles hive.http.request's single opts table. Like
-// applyHTTPOpts but also reads method and url from the table.
-func (m *HTTPModule) parseRequestTable(opts *glua.LTable) (httpRequest, error) {
-	req := m.defaultRequest()
-	req.Method = "GET"
-	if method, ok := opts.RawGetString("method").(glua.LString); ok && method != "" {
-		req.Method = strings.ToUpper(string(method))
-	}
-	rawURL, ok := opts.RawGetString("url").(glua.LString)
-	if !ok || rawURL == "" {
-		return httpRequest{}, fmt.Errorf("opts.url must be a non-empty string")
-	}
-	req.URL = string(rawURL)
-	if err := applyHTTPOpts(opts, &req); err != nil {
-		return httpRequest{}, err
-	}
-	if err := finaliseRequest(&req); err != nil {
-		return httpRequest{}, err
-	}
-	return req, nil
-}
-
-// defaultRequest seeds a request with the module's default timeout and
-// max-bytes plus an empty headers map ready for opt copying.
-func (m *HTTPModule) defaultRequest() httpRequest {
-	return httpRequest{
+	req := httpRequest{
+		Method:   "GET",
 		Headers:  http.Header{},
 		Timeout:  m.DefaultTimeout,
 		MaxBytes: m.DefaultMaxBytes,
 	}
+	if method, ok := opts.RawGetString("method").(glua.LString); ok && method != "" {
+		req.Method = strings.ToUpper(string(method))
+	}
+	if rawURL, ok := opts.RawGetString("url").(glua.LString); ok {
+		req.URL = string(rawURL)
+	}
+	if err := applyHTTPOpts(opts, &req); err != nil {
+		state.RaiseError("hive.http.request: %s", err.Error())
+		return 0
+	}
+	if req.URL == "" {
+		state.RaiseError("hive.http.request: opts.url must be a non-empty string")
+		return 0
+	}
+
+	state.Push(m.registry.handleUserData(state, m.spawnAsync(state, callback, req)))
+	return 1
 }
 
 // applyHTTPOpts copies headers/query/body/timeout/max_bytes from t into
-// req. Unknown keys are ignored so plugins can add forward-compatible
-// extensions to their own opts tables without surprise errors.
+// req. Unknown keys are ignored so plugins can extend their own opts
+// tables forward-compatibly.
 func applyHTTPOpts(t *glua.LTable, req *httpRequest) error {
 	if headers, ok := t.RawGetString("headers").(*glua.LTable); ok {
 		if err := copyHeaders(headers, req.Headers); err != nil {
@@ -236,22 +199,8 @@ func applyHTTPOpts(t *glua.LTable, req *httpRequest) error {
 	return nil
 }
 
-// finaliseRequest validates the assembled request shape so dispatcher
-// goroutines never fire a malformed call.
-func finaliseRequest(req *httpRequest) error {
-	if req.URL == "" {
-		return fmt.Errorf("url must be a non-empty string")
-	}
-	if req.Method == "" {
-		return fmt.Errorf("method must be a non-empty string")
-	}
-	return nil
-}
-
-// copyHeaders copies string-valued entries from t into dst. Numeric
-// values are coerced via tostring so plugins can pass bare numbers
-// (e.g. Content-Length) without manual conversion. Other types are
-// rejected so silent string("") substitutions don't strip data.
+// copyHeaders rejects non-string/number values explicitly — silently
+// stringifying a table or function would strip data without warning.
 func copyHeaders(t *glua.LTable, dst http.Header) error {
 	var walkErr error
 	t.ForEach(func(key, value glua.LValue) {
@@ -275,8 +224,6 @@ func copyHeaders(t *glua.LTable, dst http.Header) error {
 	return walkErr
 }
 
-// mergeQuery splices key=value pairs from t into rawURL's query string.
-// Existing query parameters are preserved.
 func mergeQuery(rawURL string, t *glua.LTable) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -296,9 +243,7 @@ func mergeQuery(rawURL string, t *glua.LTable) (string, error) {
 		switch v := value.(type) {
 		case glua.LString:
 			q.Add(string(name), string(v))
-		case glua.LNumber:
-			q.Add(string(name), glua.LVAsString(v))
-		case glua.LBool:
+		case glua.LNumber, glua.LBool:
 			q.Add(string(name), glua.LVAsString(v))
 		default:
 			walkErr = fmt.Errorf("query %q must be a string, number, or boolean", string(name))
@@ -311,30 +256,16 @@ func mergeQuery(rawURL string, t *glua.LTable) (string, error) {
 	return u.String(), nil
 }
 
-// spawnAsync mirrors ShModule.spawnAsync — pin the callback in the Lua
+// spawnAsync mirrors ShModule.spawnAsync: pin the callback in the Lua
 // registry, allocate a per-handle context, run the request on a tracked
 // goroutine, and dispatch the result back through the runtime so
-// shutdown can drain in-flight work. Each request emits paired
-// start/finish log lines tagged with the handle id so operators can
-// correlate events for a specific in-flight call.
-func (m *HTTPModule) spawnAsync(
-	state *glua.LState,
-	fn *glua.LFunction,
-	req httpRequest,
-) *asyncHandle {
+// shutdown can drain in-flight work.
+func (m *HTTPModule) spawnAsync(state *glua.LState, fn *glua.LFunction, req httpRequest) *asyncHandle {
 	id, ctx := m.registry.allocate(state, fn)
 	h := m.registry.newHandle(id, m.Runtime)
 
 	m.registry.Go(func() {
 		start := time.Now()
-		m.Logger.Debug().
-			Uint64("handle", id).
-			Str("method", req.Method).
-			Str("url", req.URL).
-			Dur("timeout", req.Timeout).
-			Int64("max_bytes", req.MaxBytes).
-			Msg("hive.http: starting request")
-
 		result := m.do(ctx, req)
 
 		level := m.Logger.Debug
@@ -373,9 +304,6 @@ func (m *HTTPModule) spawnAsync(
 	return h
 }
 
-// do builds and sends the HTTP request, capping the response body at
-// req.MaxBytes. Cancellation comes from ctx (per-handle) and the
-// per-call timeout layered on top.
 func (m *HTTPModule) do(ctx context.Context, req httpRequest) httpResult {
 	if req.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -404,21 +332,15 @@ func (m *HTTPModule) do(ctx context.Context, req httpRequest) httpResult {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	limit := req.MaxBytes
-	if limit <= 0 {
-		limit = httpDefaultMaxBytes
-	}
-	// Read up to limit+1 so we can tell "exactly limit" apart from
-	// "exceeded the cap"; on overrun, surface a single deterministic
-	// error rather than a partially-truncated body.
-	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	// Read up to MaxBytes+1 so an exact-cap body is distinguishable from
+	// an over-cap body. Over-cap surfaces a single deterministic error
+	// rather than a partially-truncated body.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, req.MaxBytes+1))
 	if err != nil {
 		return httpResult{Err: err}
 	}
-	if int64(len(data)) > limit {
-		return httpResult{
-			Err: fmt.Errorf("response body exceeded max_bytes (%d)", limit),
-		}
+	if int64(len(data)) > req.MaxBytes {
+		return httpResult{Err: fmt.Errorf("response body exceeded max_bytes (%d)", req.MaxBytes)}
 	}
 
 	headers, cookies := splitHeaders(resp.Header)
@@ -430,16 +352,9 @@ func (m *HTTPModule) do(ctx context.Context, req httpRequest) httpResult {
 	}
 }
 
-// splitHeaders flattens http.Header into a single-value map plus a
-// cookies slice. Set-Cookie is split off because comma-joining cookie
-// header lines corrupts dates (Expires=Tue, 06 May ...). Other
-// multi-value headers join with ", " — plugins can split if they need
-// the original values.
-//
-// Header names follow net/http's canonical MIME case (e.g. "X-Echo")
-// because the response is keyed by the values http.Header chose; this
-// is documented in the Lua-facing docs so plugin authors don't have to
-// guess the casing.
+// splitHeaders peels Set-Cookie off into its own slice because comma-joining
+// cookie header lines corrupts dates (Expires=Tue, 06 May ...). All other
+// multi-value headers join with ", ".
 func splitHeaders(h http.Header) (map[string]string, []string) {
 	headers := make(map[string]string, len(h))
 	var cookies []string
@@ -453,10 +368,9 @@ func splitHeaders(h http.Header) (map[string]string, []string) {
 	return headers, cookies
 }
 
-// dispatch invokes the callback on the dispatcher with (response, err).
-// On network/protocol failure, response is LNil and err is a string.
-// Non-2xx HTTP responses are NOT failures here — the callback gets a
-// populated response and can branch on response.status.
+// dispatch invokes the callback with (response, err). On failure,
+// response is LNil and err is a string. Non-2xx HTTP responses get a
+// populated response — the plugin branches on response.status.
 func (m *HTTPModule) dispatch(state *glua.LState, fn *glua.LFunction, result httpResult) {
 	var responseArg, errArg glua.LValue
 	if result.Err != nil {
@@ -471,16 +385,10 @@ func (m *HTTPModule) dispatch(state *glua.LState, fn *glua.LFunction, result htt
 		NRet:    0,
 		Protect: true,
 	}, responseArg, errArg); err != nil {
-		m.Logger.Warn().
-			Err(err).
-			Msg("hive.http: callback returned error")
+		m.Logger.Warn().Err(err).Msg("hive.http: callback returned error")
 	}
 }
 
-// buildResponseTable shapes the success response for Lua: status, body,
-// a string-valued headers map, and a cookies array. Cookies are always
-// present (empty array when none were sent) so plugins can iterate
-// without nil-checking.
 func buildResponseTable(state *glua.LState, r httpResult) *glua.LTable {
 	out := state.NewTable()
 	state.SetField(out, "status", glua.LNumber(r.Status))
@@ -492,6 +400,7 @@ func buildResponseTable(state *glua.LState, r httpResult) *glua.LTable {
 	}
 	state.SetField(out, "headers", headers)
 
+	// Empty array (not nil) so plugins can iterate without nil-checking.
 	cookies := state.NewTable()
 	for i, c := range r.Cookies {
 		cookies.RawSetInt(i+1, glua.LString(c))

--- a/internal/hive/plugins/lua/module_http.go
+++ b/internal/hive/plugins/lua/module_http.go
@@ -314,7 +314,9 @@ func mergeQuery(rawURL string, t *glua.LTable) (string, error) {
 // spawnAsync mirrors ShModule.spawnAsync — pin the callback in the Lua
 // registry, allocate a per-handle context, run the request on a tracked
 // goroutine, and dispatch the result back through the runtime so
-// shutdown can drain in-flight work.
+// shutdown can drain in-flight work. Each request emits paired
+// start/finish log lines tagged with the handle id so operators can
+// correlate events for a specific in-flight call.
 func (m *HTTPModule) spawnAsync(
 	state *glua.LState,
 	fn *glua.LFunction,
@@ -324,7 +326,33 @@ func (m *HTTPModule) spawnAsync(
 	h := m.registry.newHandle(id, m.Runtime)
 
 	m.registry.Go(func() {
-		result := m.execWithLogging(id, ctx, req)
+		start := time.Now()
+		m.Logger.Debug().
+			Uint64("handle", id).
+			Str("method", req.Method).
+			Str("url", req.URL).
+			Dur("timeout", req.Timeout).
+			Int64("max_bytes", req.MaxBytes).
+			Msg("hive.http: starting request")
+
+		result := m.do(ctx, req)
+
+		level := m.Logger.Debug
+		if result.Err != nil {
+			level = m.Logger.Warn
+		}
+		event := level().
+			Uint64("handle", id).
+			Str("method", req.Method).
+			Str("url", req.URL).
+			Dur("duration", time.Since(start))
+		if result.Err != nil {
+			event = event.Err(result.Err)
+		} else {
+			event = event.Int("status", result.Status).Int("bytes", len(result.Body))
+		}
+		event.Msg("hive.http: request finished")
+
 		err := m.Runtime.submitSync(func(state *glua.LState) error {
 			fn := m.registry.loadFunction(state, id)
 			if fn == nil {
@@ -343,19 +371,6 @@ func (m *HTTPModule) spawnAsync(
 		}
 	})
 	return h
-}
-
-// execWithLogging runs the HTTP call with start/finish/cancel logs
-// tagged by handle id so operators can correlate events for an
-// in-flight request.
-func (m *HTTPModule) execWithLogging(id uint64, ctx context.Context, req httpRequest) httpResult {
-	start := time.Now()
-	m.logRequestStart(id, req)
-
-	result := m.do(ctx, req)
-
-	m.logRequestFinish(id, req, time.Since(start), result)
-	return result
 }
 
 // do builds and sends the HTTP request, capping the response body at
@@ -483,32 +498,4 @@ func buildResponseTable(state *glua.LState, r httpResult) *glua.LTable {
 	}
 	state.SetField(out, "cookies", cookies)
 	return out
-}
-
-func (m *HTTPModule) logRequestStart(id uint64, req httpRequest) {
-	m.Logger.Debug().
-		Uint64("handle", id).
-		Str("method", req.Method).
-		Str("url", req.URL).
-		Dur("timeout", req.Timeout).
-		Int64("max_bytes", req.MaxBytes).
-		Msg("hive.http: starting request")
-}
-
-func (m *HTTPModule) logRequestFinish(id uint64, req httpRequest, dur time.Duration, result httpResult) {
-	level := m.Logger.Debug
-	if result.Err != nil {
-		level = m.Logger.Warn
-	}
-	event := level().
-		Uint64("handle", id).
-		Str("method", req.Method).
-		Str("url", req.URL).
-		Dur("duration", dur)
-	if result.Err != nil {
-		event = event.Err(result.Err)
-	} else {
-		event = event.Int("status", result.Status).Int("bytes", len(result.Body))
-	}
-	event.Msg("hive.http: request finished")
 }

--- a/internal/hive/plugins/lua/module_http.go
+++ b/internal/hive/plugins/lua/module_http.go
@@ -44,11 +44,15 @@ type httpRequest struct {
 // failures populate Err; non-2xx status codes are not failures and live
 // alongside Body+Headers.
 type httpResult struct {
-	Status    int
-	Body      string
-	Headers   map[string]string
-	Truncated bool
-	Err       error
+	Status  int
+	Body    string
+	Headers map[string]string
+	// Cookies preserves Set-Cookie verbatim and in order. Set-Cookie
+	// cannot be safely flattened into Headers because cookie values
+	// legitimately contain commas (Expires dates), so a comma-joined
+	// string corrupts every cookie after the first.
+	Cookies []string
+	Err     error
 }
 
 // HTTPModule exposes hive.http.{get,post,put,delete,request} for outbound
@@ -398,28 +402,40 @@ func (m *HTTPModule) do(ctx context.Context, req httpRequest) httpResult {
 	}
 	if int64(len(data)) > limit {
 		return httpResult{
-			Status:    resp.StatusCode,
-			Truncated: true,
-			Err:       fmt.Errorf("response body exceeded max_bytes (%d)", limit),
+			Err: fmt.Errorf("response body exceeded max_bytes (%d)", limit),
 		}
 	}
 
+	headers, cookies := splitHeaders(resp.Header)
 	return httpResult{
 		Status:  resp.StatusCode,
 		Body:    string(data),
-		Headers: collapseHeaders(resp.Header),
+		Headers: headers,
+		Cookies: cookies,
 	}
 }
 
-// collapseHeaders flattens http.Header (multimap) into a single-value
-// map for the Lua side. Multi-value headers join with ", " so plugins
-// can split if they need the original values.
-func collapseHeaders(h http.Header) map[string]string {
-	out := make(map[string]string, len(h))
+// splitHeaders flattens http.Header into a single-value map plus a
+// cookies slice. Set-Cookie is split off because comma-joining cookie
+// header lines corrupts dates (Expires=Tue, 06 May ...). Other
+// multi-value headers join with ", " — plugins can split if they need
+// the original values.
+//
+// Header names follow net/http's canonical MIME case (e.g. "X-Echo")
+// because the response is keyed by the values http.Header chose; this
+// is documented in the Lua-facing docs so plugin authors don't have to
+// guess the casing.
+func splitHeaders(h http.Header) (map[string]string, []string) {
+	headers := make(map[string]string, len(h))
+	var cookies []string
 	for name, values := range h {
-		out[name] = strings.Join(values, ", ")
+		if http.CanonicalHeaderKey(name) == "Set-Cookie" {
+			cookies = append(cookies, values...)
+			continue
+		}
+		headers[name] = strings.Join(values, ", ")
 	}
-	return out
+	return headers, cookies
 }
 
 // dispatch invokes the callback on the dispatcher with (response, err).
@@ -447,7 +463,9 @@ func (m *HTTPModule) dispatch(state *glua.LState, fn *glua.LFunction, result htt
 }
 
 // buildResponseTable shapes the success response for Lua: status, body,
-// and a string-valued headers map.
+// a string-valued headers map, and a cookies array. Cookies are always
+// present (empty array when none were sent) so plugins can iterate
+// without nil-checking.
 func buildResponseTable(state *glua.LState, r httpResult) *glua.LTable {
 	out := state.NewTable()
 	state.SetField(out, "status", glua.LNumber(r.Status))
@@ -458,6 +476,12 @@ func buildResponseTable(state *glua.LState, r httpResult) *glua.LTable {
 		state.SetField(headers, name, glua.LString(value))
 	}
 	state.SetField(out, "headers", headers)
+
+	cookies := state.NewTable()
+	for i, c := range r.Cookies {
+		cookies.RawSetInt(i+1, glua.LString(c))
+	}
+	state.SetField(out, "cookies", cookies)
 	return out
 }
 
@@ -485,9 +509,6 @@ func (m *HTTPModule) logRequestFinish(id uint64, req httpRequest, dur time.Durat
 		event = event.Err(result.Err)
 	} else {
 		event = event.Int("status", result.Status).Int("bytes", len(result.Body))
-	}
-	if result.Truncated {
-		event = event.Bool("truncated", true)
 	}
 	event.Msg("hive.http: request finished")
 }

--- a/internal/hive/plugins/lua/module_http.go
+++ b/internal/hive/plugins/lua/module_http.go
@@ -1,0 +1,493 @@
+package lua
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// httpDefaultTimeout is used when HTTPModule.DefaultTimeout is zero.
+const httpDefaultTimeout = 30 * time.Second
+
+// httpDefaultMaxBytes caps response bodies so a runaway download cannot
+// OOM the process. Plugins that legitimately need more must opt in
+// per-call via opts.max_bytes.
+const httpDefaultMaxBytes = int64(10 * 1024 * 1024)
+
+// httpClient is the subset of *http.Client the module uses; tests
+// inject a fake to avoid hitting the network.
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// httpRequest captures the resolved per-call inputs for an HTTP call.
+// Built from the Lua opts table by applyHTTPOpts so the executor stays
+// independent of glua types.
+type httpRequest struct {
+	Method   string
+	URL      string
+	Headers  http.Header
+	Body     string
+	Timeout  time.Duration
+	MaxBytes int64
+}
+
+// httpResult is the executor's complete return value. Network/protocol
+// failures populate Err; non-2xx status codes are not failures and live
+// alongside Body+Headers.
+type httpResult struct {
+	Status    int
+	Body      string
+	Headers   map[string]string
+	Truncated bool
+	Err       error
+}
+
+// HTTPModule exposes hive.http.{get,post,put,delete,request} for outbound
+// HTTP requests. Every entry point is async: the call returns a handle
+// immediately, the request runs on a goroutine bound to a per-handle
+// context, and the caller-supplied callback fires on the dispatcher when
+// the response (or error) is in. Close cancels every in-flight call.
+type HTTPModule struct {
+	Client          httpClient
+	DefaultTimeout  time.Duration
+	DefaultMaxBytes int64
+	Logger          zerolog.Logger
+
+	Runtime *Runtime
+
+	registry asyncRegistry
+
+	closeOnce sync.Once
+}
+
+// Register installs the hive.http subtable and initialises the per-module
+// async registry. Defaults the client, timeout, and max-bytes if unset.
+func (m *HTTPModule) Register(state *glua.LState, hive *glua.LTable) error {
+	if m.Client == nil {
+		m.Client = &http.Client{}
+	}
+	if m.DefaultTimeout <= 0 {
+		m.DefaultTimeout = httpDefaultTimeout
+	}
+	if m.DefaultMaxBytes <= 0 {
+		m.DefaultMaxBytes = httpDefaultMaxBytes
+	}
+
+	if err := m.registry.init(state, m, asyncRegistryConfig{
+		KeyPrefix:     "hive.http.",
+		MetatableName: "hive.http.handle",
+	}); err != nil {
+		return fmt.Errorf("http module: %w", err)
+	}
+
+	tbl := state.NewTable()
+	state.SetField(tbl, "get", state.NewFunction(m.luaVerb("GET")))
+	state.SetField(tbl, "post", state.NewFunction(m.luaVerb("POST")))
+	state.SetField(tbl, "put", state.NewFunction(m.luaVerb("PUT")))
+	state.SetField(tbl, "delete", state.NewFunction(m.luaVerb("DELETE")))
+	state.SetField(tbl, "request", state.NewFunction(m.luaRequest))
+	state.SetField(hive, "http", tbl)
+	return nil
+}
+
+// Close cancels every in-flight request and waits for the workers to
+// drain. Idempotent.
+func (m *HTTPModule) Close() error {
+	m.closeOnce.Do(func() { m.registry.shutdown() })
+	return nil
+}
+
+// luaVerb returns the Lua handler for a verb where the URL is the first
+// positional argument. Accepts (url, fn) or (url, opts, fn).
+func (m *HTTPModule) luaVerb(method string) glua.LGFunction {
+	return func(state *glua.LState) int {
+		req, callback, err := m.parseVerbArgs(state, method)
+		if err != nil {
+			state.RaiseError("hive.http.%s: %s", strings.ToLower(method), err.Error())
+			return 0
+		}
+		handle := m.spawnAsync(state, callback, req)
+		state.Push(m.registry.handleUserData(state, handle))
+		return 1
+	}
+}
+
+// luaRequest is hive.http.request(opts, fn). opts.method defaults to GET
+// and opts.url is required.
+func (m *HTTPModule) luaRequest(state *glua.LState) int {
+	opts := state.CheckTable(1)
+	callback := state.CheckFunction(2)
+
+	req, err := m.parseRequestTable(opts)
+	if err != nil {
+		state.RaiseError("hive.http.request: %s", err.Error())
+		return 0
+	}
+	handle := m.spawnAsync(state, callback, req)
+	state.Push(m.registry.handleUserData(state, handle))
+	return 1
+}
+
+// parseVerbArgs handles the (url, fn) and (url, opts, fn) shapes shared
+// by get/post/put/delete.
+func (m *HTTPModule) parseVerbArgs(state *glua.LState, method string) (httpRequest, *glua.LFunction, error) {
+	rawURL := state.CheckString(1)
+
+	var (
+		optsTable *glua.LTable
+		callback  *glua.LFunction
+	)
+	switch state.GetTop() {
+	case 2:
+		callback = state.CheckFunction(2)
+	case 3:
+		if state.Get(2) != glua.LNil {
+			optsTable = state.CheckTable(2)
+		}
+		callback = state.CheckFunction(3)
+	default:
+		return httpRequest{}, nil, fmt.Errorf("expected (url, fn) or (url, opts, fn)")
+	}
+
+	req := m.defaultRequest()
+	req.Method = method
+	req.URL = rawURL
+	if optsTable != nil {
+		if err := applyHTTPOpts(optsTable, &req); err != nil {
+			return httpRequest{}, nil, err
+		}
+	}
+	if err := finaliseRequest(&req); err != nil {
+		return httpRequest{}, nil, err
+	}
+	return req, callback, nil
+}
+
+// parseRequestTable handles hive.http.request's single opts table. Like
+// applyHTTPOpts but also reads method and url from the table.
+func (m *HTTPModule) parseRequestTable(opts *glua.LTable) (httpRequest, error) {
+	req := m.defaultRequest()
+	req.Method = "GET"
+	if method, ok := opts.RawGetString("method").(glua.LString); ok && method != "" {
+		req.Method = strings.ToUpper(string(method))
+	}
+	rawURL, ok := opts.RawGetString("url").(glua.LString)
+	if !ok || rawURL == "" {
+		return httpRequest{}, fmt.Errorf("opts.url must be a non-empty string")
+	}
+	req.URL = string(rawURL)
+	if err := applyHTTPOpts(opts, &req); err != nil {
+		return httpRequest{}, err
+	}
+	if err := finaliseRequest(&req); err != nil {
+		return httpRequest{}, err
+	}
+	return req, nil
+}
+
+// defaultRequest seeds a request with the module's default timeout and
+// max-bytes plus an empty headers map ready for opt copying.
+func (m *HTTPModule) defaultRequest() httpRequest {
+	return httpRequest{
+		Headers:  http.Header{},
+		Timeout:  m.DefaultTimeout,
+		MaxBytes: m.DefaultMaxBytes,
+	}
+}
+
+// applyHTTPOpts copies headers/query/body/timeout/max_bytes from t into
+// req. Unknown keys are ignored so plugins can add forward-compatible
+// extensions to their own opts tables without surprise errors.
+func applyHTTPOpts(t *glua.LTable, req *httpRequest) error {
+	if headers, ok := t.RawGetString("headers").(*glua.LTable); ok {
+		if err := copyHeaders(headers, req.Headers); err != nil {
+			return err
+		}
+	}
+	if query, ok := t.RawGetString("query").(*glua.LTable); ok {
+		merged, err := mergeQuery(req.URL, query)
+		if err != nil {
+			return err
+		}
+		req.URL = merged
+	}
+	if body, ok := t.RawGetString("body").(glua.LString); ok {
+		req.Body = string(body)
+	}
+	if timeoutSecs, ok := t.RawGetString("timeout").(glua.LNumber); ok {
+		req.Timeout = time.Duration(float64(timeoutSecs) * float64(time.Second))
+	}
+	if maxBytes, ok := t.RawGetString("max_bytes").(glua.LNumber); ok {
+		req.MaxBytes = int64(maxBytes)
+	}
+	return nil
+}
+
+// finaliseRequest validates the assembled request shape so dispatcher
+// goroutines never fire a malformed call.
+func finaliseRequest(req *httpRequest) error {
+	if req.URL == "" {
+		return fmt.Errorf("url must be a non-empty string")
+	}
+	if req.Method == "" {
+		return fmt.Errorf("method must be a non-empty string")
+	}
+	return nil
+}
+
+// copyHeaders copies string-valued entries from t into dst. Numeric
+// values are coerced via tostring so plugins can pass bare numbers
+// (e.g. Content-Length) without manual conversion. Other types are
+// rejected so silent string("") substitutions don't strip data.
+func copyHeaders(t *glua.LTable, dst http.Header) error {
+	var walkErr error
+	t.ForEach(func(key, value glua.LValue) {
+		if walkErr != nil {
+			return
+		}
+		name, ok := key.(glua.LString)
+		if !ok {
+			walkErr = fmt.Errorf("header names must be strings")
+			return
+		}
+		switch v := value.(type) {
+		case glua.LString:
+			dst.Add(string(name), string(v))
+		case glua.LNumber:
+			dst.Add(string(name), glua.LVAsString(v))
+		default:
+			walkErr = fmt.Errorf("header %q must be a string", string(name))
+		}
+	})
+	return walkErr
+}
+
+// mergeQuery splices key=value pairs from t into rawURL's query string.
+// Existing query parameters are preserved.
+func mergeQuery(rawURL string, t *glua.LTable) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid url %q: %w", rawURL, err)
+	}
+	q := u.Query()
+	var walkErr error
+	t.ForEach(func(key, value glua.LValue) {
+		if walkErr != nil {
+			return
+		}
+		name, ok := key.(glua.LString)
+		if !ok {
+			walkErr = fmt.Errorf("query keys must be strings")
+			return
+		}
+		switch v := value.(type) {
+		case glua.LString:
+			q.Add(string(name), string(v))
+		case glua.LNumber:
+			q.Add(string(name), glua.LVAsString(v))
+		case glua.LBool:
+			q.Add(string(name), glua.LVAsString(v))
+		default:
+			walkErr = fmt.Errorf("query %q must be a string, number, or boolean", string(name))
+		}
+	})
+	if walkErr != nil {
+		return "", walkErr
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// spawnAsync mirrors ShModule.spawnAsync — pin the callback in the Lua
+// registry, allocate a per-handle context, run the request on a tracked
+// goroutine, and dispatch the result back through the runtime so
+// shutdown can drain in-flight work.
+func (m *HTTPModule) spawnAsync(
+	state *glua.LState,
+	fn *glua.LFunction,
+	req httpRequest,
+) *asyncHandle {
+	id, ctx := m.registry.allocate(state, fn)
+	h := m.registry.newHandle(id, m.Runtime)
+
+	m.registry.Go(func() {
+		result := m.execWithLogging(id, ctx, req)
+		err := m.Runtime.submitSync(func(state *glua.LState) error {
+			fn := m.registry.loadFunction(state, id)
+			if fn == nil {
+				return nil
+			}
+			m.dispatch(state, fn, result)
+			m.registry.release(state, id)
+			h.poison()
+			return nil
+		})
+		if err != nil {
+			m.Logger.Debug().
+				Uint64("handle", id).
+				Err(err).
+				Msg("hive.http: dispatch dropped (runtime closed)")
+		}
+	})
+	return h
+}
+
+// execWithLogging runs the HTTP call with start/finish/cancel logs
+// tagged by handle id so operators can correlate events for an
+// in-flight request.
+func (m *HTTPModule) execWithLogging(id uint64, ctx context.Context, req httpRequest) httpResult {
+	start := time.Now()
+	m.logRequestStart(id, req)
+
+	result := m.do(ctx, req)
+
+	m.logRequestFinish(id, req, time.Since(start), result)
+	return result
+}
+
+// do builds and sends the HTTP request, capping the response body at
+// req.MaxBytes. Cancellation comes from ctx (per-handle) and the
+// per-call timeout layered on top.
+func (m *HTTPModule) do(ctx context.Context, req httpRequest) httpResult {
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	var body io.Reader
+	if req.Body != "" {
+		body = strings.NewReader(req.Body)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, body)
+	if err != nil {
+		return httpResult{Err: err}
+	}
+	for name, values := range req.Headers {
+		for _, v := range values {
+			httpReq.Header.Add(name, v)
+		}
+	}
+
+	resp, err := m.Client.Do(httpReq)
+	if err != nil {
+		return httpResult{Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	limit := req.MaxBytes
+	if limit <= 0 {
+		limit = httpDefaultMaxBytes
+	}
+	// Read up to limit+1 so we can tell "exactly limit" apart from
+	// "exceeded the cap"; on overrun, surface a single deterministic
+	// error rather than a partially-truncated body.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return httpResult{Err: err}
+	}
+	if int64(len(data)) > limit {
+		return httpResult{
+			Status:    resp.StatusCode,
+			Truncated: true,
+			Err:       fmt.Errorf("response body exceeded max_bytes (%d)", limit),
+		}
+	}
+
+	return httpResult{
+		Status:  resp.StatusCode,
+		Body:    string(data),
+		Headers: collapseHeaders(resp.Header),
+	}
+}
+
+// collapseHeaders flattens http.Header (multimap) into a single-value
+// map for the Lua side. Multi-value headers join with ", " so plugins
+// can split if they need the original values.
+func collapseHeaders(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for name, values := range h {
+		out[name] = strings.Join(values, ", ")
+	}
+	return out
+}
+
+// dispatch invokes the callback on the dispatcher with (response, err).
+// On network/protocol failure, response is LNil and err is a string.
+// Non-2xx HTTP responses are NOT failures here — the callback gets a
+// populated response and can branch on response.status.
+func (m *HTTPModule) dispatch(state *glua.LState, fn *glua.LFunction, result httpResult) {
+	var responseArg, errArg glua.LValue
+	if result.Err != nil {
+		responseArg = glua.LNil
+		errArg = glua.LString(result.Err.Error())
+	} else {
+		responseArg = buildResponseTable(state, result)
+		errArg = glua.LNil
+	}
+	if err := state.CallByParam(glua.P{
+		Fn:      fn,
+		NRet:    0,
+		Protect: true,
+	}, responseArg, errArg); err != nil {
+		m.Logger.Warn().
+			Err(err).
+			Msg("hive.http: callback returned error")
+	}
+}
+
+// buildResponseTable shapes the success response for Lua: status, body,
+// and a string-valued headers map.
+func buildResponseTable(state *glua.LState, r httpResult) *glua.LTable {
+	out := state.NewTable()
+	state.SetField(out, "status", glua.LNumber(r.Status))
+	state.SetField(out, "body", glua.LString(r.Body))
+
+	headers := state.NewTable()
+	for name, value := range r.Headers {
+		state.SetField(headers, name, glua.LString(value))
+	}
+	state.SetField(out, "headers", headers)
+	return out
+}
+
+func (m *HTTPModule) logRequestStart(id uint64, req httpRequest) {
+	m.Logger.Debug().
+		Uint64("handle", id).
+		Str("method", req.Method).
+		Str("url", req.URL).
+		Dur("timeout", req.Timeout).
+		Int64("max_bytes", req.MaxBytes).
+		Msg("hive.http: starting request")
+}
+
+func (m *HTTPModule) logRequestFinish(id uint64, req httpRequest, dur time.Duration, result httpResult) {
+	level := m.Logger.Debug
+	if result.Err != nil {
+		level = m.Logger.Warn
+	}
+	event := level().
+		Uint64("handle", id).
+		Str("method", req.Method).
+		Str("url", req.URL).
+		Dur("duration", dur)
+	if result.Err != nil {
+		event = event.Err(result.Err)
+	} else {
+		event = event.Int("status", result.Status).Int("bytes", len(result.Body))
+	}
+	if result.Truncated {
+		event = event.Bool("truncated", true)
+	}
+	event.Msg("hive.http: request finished")
+}

--- a/internal/hive/plugins/lua/module_http_test.go
+++ b/internal/hive/plugins/lua/module_http_test.go
@@ -480,6 +480,63 @@ end
 	assert.Equal(t, 0, client.requestCount())
 }
 
+func TestHTTPModule_SetCookieSurfacedSeparately(t *testing.T) {
+	t.Parallel()
+
+	// Two cookies with commas in Expires dates — joining with ", " would
+	// corrupt both. The module surfaces them via res.cookies (verbatim,
+	// in order) and omits Set-Cookie from res.headers.
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			h := http.Header{}
+			h.Add("Set-Cookie", "session=abc123; Expires=Tue, 06 May 2026 12:00:00 GMT")
+			h.Add("Set-Cookie", "tracking=xyz; Path=/")
+			h.Set("Content-Type", "text/plain")
+			return jsonResponse(200, "ok", h), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com", function(res, _)
+    hive.test_capture("cookie_count", #res.cookies)
+    hive.test_capture("cookie_1", res.cookies[1])
+    hive.test_capture("cookie_2", res.cookies[2])
+    hive.test_capture("set_cookie_in_headers", res.headers["Set-Cookie"] == nil and "absent" or "present")
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "cookie_count")
+	assert.Equal(t, 2, int(h.capture.Number("cookie_count")))
+	assert.Equal(t, "session=abc123; Expires=Tue, 06 May 2026 12:00:00 GMT", h.capture.String("cookie_1"))
+	assert.Equal(t, "tracking=xyz; Path=/", h.capture.String("cookie_2"))
+	assert.Equal(t, "absent", h.capture.String("set_cookie_in_headers"))
+}
+
+func TestHTTPModule_NoCookiesIsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(200, "ok", nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com", function(res, _)
+    hive.test_capture("type", type(res.cookies))
+    hive.test_capture("count", #res.cookies)
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "type")
+	assert.Equal(t, "table", h.capture.String("type"))
+	assert.Equal(t, 0, int(h.capture.Number("count")))
+}
+
 // waitForKey polls for a keyed capture entry with a generous CI-friendly
 // timeout. Use when tests need to await a single named callback rather
 // than an N-element list (waitForCaptures handles the latter).

--- a/internal/hive/plugins/lua/module_http_test.go
+++ b/internal/hive/plugins/lua/module_http_test.go
@@ -1,0 +1,498 @@
+package lua
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+)
+
+// fakeHTTPClient implements httpClient with caller-provided behaviour.
+// Every Do call records the request and dispatches to respond.
+type fakeHTTPClient struct {
+	mu       sync.Mutex
+	respond  func(req *http.Request) (*http.Response, error)
+	requests []*http.Request
+}
+
+func (f *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, req)
+	respond := f.respond
+	f.mu.Unlock()
+	if respond == nil {
+		return jsonResponse(200, "", nil), nil
+	}
+	return respond(req)
+}
+
+func (f *fakeHTTPClient) lastRequest() *http.Request {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.requests) == 0 {
+		return nil
+	}
+	return f.requests[len(f.requests)-1]
+}
+
+func (f *fakeHTTPClient) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.requests)
+}
+
+// jsonResponse builds a 200-class *http.Response with the given body and
+// optional header overrides. Used by the fake client's respond funcs.
+func jsonResponse(status int, body string, headers http.Header) *http.Response {
+	h := http.Header{}
+	maps.Copy(h, headers)
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", "text/plain")
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// httpHarness wraps luaHarness with the HTTPModule reference so tests can
+// reach the module for explicit shutdown ordering.
+type httpHarness struct {
+	*luaHarness
+	module *HTTPModule
+	client *fakeHTTPClient
+}
+
+func newHTTPHarness(t *testing.T, script string, client *fakeHTTPClient) *httpHarness {
+	t.Helper()
+	module := &HTTPModule{
+		Client:          client,
+		DefaultTimeout:  5 * time.Second,
+		DefaultMaxBytes: 1024,
+		Logger:          zerolog.Nop(),
+	}
+	return &httpHarness{
+		luaHarness: newLuaHarness(t, script, module),
+		module:     module,
+		client:     client,
+	}
+}
+
+func TestHTTPModule_GetReturnsResponse(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "GET", req.Method)
+			assert.Equal(t, "https://example.com/api", req.URL.String())
+			return jsonResponse(200, `{"ok":true}`, http.Header{"X-Echo": []string{"yes"}}), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com/api", function(res, err)
+    if err ~= nil then
+      hive.test_capture("err", err)
+      return
+    end
+    hive.test_capture("status", res.status)
+    hive.test_capture("body", res.body)
+    hive.test_capture("echo", res.headers["X-Echo"])
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "status")
+	assert.Equal(t, 200, int(h.capture.Number("status")))
+	assert.Equal(t, `{"ok":true}`, h.capture.String("body"))
+	assert.Equal(t, "yes", h.capture.String("echo"))
+	assert.False(t, h.capture.Has("err"))
+}
+
+func TestHTTPModule_PostSendsBodyAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotBody    string
+		gotMethod  string
+		gotHeader  string
+		bodyReadOK bool
+	)
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			gotMethod = req.Method
+			gotHeader = req.Header.Get("Content-Type")
+			if req.Body != nil {
+				data, err := io.ReadAll(req.Body)
+				bodyReadOK = err == nil
+				gotBody = string(data)
+			}
+			return jsonResponse(201, "ok", nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.post("https://example.com/items", {
+    headers = { ["Content-Type"] = "application/json" },
+    body = '{"a":1}',
+  }, function(res, err)
+    if err ~= nil then
+      hive.test_capture("err", err)
+      return
+    end
+    hive.test_capture("status", res.status)
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "status")
+	assert.Equal(t, 201, int(h.capture.Number("status")))
+	assert.Equal(t, "POST", gotMethod)
+	assert.Equal(t, "application/json", gotHeader)
+	assert.True(t, bodyReadOK)
+	assert.Equal(t, `{"a":1}`, gotBody)
+}
+
+func TestHTTPModule_PutAndDelete(t *testing.T) {
+	t.Parallel()
+
+	methods := make(chan string, 2)
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			methods <- req.Method
+			return jsonResponse(204, "", nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.put("https://example.com/x", { body = "u" }, function(res, _)
+    hive.test_capture(res.status)
+  end)
+  hive.http.delete("https://example.com/x", function(res, _)
+    hive.test_capture(res.status)
+  end)
+end
+`, client)
+
+	values := waitForCaptures(t, h.capture, 2)
+	for _, v := range values {
+		assert.Equal(t, 204, asLuaInt(t, v))
+	}
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case m := <-methods:
+			seen[m] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected two methods")
+		}
+	}
+	assert.True(t, seen["PUT"])
+	assert.True(t, seen["DELETE"])
+}
+
+func TestHTTPModule_RequestUsesMethodAndURL(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "PATCH", req.Method)
+			assert.Equal(t, "https://example.com/r", req.URL.String())
+			return jsonResponse(200, "ok", nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.request({ method = "PATCH", url = "https://example.com/r", body = "x" }, function(res, _)
+    hive.test_capture("status", res.status)
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "status")
+	assert.Equal(t, 200, int(h.capture.Number("status")))
+}
+
+func TestHTTPModule_QueryParamsMerged(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(200, "", nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com/api?keep=1", { query = { extra = "two", n = 3 } }, function(res, _)
+    hive.test_capture("status", res.status)
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "status")
+
+	req := h.client.lastRequest()
+	require.NotNil(t, req)
+	q := req.URL.Query()
+	assert.Equal(t, "1", q.Get("keep"))
+	assert.Equal(t, "two", q.Get("extra"))
+	assert.Equal(t, "3", q.Get("n"))
+}
+
+func TestHTTPModule_NetworkErrorPassedToCallback(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com", function(res, err)
+    hive.test_capture("res", res == nil and "nil" or "set")
+    hive.test_capture("err", err == nil and "nil" or err)
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "err")
+	assert.Equal(t, "nil", h.capture.String("res"))
+	assert.Contains(t, h.capture.String("err"), "connection refused")
+}
+
+func TestHTTPModule_NonZeroStatusIsSuccess(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(503, "down for maintenance", nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com", function(res, err)
+    hive.test_capture("err_is_nil", err == nil)
+    if res ~= nil then
+      hive.test_capture("status", res.status)
+      hive.test_capture("body", res.body)
+    end
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "status")
+	assert.True(t, h.capture.Bool("err_is_nil"))
+	assert.Equal(t, 503, int(h.capture.Number("status")))
+	assert.Equal(t, "down for maintenance", h.capture.String("body"))
+}
+
+func TestHTTPModule_MaxBytesEnforced(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("a", 2000)
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(200, big, nil), nil
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com", { max_bytes = 100 }, function(res, err)
+    hive.test_capture("res", res == nil and "nil" or "set")
+    hive.test_capture("err", err == nil and "" or err)
+  end)
+end
+`, client)
+
+	waitForKey(t, h.capture, "err")
+	assert.Equal(t, "nil", h.capture.String("res"), "response should be nil when cap exceeded")
+	assert.Contains(t, h.capture.String("err"), "max_bytes")
+}
+
+func TestHTTPModule_PerCallTimeoutCancelsCtx(t *testing.T) {
+	t.Parallel()
+
+	captureCtx := make(chan context.Context, 1)
+	released := make(chan struct{})
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			captureCtx <- req.Context()
+			<-req.Context().Done()
+			close(released)
+			return nil, req.Context().Err()
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  hive.http.get("https://example.com", { timeout = 0.05 }, function(res, err)
+    hive.test_capture("res", res == nil and "nil" or "set")
+    hive.test_capture("err", err == nil and "" or err)
+  end)
+end
+`, client)
+
+	select {
+	case ctx := <-captureCtx:
+		select {
+		case <-released:
+			require.Error(t, ctx.Err())
+		case <-time.After(2 * time.Second):
+			t.Fatalf("request never released after timeout")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("request never received a context")
+	}
+
+	waitForKey(t, h.capture, "err")
+	assert.Equal(t, "nil", h.capture.String("res"))
+	assert.NotEmpty(t, h.capture.String("err"))
+}
+
+func TestHTTPModule_HandleCancelStopsRequest(t *testing.T) {
+	t.Parallel()
+
+	captureCtx := make(chan context.Context, 1)
+	released := make(chan struct{})
+
+	client := &fakeHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			captureCtx <- req.Context()
+			<-req.Context().Done()
+			close(released)
+			return nil, req.Context().Err()
+		},
+	}
+
+	h := newHTTPHarness(t, `
+return function(hive)
+  HANDLE = hive.http.get("https://example.com", function(res, err) hive.test_capture(res, err) end)
+end
+`, client)
+
+	var ctx context.Context
+	select {
+	case ctx = <-captureCtx:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("request never received a context")
+	}
+
+	cancelDone := make(chan struct{})
+	h.runtime.Submit(func(state *glua.LState) {
+		defer close(cancelDone)
+		ud, ok := state.GetGlobal("HANDLE").(*glua.LUserData)
+		require.True(t, ok)
+		handle, ok := ud.Value.(*asyncHandle)
+		require.True(t, ok)
+		handle.Cancel()
+	})
+	<-cancelDone
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("request never released after cancel")
+	}
+	require.Error(t, ctx.Err())
+
+	// Cancellation prevents the dispatch path from loading the registry
+	// pin, so the callback should never fire.
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, h.capture.Snapshot())
+}
+
+func TestHTTPModule_RequestRequiresURL(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{}
+	h := newHTTPHarness(t, `
+return function(hive)
+  local ok, err = pcall(hive.http.request, { method = "GET" }, function() end)
+  hive.test_capture("ok", tostring(ok))
+  hive.test_capture("err", tostring(err))
+end
+`, client)
+
+	assert.Equal(t, "false", h.capture.String("ok"))
+	assert.Contains(t, h.capture.String("err"), "url")
+	assert.Equal(t, 0, client.requestCount())
+}
+
+func TestHTTPModule_VerbsRequireCallback(t *testing.T) {
+	t.Parallel()
+
+	for _, verb := range []string{"get", "post", "put", "delete"} {
+		t.Run(verb, func(t *testing.T) {
+			client := &fakeHTTPClient{}
+			h := newHTTPHarness(t, fmt.Sprintf(`
+return function(hive)
+  local ok = pcall(hive.http.%s, "https://example.com")
+  hive.test_capture("ok", tostring(ok))
+end
+`, verb), client)
+
+			assert.Equal(t, "false", h.capture.String("ok"))
+			assert.Equal(t, 0, client.requestCount())
+		})
+	}
+}
+
+func TestHTTPModule_HeaderTypeRejected(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeHTTPClient{}
+	h := newHTTPHarness(t, `
+return function(hive)
+  local ok, err = pcall(hive.http.get, "https://example.com",
+    { headers = { Bad = {1, 2} } },
+    function() end)
+  hive.test_capture("ok", tostring(ok))
+  hive.test_capture("err", tostring(err))
+end
+`, client)
+
+	assert.Equal(t, "false", h.capture.String("ok"))
+	assert.Contains(t, h.capture.String("err"), "header")
+	assert.Equal(t, 0, client.requestCount())
+}
+
+// waitForKey polls for a keyed capture entry with a generous CI-friendly
+// timeout. Use when tests need to await a single named callback rather
+// than an N-element list (waitForCaptures handles the latter).
+func waitForKey(t *testing.T, c *captureModule, key string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if c.Has(key) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected capture key %q within 2s", key)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/hive/plugins/lua/module_http_test.go
+++ b/internal/hive/plugins/lua/module_http_test.go
@@ -115,7 +115,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "status")
+	h.capture.WaitForKey(t, "status")
 	assert.Equal(t, 200, int(h.capture.Number("status")))
 	assert.Equal(t, `{"ok":true}`, h.capture.String("body"))
 	assert.Equal(t, "yes", h.capture.String("echo"))
@@ -160,7 +160,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "status")
+	h.capture.WaitForKey(t, "status")
 	assert.Equal(t, 201, int(h.capture.Number("status")))
 	assert.Equal(t, "POST", gotMethod)
 	assert.Equal(t, "application/json", gotHeader)
@@ -190,7 +190,7 @@ return function(hive)
 end
 `, client)
 
-	values := waitForCaptures(t, h.capture, 2)
+	values := h.capture.WaitForCaptures(t, 2)
 	for _, v := range values {
 		assert.Equal(t, 204, asLuaInt(t, v))
 	}
@@ -227,7 +227,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "status")
+	h.capture.WaitForKey(t, "status")
 	assert.Equal(t, 200, int(h.capture.Number("status")))
 }
 
@@ -248,7 +248,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "status")
+	h.capture.WaitForKey(t, "status")
 
 	req := h.client.lastRequest()
 	require.NotNil(t, req)
@@ -276,7 +276,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "err")
+	h.capture.WaitForKey(t, "err")
 	assert.Equal(t, "nil", h.capture.String("res"))
 	assert.Contains(t, h.capture.String("err"), "connection refused")
 }
@@ -302,7 +302,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "status")
+	h.capture.WaitForKey(t, "status")
 	assert.True(t, h.capture.Bool("err_is_nil"))
 	assert.Equal(t, 503, int(h.capture.Number("status")))
 	assert.Equal(t, "down for maintenance", h.capture.String("body"))
@@ -327,7 +327,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "err")
+	h.capture.WaitForKey(t, "err")
 	assert.Equal(t, "nil", h.capture.String("res"), "response should be nil when cap exceeded")
 	assert.Contains(t, h.capture.String("err"), "max_bytes")
 }
@@ -335,12 +335,12 @@ end
 func TestHTTPModule_PerCallTimeoutCancelsCtx(t *testing.T) {
 	t.Parallel()
 
-	captureCtx := make(chan context.Context, 1)
+	executorCtx := make(chan context.Context, 1)
 	released := make(chan struct{})
 
 	client := &fakeHTTPClient{
 		respond: func(req *http.Request) (*http.Response, error) {
-			captureCtx <- req.Context()
+			executorCtx <- req.Context()
 			<-req.Context().Done()
 			close(released)
 			return nil, req.Context().Err()
@@ -357,7 +357,7 @@ end
 `, client)
 
 	select {
-	case ctx := <-captureCtx:
+	case ctx := <-executorCtx:
 		select {
 		case <-released:
 			require.Error(t, ctx.Err())
@@ -368,7 +368,7 @@ end
 		t.Fatalf("request never received a context")
 	}
 
-	waitForKey(t, h.capture, "err")
+	h.capture.WaitForKey(t, "err")
 	assert.Equal(t, "nil", h.capture.String("res"))
 	assert.NotEmpty(t, h.capture.String("err"))
 }
@@ -376,12 +376,12 @@ end
 func TestHTTPModule_HandleCancelStopsRequest(t *testing.T) {
 	t.Parallel()
 
-	captureCtx := make(chan context.Context, 1)
+	executorCtx := make(chan context.Context, 1)
 	released := make(chan struct{})
 
 	client := &fakeHTTPClient{
 		respond: func(req *http.Request) (*http.Response, error) {
-			captureCtx <- req.Context()
+			executorCtx <- req.Context()
 			<-req.Context().Done()
 			close(released)
 			return nil, req.Context().Err()
@@ -396,7 +396,7 @@ end
 
 	var ctx context.Context
 	select {
-	case ctx = <-captureCtx:
+	case ctx = <-executorCtx:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("request never received a context")
 	}
@@ -507,7 +507,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "cookie_count")
+	h.capture.WaitForKey(t, "cookie_count")
 	assert.Equal(t, 2, int(h.capture.Number("cookie_count")))
 	assert.Equal(t, "session=abc123; Expires=Tue, 06 May 2026 12:00:00 GMT", h.capture.String("cookie_1"))
 	assert.Equal(t, "tracking=xyz; Path=/", h.capture.String("cookie_2"))
@@ -532,24 +532,7 @@ return function(hive)
 end
 `, client)
 
-	waitForKey(t, h.capture, "type")
+	h.capture.WaitForKey(t, "type")
 	assert.Equal(t, "table", h.capture.String("type"))
 	assert.Equal(t, 0, int(h.capture.Number("count")))
-}
-
-// waitForKey polls for a keyed capture entry with a generous CI-friendly
-// timeout. Use when tests need to await a single named callback rather
-// than an N-element list (waitForCaptures handles the latter).
-func waitForKey(t *testing.T, c *captureModule, key string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if c.Has(key) {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("expected capture key %q within 2s", key)
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
 }

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -68,6 +68,12 @@ func (p *Plugin) Init(_ context.Context) error {
 		Logger:         p.logger.With().Str("module", "sh").Logger(),
 	}
 
+	httpModule := &HTTPModule{
+		DefaultTimeout:  cmp.Or(p.cfg.HTTPTimeout, 30*time.Second),
+		DefaultMaxBytes: cmp.Or(p.cfg.HTTPMaxBytes, int64(10*1024*1024)),
+		Logger:          p.logger.With().Str("module", "http").Logger(),
+	}
+
 	modules := []HostModule{
 		&LogModule{PluginName: p.Name(), Logger: p.logger},
 		&PluginInfoModule{
@@ -83,6 +89,7 @@ func (p *Plugin) Init(_ context.Context) error {
 			Logger: p.logger.With().Str("module", "kv").Logger(),
 		},
 		shModule,
+		httpModule,
 	}
 
 	runtime, err := NewRuntime(p.cfg.ModuleRoot(), p.logger, modules...)
@@ -92,6 +99,7 @@ func (p *Plugin) Init(_ context.Context) error {
 	// Wired post-construction; Register makes no Runtime calls.
 	tickerModule.Runtime = runtime
 	shModule.Runtime = runtime
+	httpModule.Runtime = runtime
 
 	// Stash now so an entrypoint failure below cleans up via shutdown().
 	p.runtime = runtime

--- a/test/integration/lua_plugin_http_test.go
+++ b/test/integration/lua_plugin_http_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLuaPluginHTTPModule_GetPostStatus verifies that hive.http.{get,post}
+// reach a real HTTP server through the Lua runtime end-to-end.
+//
+// The plugin entrypoint runs during plugin init (any hive command triggers
+// it). The first call hits /ok and writes the status code; the second hits
+// /echo with a JSON body and writes both the status and the echoed body.
+// Plugin shutdown drains in-flight async work, so the callbacks all run
+// before `hive config` returns.
+func TestLuaPluginHTTPModule_GetPostStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			w.Header().Set("X-Echo", "hello")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("plain-ok"))
+		case "/echo":
+			body := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(body)
+		case "/error":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	h := NewHarness(t)
+
+	outputFile := filepath.Join(h.DataDir(), "http-output.txt")
+
+	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
+	require.NoError(t, os.WriteFile(entry, []byte(fmt.Sprintf(`
+local OUT = %q
+local BASE = %q
+
+return function(hive)
+  hive.http.get(BASE .. "/ok", function(res, err)
+    if err ~= nil then error("get /ok failed: " .. err) end
+    hive.http.post(BASE .. "/echo", { body = "ping" }, function(post, postErr)
+      if postErr ~= nil then error("post /echo failed: " .. postErr) end
+      hive.http.get(BASE .. "/error", function(errRes, errErr)
+        if errErr ~= nil then error("get /error failed: " .. errErr) end
+        local summary = string.format(
+          "ok_status=%%d|ok_echo=%%s|ok_body=%%s|post_status=%%d|post_body=%%s|err_status=%%d|err_body=%%s",
+          res.status, res.headers["X-Echo"], res.body,
+          post.status, post.body,
+          errRes.status, errRes.body
+        )
+        hive.sh.run(string.format("printf %%%%s '%%s' > %%s", summary, OUT), function(_) end)
+      end)
+    end)
+  end)
+end
+`, outputFile, server.URL)), 0o644))
+
+	h.WithConfig(fmt.Sprintf(`
+plugins:
+  lua:
+    entry: %q
+`, entry))
+
+	_, err := h.RunStdout("config")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outputFile)
+	require.NoError(t, err, "summary file should be created by the lua plugin entrypoint")
+
+	got := string(content)
+	assert.Contains(t, got, "ok_status=200")
+	assert.Contains(t, got, "ok_echo=hello")
+	assert.Contains(t, got, "ok_body=plain-ok")
+	assert.Contains(t, got, "post_status=201")
+	assert.Contains(t, got, "post_body=ping")
+	// Non-2xx responses are still successes — the plugin sees the status.
+	assert.Contains(t, got, "err_status=500")
+	assert.Contains(t, got, "err_body=boom")
+}


### PR DESCRIPTION
## Summary

Adds `hive.http` so Lua plugins can make outbound HTTP requests without
spawning curl. Every entry point is async-by-callback, mirroring the
shape `hive.sh` settled on after #326:

- `hive.http.get(url[, opts], fn)`
- `hive.http.post(url[, opts], fn)`
- `hive.http.put(url[, opts], fn)`
- `hive.http.delete(url[, opts], fn)`
- `hive.http.request(opts, fn)` — full control (`opts.method`, `opts.url`)

The call returns a handle immediately, the request runs on a goroutine
bound to a per-handle context, and the callback fires on the Lua
dispatcher with `(response, err)`:

- On success, `response = { status, body, headers }` and `err = nil`. Non-2xx HTTP responses are still successes — the plugin branches on `response.status`.
- On network/protocol failure, per-call timeout, or `max_bytes` overrun, `response = nil` and `err` is a string.

Each handle exposes `:cancel()`. Plugin shutdown drains in-flight calls
through the existing `asyncRegistry`.

`opts` accepts `headers`, `query`, `body`, `timeout` (seconds), and
`max_bytes`. Defaults are configurable via `plugins.lua.http_timeout`
(30s) and `plugins.lua.http_max_bytes` (10 MiB).

Closes #307.

## Test plan

- [x] `go test -count=1 -race ./internal/hive/plugins/lua/...` passes
- [x] `go build -tags integration ./test/integration/...` compiles; new `TestLuaPluginHTTPModule_GetPostStatus` covers GET, POST with body, and non-2xx-as-success against an `httptest.Server`
- [x] `golangci-lint run ./internal/hive/plugins/lua/...` clean (no new issues)
- [x] Documented in `docs/configuration/plugins.md`
- [ ] CI green