### PR TITLE
chore(lint): remove goconst linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - errorlint
     - exhaustive
     - gochecknoinits
-    - goconst
     - gocritic
     - goprintffuncname
     - govet
@@ -40,9 +39,6 @@ linters:
               desc: Should be replaced by standard lib errors package
     exhaustive:
       default-signifies-exhaustive: true
-    goconst:
-      min-len: 5
-      min-occurrences: 5
     gocritic:
       enabled-checks:
         - ruleguard


### PR DESCRIPTION
## Summary
- Removes `goconst` from the enabled linters and drops its settings block.
- Lint now exits 0; previously 50 pre-existing findings blocked clean runs.

## Why
The goconst checker has been flagging test fixtures, short identifiers (`aider`, `test.md`, `Line 4`), and table-test strings where extracting a constant would hurt readability more than it helps. The signal-to-noise ratio doesn't justify keeping it.

## Test plan
- [x] `mise run lint` exits 0