### PR TITLE
feat(plugins): dynamic hive.commands registration

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -145,6 +145,14 @@ hv
 
 Open the command palette with `:`, run `LuaHello`, and confirm that `.lua-plugin-output` was created in the selected session directory.
 
+### Dynamic command registration
+
+`hive.commands(table)` can be called from any Lua context — including ticker callbacks and other deferred work — not just the entrypoint. Each successful call merges its entries into the plugin's command slot; existing names are replaced (last write wins), and new names are added. The TUI command palette picks up changes on the next palette open; an open palette continues to show the snapshot taken when it was opened.
+
+Failures are non-fatal: invalid registrations log an error and leave the existing command set unchanged. The dispatcher work queue is bounded by `plugins.lua.dispatcher_queue_size` (default 128); bursts above this size drop the oldest fire-and-forget submissions with a warn-level log.
+
+The standalone `hc` TUI (`hive hc`) does not load plugins and does not display Lua-registered commands. Run the full `hive` TUI to see them.
+
 ### hive.ticker
 
 Schedule callbacks to run repeatedly or after a delay.

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -177,7 +177,7 @@ end
     All ticker fires share the same dispatcher goroutine as your entrypoint and command handlers, so a long-running callback delays every other ticker on the plugin's Lua state.
 
 !!! warning "Backpressure: drop + log"
-    If a callback runs longer than the tick interval, additional ticks queue in a bounded buffer (currently 64 items per plugin). When the buffer is full, further ticks are dropped and a warning is logged. The module does **not** coalesce or skip cleanly — it drops, so plan for callbacks that may not fire on every tick under heavy load.
+    If a callback runs longer than the tick interval, additional ticks queue in a bounded buffer (default 128 items per plugin, configurable via `plugins.lua.dispatcher_queue_size`). When the buffer is full, further ticks are dropped and a warning is logged. The module does **not** coalesce or skip cleanly — it drops, so plan for callbacks that may not fire on every tick under heavy load.
 
 !!! note "Shutdown cancels everything"
     When hive shuts down or the plugin is reloaded, every outstanding ticker is cancelled and its callback is released for GC.
@@ -323,7 +323,8 @@ end
 plugins:
   lua:
     enabled: true
-    shell_timeout: 30s   # per-call timeout for hive.sh.* (default: 30s)
+    shell_timeout: 30s            # per-call timeout for hive.sh.* (default: 30s)
+    dispatcher_queue_size: 128    # bounded buffer for ticker fires and other deferred work (default: 128)
 ```
 
 ### hive.http

--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -96,6 +96,7 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 		Bus:             cmd.app.Bus,
 		TerminalManager: termMgr,
 		PluginManager:   cmd.app.Plugins,
+		CommandSet:      cmd.app.CommandSet,
 		DB:              cmd.app.DB,
 		KVStore:         cmd.app.KV,
 		Renderer:        cmd.app.Renderer,

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -894,6 +894,7 @@ func (c *Config) Validate() error {
 		criterio.Run("database.max_open_conns", c.Database.MaxOpenConns, criterio.Min(1)),
 		criterio.Run("database.max_idle_conns", c.Database.MaxIdleConns, criterio.Min(1)),
 		criterio.Run("database.busy_timeout", c.Database.BusyTimeout, criterio.Min(0)),
+		criterio.Run("plugins.lua.dispatcher_queue_size", c.Plugins.Lua.DispatcherQueueSize, criterio.Min(0)),
 		c.validateTheme(),
 		c.validateGroupBy(),
 		c.validateKeybindingsBasic(),

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"cmp"
 	"fmt"
 	"maps"
 	"os"
@@ -509,6 +510,9 @@ type LuaPluginConfig struct {
 	ShellTimeout time.Duration `json:"shell_timeout"  yaml:"shell_timeout"`  // per-call timeout for hive.sh.* (default: 30s)
 	HTTPTimeout  time.Duration `json:"http_timeout"   yaml:"http_timeout"`   // per-call timeout for hive.http.* (default: 30s)
 	HTTPMaxBytes int64         `json:"http_max_bytes" yaml:"http_max_bytes"` // response body cap for hive.http.* (default: 10 MiB)
+	// DispatcherQueueSize bounds the Lua dispatcher work queue; bursts above
+	// this size drop with a warn log. Default: 128.
+	DispatcherQueueSize int `json:"dispatcher_queue_size" yaml:"dispatcher_queue_size"`
 }
 
 // ResolvedEntry returns the configured Lua entry path or the default discovery path.
@@ -833,6 +837,7 @@ func (c *Config) applyDefaults() {
 	if c.Plugins.GitHub.ResultsCache == 0 {
 		c.Plugins.GitHub.ResultsCache = 8 * time.Minute
 	}
+	c.Plugins.Lua.DispatcherQueueSize = cmp.Or(c.Plugins.Lua.DispatcherQueueSize, 128)
 	if len(c.Agents.Profiles) == 0 {
 		c.Agents.Profiles = map[string]AgentProfile{
 			"claude": {},

--- a/internal/core/config/lua_plugin_test.go
+++ b/internal/core/config/lua_plugin_test.go
@@ -127,3 +127,34 @@ func TestValidate_LuaPluginEntryRejectsRelativePath(t *testing.T) {
 	assert.Equal(t, "plugins.lua.entry", fieldErrs[0].Field)
 	assert.Contains(t, fieldErrs[0].Err.Error(), "must be an absolute path")
 }
+
+func TestValidate_LuaPluginDispatcherQueueSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    int
+		wantErr bool
+	}{
+		{"default fills via applyDefaults", 0, false},
+		{"explicit small positive", 1, false},
+		{"explicit large positive", 1024, false},
+		{"negative rejected", -1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.Plugins.Lua.DispatcherQueueSize = tt.size
+			cfg.applyDefaults()
+
+			err := cfg.Validate()
+			if tt.wantErr {
+				var fieldErrs criterio.FieldErrors
+				require.ErrorAs(t, err, &fieldErrs)
+				require.Len(t, fieldErrs, 1)
+				assert.Equal(t, "plugins.lua.dispatcher_queue_size", fieldErrs[0].Field)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/hive/app.go
+++ b/internal/hive/app.go
@@ -32,14 +32,15 @@ type App struct {
 	Todos     *TodoService
 	Honeycomb *HoneycombService
 
-	Bus      *eventbus.EventBus
-	Terminal *terminal.Manager
-	Plugins  *plugins.Manager
-	Config   *config.Config
-	DB       *db.DB
-	KV       kv.KV
-	Renderer *tmpl.Renderer
-	Build    BuildInfo
+	Bus        *eventbus.EventBus
+	Terminal   *terminal.Manager
+	Plugins    *plugins.Manager
+	CommandSet *plugins.CommandSet
+	Config     *config.Config
+	DB         *db.DB
+	KV         kv.KV
+	Renderer   *tmpl.Renderer
+	Build      BuildInfo
 }
 
 // NewApp constructs an App from explicit dependencies.
@@ -52,6 +53,7 @@ func NewApp(
 	bus *eventbus.EventBus,
 	termMgr *terminal.Manager,
 	pluginMgr *plugins.Manager,
+	commandSet *plugins.CommandSet,
 	database *db.DB,
 	kvStore kv.KV,
 	renderer *tmpl.Renderer,
@@ -59,18 +61,19 @@ func NewApp(
 	logger zerolog.Logger,
 ) *App {
 	return &App{
-		Sessions:  sessions,
-		Messages:  NewMessageService(msgStore, cfg, bus),
-		Context:   NewContextService(cfg, sessions.git),
-		Doctor:    NewDoctorService(sessions.sessions, cfg, pluginInfos),
-		Todos:     NewTodoService(todoStore, bus, cfg, logger.With().Str("component", "todos").Logger()),
-		Honeycomb: NewHoneycombService(hcStore, logger.With().Str("component", "honeycomb").Logger()),
-		Bus:       bus,
-		Terminal:  termMgr,
-		Plugins:   pluginMgr,
-		Config:    cfg,
-		DB:        database,
-		KV:        kvStore,
-		Renderer:  renderer,
+		Sessions:   sessions,
+		Messages:   NewMessageService(msgStore, cfg, bus),
+		Context:    NewContextService(cfg, sessions.git),
+		Doctor:     NewDoctorService(sessions.sessions, cfg, pluginInfos),
+		Todos:      NewTodoService(todoStore, bus, cfg, logger.With().Str("component", "todos").Logger()),
+		Honeycomb:  NewHoneycombService(hcStore, logger.With().Str("component", "honeycomb").Logger()),
+		Bus:        bus,
+		Terminal:   termMgr,
+		Plugins:    pluginMgr,
+		CommandSet: commandSet,
+		Config:     cfg,
+		DB:         database,
+		KV:         kvStore,
+		Renderer:   renderer,
 	}
 }

--- a/internal/hive/plugins/commandset.go
+++ b/internal/hive/plugins/commandset.go
@@ -1,0 +1,126 @@
+package plugins
+
+import (
+	"maps"
+	"sync"
+
+	"github.com/colonyops/hive/internal/core/config"
+)
+
+// CommandSet is the canonical merged registry of user commands across system
+// defaults, plugin contributions, and user-config overrides. It is concurrent-
+// safe: writers from any goroutine push via Set*/Merge*; readers via Lookup
+// or All. Merge precedence in reads is user > plugin > system.
+//
+// Slots are kept separate so writers touch only their own source — a plugin
+// re-registering does not need to know about user/system entries to avoid
+// clobbering them.
+type CommandSet struct {
+	mu      sync.RWMutex
+	system  map[string]config.UserCommand
+	user    map[string]config.UserCommand
+	plugins map[string]map[string]config.UserCommand // plugin name -> commands
+}
+
+// NewCommandSet constructs a CommandSet seeded with system and user commands.
+// Either map may be nil (treated as empty). System and user are immutable
+// after construction; if a config-reload story arrives later, add setters then.
+func NewCommandSet(system, user map[string]config.UserCommand) *CommandSet {
+	return &CommandSet{
+		system:  cloneCommands(system),
+		user:    cloneCommands(user),
+		plugins: map[string]map[string]config.UserCommand{},
+	}
+}
+
+// SetPlugin replaces the named plugin's slot. Used by static plugins at
+// InitAll time and to clear a per-plugin slot during a Plugin re-init.
+// Pass nil cmds to clear (removes the entry from plugins map).
+func (s *CommandSet) SetPlugin(name string, cmds map[string]config.UserCommand) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if cmds == nil {
+		delete(s.plugins, name)
+		return
+	}
+	s.plugins[name] = cloneCommands(cmds)
+}
+
+// MergePlugin merges cmds into the named plugin's slot. Existing entries
+// not in cmds are preserved; entries in cmds replace any existing same-named
+// entry. Used by the Lua plugin on each hive.commands(...) call.
+func (s *CommandSet) MergePlugin(name string, cmds map[string]config.UserCommand) {
+	if cmds == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	slot, ok := s.plugins[name]
+	if !ok {
+		slot = make(map[string]config.UserCommand, len(cmds))
+		s.plugins[name] = slot
+	}
+	maps.Copy(slot, cmds)
+}
+
+// Plugin returns a defensive copy of the named plugin's slot, or nil if the
+// plugin has no slot.
+func (s *CommandSet) Plugin(name string) map[string]config.UserCommand {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	slot, ok := s.plugins[name]
+	if !ok {
+		return nil
+	}
+	return cloneCommands(slot)
+}
+
+// Lookup returns a single merged command by name, applying precedence
+// (user > plugin > system). The boolean is false if no source defines name.
+// Hot path: called per keystroke from the keybinding resolver. One RLock,
+// up to three map lookups, no allocation.
+func (s *CommandSet) Lookup(name string) (config.UserCommand, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if cmd, ok := s.user[name]; ok {
+		return cmd, true
+	}
+	for _, slot := range s.plugins {
+		if cmd, ok := slot[name]; ok {
+			return cmd, true
+		}
+	}
+	if cmd, ok := s.system[name]; ok {
+		return cmd, true
+	}
+	return config.UserCommand{}, false
+}
+
+// All returns a defensive copy of the fully merged command map.
+func (s *CommandSet) All() map[string]config.UserCommand {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make(map[string]config.UserCommand, len(s.system)+len(s.user))
+	maps.Copy(result, s.system)
+	for _, slot := range s.plugins {
+		maps.Copy(result, slot)
+	}
+	maps.Copy(result, s.user)
+	return result
+}
+
+// cloneCommands returns a shallow copy of m, or an empty map if m is nil.
+// UserCommand contains slice fields (Windows, Form, Scope); we deliberately
+// do NOT deep-copy those — callers are expected to treat command values as
+// immutable once published into the set.
+func cloneCommands(m map[string]config.UserCommand) map[string]config.UserCommand {
+	out := make(map[string]config.UserCommand, len(m))
+	maps.Copy(out, m)
+	return out
+}

--- a/internal/hive/plugins/commandset_test.go
+++ b/internal/hive/plugins/commandset_test.go
@@ -1,0 +1,242 @@
+package plugins
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/colonyops/hive/internal/core/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandSet_PrecedenceOrdering(t *testing.T) {
+	system := map[string]config.UserCommand{"Foo": {Sh: "S"}}
+	user := map[string]config.UserCommand{"Foo": {Sh: "U"}}
+
+	// All three sources contribute Foo: user wins.
+	s := NewCommandSet(system, user)
+	s.SetPlugin("p", map[string]config.UserCommand{"Foo": {Sh: "P"}})
+
+	got, ok := s.Lookup("Foo")
+	assert.True(t, ok)
+	assert.Equal(t, "U", got.Sh)
+	assert.Equal(t, "U", s.All()["Foo"].Sh)
+
+	// Drop user: plugin wins.
+	s = NewCommandSet(system, nil)
+	s.SetPlugin("p", map[string]config.UserCommand{"Foo": {Sh: "P"}})
+
+	got, ok = s.Lookup("Foo")
+	assert.True(t, ok)
+	assert.Equal(t, "P", got.Sh)
+	assert.Equal(t, "P", s.All()["Foo"].Sh)
+
+	// Drop user and plugin: system wins.
+	s = NewCommandSet(system, nil)
+
+	got, ok = s.Lookup("Foo")
+	assert.True(t, ok)
+	assert.Equal(t, "S", got.Sh)
+	assert.Equal(t, "S", s.All()["Foo"].Sh)
+}
+
+func TestCommandSet_MergePlugin_PerKeyMerge(t *testing.T) {
+	s := NewCommandSet(nil, nil)
+
+	s.MergePlugin("lua", map[string]config.UserCommand{
+		"A": {Sh: "a1"},
+		"B": {Sh: "b1"},
+	})
+	s.MergePlugin("lua", map[string]config.UserCommand{
+		"B": {Sh: "b2"},
+		"C": {Sh: "c1"},
+	})
+
+	got := s.Plugin("lua")
+	assert.Len(t, got, 3)
+	assert.Equal(t, "a1", got["A"].Sh)
+	assert.Equal(t, "b2", got["B"].Sh) // replaced
+	assert.Equal(t, "c1", got["C"].Sh)
+}
+
+func TestCommandSet_SetPlugin_ReplacesSlot(t *testing.T) {
+	s := NewCommandSet(nil, nil)
+
+	s.SetPlugin("lua", map[string]config.UserCommand{
+		"A": {Sh: "a"},
+		"B": {Sh: "b"},
+	})
+	s.SetPlugin("lua", map[string]config.UserCommand{
+		"C": {Sh: "c"},
+	})
+
+	got := s.Plugin("lua")
+	assert.Len(t, got, 1)
+	_, hasA := got["A"]
+	_, hasB := got["B"]
+	assert.False(t, hasA)
+	assert.False(t, hasB)
+	assert.Equal(t, "c", got["C"].Sh)
+}
+
+func TestCommandSet_SetPluginNil_ClearsSlot(t *testing.T) {
+	s := NewCommandSet(nil, nil)
+
+	s.SetPlugin("lua", map[string]config.UserCommand{"A": {Sh: "a"}})
+	s.SetPlugin("lua", nil)
+
+	assert.Nil(t, s.Plugin("lua"))
+
+	all := s.All()
+	_, hasA := all["A"]
+	assert.False(t, hasA)
+}
+
+func TestCommandSet_DefensiveCopy_All(t *testing.T) {
+	s := NewCommandSet(
+		map[string]config.UserCommand{"Sys": {Sh: "s"}},
+		map[string]config.UserCommand{"Usr": {Sh: "u"}},
+	)
+	s.SetPlugin("p", map[string]config.UserCommand{"Plug": {Sh: "p"}})
+
+	first := s.All()
+	first["Injected"] = config.UserCommand{Sh: "x"}
+	mutated := first["Sys"]
+	mutated.Sh = "MUTATED"
+	first["Sys"] = mutated
+
+	second := s.All()
+	_, hasInjected := second["Injected"]
+	assert.False(t, hasInjected)
+	assert.Equal(t, "s", second["Sys"].Sh)
+	assert.Equal(t, "u", second["Usr"].Sh)
+	assert.Equal(t, "p", second["Plug"].Sh)
+}
+
+func TestCommandSet_DefensiveCopy_Plugin(t *testing.T) {
+	s := NewCommandSet(nil, nil)
+	s.SetPlugin("lua", map[string]config.UserCommand{"A": {Sh: "a"}})
+
+	first := s.Plugin("lua")
+	first["Injected"] = config.UserCommand{Sh: "x"}
+	mutated := first["A"]
+	mutated.Sh = "MUTATED"
+	first["A"] = mutated
+
+	second := s.Plugin("lua")
+	_, hasInjected := second["Injected"]
+	assert.False(t, hasInjected)
+	assert.Equal(t, "a", second["A"].Sh)
+
+	// And Lookup is unaffected.
+	got, ok := s.Lookup("A")
+	assert.True(t, ok)
+	assert.Equal(t, "a", got.Sh)
+}
+
+func TestCommandSet_NewCommandSet_DefensiveCopy(t *testing.T) {
+	system := map[string]config.UserCommand{"Sys": {Sh: "s"}}
+	user := map[string]config.UserCommand{"Usr": {Sh: "u"}}
+
+	s := NewCommandSet(system, user)
+
+	// Mutate input maps after construction.
+	system["Sys"] = config.UserCommand{Sh: "MUTATED"}
+	system["Injected"] = config.UserCommand{Sh: "x"}
+	user["Usr"] = config.UserCommand{Sh: "MUTATED"}
+	user["Injected"] = config.UserCommand{Sh: "x"}
+
+	all := s.All()
+	assert.Equal(t, "s", all["Sys"].Sh)
+	assert.Equal(t, "u", all["Usr"].Sh)
+	_, hasInjected := all["Injected"]
+	assert.False(t, hasInjected)
+}
+
+func TestCommandSet_Lookup_NoAllocations(t *testing.T) {
+	s := NewCommandSet(
+		map[string]config.UserCommand{"OnlySys": {Sh: "s"}},
+		map[string]config.UserCommand{"OnlyUsr": {Sh: "u"}},
+	)
+	s.SetPlugin("p", map[string]config.UserCommand{"OnlyPlug": {Sh: "p"}})
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"user", "OnlyUsr"},
+		{"plugin", "OnlyPlug"},
+		{"system", "OnlySys"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := testing.AllocsPerRun(100, func() {
+				_, ok := s.Lookup(tc.key)
+				if !ok {
+					t.Fatalf("Lookup(%q) returned !ok", tc.key)
+				}
+			})
+			assert.InDelta(t, 0.0, got, 0, "Lookup must not allocate (%s slot)", tc.name)
+		})
+	}
+}
+
+func TestCommandSet_ConcurrentReadersWriters(t *testing.T) {
+	const sharedKey = "Shared"
+
+	s := NewCommandSet(
+		map[string]config.UserCommand{"Sys": {Sh: "s"}},
+		map[string]config.UserCommand{"Usr": {Sh: "u"}},
+	)
+	// Seed a few plugin slots so readers have something to find.
+	for i := range 4 {
+		s.SetPlugin(pluginName(i), map[string]config.UserCommand{
+			sharedKey: {Sh: "p"},
+		})
+	}
+
+	const writers = 10
+	const writerIters = 100
+	const readers = 10
+	const readerIters = 1000
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for w := range writers {
+		wg.Go(func() {
+			<-start
+			pname := pluginName(w)
+			for i := range writerIters {
+				if i%2 == 0 {
+					s.MergePlugin(pname, map[string]config.UserCommand{
+						sharedKey: {Sh: "merged"},
+					})
+				} else {
+					s.SetPlugin(pname, map[string]config.UserCommand{
+						sharedKey: {Sh: "set"},
+					})
+				}
+			}
+		})
+	}
+
+	for range readers {
+		wg.Go(func() {
+			<-start
+			for range readerIters {
+				_, _ = s.Lookup(sharedKey)
+				_, _ = s.Lookup("Sys")
+				_, _ = s.Lookup("Usr")
+				_ = s.All()
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+func pluginName(i int) string {
+	return "p-" + string(rune('a'+i))
+}

--- a/internal/hive/plugins/lua/helpers_test.go
+++ b/internal/hive/plugins/lua/helpers_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	glua "github.com/yuin/gopher-lua"
+
+	"github.com/colonyops/hive/internal/hive/plugins"
 )
 
 // testPluginName is the plugin name registered with LogModule and
@@ -233,11 +235,11 @@ func newLuaHarness(t *testing.T, script string, extras ...HostModule) *luaHarnes
 	modules := append([]HostModule{
 		&LogModule{PluginName: testPluginName, Logger: zerolog.Nop()},
 		&PluginInfoModule{Name: testPluginName, Entry: entry, ModuleRoot: root},
-		&CommandsModule{},
+		&CommandsModule{PluginName: testPluginName, Set: plugins.NewCommandSet(nil, nil)},
 		capture,
 	}, extras...)
 
-	rt, err := NewRuntime(root, zerolog.Nop(), modules...)
+	rt, err := NewRuntime(zerolog.Nop(), root, 64, modules...)
 	require.NoError(t, err)
 
 	for _, m := range extras {

--- a/internal/hive/plugins/lua/module_commands.go
+++ b/internal/hive/plugins/lua/module_commands.go
@@ -2,48 +2,44 @@ package lua
 
 import (
 	"fmt"
-	"maps"
 	"strconv"
 
 	"github.com/colonyops/hive/internal/core/config"
+	"github.com/colonyops/hive/internal/hive/plugins"
 	glua "github.com/yuin/gopher-lua"
 )
 
-// CommandsModule exposes `hive.commands(map)` and accumulates registered
-// commands. Read them out via Commands() after the entrypoint runs.
+// CommandsModule exposes `hive.commands(table)` to Lua plugins. Each call
+// merges its entries into the plugin's slot in the shared CommandSet via
+// MergePlugin. Registrations from any Lua context (entrypoint, ticker
+// callback, deferred work) are supported; re-registering an existing name
+// replaces it (last-write-wins).
 //
-// A CommandsModule is single-use: registration writes into its commands map,
-// so create a fresh instance per Runtime.
+// Concurrency: the dispatcher goroutine is the sole writer through this
+// module. CommandSet.MergePlugin takes its own write lock and is safe to
+// call from any goroutine.
 type CommandsModule struct {
-	commands map[string]config.UserCommand
+	PluginName string
+	Set        *plugins.CommandSet
 }
 
 // Register exposes hive.commands(map) and lazily allocates the
 // accumulator if a previous Register hasn't already done so.
 func (m *CommandsModule) Register(state *glua.LState, hive *glua.LTable) error {
-	if m.commands == nil {
-		m.commands = map[string]config.UserCommand{}
-	}
 	state.SetField(hive, "commands", state.NewFunction(func(state *glua.LState) int {
 		table := state.CheckTable(1)
-		next, err := commandsFromTable(table, m.commands)
+		next, err := commandsFromTable(table)
 		if err != nil {
 			state.RaiseError("hive.commands: %s", err.Error())
 			return 0
 		}
-		maps.Copy(m.commands, next)
+		m.Set.MergePlugin(m.PluginName, next)
 		return 0
 	}))
 	return nil
 }
 
-// Commands returns the commands registered by the Lua plugin. Returns an
-// empty map until at least one Register call has occurred.
-func (m *CommandsModule) Commands() map[string]config.UserCommand {
-	return m.commands
-}
-
-func commandsFromTable(commandsTable *glua.LTable, existing map[string]config.UserCommand) (map[string]config.UserCommand, error) {
+func commandsFromTable(commandsTable *glua.LTable) (map[string]config.UserCommand, error) {
 	commands := make(map[string]config.UserCommand)
 	var parseErr error
 
@@ -55,10 +51,6 @@ func commandsFromTable(commandsTable *glua.LTable, existing map[string]config.Us
 		name, ok := key.(glua.LString)
 		if !ok {
 			parseErr = fmt.Errorf("command names must be strings")
-			return
-		}
-		if _, dup := existing[string(name)]; dup {
-			parseErr = fmt.Errorf("duplicate command %q", string(name))
 			return
 		}
 

--- a/internal/hive/plugins/lua/module_commands_test.go
+++ b/internal/hive/plugins/lua/module_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -247,4 +248,38 @@ end
 	t.Cleanup(func() { require.NoError(t, plugin.Close()) })
 
 	assert.Equal(t, "echo second", plugin.Commands()["LuaHello"].Sh)
+}
+
+// TestCommandsModule_TickerFiredRegistration is the regression test for the
+// dynamic-registration scenario the epic targets: an entrypoint registers a
+// command, schedules a ticker callback that re-registers the same command
+// with a different sh, and the post-tick value is observable in the shared
+// CommandSet. Uses a 1s after() because tickerMinInterval floors at 1s.
+func TestCommandsModule_TickerFiredRegistration(t *testing.T) {
+	entry := filepath.Join(t.TempDir(), "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.commands({ Foo = { sh = "first" } })
+  hive.ticker.after("1s", function()
+    hive.commands({ Foo = { sh = "second" } })
+  end)
+end
+`), 0o644))
+
+	plugin, set := newConfigPluginWithSet(entry)
+	require.NoError(t, plugin.Init(context.Background()))
+	t.Cleanup(func() { require.NoError(t, plugin.Close()) })
+
+	// Initial registration is synchronous through the entrypoint.
+	require.Equal(t, "first", set.Plugin("lua")["Foo"].Sh)
+
+	// Wait for the ticker to fire and replace.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if set.Plugin("lua")["Foo"].Sh == "second" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("ticker did not fire registration within deadline; got Sh=%q", set.Plugin("lua")["Foo"].Sh)
 }

--- a/internal/hive/plugins/lua/module_commands_test.go
+++ b/internal/hive/plugins/lua/module_commands_test.go
@@ -168,20 +168,6 @@ end
 			errMsg: `command "Broken"`,
 		},
 		{
-			name: "duplicate command names",
-			script: `
-return function(hive)
-  hive.commands({
-    LuaHello = { sh = "echo first" },
-  })
-  hive.commands({
-    LuaHello = { sh = "echo second" },
-  })
-end
-`,
-			errMsg: `duplicate command "LuaHello"`,
-		},
-		{
 			name: "invalid template syntax",
 			script: `
 return function(hive)
@@ -245,4 +231,20 @@ end
 			assert.Contains(t, err.Error(), `field "`+field+`" is not supported`)
 		})
 	}
+}
+
+func TestCommandsModule_ReplaceByName(t *testing.T) {
+	entry := filepath.Join(t.TempDir(), "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.commands({ LuaHello = { sh = "echo first" } })
+  hive.commands({ LuaHello = { sh = "echo second" } })
+end
+`), 0o644))
+
+	plugin := NewConfigPlugin(entry)
+	require.NoError(t, plugin.Init(context.Background()))
+	t.Cleanup(func() { require.NoError(t, plugin.Close()) })
+
+	assert.Equal(t, "echo second", plugin.Commands()["LuaHello"].Sh)
 }

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -51,7 +51,7 @@ func (p *Plugin) Available() bool {
 // Init builds the Lua runtime, loads the entrypoint, and runs it once
 // to register commands and other plugin state. Re-initialisation is
 // supported: any prior runtime is shut down first so commands from a
-// previous Init can't leak into MergedCommands.
+// previous Init can't leak into the shared CommandSet's plugin slot.
 func (p *Plugin) Init(_ context.Context) error {
 	p.shutdown()
 
@@ -128,15 +128,13 @@ func (p *Plugin) Close() error {
 	return nil
 }
 
-// shutdown clears the plugin's slot in the shared CommandSet, then closes
-// every HostModuleCloser in reverse-registration order before closing the
-// runtime. Errors are logged but do not short-circuit. Safe on a partial
-// init; idempotent.
+// shutdown stops the runtime and host modules before clearing the plugin's
+// slot in the shared CommandSet. Order matters: closing the runtime drains
+// any queued hive.commands(...) work, and closing host modules stops tickers
+// that could still submit more. Clearing the slot last guarantees no writer
+// can repopulate it after the clear. Errors are logged but do not
+// short-circuit. Safe on a partial init; idempotent.
 func (p *Plugin) shutdown() {
-	if p.cmdSet != nil {
-		p.cmdSet.SetPlugin(p.Name(), nil)
-	}
-
 	for i := len(p.modules) - 1; i >= 0; i-- {
 		closer, ok := p.modules[i].(HostModuleCloser)
 		if !ok {
@@ -153,6 +151,10 @@ func (p *Plugin) shutdown() {
 	if p.runtime != nil {
 		p.runtime.Close()
 		p.runtime = nil
+	}
+
+	if p.cmdSet != nil {
+		p.cmdSet.SetPlugin(p.Name(), nil)
 	}
 }
 

--- a/internal/hive/plugins/lua/plugin.go
+++ b/internal/hive/plugins/lua/plugin.go
@@ -20,20 +20,22 @@ const pluginName = "lua"
 
 // Plugin adapts a Lua entry file to Hive's plugin interface.
 type Plugin struct {
-	cfg      config.LuaPluginConfig
-	kvStore  kv.KV
-	pool     *plugins.WorkerPool
-	logger   zerolog.Logger
-	runtime  *Runtime
-	modules  []HostModule
-	commands map[string]config.UserCommand
+	cfg     config.LuaPluginConfig
+	kvStore kv.KV
+	pool    *plugins.WorkerPool
+	cmdSet  *plugins.CommandSet
+	logger  zerolog.Logger
+	runtime *Runtime
+	modules []HostModule
 }
 
 // New creates a Lua-backed Hive plugin. The shared worker pool throttles
 // hive.sh.* shell execution; pass nil only in tests that don't exercise the
-// shell module.
-func New(cfg config.LuaPluginConfig, kvStore kv.KV, pool *plugins.WorkerPool, logger zerolog.Logger) *Plugin {
-	return &Plugin{cfg: cfg, kvStore: kvStore, pool: pool, logger: logger}
+// shell module. cmdSet is the shared command registry the plugin pushes
+// hive.commands(...) registrations into; tests that don't exercise commands
+// may pass plugins.NewCommandSet(nil, nil).
+func New(cfg config.LuaPluginConfig, kvStore kv.KV, pool *plugins.WorkerPool, cmdSet *plugins.CommandSet, logger zerolog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, kvStore: kvStore, pool: pool, cmdSet: cmdSet, logger: logger}
 }
 
 // Name returns the plugin identifier used in logs and the kv namespace.
@@ -53,10 +55,10 @@ func (p *Plugin) Available() bool {
 func (p *Plugin) Init(_ context.Context) error {
 	p.shutdown()
 
-	// Build into a fresh CommandsModule so a partial init (failure during
-	// entry-file load or while calling the entrypoint) cannot leave stale
-	// commands reachable from MergedCommands.
-	cmdModule := &CommandsModule{}
+	cmdModule := &CommandsModule{
+		PluginName: p.Name(),
+		Set:        p.cmdSet,
+	}
 
 	tickerModule := &TickerModule{
 		Logger: p.logger.With().Str("module", "ticker").Logger(),
@@ -92,7 +94,7 @@ func (p *Plugin) Init(_ context.Context) error {
 		httpModule,
 	}
 
-	runtime, err := NewRuntime(p.cfg.ModuleRoot(), p.logger, modules...)
+	runtime, err := NewRuntime(p.logger, p.cfg.ModuleRoot(), p.cfg.DispatcherQueueSize, modules...)
 	if err != nil {
 		return err
 	}
@@ -116,7 +118,6 @@ func (p *Plugin) Init(_ context.Context) error {
 		return fmt.Errorf("initialize lua plugin %q: %w", p.cfg.ResolvedEntry(), err)
 	}
 
-	p.commands = cmdModule.Commands()
 	return nil
 }
 
@@ -127,10 +128,15 @@ func (p *Plugin) Close() error {
 	return nil
 }
 
-// shutdown closes every HostModuleCloser in reverse-registration order
-// before closing the runtime. Errors are logged but do not short-circuit.
-// Safe on a partial init; idempotent.
+// shutdown clears the plugin's slot in the shared CommandSet, then closes
+// every HostModuleCloser in reverse-registration order before closing the
+// runtime. Errors are logged but do not short-circuit. Safe on a partial
+// init; idempotent.
 func (p *Plugin) shutdown() {
+	if p.cmdSet != nil {
+		p.cmdSet.SetPlugin(p.Name(), nil)
+	}
+
 	for i := len(p.modules) - 1; i >= 0; i-- {
 		closer, ok := p.modules[i].(HostModuleCloser)
 		if !ok {
@@ -148,13 +154,15 @@ func (p *Plugin) shutdown() {
 		p.runtime.Close()
 		p.runtime = nil
 	}
-	p.commands = nil
 }
 
 // Commands returns the user commands registered by the plugin's
 // entrypoint. Returns nil if Init has not run or if it failed.
 func (p *Plugin) Commands() map[string]config.UserCommand {
-	return p.commands
+	if p.cmdSet == nil {
+		return nil
+	}
+	return p.cmdSet.Plugin(p.Name())
 }
 
 // StatusProvider returns nil because Lua plugins don't expose a status

--- a/internal/hive/plugins/lua/plugin_test.go
+++ b/internal/hive/plugins/lua/plugin_test.go
@@ -75,7 +75,13 @@ end
 // NewConfigPlugin builds a Plugin from a single entry file path. Shared by
 // the lifecycle, runtime, and per-module tests in this package.
 func NewConfigPlugin(entry string) *Plugin {
-	return New(config.LuaPluginConfig{Entry: entry}, newFakeKV(), plugins.NewWorkerPool(1), zerolog.Nop())
+	return New(
+		config.LuaPluginConfig{Entry: entry, DispatcherQueueSize: 64},
+		newFakeKV(),
+		plugins.NewWorkerPool(1),
+		plugins.NewCommandSet(nil, nil),
+		zerolog.Nop(),
+	)
 }
 
 // fakeKV is an in-memory kv.KV used purely for test wiring. It JSON-encodes

--- a/internal/hive/plugins/lua/plugin_test.go
+++ b/internal/hive/plugins/lua/plugin_test.go
@@ -72,6 +72,27 @@ end
 	assert.Empty(t, plugin.Commands(), "Commands() must be empty after a failed Init")
 }
 
+func TestPlugin_Reinit_ClearsLuaSlot(t *testing.T) {
+	entry := filepath.Join(t.TempDir(), "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.commands({ Foo = { sh = "echo foo" } })
+end
+`), 0o644))
+
+	plugin, set := newConfigPluginWithSet(entry)
+	require.NoError(t, plugin.Init(context.Background()))
+	require.Contains(t, set.Plugin("lua"), "Foo")
+
+	// Re-write entry to register nothing.
+	require.NoError(t, os.WriteFile(entry, []byte(`return function(hive) end`), 0o644))
+	require.NoError(t, plugin.Init(context.Background()))
+	t.Cleanup(func() { require.NoError(t, plugin.Close()) })
+
+	// After re-init, the slot must not contain Foo from the prior run.
+	assert.NotContains(t, set.Plugin("lua"), "Foo")
+}
+
 // NewConfigPlugin builds a Plugin from a single entry file path. Shared by
 // the lifecycle, runtime, and per-module tests in this package.
 func NewConfigPlugin(entry string) *Plugin {
@@ -82,6 +103,21 @@ func NewConfigPlugin(entry string) *Plugin {
 		plugins.NewCommandSet(nil, nil),
 		zerolog.Nop(),
 	)
+}
+
+// newConfigPluginWithSet builds a Plugin and returns the shared CommandSet so
+// tests can inspect plugin slot writes directly. Mirrors NewConfigPlugin but
+// hands the set back to the caller.
+func newConfigPluginWithSet(entry string) (*Plugin, *plugins.CommandSet) {
+	set := plugins.NewCommandSet(nil, nil)
+	p := New(
+		config.LuaPluginConfig{Entry: entry, DispatcherQueueSize: 64},
+		newFakeKV(),
+		plugins.NewWorkerPool(1),
+		set,
+		zerolog.Nop(),
+	)
+	return p, set
 }
 
 // fakeKV is an in-memory kv.KV used purely for test wiring. It JSON-encodes

--- a/internal/hive/plugins/lua/plugin_test.go
+++ b/internal/hive/plugins/lua/plugin_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
 )
 
 func TestPluginAvailable(t *testing.T) {
@@ -91,6 +92,34 @@ end
 
 	// After re-init, the slot must not contain Foo from the prior run.
 	assert.NotContains(t, set.Plugin("lua"), "Foo")
+}
+
+func TestPlugin_Close_ClearsSlotAfterDispatcherDrains(t *testing.T) {
+	entry := filepath.Join(t.TempDir(), "init.lua")
+	require.NoError(t, os.WriteFile(entry, []byte(`
+return function(hive)
+  hive.commands({ Foo = { sh = "echo foo" } })
+end
+`), 0o644))
+
+	p, set := newConfigPluginWithSet(entry)
+	require.NoError(t, p.Init(context.Background()))
+	require.Contains(t, set.Plugin("lua"), "Foo")
+
+	// Queue a MergePlugin on the dispatcher right before Close. The
+	// dispatcher drains pending work during Close, so this work is
+	// guaranteed to run; the bug fix ensures the slot is cleared *after*
+	// the runtime has fully shut down, so any late writer cannot leave
+	// stale commands behind.
+	p.runtime.Submit(func(_ *glua.LState) {
+		set.MergePlugin("lua", map[string]config.UserCommand{
+			"LateRegistered": {Sh: "echo late"},
+		})
+	})
+
+	require.NoError(t, p.Close())
+
+	assert.Empty(t, set.Plugin("lua"), "slot must be empty after Close, regardless of in-flight dispatcher work")
 }
 
 // NewConfigPlugin builds a Plugin from a single entry file path. Shared by

--- a/internal/hive/plugins/lua/runtime.go
+++ b/internal/hive/plugins/lua/runtime.go
@@ -13,11 +13,6 @@ import (
 	glua "github.com/yuin/gopher-lua"
 )
 
-// dispatcherQueueSize buffers async work (ticker fires, etc.) without
-// blocking producers, but stays small enough that a runaway producer
-// surfaces via drop+log.
-const dispatcherQueueSize = 64
-
 // Runtime owns a sandboxed Lua state. Exactly one goroutine — the
 // dispatcher started in NewRuntime — touches state. Schedule work via
 // Submit, LoadEntrypoint, or CallEntrypoint; tear down with Close.
@@ -36,9 +31,15 @@ type Runtime struct {
 
 // NewRuntime constructs a sandboxed Lua runtime, configures `require()` to
 // resolve relative to moduleRoot, and registers each HostModule onto the
-// global `hive` table. Setup is synchronous; the dispatcher goroutine takes
-// over LState ownership when this returns.
-func NewRuntime(moduleRoot string, logger zerolog.Logger, modules ...HostModule) (*Runtime, error) {
+// global `hive` table. queueSize bounds the dispatcher's work-channel buffer;
+// producers that exceed it drop with a warn-level log via Submit. Setup is
+// synchronous; the dispatcher goroutine takes over LState ownership when
+// this returns.
+func NewRuntime(logger zerolog.Logger, moduleRoot string, queueSize int, modules ...HostModule) (*Runtime, error) {
+	if queueSize < 1 {
+		return nil, fmt.Errorf("dispatcher queue size must be >= 1, got %d", queueSize)
+	}
+
 	state := glua.NewState(glua.Options{SkipOpenLibs: true})
 
 	// Opt-in standard libraries: omit io/os/debug so plugins cannot touch the
@@ -71,7 +72,7 @@ func NewRuntime(moduleRoot string, logger zerolog.Logger, modules ...HostModule)
 	r := &Runtime{
 		state:  state,
 		logger: logger,
-		work:   make(chan func(*glua.LState), dispatcherQueueSize),
+		work:   make(chan func(*glua.LState), queueSize),
 		ctx:    ctx,
 		cancel: cancel,
 	}

--- a/internal/hive/plugins/lua/runtime_test.go
+++ b/internal/hive/plugins/lua/runtime_test.go
@@ -76,9 +76,28 @@ end
 // newBareRuntime is a Runtime with no host modules — for dispatcher tests.
 func newBareRuntime(t *testing.T) *Runtime {
 	t.Helper()
-	rt, err := NewRuntime(t.TempDir(), zerolog.Nop())
+	rt, err := NewRuntime(zerolog.Nop(), t.TempDir(), 64)
 	require.NoError(t, err)
 	return rt
+}
+
+func TestNewRuntime_RejectsNonPositiveQueueSize(t *testing.T) {
+	t.Parallel()
+	_, err := NewRuntime(zerolog.Nop(), t.TempDir(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dispatcher queue size")
+
+	_, err = NewRuntime(zerolog.Nop(), t.TempDir(), -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dispatcher queue size")
+}
+
+func TestNewRuntime_HonorsQueueSize(t *testing.T) {
+	t.Parallel()
+	rt, err := NewRuntime(zerolog.Nop(), t.TempDir(), 256)
+	require.NoError(t, err)
+	t.Cleanup(rt.Close)
+	assert.Equal(t, 256, cap(rt.work))
 }
 
 func TestRuntimeSubmitSerializesConcurrentCalls(t *testing.T) {
@@ -89,7 +108,7 @@ func TestRuntimeSubmitSerializesConcurrentCalls(t *testing.T) {
 
 	// Non-atomic increments are safe iff the dispatcher serializes
 	// closures; -race catches a regression.
-	const n = 50 // < dispatcherQueueSize (64), no drops.
+	const n = 50 // < queueSize (64 here), no drops.
 	var counter int
 	var wg sync.WaitGroup
 	wg.Add(n)

--- a/internal/hive/plugins/manager.go
+++ b/internal/hive/plugins/manager.go
@@ -2,11 +2,9 @@ package plugins
 
 import (
 	"context"
-	"maps"
 	"sync"
 	"time"
 
-	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/rs/zerolog/log"
 )
@@ -22,9 +20,10 @@ const (
 
 // Manager manages plugin registration, lifecycle, and status fetching.
 type Manager struct {
-	plugins map[string]Plugin
-	pool    *WorkerPool
-	mu      sync.RWMutex
+	plugins    map[string]Plugin
+	pool       *WorkerPool
+	commandSet *CommandSet
+	mu         sync.RWMutex
 
 	// Background worker state
 	collector     *StatusCollector
@@ -44,11 +43,14 @@ type Manager struct {
 
 // NewManager creates a new plugin manager. The pool is injected so it can be
 // shared with plugins (e.g. the Lua hive.sh module) that draw from the same
-// concurrency budget as status refreshes.
-func NewManager(pool *WorkerPool) *Manager {
+// concurrency budget as status refreshes. commandSet is the canonical command
+// registry the manager seeds plugin slots into during InitAll; the manager
+// does not own or expose it — callers keep the reference for lookups.
+func NewManager(pool *WorkerPool, commandSet *CommandSet) *Manager {
 	return &Manager{
 		plugins:        make(map[string]Plugin),
 		pool:           pool,
+		commandSet:     commandSet,
 		collector:      NewStatusCollector(),
 		jobs:           make(chan Job, defaultJobBufferSize),
 		results:        make(chan Result, defaultResultBufferSize),
@@ -72,8 +74,10 @@ func (m *Manager) Register(p Plugin) {
 	log.Debug().Str("plugin", p.Name()).Msg("plugin registered")
 }
 
-// InitAll initializes all registered plugins.
-// Errors are logged but do not stop initialization of other plugins.
+// InitAll initializes all registered plugins. Errors are logged but do not
+// stop initialization of other plugins. After each successful Init the
+// plugin's Commands() are seeded into the shared CommandSet's plugin slot;
+// failed inits leave the slot untouched.
 func (m *Manager) InitAll(ctx context.Context) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -81,6 +85,13 @@ func (m *Manager) InitAll(ctx context.Context) error {
 	for name, p := range m.plugins {
 		if err := p.Init(ctx); err != nil {
 			log.Warn().Err(err).Str("plugin", name).Msg("plugin initialization failed")
+			continue
+		}
+		if m.commandSet == nil {
+			continue
+		}
+		if cmds := p.Commands(); cmds != nil {
+			m.commandSet.SetPlugin(name, cmds)
 		}
 	}
 	return nil
@@ -111,27 +122,6 @@ func (m *Manager) EnabledPlugins() []Plugin {
 		plugins = append(plugins, p)
 	}
 	return plugins
-}
-
-// MergedCommands merges system, plugin, and user commands.
-// Priority order: system (lowest) → plugins → user (highest).
-func (m *Manager) MergedCommands(systemCmds, userCmds map[string]config.UserCommand) map[string]config.UserCommand {
-	result := make(map[string]config.UserCommand)
-
-	// 1. System defaults (lowest priority)
-	maps.Copy(result, systemCmds)
-
-	// 2. Plugin commands (middle priority)
-	m.mu.RLock()
-	for _, p := range m.plugins {
-		maps.Copy(result, p.Commands())
-	}
-	m.mu.RUnlock()
-
-	// 3. User commands (highest priority - always wins)
-	maps.Copy(result, userCmds)
-
-	return result
 }
 
 // Collector returns the status collector for reading cached statuses.

--- a/internal/hive/plugins/manager.go
+++ b/internal/hive/plugins/manager.go
@@ -76,8 +76,12 @@ func (m *Manager) Register(p Plugin) {
 
 // InitAll initializes all registered plugins. Errors are logged but do not
 // stop initialization of other plugins. After each successful Init the
-// plugin's Commands() are seeded into the shared CommandSet's plugin slot;
-// failed inits leave the slot untouched.
+// plugin's Commands() are seeded into the shared CommandSet's plugin slot,
+// unless the plugin already populated its own slot during Init (e.g. the
+// Lua plugin via MergePlugin from its entrypoint or a ticker callback).
+// Skipping in that case avoids a lost-update race: reading Commands() and
+// then SetPlugin'ing it back would clobber any writes that landed in
+// between. Failed inits leave the slot untouched.
 func (m *Manager) InitAll(ctx context.Context) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -88,6 +92,9 @@ func (m *Manager) InitAll(ctx context.Context) error {
 			continue
 		}
 		if m.commandSet == nil {
+			continue
+		}
+		if m.commandSet.Plugin(name) != nil {
 			continue
 		}
 		if cmds := p.Commands(); cmds != nil {

--- a/internal/hive/plugins/manager_test.go
+++ b/internal/hive/plugins/manager_test.go
@@ -1,10 +1,8 @@
 package plugins
 
 import (
-	"context"
 	"testing"
 
-	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/stretchr/testify/assert"
 )
@@ -77,42 +75,3 @@ func TestSessionsChanged(t *testing.T) {
 		})
 	}
 }
-
-func TestMergedCommandsPriority(t *testing.T) {
-	mgr := NewManager(NewWorkerPool(0))
-	mgr.Register(&mockPlugin{
-		name: "plugin",
-		commands: map[string]config.UserCommand{
-			"Shared":     {Sh: "plugin"},
-			"PluginOnly": {Sh: "plugin-only"},
-		},
-	})
-
-	system := map[string]config.UserCommand{
-		"Shared":     {Sh: "system"},
-		"SystemOnly": {Sh: "system-only"},
-	}
-	user := map[string]config.UserCommand{
-		"Shared":   {Sh: "user"},
-		"UserOnly": {Sh: "user-only"},
-	}
-
-	merged := mgr.MergedCommands(system, user)
-
-	assert.Equal(t, "user", merged["Shared"].Sh)
-	assert.Equal(t, "plugin-only", merged["PluginOnly"].Sh)
-	assert.Equal(t, "system-only", merged["SystemOnly"].Sh)
-	assert.Equal(t, "user-only", merged["UserOnly"].Sh)
-}
-
-type mockPlugin struct {
-	name     string
-	commands map[string]config.UserCommand
-}
-
-func (p *mockPlugin) Name() string                            { return p.name }
-func (p *mockPlugin) Available() bool                         { return true }
-func (p *mockPlugin) Init(_ context.Context) error            { return nil }
-func (p *mockPlugin) Close() error                            { return nil }
-func (p *mockPlugin) Commands() map[string]config.UserCommand { return p.commands }
-func (p *mockPlugin) StatusProvider() StatusProvider          { return nil }

--- a/internal/hive/plugins/manager_test.go
+++ b/internal/hive/plugins/manager_test.go
@@ -1,11 +1,59 @@
 package plugins
 
 import (
+	"context"
 	"testing"
 
+	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// mockPlugin is a minimal Plugin implementation used by manager-level tests
+// to exercise registration, init, and command-slot seeding without spinning
+// up a real Lua/GitHub backend.
+type mockPlugin struct {
+	name     string
+	commands map[string]config.UserCommand
+}
+
+func (p *mockPlugin) Name() string                            { return p.name }
+func (p *mockPlugin) Available() bool                         { return true }
+func (p *mockPlugin) Init(_ context.Context) error            { return nil }
+func (p *mockPlugin) Close() error                            { return nil }
+func (p *mockPlugin) Commands() map[string]config.UserCommand { return p.commands }
+func (p *mockPlugin) StatusProvider() StatusProvider          { return nil }
+
+func TestManager_InitAll_SeedsStaticPluginSlots(t *testing.T) {
+	set := NewCommandSet(nil, nil)
+	mgr := NewManager(NewWorkerPool(0), set)
+
+	stub := &mockPlugin{
+		name: "stub",
+		commands: map[string]config.UserCommand{
+			"Foo": {Sh: "echo foo"},
+		},
+	}
+	mgr.Register(stub)
+
+	require.NoError(t, mgr.InitAll(context.Background()))
+
+	got := set.Plugin("stub")
+	require.NotNil(t, got)
+	assert.Equal(t, "echo foo", got["Foo"].Sh)
+}
+
+func TestManager_InitAll_SkipsPluginsWithNilCommands(t *testing.T) {
+	set := NewCommandSet(nil, nil)
+	mgr := NewManager(NewWorkerPool(0), set)
+
+	mgr.Register(&mockPlugin{name: "empty", commands: nil})
+
+	require.NoError(t, mgr.InitAll(context.Background()))
+
+	assert.Nil(t, set.Plugin("empty"), "no slot should be created for plugins that return nil commands")
+}
 
 func TestSessionsChanged(t *testing.T) {
 	mkSession := func(id string) *session.Session {

--- a/internal/hive/plugins/manager_test.go
+++ b/internal/hive/plugins/manager_test.go
@@ -55,6 +55,53 @@ func TestManager_InitAll_SkipsPluginsWithNilCommands(t *testing.T) {
 	assert.Nil(t, set.Plugin("empty"), "no slot should be created for plugins that return nil commands")
 }
 
+// selfRegisteringPlugin populates its slot directly from Init, mirroring
+// the Lua plugin's MergePlugin-from-entrypoint behavior. Commands() reads
+// back from the slot.
+type selfRegisteringPlugin struct {
+	name string
+	set  *CommandSet
+	init map[string]config.UserCommand
+	post map[string]config.UserCommand
+}
+
+func (p *selfRegisteringPlugin) Name() string    { return p.name }
+func (p *selfRegisteringPlugin) Available() bool { return true }
+func (p *selfRegisteringPlugin) Init(_ context.Context) error {
+	p.set.MergePlugin(p.name, p.init)
+	if p.post != nil {
+		p.set.MergePlugin(p.name, p.post)
+	}
+	return nil
+}
+func (p *selfRegisteringPlugin) Close() error { return nil }
+func (p *selfRegisteringPlugin) Commands() map[string]config.UserCommand {
+	return p.set.Plugin(p.name)
+}
+func (p *selfRegisteringPlugin) StatusProvider() StatusProvider { return nil }
+
+func TestManager_InitAll_PreservesSelfRegisteredCommands(t *testing.T) {
+	set := NewCommandSet(nil, nil)
+	mgr := NewManager(NewWorkerPool(0), set)
+
+	// Simulates a Lua-style plugin whose entrypoint registers Foo and a
+	// ticker callback registers Bar between Init returning and the
+	// manager's seeding step.
+	mgr.Register(&selfRegisteringPlugin{
+		name: "self",
+		set:  set,
+		init: map[string]config.UserCommand{"Foo": {Sh: "echo foo"}},
+		post: map[string]config.UserCommand{"Bar": {Sh: "echo bar"}},
+	})
+
+	require.NoError(t, mgr.InitAll(context.Background()))
+
+	got := set.Plugin("self")
+	require.NotNil(t, got)
+	assert.Equal(t, "echo foo", got["Foo"].Sh, "entrypoint registration must survive InitAll")
+	assert.Equal(t, "echo bar", got["Bar"].Sh, "post-Init registration must survive InitAll")
+}
+
 func TestSessionsChanged(t *testing.T) {
 	mkSession := func(id string) *session.Session {
 		return &session.Session{ID: id}

--- a/internal/tui/hc_only.go
+++ b/internal/tui/hc_only.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"maps"
 	"os/exec"
 	"strings"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/colonyops/hive/internal/core/notify"
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/hive"
+	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/internal/tui/components"
 	"github.com/colonyops/hive/internal/tui/views/tasks"
 	"github.com/colonyops/hive/pkg/tmpl"
@@ -38,7 +38,7 @@ const hcHeaderLines = 3
 type HoneycombOnlyModel struct {
 	tasksView       *tasks.View
 	handler         *KeybindingResolver
-	mergedCmds      map[string]config.UserCommand
+	commandSet      *plugins.CommandSet
 	copyCmd         string
 	width, height   int
 	quitting        bool
@@ -57,9 +57,11 @@ func NewHoneycombOnly(opts HoneycombOnlyOptions) HoneycombOnlyModel {
 		"global": cfg.Views.Global.Keybindings,
 		"tasks":  cfg.Views.Tasks.Keybindings,
 	}
-	mergedCmds := config.DefaultUserCommands()
-	maps.Copy(mergedCmds, cfg.UserCommands)
-	handler := NewKeybindingResolver(viewKBs, mergedCmds, opts.Renderer)
+	// Standalone honeycomb mode bypasses the plugin manager — no Lua-registered
+	// commands surface here. Build a CommandSet directly so the resolver has a
+	// canonical registry to query.
+	commandSet := plugins.NewCommandSet(config.DefaultUserCommands(), cfg.UserCommands)
+	handler := NewKeybindingResolver(viewKBs, commandSet, opts.Renderer)
 	handler.SetActiveView(ViewTasks)
 
 	tasksView := tasks.New(opts.Honeycomb, opts.RepoKey, handler, opts.KVStore, cfg.Views.Tasks.SplitRatio)
@@ -67,7 +69,7 @@ func NewHoneycombOnly(opts HoneycombOnlyOptions) HoneycombOnlyModel {
 	return HoneycombOnlyModel{
 		tasksView:       tasksView,
 		handler:         handler,
-		mergedCmds:      mergedCmds,
+		commandSet:      commandSet,
 		copyCmd:         cfg.CopyCommand,
 		toastController: toastCtrl,
 		toastView:       NewToastView(toastCtrl),
@@ -199,8 +201,9 @@ func (m HoneycombOnlyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // Non-task action commands (e.g. HiveDoctor, ThemePreview) are excluded since
 // they require infrastructure only present in the full TUI.
 func (m HoneycombOnlyModel) taskCommands() map[string]config.UserCommand {
-	filtered := make(map[string]config.UserCommand, len(m.mergedCmds))
-	for name, cmd := range m.mergedCmds {
+	all := m.commandSet.All()
+	filtered := make(map[string]config.UserCommand, len(all))
+	for name, cmd := range all {
 		if cmd.Action != "" && !isTaskAction(cmd.Action) {
 			continue
 		}

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -13,6 +13,7 @@ import (
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/hive"
+	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/pkg/tmpl"
 )
 
@@ -39,7 +40,7 @@ func docTemplateValue(doc *DocTemplateData) DocTemplateData {
 type KeybindingResolver struct {
 	viewKeybindings        map[string]map[string]config.Keybinding // view name -> key -> binding
 	effectiveKeybindings   map[string]config.Keybinding            // merged global + active view
-	commands               map[string]config.UserCommand
+	commandSet             *plugins.CommandSet
 	renderer               *tmpl.Renderer
 	activeView             ViewType                      // current active view for scope checking
 	tmuxWindowLookup       func(sessionID string) string // optional: returns tmux window name for a session
@@ -47,16 +48,18 @@ type KeybindingResolver struct {
 	selectedWindowOverride string                        // if set, overrides tmuxWindowLookup for the next resolve
 }
 
-// NewKeybindingResolver creates a new resolver with per-view keybinding maps.
-// Commands should be the merged user commands (user config + system defaults).
+// NewKeybindingResolver creates a resolver. commandSet is the canonical
+// command registry; the resolver reads from it on every IsAction/Resolve
+// call, so mutations from any goroutine become visible immediately without
+// rebuilding the resolver.
 func NewKeybindingResolver(
 	viewKeybindings map[string]map[string]config.Keybinding,
-	commands map[string]config.UserCommand,
+	commandSet *plugins.CommandSet,
 	renderer *tmpl.Renderer,
 ) *KeybindingResolver {
 	r := &KeybindingResolver{
 		viewKeybindings: viewKeybindings,
-		commands:        commands,
+		commandSet:      commandSet,
 		renderer:        renderer,
 		activeView:      ViewSessions, // default to sessions view
 	}
@@ -145,7 +148,7 @@ func (h *KeybindingResolver) IsAction(key string, t action.Type) bool {
 	if !exists {
 		return false
 	}
-	cmd, exists := h.commands[kb.Cmd]
+	cmd, exists := h.commandSet.Lookup(kb.Cmd)
 	return exists && cmd.Action == t
 }
 
@@ -242,7 +245,7 @@ func (h *KeybindingResolver) Resolve(key string, sess session.Session) (Action, 
 	}
 
 	// Look up the referenced command
-	cmd, cmdExists := h.commands[kb.Cmd]
+	cmd, cmdExists := h.commandSet.Lookup(kb.Cmd)
 	if !cmdExists {
 		// Command reference is invalid - validation should catch this,
 		// but log and return gracefully for debugging
@@ -340,7 +343,7 @@ func (h *KeybindingResolver) ResolveAction(key string) (Action, bool) {
 		return Action{}, false
 	}
 
-	cmd, cmdExists := h.commands[kb.Cmd]
+	cmd, cmdExists := h.commandSet.Lookup(kb.Cmd)
 	if !cmdExists {
 		log.Warn().Str("key", key).Str("cmd", kb.Cmd).Msg("keybinding references unknown command")
 		return Action{}, false
@@ -382,7 +385,7 @@ func (h *KeybindingResolver) HelpEntries() []string {
 		kb := h.effectiveKeybindings[key]
 
 		// Get command and check scope
-		cmd, ok := h.commands[kb.Cmd]
+		cmd, ok := h.commandSet.Lookup(kb.Cmd)
 		if !ok || !h.isCommandInScope(cmd) {
 			continue // skip out-of-scope commands
 		}
@@ -420,7 +423,7 @@ func (h *KeybindingResolver) KeyBindings() []key.Binding {
 		kb := h.effectiveKeybindings[k]
 
 		// Get command and check scope
-		cmd, ok := h.commands[kb.Cmd]
+		cmd, ok := h.commandSet.Lookup(kb.Cmd)
 		if !ok || !h.isCommandInScope(cmd) {
 			continue // skip out-of-scope commands
 		}
@@ -571,7 +574,7 @@ func (h *KeybindingResolver) ResolveFormCommand(key string, sess session.Session
 		return "", config.UserCommand{}, false
 	}
 
-	cmd, cmdExists := h.commands[kb.Cmd]
+	cmd, cmdExists := h.commandSet.Lookup(kb.Cmd)
 	if !cmdExists || len(cmd.Form) == 0 {
 		return "", config.UserCommand{}, false
 	}

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -6,6 +6,7 @@ import (
 	act "github.com/colonyops/hive/internal/core/action"
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/pkg/tmpl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,13 @@ var testRenderer = tmpl.New(tmpl.Config{})
 // sessionsKBs wraps a flat keybinding map as sessions-view keybindings for testing.
 func sessionsKBs(kbs map[string]config.Keybinding) map[string]map[string]config.Keybinding {
 	return map[string]map[string]config.Keybinding{"sessions": kbs}
+}
+
+// commandSetFromMap builds a CommandSet from a flat command map for test
+// convenience. The map lands in the system slot so tests behave as if no
+// plugin/user overrides exist.
+func commandSetFromMap(commands map[string]config.UserCommand) *plugins.CommandSet {
+	return plugins.NewCommandSet(commands, nil)
 }
 
 func TestKeybindingHandler_Resolve_RecycledSession(t *testing.T) {
@@ -30,7 +38,7 @@ func TestKeybindingHandler_Resolve_RecycledSession(t *testing.T) {
 		"o": {Cmd: "open"},
 	}
 
-	handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+	handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 	activeSession := session.Session{
 		ID:    "test-id",
@@ -111,7 +119,7 @@ func TestKeybindingHandler_Resolve_RecycledSession(t *testing.T) {
 }
 
 func TestKeybindingHandler_ResolveUserCommand(t *testing.T) {
-	handler := NewKeybindingResolver(nil, nil, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
 
 	sess := session.Session{
 		ID:     "test-id",
@@ -231,7 +239,7 @@ func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"r": {Cmd: "Recycle", Help: "keybinding help"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		action, ok := handler.Resolve("r", sess)
 		require.True(t, ok, "expected ok = true")
@@ -242,7 +250,7 @@ func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"r": {Cmd: "Recycle", Confirm: "keybinding confirm"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		action, ok := handler.Resolve("r", sess)
 		require.True(t, ok, "expected ok = true")
@@ -253,7 +261,7 @@ func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"s": {Cmd: "shell-cmd"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		action, ok := handler.Resolve("s", sess)
 		require.True(t, ok, "expected ok = true")
@@ -266,7 +274,7 @@ func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"x": {Cmd: "NonExistent"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		_, ok := handler.Resolve("x", sess)
 		assert.False(t, ok, "expected ok = false for invalid command reference")
@@ -280,7 +288,7 @@ func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"e": {Cmd: "empty"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), emptyCommands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(emptyCommands), testRenderer)
 
 		_, ok := handler.Resolve("e", sess)
 		assert.False(t, ok, "expected ok = false for command with neither action nor sh")
@@ -293,7 +301,7 @@ func TestKeybindingHandler_Resolve_Overrides(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"b": {Cmd: "bad"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), badTemplateCommands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(badTemplateCommands), testRenderer)
 
 		action, ok := handler.Resolve("b", sess)
 		require.True(t, ok, "expected ok = true even with template error")
@@ -314,7 +322,7 @@ func TestKeybindingHandler_HelpEntries(t *testing.T) {
 			"o": {Cmd: "open"},
 			"r": {Cmd: "Recycle"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		entries := handler.HelpEntries()
 		// Entries are sorted by key
@@ -327,7 +335,7 @@ func TestKeybindingHandler_HelpEntries(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"r": {Cmd: "Recycle", Help: "custom help"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		entries := handler.HelpEntries()
 		require.Len(t, entries, 1, "expected 1 entry, got %d", len(entries))
@@ -338,7 +346,7 @@ func TestKeybindingHandler_HelpEntries(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"d": {Cmd: "Delete"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		entries := handler.HelpEntries()
 		require.Len(t, entries, 1, "expected 1 entry, got %d", len(entries))
@@ -349,7 +357,7 @@ func TestKeybindingHandler_HelpEntries(t *testing.T) {
 		keybindings := map[string]config.Keybinding{
 			"x": {Cmd: "NonExistent"},
 		}
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		entries := handler.HelpEntries()
 		// Invalid command references are filtered out (not shown in help)
@@ -372,7 +380,7 @@ func TestKeybindingResolver_TmuxWindowAndTool(t *testing.T) {
 	}
 
 	t.Run("uses lookup functions for TmuxWindow and Tool", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 		handler.SetTmuxWindowLookup(func(id string) string { return "claude-window" })
 		handler.SetToolLookup(func(id string) string { return "claude" })
 
@@ -382,7 +390,7 @@ func TestKeybindingResolver_TmuxWindowAndTool(t *testing.T) {
 	})
 
 	t.Run("SetSelectedWindow overrides lookup", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 		handler.SetTmuxWindowLookup(func(id string) string { return "default-window" })
 		handler.SetToolLookup(func(id string) string { return "claude" })
 		handler.SetSelectedWindow("override-window")
@@ -393,7 +401,7 @@ func TestKeybindingResolver_TmuxWindowAndTool(t *testing.T) {
 	})
 
 	t.Run("override is consumed after resolve", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 		handler.SetTmuxWindowLookup(func(id string) string { return "default-window" })
 		handler.SetToolLookup(func(id string) string { return "claude" })
 		handler.SetSelectedWindow("override-window")
@@ -410,7 +418,7 @@ func TestKeybindingResolver_TmuxWindowAndTool(t *testing.T) {
 	})
 
 	t.Run("ResolveUserCommand also consumes override", func(t *testing.T) {
-		handler := NewKeybindingResolver(nil, nil, testRenderer)
+		handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
 		handler.SetTmuxWindowLookup(func(id string) string { return "default-window" })
 		handler.SetToolLookup(func(id string) string { return "claude" })
 		handler.SetSelectedWindow("override-window")
@@ -442,7 +450,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 	}
 
 	t.Run("TmuxOpen consumes window override", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 		handler.SetTmuxWindowLookup(func(id string) string { return "default-window" })
 		handler.SetSelectedWindow("editor")
 
@@ -458,7 +466,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 	})
 
 	t.Run("TmuxOpen without override uses lookup", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 		handler.SetTmuxWindowLookup(func(id string) string { return "agent" })
 
 		action, ok := handler.Resolve("enter", sess)
@@ -467,7 +475,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 	})
 
 	t.Run("TmuxOpen without override or lookup returns empty", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 
 		action, ok := handler.Resolve("enter", sess)
 		require.True(t, ok)
@@ -475,7 +483,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 	})
 
 	t.Run("TmuxStart also consumes window override", func(t *testing.T) {
-		handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, testRenderer)
+		handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), testRenderer)
 		handler.SetSelectedWindow("editor")
 
 		action, ok := handler.Resolve("s", sess)
@@ -485,7 +493,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 	})
 
 	t.Run("ResolveUserCommand TmuxOpen consumes override", func(t *testing.T) {
-		handler := NewKeybindingResolver(nil, nil, testRenderer)
+		handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
 		handler.SetSelectedWindow("editor")
 
 		cmd := config.UserCommand{Action: act.TypeTmuxOpen, Help: "open"}
@@ -496,7 +504,7 @@ func TestKeybindingResolver_TmuxActionConsumesWindowOverride(t *testing.T) {
 }
 
 func TestKeybindingResolver_RenderWithFormData(t *testing.T) {
-	handler := NewKeybindingResolver(nil, nil, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
 
 	sess := session.Session{
 		ID:     "test-id",
@@ -547,7 +555,7 @@ func TestKeybindingResolver_RenderWithFormData(t *testing.T) {
 }
 
 func TestKeybindingResolver_DocTemplateData(t *testing.T) {
-	handler := NewKeybindingResolver(nil, nil, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
 	sess := session.Session{
 		ID:   "test-id",
 		Path: "/test/path",
@@ -613,7 +621,7 @@ func TestKeybindingResolver_Scope(t *testing.T) {
 	// Place all keybindings in "global" so they're visible in every view.
 	// Command-level scope filtering is what this test validates.
 	globalKBs := map[string]map[string]config.Keybinding{"global": keybindings}
-	handler := NewKeybindingResolver(globalKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(globalKBs, commandSetFromMap(commands), testRenderer)
 	sess := session.Session{
 		ID:    "test-id",
 		Path:  "/test/path",
@@ -692,7 +700,7 @@ func TestKeybindingResolver_ShellDirIsSessionPath(t *testing.T) {
 	keybindings := map[string]config.Keybinding{
 		"r": {Cmd: "run"},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), renderer)
 	sess := session.Session{
 		ID:    "abc123",
 		Path:  "/repos/my-repo",
@@ -745,7 +753,7 @@ func TestResolveWindowsAction_SameSession(t *testing.T) {
 		"s": {Cmd: "Spawn"},
 	}
 
-	handler := NewKeybindingResolver(sessionsKBs(keybindings), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(keybindings), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	a, ok := handler.Resolve("s", sess)
@@ -770,7 +778,7 @@ func TestResolveWindowsAction_SameSessionWithSh(t *testing.T) {
 			},
 		},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{"r": {Cmd: "Review"}}), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{"r": {Cmd: "Review"}}), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	a, ok := handler.Resolve("r", sess)
@@ -797,7 +805,7 @@ func TestResolveWindowsAction_NewSession(t *testing.T) {
 			Form: []config.FormField{{Variable: "pr", Type: config.FormTypeText, Label: "PR"}},
 		},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	cmd := commands["PRReview"]
@@ -825,7 +833,7 @@ func TestResolveWindowsAction_NewSessionInheritsRemote(t *testing.T) {
 			},
 		},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	cmd := commands["NewWin"]
@@ -851,7 +859,7 @@ func TestResolveWindowsAction_NewSessionExplicitRemote(t *testing.T) {
 			},
 		},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	cmd := commands["NewWin"]
@@ -874,7 +882,7 @@ func TestResolveWindowsAction_TemplateError(t *testing.T) {
 			},
 		},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	cmd := commands["Bad"]
@@ -896,7 +904,7 @@ func TestResolver_PerViewKeybindings(t *testing.T) {
 		"Recycle":      {Action: act.TypeRecycle, Help: "recycle"},
 		"TasksRefresh": {Action: act.TypeTasksRefresh, Help: "refresh tasks", Scope: []string{"tasks"}},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 	sess := session.Session{ID: "test", Path: "/test", State: session.StateActive}
 
 	// Sessions view: "r" -> Recycle
@@ -925,7 +933,7 @@ func TestResolver_GlobalFallback(t *testing.T) {
 	commands := map[string]config.UserCommand{
 		"HiveInfo": {Action: act.TypeHiveInfo, Help: "info"},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 
 	// "?" should resolve on both sessions and tasks views
 	for _, view := range []ViewType{ViewSessions, ViewTasks} {
@@ -945,7 +953,7 @@ func TestResolver_ViewOverridesGlobal(t *testing.T) {
 		"HiveInfo": {Action: act.TypeHiveInfo, Help: "info"},
 		"Recycle":  {Action: act.TypeRecycle, Help: "recycle"},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 	sess := session.Session{ID: "test", Path: "/test", State: session.StateActive}
 
 	// On sessions view, view-specific "x" -> Recycle overrides global "x" -> HiveInfo
@@ -972,7 +980,7 @@ func TestResolver_ResolveAction_SkipsShellCommands(t *testing.T) {
 		"ActionCmd": {Action: act.TypeTasksRefresh, Help: "action", Scope: []string{"tasks"}},
 		"ShellCmd":  {Sh: "echo hello", Help: "shell", Scope: []string{"tasks"}},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 	handler.SetActiveView(ViewTasks)
 
 	// Built-in action resolves
@@ -992,7 +1000,7 @@ func TestResolver_ResolveAction_UnknownCommand(t *testing.T) {
 		},
 	}
 	commands := map[string]config.UserCommand{}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 	handler.SetActiveView(ViewTasks)
 
 	_, ok := handler.ResolveAction("x")
@@ -1008,7 +1016,7 @@ func TestResolver_ResolveAction_OutOfScope(t *testing.T) {
 	commands := map[string]config.UserCommand{
 		"SessionsOnly": {Action: act.TypeRecycle, Help: "recycle", Scope: []string{"sessions"}},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 	handler.SetActiveView(ViewTasks)
 
 	_, ok := handler.ResolveAction("r")
@@ -1024,7 +1032,7 @@ func TestResolver_IsAction(t *testing.T) {
 		"Recycle":      {Action: act.TypeRecycle, Help: "recycle"},
 		"TasksRefresh": {Action: act.TypeTasksRefresh, Help: "refresh", Scope: []string{"tasks"}},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 
 	// Sessions view: "r" maps to Recycle
 	handler.SetActiveView(ViewSessions)
@@ -1045,7 +1053,7 @@ func TestResolver_IsCommand(t *testing.T) {
 	commands := map[string]config.UserCommand{
 		"Recycle": {Action: act.TypeRecycle},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 	handler.SetActiveView(ViewSessions)
 
 	assert.True(t, handler.IsCommand("r", "Recycle"))
@@ -1068,7 +1076,7 @@ func TestResolver_HelpString(t *testing.T) {
 		"TasksFilter":  {Action: act.TypeTasksFilter, Help: "filter", Scope: []string{"tasks"}},
 		"Delete":       {Action: act.TypeDelete, Help: "delete", Scope: []string{"sessions"}},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 
 	// Tasks view: should show tasks keybindings, not sessions
 	handler.SetActiveView(ViewTasks)
@@ -1096,7 +1104,7 @@ func TestResolver_ViewWithNoKeybindings(t *testing.T) {
 	commands := map[string]config.UserCommand{
 		"HiveInfo": {Action: act.TypeHiveInfo, Help: "info"},
 	}
-	handler := NewKeybindingResolver(viewKBs, commands, testRenderer)
+	handler := NewKeybindingResolver(viewKBs, commandSetFromMap(commands), testRenderer)
 
 	// Messages view has no keybinding map entry — only global keybindings resolve
 	handler.SetActiveView(ViewMessages)
@@ -1115,7 +1123,7 @@ func TestRenderWithFormData_WindowsWithFormValues(t *testing.T) {
 			Form: []config.FormField{{Variable: "pr", Type: config.FormTypeText, Label: "PR"}},
 		},
 	}
-	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commands, renderer)
+	handler := NewKeybindingResolver(sessionsKBs(map[string]config.Keybinding{}), commandSetFromMap(commands), renderer)
 	sess := testSession()
 
 	cmd := commands["Spawn"]
@@ -1126,4 +1134,46 @@ func TestRenderWithFormData_WindowsWithFormValues(t *testing.T) {
 	require.Len(t, a.SpawnWindows.Windows, 1)
 	assert.Contains(t, a.SpawnWindows.Windows[0].Command, "Review PR 456")
 	assert.Contains(t, a.SpawnWindows.Windows[0].Command, "/repos/my-repo")
+}
+
+// TestKeybindingResolver_LookupReadsLive verifies IsAction sees commands
+// added to the CommandSet after the resolver was constructed (no rebuild).
+func TestKeybindingResolver_LookupReadsLive(t *testing.T) {
+	set := plugins.NewCommandSet(nil, nil)
+	keybindings := map[string]config.Keybinding{
+		"x": {Cmd: "Foo"},
+	}
+	handler := NewKeybindingResolver(sessionsKBs(keybindings), set, testRenderer)
+
+	// Before push: the keybinding references an unknown command, so IsAction is false.
+	assert.False(t, handler.IsAction("x", act.TypeRecycle))
+
+	set.MergePlugin("test", map[string]config.UserCommand{
+		"Foo": {Action: act.TypeRecycle},
+	})
+
+	// After push: the resolver picks it up on the next call without any rebuild.
+	assert.True(t, handler.IsAction("x", act.TypeRecycle))
+}
+
+// TestKeybindingResolver_ResolveReadsLive verifies Resolve returns a fresh
+// command after CommandSet mutation.
+func TestKeybindingResolver_ResolveReadsLive(t *testing.T) {
+	set := plugins.NewCommandSet(nil, nil)
+	keybindings := map[string]config.Keybinding{
+		"x": {Cmd: "Foo"},
+	}
+	handler := NewKeybindingResolver(sessionsKBs(keybindings), set, testRenderer)
+
+	sess := session.Session{ID: "s", Name: "s", Path: "/tmp", State: session.StateActive}
+	_, ok := handler.Resolve("x", sess)
+	require.False(t, ok)
+
+	set.MergePlugin("test", map[string]config.UserCommand{
+		"Foo": {Sh: "echo updated"},
+	})
+
+	a, ok := handler.Resolve("x", sess)
+	require.True(t, ok)
+	assert.Contains(t, a.ShellCmd, "echo updated")
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -125,8 +125,9 @@ type Model struct {
 
 	copyCommand string
 
-	// Merged commands (system + plugins + user)
-	mergedCommands map[string]config.UserCommand
+	// Canonical command registry (system + plugins + user). Read at palette
+	// open time so newly registered Lua commands appear without rebuilds.
+	commandSet *plugins.CommandSet
 
 	reviewView *review.View
 
@@ -231,18 +232,13 @@ func New(deps Deps, opts Opts) Model {
 	cfg := deps.Config
 	service := deps.Service
 
-	// Snapshot of merged commands at construction time. CommandSet is the
-	// canonical registry; later phases will consult it directly to pick up
-	// dynamic Lua registrations without rebuilding this map.
-	mergedCommands := deps.CommandSet.All()
-
 	viewKBs := map[string]map[string]config.Keybinding{
 		"global":   cfg.Views.Global.Keybindings,
 		"sessions": cfg.Views.Sessions.Keybindings,
 		"tasks":    cfg.Views.Tasks.Keybindings,
 		"review":   cfg.Views.Review.Keybindings,
 	}
-	handler := NewKeybindingResolver(viewKBs, mergedCommands, deps.Renderer)
+	handler := NewKeybindingResolver(viewKBs, deps.CommandSet, deps.Renderer)
 	cmdService := command.NewService(service, service, service, service, service)
 
 	sessionsView := sessions.New(sessions.ViewOpts{
@@ -350,7 +346,7 @@ func New(deps Deps, opts Opts) Model {
 		msgView:         msgView,
 		activeView:      ViewSessions,
 		copyCommand:     cfg.CopyCommand,
-		mergedCommands:  mergedCommands,
+		commandSet:      deps.CommandSet,
 		reviewView:      &reviewView,
 		kvStore:         deps.KVStore,
 		kvView:          kvView,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -75,6 +75,7 @@ type Deps struct {
 	Renderer        *tmpl.Renderer
 	TerminalManager *terminal.Manager
 	PluginManager   *plugins.Manager
+	CommandSet      *plugins.CommandSet
 	TodoService     *hive.TodoService
 	DB              *db.DB
 
@@ -224,14 +225,16 @@ type todoCreatedMsg struct {
 
 // New creates a new TUI model. Panics if required Deps fields are nil.
 func New(deps Deps, opts Opts) Model {
-	if deps.Config == nil || deps.Service == nil || deps.Renderer == nil || deps.TerminalManager == nil || deps.PluginManager == nil || deps.TodoService == nil || deps.DB == nil {
-		panic("tui.New: Config, Service, Renderer, TerminalManager, PluginManager, TodoService, and DB are required")
+	if deps.Config == nil || deps.Service == nil || deps.Renderer == nil || deps.TerminalManager == nil || deps.PluginManager == nil || deps.CommandSet == nil || deps.TodoService == nil || deps.DB == nil {
+		panic("tui.New: Config, Service, Renderer, TerminalManager, PluginManager, CommandSet, TodoService, and DB are required")
 	}
 	cfg := deps.Config
 	service := deps.Service
 
-	// Compute merged commands: system → plugins → user
-	mergedCommands := deps.PluginManager.MergedCommands(config.DefaultUserCommands(), cfg.UserCommands)
+	// Snapshot of merged commands at construction time. CommandSet is the
+	// canonical registry; later phases will consult it directly to pick up
+	// dynamic Lua registrations without rebuilding this map.
+	mergedCommands := deps.CommandSet.All()
 
 	viewKBs := map[string]map[string]config.Keybinding{
 		"global":   cfg.Views.Global.Keybindings,

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -173,7 +173,7 @@ func (m Model) handleSessionFormCommand(msg sessions.FormCommandRequestMsg) (tea
 }
 
 func (m Model) handleSessionCommandPalette(msg sessions.CommandPaletteRequestMsg) (tea.Model, tea.Cmd) {
-	m.modals.CommandPalette = NewCommandPalette(m.mergedCommands, msg.Session, m.width, m.height, m.activeView)
+	m.modals.CommandPalette = NewCommandPalette(m.commandSet.All(), msg.Session, m.width, m.height, m.activeView)
 	m.state = stateCommandPalette
 	return m, nil
 }
@@ -447,13 +447,13 @@ func (m Model) handleDocsRepoKeysLoaded(msg docsRepoKeysLoadedMsg) (tea.Model, t
 }
 
 func (m Model) handleTaskCommandPalette(_ tasks.CommandPaletteRequestMsg) (tea.Model, tea.Cmd) {
-	m.modals.CommandPalette = NewCommandPalette(m.mergedCommands, nil, m.width, m.height, m.activeView)
+	m.modals.CommandPalette = NewCommandPalette(m.commandSet.All(), nil, m.width, m.height, m.activeView)
 	m.state = stateCommandPalette
 	return m, nil
 }
 
 func (m Model) handleReviewCommandPalette() (tea.Model, tea.Cmd) {
-	m.modals.CommandPalette = NewCommandPalette(m.mergedCommands, nil, m.width, m.height, m.activeView)
+	m.modals.CommandPalette = NewCommandPalette(m.commandSet.All(), nil, m.width, m.height, m.activeView)
 	m.state = stateCommandPalette
 	return m, nil
 }

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -103,7 +103,7 @@ func newMouseTestSessionsView(t *testing.T) *sessions.View {
 	t.Helper()
 	svc := newMouseTestSessionService(t)
 	cfg := &config.Config{}
-	handler := NewKeybindingResolver(nil, nil, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
 	mgr := terminal.NewManager(nil)
 	pm := plugins.NewManager(plugins.NewWorkerPool(0), plugins.NewCommandSet(nil, nil))
 	return sessions.New(sessions.ViewOpts{
@@ -120,7 +120,7 @@ func newMouseTestSessionsView(t *testing.T) *sessions.View {
 // handleKey doesn't dereference a nil pointer when dispatching Enter on a double-click.
 func newBaseMouseModel(t *testing.T) Model {
 	t.Helper()
-	handler := NewKeybindingResolver(nil, map[string]config.UserCommand{}, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(map[string]config.UserCommand{}, nil), testRenderer)
 	return Model{
 		cfg:             &config.Config{},
 		activeView:      ViewSessions,

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -105,7 +105,7 @@ func newMouseTestSessionsView(t *testing.T) *sessions.View {
 	cfg := &config.Config{}
 	handler := NewKeybindingResolver(nil, nil, testRenderer)
 	mgr := terminal.NewManager(nil)
-	pm := plugins.NewManager(plugins.NewWorkerPool(0))
+	pm := plugins.NewManager(plugins.NewWorkerPool(0), plugins.NewCommandSet(nil, nil))
 	return sessions.New(sessions.ViewOpts{
 		Cfg:             cfg,
 		Service:         svc,

--- a/internal/tui/review_doc_cmd_test.go
+++ b/internal/tui/review_doc_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/eventbus"
 	"github.com/colonyops/hive/internal/core/eventbus/testbus"
+	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/internal/tui/views/review"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func TestHiveDocReviewCmd_nil_reviewView_shows_toast(t *testing.T) {
 		received.Add(1)
 	})
 
-	handler := NewKeybindingResolver(nil, map[string]config.UserCommand{}, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(map[string]config.UserCommand{}, nil), testRenderer)
 	m := &Model{
 		activeView:      ViewSessions,
 		reviewView:      nil,
@@ -57,7 +58,7 @@ func TestHiveDocReviewCmd_Execute(t *testing.T) {
 	reviewView.SetSize(100, 40)
 
 	// Create a minimal handler for testing
-	handler := NewKeybindingResolver(nil, map[string]config.UserCommand{}, testRenderer)
+	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(map[string]config.UserCommand{}, nil), testRenderer)
 
 	m := &Model{
 		activeView: ViewSessions,

--- a/main.go
+++ b/main.go
@@ -279,6 +279,7 @@ Run 'hive new' to create a new session from the current repository.`,
 			}
 
 			shellPool := plugins.NewWorkerPool(cfg.Plugins.ShellWorkers)
+			commandSet := plugins.NewCommandSet(config.DefaultUserCommands(), cfg.UserCommands)
 
 			allPlugins := []configuredPlugin{
 				{plugin: github.New(cfg.Plugins.GitHub, kvStore), disabled: isDisabled(cfg.Plugins.GitHub.Enabled)},
@@ -287,7 +288,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				{plugin: contextdir.New(cfg.Plugins.ContextDir, cfg.DataDir), disabled: isDisabled(cfg.Plugins.ContextDir.Enabled)},
 				{plugin: claude.New(cfg.Plugins.Claude, kvStore), disabled: isDisabled(cfg.Plugins.Claude.Enabled)},
 				{plugin: plugintmux.New(cfg.Plugins.Tmux), disabled: isDisabled(cfg.Plugins.Tmux.Enabled)},
-				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore, shellPool, log.With().Str("component", "lua").Logger()), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
+				{plugin: luaplugin.New(cfg.Plugins.Lua, kvStore, shellPool, commandSet, log.With().Str("component", "lua").Logger()), disabled: isDisabled(cfg.Plugins.Lua.Enabled)},
 			}
 
 			pluginInfos := make([]doctor.PluginInfo, len(allPlugins))
@@ -300,7 +301,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				}
 			}
 
-			pluginMgr = plugins.NewManager(shellPool)
+			pluginMgr = plugins.NewManager(shellPool, commandSet)
 			for _, candidate := range allPlugins {
 				pluginMgr.Register(candidate.plugin)
 			}
@@ -320,6 +321,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				bus,
 				nil, // terminal manager created in TUI command
 				pluginMgr,
+				commandSet,
 				database,
 				kvStore,
 				renderer,

--- a/test/integration/lua_plugin_dynamic_commands_test.go
+++ b/test/integration/lua_plugin_dynamic_commands_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLuaPluginDynamicCommandRegistrationFromTicker(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "lua-dynamic-repo")
+
+	entry := filepath.Join(h.DataDir(), "lua", "plugins", "init.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(entry), 0o755))
+
+	// Sentinel path is in the harness data dir so the test can read it back.
+	sentinel := filepath.Join(h.DataDir(), "dynamic-output")
+
+	// Register LuaDynamic with the "first" payload at init, then re-register it
+	// from a ticker callback with "second". After 1s the ticker fires; the
+	// command palette should resolve LuaDynamic to the second definition.
+	require.NoError(t, os.WriteFile(entry, []byte(fmt.Sprintf(`
+return function(hive)
+  hive.commands({
+    LuaDynamic = {
+      sh = [[printf 'first' > %s]],
+      help = "dynamic command (initial)",
+      scope = {"sessions"},
+      silent = true,
+    },
+  })
+  hive.ticker.after("1s", function()
+    hive.commands({
+      LuaDynamic = {
+        sh = [[printf 'second' > %s]],
+        help = "dynamic command (replaced)",
+        scope = {"sessions"},
+        silent = true,
+      },
+    })
+  end)
+end
+`, sentinel, sentinel)), 0o644))
+
+	h.WithConfig(fmt.Sprintf(`version: "0.2.4"
+git_path: git
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+    batch_spawn:
+      - "tmux new-session -d -s {{ .Name | shq }} -c {{ .Path | shq }}"
+plugins:
+  lua:
+    entry: %q
+`, entry))
+
+	sessionName := "lua-dynamic-cmd"
+	_, err := h.Run("new", "--remote", repo, sessionName)
+	require.NoError(t, err)
+
+	uiSession := "lua-dynamic-ui"
+	cleanupTmuxSession(t, sessionName)
+	cleanupTmuxSession(t, uiSession)
+
+	tmuxArgs := []string{"new-session", "-d", "-s", uiSession, "-x", "200", "-y", "50"}
+	for _, kv := range h.command().Env {
+		tmuxArgs = append(tmuxArgs, "-e", kv)
+	}
+	tmuxArgs = append(tmuxArgs, hiveBin)
+	cmd := exec.Command("tmux", tmuxArgs...)
+	cmd.Env = h.command().Env
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+
+	assertTmuxSessionExists(t, uiSession)
+
+	// Wait for the TUI to render the session row.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		out, err := exec.Command("tmux", "capture-pane", "-t", uiSession, "-p").CombinedOutput()
+		assert.NoError(c, err, "tmux capture-pane: %s", out)
+		assert.Contains(c, string(out), sessionName)
+	}, 5*time.Second, 200*time.Millisecond)
+
+	// Wait for the ticker to fire so the second registration is in the
+	// CommandSet before we open the palette. tickerMinInterval is 1s, so
+	// wait a bit longer than that.
+	time.Sleep(1500 * time.Millisecond)
+
+	// Move cursor down past the repo header onto the session row.
+	_, err = exec.Command("tmux", "send-keys", "-t", uiSession, "j").CombinedOutput()
+	require.NoError(t, err)
+
+	// Open the palette and run :LuaDynamic. The palette consults the live
+	// CommandSet at open, so the second-write-wins registration must be
+	// resolved here — proving both the dynamic registration and the
+	// Phase 2 palette migration.
+	_, err = exec.Command("tmux", "send-keys", "-t", uiSession, ":", "LuaDynamic", "Enter").CombinedOutput()
+	require.NoError(t, err)
+
+	// Assert the sentinel contains "second" (the post-ticker payload).
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		content, err := os.ReadFile(sentinel)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, "second", string(content))
+	}, 5*time.Second, 200*time.Millisecond)
+}


### PR DESCRIPTION
Fixes #323

## Purpose

`hive.commands(...)` previously snapshotted at init, so registrations from ticker callbacks or other deferred Lua contexts never reached the TUI. Replaces the snapshot model with a single shared `CommandSet` that owns the merged command state — writers push by plugin slot, readers pull on demand.

## Proposed Changes

- Add `CommandSet` (`internal/hive/plugins/commandset.go`) with `Lookup` (allocation-free, hot path) and `All` (defensive copy, palette open). Precedence is encoded in the data structure: user > plugin > system.
- Wire `CommandSet` from `main.go` into `Manager` (seeds plugin slots in `InitAll`), the Lua plugin (pushes via `MergePlugin` on each `hive.commands` call), and TUI `Deps`.
- Drop `Manager.MergedCommands` and the cross-call duplicate-name guard in `commandsFromTable` — re-registering a name now replaces, last-write-wins.
- `KeybindingResolver` and the command palette consume the `CommandSet` directly; `Model.mergedCommands` is gone.
- New config field `plugins.lua.dispatcher_queue_size` (default 128, was a fixed const at 64); `NewRuntime` validates `queueSize >= 1`.
- Integration test under `-tags integration` exercises a ticker re-registering a command from inside the running TUI.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)