### PR TITLE
feat(tui): agent selector in new session form

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -58,11 +58,12 @@ rules:
 
 Agent profiles define the AI tools available for spawning in sessions. The `default` key selects which profile to use when creating a new session.
 
-| Option                  | Type       | Default        | Description                                          |
-| ----------------------- | ---------- | -------------- | ---------------------------------------------------- |
-| `agents.default`        | `string`   | `"claude"`     | Profile name to use by default                       |
-| `agents.<name>.command` | `string`   | profile name   | CLI binary to run (defaults to profile name if empty)|
-| `agents.<name>.flags`   | `[]string` | `[]`           | Extra CLI args appended to the command on spawn      |
+| Option                    | Type       | Default        | Description                                                                    |
+| ------------------------- | ---------- | -------------- | ------------------------------------------------------------------------------ |
+| `agents.default`          | `string`   | `"claude"`     | Profile name to use by default                                                 |
+| `agents.agent_selector`   | `bool`     | `false`        | Show an inline agent picker in the new-session form; default profile pre-selected |
+| `agents.<name>.command`   | `string`   | profile name   | CLI binary to run (defaults to profile name if empty)                          |
+| `agents.<name>.flags`     | `[]string` | `[]`           | Extra CLI args appended to the command on spawn                                |
 
 Sessions can run multiple agents by opening additional tmux windows — use `tmux.preview_window_matcher` to control which windows the TUI monitors.
 

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -420,11 +420,12 @@ type Config struct {
 // AgentsConfig holds agent profile configuration.
 // The "default" key selects which profile to use; all other keys are profile definitions.
 type AgentsConfig struct {
-	Default  string                  // reserved key selecting the active profile
-	Profiles map[string]AgentProfile // profile name → agent configuration
+	Default       string                  // reserved key selecting the active profile
+	AgentSelector bool                    // when true, the TUI new-session form prompts for agent selection
+	Profiles      map[string]AgentProfile // profile name → agent configuration
 }
 
-// UnmarshalYAML separates the "default" key from profile entries.
+// UnmarshalYAML separates the "default" and "agent_selector" keys from profile entries.
 func (a *AgentsConfig) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("agents: expected mapping, got %v", node.Kind)
@@ -436,20 +437,26 @@ func (a *AgentsConfig) UnmarshalYAML(node *yaml.Node) error {
 		key := node.Content[i].Value
 		val := node.Content[i+1]
 
-		if key == "default" {
+		switch key {
+		case "default":
 			var s string
 			if err := val.Decode(&s); err != nil {
 				return fmt.Errorf("agents.default: %w", err)
 			}
 			a.Default = s
-			continue
+		case "agent_selector":
+			var b bool
+			if err := val.Decode(&b); err != nil {
+				return fmt.Errorf("agents.agent_selector: %w", err)
+			}
+			a.AgentSelector = b
+		default:
+			var profile AgentProfile
+			if err := val.Decode(&profile); err != nil {
+				return fmt.Errorf("agents.%s: %w", key, err)
+			}
+			a.Profiles[key] = profile
 		}
-
-		var profile AgentProfile
-		if err := val.Decode(&profile); err != nil {
-			return fmt.Errorf("agents.%s: %w", key, err)
-		}
-		a.Profiles[key] = profile
 	}
 
 	return nil

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -41,6 +41,10 @@ type CreateOptions struct {
 	// when the session directory is needed but terminal management happens elsewhere
 	// (e.g. CreateSessionWithWindows, which creates the tmux session itself).
 	SkipSpawn bool
+	// AgentKey selects a named agent profile for this session's spawn command.
+	// When non-empty, the spawn templates use that profile's command/flags instead
+	// of the process-wide default. Must match a key in config.Agents.Profiles.
+	AgentKey string
 	// Progress receives human-readable progress lines during session creation.
 	// When non-nil, service output (hooks, file copies) is also redirected here.
 	Progress io.Writer
@@ -334,14 +338,24 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	}
 
 	if !opts.SkipSpawn {
+		renderer := s.renderer
+		if opts.AgentKey != "" {
+			if profile, ok := s.config.Agents.Profiles[opts.AgentKey]; ok {
+				renderer = s.renderer.WithAgent(
+					profile.CommandOrDefault(opts.AgentKey),
+					opts.AgentKey,
+					profile.ShellFlags(),
+				)
+			}
+		}
 		strategy := config.ResolveSpawn(s.config.Rules, remote, opts.UseBatchSpawn)
 		switch {
 		case strategy.IsWindows():
-			if err := s.spawner.SpawnWindows(ctx, strategy.Windows, data, opts.UseBatchSpawn || opts.Background); err != nil {
+			if err := s.spawner.SpawnWindowsWith(ctx, strategy.Windows, data, opts.UseBatchSpawn || opts.Background, renderer); err != nil {
 				return nil, fmt.Errorf("spawn terminal: %w", err)
 			}
 		case len(strategy.Commands) > 0:
-			if err := s.spawner.Spawn(ctx, strategy.Commands, data); err != nil {
+			if err := s.spawner.SpawnWith(ctx, strategy.Commands, data, renderer); err != nil {
 				return nil, fmt.Errorf("spawn terminal: %w", err)
 			}
 		default:

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -57,10 +57,15 @@ func NewSpawner(log zerolog.Logger, executor executil.Executor, renderer *tmpl.R
 
 // Spawn executes spawn commands sequentially with template rendering.
 func (s *Spawner) Spawn(ctx context.Context, commands []string, data SpawnData) error {
+	return s.SpawnWith(ctx, commands, data, s.renderer)
+}
+
+// SpawnWith executes spawn commands using the given renderer instead of the default.
+func (s *Spawner) SpawnWith(ctx context.Context, commands []string, data SpawnData, renderer *tmpl.Renderer) error {
 	for _, cmdTmpl := range commands {
 		s.log.Debug().Str("command", cmdTmpl).Msg("executing spawn command")
 
-		rendered, err := s.renderer.Render(cmdTmpl, data)
+		rendered, err := renderer.Render(cmdTmpl, data)
 		if err != nil {
 			return fmt.Errorf("render spawn command %q: %w", cmdTmpl, err)
 		}
@@ -76,7 +81,12 @@ func (s *Spawner) Spawn(ctx context.Context, commands []string, data SpawnData) 
 
 // SpawnWindows renders window templates and creates a tmux session.
 func (s *Spawner) SpawnWindows(ctx context.Context, windows []config.WindowConfig, data SpawnData, background bool) error {
-	rendered, err := RenderWindows(s.renderer, windows, data)
+	return s.SpawnWindowsWith(ctx, windows, data, background, s.renderer)
+}
+
+// SpawnWindowsWith renders window templates using the given renderer and creates a tmux session.
+func (s *Spawner) SpawnWindowsWith(ctx context.Context, windows []config.WindowConfig, data SpawnData, background bool, renderer *tmpl.Renderer) error {
+	rendered, err := RenderWindows(renderer, windows, data)
 	if err != nil {
 		return err
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -726,7 +727,7 @@ func (m Model) updateNewSessionForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.modals.NewSession.Submitted() {
 		result := m.modals.NewSession.Result()
 		m.modals.NewSession = nil
-		return m, m.startCreate(result.SessionName, result.Repo.Remote)
+		return m, m.startCreate(result.SessionName, result.Repo.Remote, result.AgentKey)
 	}
 
 	if m.modals.NewSession.Cancelled() {
@@ -1635,7 +1636,28 @@ func (m Model) openNewSessionForm() (tea.Model, tea.Cmd) {
 	for _, s := range allSessions {
 		existingNames[s.Name] = true
 	}
-	m.modals.NewSession = NewNewSessionForm(m.sessionsView.DiscoveredRepos(), preselectedRemote, existingNames)
+
+	var agentKeys []string
+	if m.cfg.Agents.AgentSelector && len(m.cfg.Agents.Profiles) > 1 {
+		// Sort alphabetically, then rotate so the configured default is first
+		// (agentPicker pre-selects index 0).
+		all := make([]string, 0, len(m.cfg.Agents.Profiles))
+		for k := range m.cfg.Agents.Profiles {
+			all = append(all, k)
+		}
+		sort.Strings(all)
+		// Put the default first so it is pre-selected.
+		def := m.cfg.Agents.Default
+		agentKeys = make([]string, 0, len(all))
+		agentKeys = append(agentKeys, def)
+		for _, k := range all {
+			if k != def {
+				agentKeys = append(agentKeys, k)
+			}
+		}
+	}
+
+	m.modals.NewSession = NewNewSessionForm(m.sessionsView.DiscoveredRepos(), preselectedRemote, existingNames, agentKeys)
 	m.state = stateCreatingSession
 	return m, m.modals.NewSession.Init()
 }
@@ -1857,13 +1879,14 @@ func (m Model) startRecycle(sessionID string) tea.Cmd {
 }
 
 // startCreate returns a command that starts session creation with streaming output.
-func (m Model) startCreate(name, remote string) tea.Cmd {
+func (m Model) startCreate(name, remote, agentKey string) tea.Cmd {
 	return func() tea.Msg {
 		exec := m.cmdService.NewCreateExecutor(hive.CreateOptions{
 			Name:       name,
 			Remote:     remote,
 			Source:     m.source,
 			Background: true,
+			AgentKey:   agentKey,
 		})
 
 		output, done, cancel := exec.Execute(context.Background())

--- a/internal/tui/new_session_form.go
+++ b/internal/tui/new_session_form.go
@@ -1,12 +1,68 @@
 package tui
 
 import (
+	"strings"
+
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/core/workspace"
+)
+
+// agentPicker is a compact inline selector for a small set of agent names.
+// It renders as a single line of options: "claude  ·  opencode  ·  pi"
+// with the selected option highlighted. Left/right (or h/l) cycle the selection.
+type agentPicker struct {
+	keys     []string
+	selected int
+	focused  bool
+}
+
+func (p *agentPicker) focus() { p.focused = true }
+func (p *agentPicker) blur()  { p.focused = false }
+
+func (p *agentPicker) update(msg tea.Msg) {
+	if !p.focused {
+		return
+	}
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return
+	}
+	switch key.String() {
+	case "left", "h":
+		if p.selected > 0 {
+			p.selected--
+		} else {
+			p.selected = len(p.keys) - 1
+		}
+	case "right", "l":
+		p.selected = (p.selected + 1) % len(p.keys)
+	}
+}
+
+func (p agentPicker) view() string {
+	sep := styles.TextMutedStyle.Render("  ·  ")
+	parts := make([]string, len(p.keys))
+	for i, k := range p.keys {
+		if i == p.selected {
+			parts[i] = styles.TextPrimaryBoldStyle.Render(k)
+		} else {
+			parts[i] = styles.TextMutedStyle.Render(k)
+		}
+	}
+	return strings.Join(parts, sep)
+}
+
+// Field index constants when the agent selector is active.
+// Agent sits at the top (0) but is not in the forward tab cycle.
+// Initial focus is on repo (1).
+const (
+	agentSelectorField = 0
+	repoFieldWithAgent = 1
+	nameFieldWithAgent = 2
 )
 
 // NewSessionForm manages the new session creation form.
@@ -17,7 +73,13 @@ type NewSessionForm struct {
 	repoSelect SelectField
 	nameInput  textinput.Model
 
-	focusedField int // 0 = repo select, 1 = name input
+	hasAgentSelector bool
+	agent            agentPicker
+
+	// focusedField tracks which field has focus.
+	// Without agent selector: 0=repo, 1=name
+	// With agent selector:    0=agent, 1=repo, 2=name  (initial focus: 1)
+	focusedField int
 	submitted    bool
 	cancelled    bool
 	nameError    string
@@ -27,12 +89,16 @@ type NewSessionForm struct {
 type NewSessionFormResult struct {
 	Repo        workspace.DiscoveredRepo
 	SessionName string
+	AgentKey    string // empty when agent selector is disabled
 }
 
 // NewNewSessionForm creates a new session form with the given repos.
 // If preselectedRemote is non-empty, the matching repo will be pre-selected.
 // existingNames is used to validate that the session name is unique.
-func NewNewSessionForm(repos []workspace.DiscoveredRepo, preselectedRemote string, existingNames map[string]bool) *NewSessionForm {
+// agentKeys, when non-empty, adds a compact agent selector at the top of the form.
+// The default agent (index 0 in agentKeys) is pre-selected; it is skipped in the
+// forward tab cycle and reachable via shift+tab from the repo field.
+func NewNewSessionForm(repos []workspace.DiscoveredRepo, preselectedRemote string, existingNames map[string]bool, agentKeys []string) *NewSessionForm {
 	selectedIdx := 0
 	for i, r := range repos {
 		if r.Remote == preselectedRemote {
@@ -43,10 +109,7 @@ func NewNewSessionForm(repos []workspace.DiscoveredRepo, preselectedRemote strin
 
 	items := make([]SelectItem, len(repos))
 	for i, r := range repos {
-		items[i] = SelectItem{
-			label: r.Name,
-			value: i,
-		}
+		items[i] = SelectItem{label: r.Name, value: i}
 	}
 
 	repoSelect := NewSelectField("Repository", items, selectedIdx)
@@ -65,85 +128,140 @@ func NewNewSessionForm(repos []workspace.DiscoveredRepo, preselectedRemote strin
 	inputStyles.Blurred.Placeholder = lipgloss.NewStyle().Foreground(styles.ColorMuted)
 	nameInput.SetStyles(inputStyles)
 
-	return &NewSessionForm{
+	f := &NewSessionForm{
 		repos:         repos,
 		existingNames: existingNames,
 		repoSelect:    repoSelect,
 		nameInput:     nameInput,
-		focusedField:  0,
+		focusedField:  0, // repo is 0 without agent, 1 with agent
 	}
+
+	if len(agentKeys) > 0 {
+		f.hasAgentSelector = true
+		f.agent = agentPicker{keys: agentKeys}
+		f.focusedField = repoFieldWithAgent // start on repo, not agent
+	}
+
+	return f
+}
+
+// repoIdx returns the focusedField value for the repo field.
+func (f *NewSessionForm) repoIdx() int {
+	if f.hasAgentSelector {
+		return repoFieldWithAgent
+	}
+	return 0
+}
+
+// nameIdx returns the focusedField value for the name input.
+func (f *NewSessionForm) nameIdx() int {
+	if f.hasAgentSelector {
+		return nameFieldWithAgent
+	}
+	return 1
 }
 
 // Init returns the initial command for the form.
-func (f *NewSessionForm) Init() tea.Cmd {
-	return nil
-}
+func (f *NewSessionForm) Init() tea.Cmd { return nil }
 
 // Update handles messages for the form.
 func (f *NewSessionForm) Update(msg tea.Msg) (NewSessionForm, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
 		return f.handleKey(keyMsg)
 	}
-
 	return f.updateFocusedField(msg)
 }
 
-// handleKey processes key events.
+// handleKey processes key events for the form.
 func (f *NewSessionForm) handleKey(msg tea.KeyPressMsg) (NewSessionForm, tea.Cmd) {
 	key := msg.String()
 
 	switch key {
-	case "tab", "shift+tab":
-		if f.focusedField == 0 {
-			f.focusedField = 1
-			f.repoSelect.Blur()
-			return *f, f.nameInput.Focus()
-		}
-		f.focusedField = 0
-		f.nameInput.Blur()
-		return *f, f.repoSelect.Focus()
+	case "tab":
+		return f.tabForward()
+
+	case "shift+tab":
+		return f.tabBackward()
 
 	case "enter":
-		if f.focusedField == 0 {
-			// On repo select, move to name input
-			f.focusedField = 1
-			f.repoSelect.Blur()
-			return *f, f.nameInput.Focus()
+		if f.focusedField == f.nameIdx() {
+			return f.validateAndSubmit()
 		}
-		// On name input, validate and submit
-		return f.validateAndSubmit()
+		// Advance to next field in forward order (same as tab, but enter on
+		// agent goes to repo rather than wrapping).
+		return f.tabForward()
 
 	case "esc":
-		// If filtering in select, let the select handle it
-		if f.focusedField == 0 && f.repoSelect.IsFiltering() {
+		if f.focusedField == f.repoIdx() && f.repoSelect.IsFiltering() {
 			return f.updateFocusedField(msg)
 		}
 		f.cancelled = true
 		return *f, nil
 	}
 
-	// Pass to focused field
 	return f.updateFocusedField(msg)
+}
+
+// tabForward advances focus to the next field (wraps around).
+// With agent selector: agent(0) → repo(1) → name(2) → agent(0)
+// Without:            repo(0)  → name(1) → repo(0)
+func (f *NewSessionForm) tabForward() (NewSessionForm, tea.Cmd) {
+	next := f.focusedField + 1
+	if next > f.nameIdx() {
+		next = 0
+	}
+	return f.moveFocus(next)
+}
+
+// tabBackward moves focus to the previous field (wraps around).
+func (f *NewSessionForm) tabBackward() (NewSessionForm, tea.Cmd) {
+	prev := f.focusedField - 1
+	if prev < 0 {
+		prev = f.nameIdx()
+	}
+	return f.moveFocus(prev)
+}
+
+// moveFocus transitions focus to the given field index.
+func (f *NewSessionForm) moveFocus(idx int) (NewSessionForm, tea.Cmd) {
+	f.repoSelect.Blur()
+	f.nameInput.Blur()
+	f.agent.blur()
+	f.focusedField = idx
+
+	if f.hasAgentSelector && idx == agentSelectorField {
+		f.agent.focus()
+		return *f, nil
+	}
+	if idx == f.repoIdx() {
+		cmd := f.repoSelect.Focus()
+		return *f, cmd
+	}
+	cmd := f.nameInput.Focus()
+	return *f, cmd
 }
 
 // updateFocusedField routes messages to the currently focused field.
 func (f *NewSessionForm) updateFocusedField(msg tea.Msg) (NewSessionForm, tea.Cmd) {
 	var cmd tea.Cmd
-
-	if f.focusedField == 0 {
-		f.repoSelect, cmd = f.repoSelect.Update(msg)
-	} else {
-		prev := f.nameInput.Value()
-		f.nameInput, cmd = f.nameInput.Update(msg)
-		if f.nameInput.Value() != prev {
-			f.nameError = ""
-		}
+	if f.hasAgentSelector && f.focusedField == agentSelectorField {
+		f.agent.update(msg)
+		return *f, nil
 	}
-
+	if f.focusedField == f.repoIdx() {
+		f.repoSelect, cmd = f.repoSelect.Update(msg)
+		return *f, cmd
+	}
+	// name field
+	prev := f.nameInput.Value()
+	f.nameInput, cmd = f.nameInput.Update(msg)
+	if f.nameInput.Value() != prev {
+		f.nameError = ""
+	}
 	return *f, cmd
 }
 
-// validateAndSubmit validates the form and submits if valid.
+// validateAndSubmit validates the name field and marks the form submitted.
 func (f *NewSessionForm) validateAndSubmit() (NewSessionForm, tea.Cmd) {
 	name := f.nameInput.Value()
 	if name == "" {
@@ -158,23 +276,17 @@ func (f *NewSessionForm) validateAndSubmit() (NewSessionForm, tea.Cmd) {
 		f.nameError = "Session name already exists"
 		return *f, nil
 	}
-
 	f.submitted = true
 	return *f, nil
 }
 
 // Submitted returns true if the form was submitted.
-func (f *NewSessionForm) Submitted() bool {
-	return f.submitted
-}
+func (f *NewSessionForm) Submitted() bool { return f.submitted }
 
 // Cancelled returns true if the form was cancelled.
-func (f *NewSessionForm) Cancelled() bool {
-	return f.cancelled
-}
+func (f *NewSessionForm) Cancelled() bool { return f.cancelled }
 
 // Result returns the form result. Only valid if Submitted() is true.
-// Returns zero value if repos slice is empty (should not happen in normal use).
 func (f *NewSessionForm) Result() NewSessionFormResult {
 	if len(f.repos) == 0 {
 		return NewSessionFormResult{}
@@ -183,52 +295,64 @@ func (f *NewSessionForm) Result() NewSessionFormResult {
 	if idx < 0 || idx >= len(f.repos) {
 		idx = 0
 	}
+
+	agentKey := ""
+	if f.hasAgentSelector && f.agent.selected >= 0 && f.agent.selected < len(f.agent.keys) {
+		agentKey = f.agent.keys[f.agent.selected]
+	}
+
 	return NewSessionFormResult{
 		Repo:        f.repos[idx],
 		SessionName: f.nameInput.Value(),
+		AgentKey:    agentKey,
 	}
 }
 
 // View renders the form.
 func (f *NewSessionForm) View() string {
-	// Repo select (already has title integrated)
-	repoView := f.repoSelect.View()
+	var sections []string
 
-	// Name input section - title integrated into bordered area
+	// Agent picker — title line then options line
+	if f.hasAgentSelector {
+		agentFocused := f.focusedField == agentSelectorField
+		titleStyle := styles.TextMutedStyle
+		if agentFocused {
+			titleStyle = styles.FormTitleStyle
+		}
+		title := titleStyle.Render("Agent")
+		agentSection := styles.FormFieldStyle.Render(
+			lipgloss.JoinVertical(lipgloss.Left, title, f.agent.view()),
+		)
+		sections = append(sections, agentSection, "")
+	}
+
+	// Repository selector
+	sections = append(sections, f.repoSelect.View())
+
+	// Session name input
+	nameFocused := f.focusedField == f.nameIdx()
 	nameTitleStyle := styles.TextMutedStyle
-	if f.focusedField == 1 {
+	if nameFocused {
 		nameTitleStyle = styles.FormTitleStyle
 	}
 	nameTitle := nameTitleStyle.Render("Session Name")
-
-	// Build content: title + input (+ error if present)
 	nameContent := lipgloss.JoinVertical(lipgloss.Left, nameTitle, f.nameInput.View())
 
-	// Always render error slot at fixed height to keep modal size stable.
-	// Width-constrain to match the input so long messages wrap instead of overflowing.
 	errText := f.nameError
 	if errText == "" {
-		errText = " " // placeholder to hold the line
+		errText = " "
 	}
 	errorView := styles.TextErrorStyle.Width(f.nameInput.Width()).Render(errText)
 	nameContent = lipgloss.JoinVertical(lipgloss.Left, nameContent, errorView)
 
-	// Apply border style
 	inputBorderStyle := styles.FormFieldStyle
-	if f.focusedField == 1 {
+	if nameFocused {
 		inputBorderStyle = styles.FormFieldFocusedStyle
 	}
-	nameSection := inputBorderStyle.Render(nameContent)
+	sections = append(sections, "", inputBorderStyle.Render(nameContent))
 
-	// Help text
 	helpText := styles.TextMutedStyle.Render("tab: switch fields • enter: submit • esc: cancel")
+	sections = append(sections, "", helpText)
 
-	return lipgloss.JoinVertical(
-		lipgloss.Left,
-		repoView,
-		"",
-		nameSection,
-		"",
-		helpText,
-	)
+	return lipgloss.JoinVertical(lipgloss.Left, sections...)
 }

--- a/internal/tui/new_session_form_test.go
+++ b/internal/tui/new_session_form_test.go
@@ -22,27 +22,27 @@ func TestNewNewSessionForm(t *testing.T) {
 	}
 
 	t.Run("creates form with repos", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		require.NotNil(t, form)
 		assert.False(t, form.Submitted())
 		assert.False(t, form.Cancelled())
 	})
 
 	t.Run("preselects matching remote", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "git@github.com:user/beta.git", nil)
+		form := NewNewSessionForm(repos, "git@github.com:user/beta.git", nil, nil)
 		// The second repo (index 1) should be selected
 		idx := form.repoSelect.SelectedIndex()
 		assert.Equal(t, 1, idx)
 	})
 
 	t.Run("defaults to first repo when no match", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "git@github.com:user/unknown.git", nil)
+		form := NewNewSessionForm(repos, "git@github.com:user/unknown.git", nil, nil)
 		idx := form.repoSelect.SelectedIndex()
 		assert.Equal(t, 0, idx)
 	})
 
 	t.Run("result returns selected repo", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "git@github.com:user/gamma.git", nil)
+		form := NewNewSessionForm(repos, "git@github.com:user/gamma.git", nil, nil)
 		// Simulate typing a session name
 		form.focusedField = 1 // Focus name input
 		form.nameInput.SetValue("my-session")
@@ -54,21 +54,21 @@ func TestNewNewSessionForm(t *testing.T) {
 	})
 
 	t.Run("tracks submitted state", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		assert.False(t, form.Submitted())
 		form.submitted = true
 		assert.True(t, form.Submitted())
 	})
 
 	t.Run("tracks cancelled state", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		assert.False(t, form.Cancelled())
 		form.cancelled = true
 		assert.True(t, form.Cancelled())
 	})
 
 	t.Run("validates empty session name", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		form.focusedField = 1 // Focus name input
 		// Empty name - try to submit
 		updated, _ := form.Update(keyPress(tea.KeyEnter))
@@ -77,7 +77,7 @@ func TestNewNewSessionForm(t *testing.T) {
 	})
 
 	t.Run("validates session name characters", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		form.focusedField = 1
 		form.nameInput.SetValue("bad~name")
 		updated, _ := form.Update(keyPress(tea.KeyEnter))
@@ -87,7 +87,7 @@ func TestNewNewSessionForm(t *testing.T) {
 
 	t.Run("validates duplicate session name", func(t *testing.T) {
 		existingNames := map[string]bool{"existing-session": true}
-		form := NewNewSessionForm(repos, "", existingNames)
+		form := NewNewSessionForm(repos, "", existingNames, nil)
 		form.focusedField = 1 // Focus name input
 		form.nameInput.SetValue("existing-session")
 		// Try to submit with duplicate name
@@ -97,14 +97,14 @@ func TestNewNewSessionForm(t *testing.T) {
 	})
 
 	t.Run("esc cancels form", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		form.focusedField = 1 // Focus name input (not filtering)
 		updated, _ := form.Update(keyPress(tea.KeyEscape))
 		assert.True(t, updated.Cancelled())
 	})
 
 	t.Run("tab switches focus", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		assert.Equal(t, 0, form.focusedField)
 		updated, _ := form.Update(keyPress(tea.KeyTab))
 		assert.Equal(t, 1, updated.focusedField)
@@ -113,14 +113,14 @@ func TestNewNewSessionForm(t *testing.T) {
 	})
 
 	t.Run("Result returns zero value for empty repos", func(t *testing.T) {
-		form := NewNewSessionForm([]workspace.DiscoveredRepo{}, "", nil)
+		form := NewNewSessionForm([]workspace.DiscoveredRepo{}, "", nil, nil)
 		result := form.Result()
 		assert.Empty(t, result.Repo.Name)
 		assert.Empty(t, result.Repo.Remote)
 	})
 
 	t.Run("enter on repo select moves to name input", func(t *testing.T) {
-		form := NewNewSessionForm(repos, "", nil)
+		form := NewNewSessionForm(repos, "", nil, nil)
 		assert.Equal(t, 0, form.focusedField)
 		updated, _ := form.Update(keyPress(tea.KeyEnter))
 		assert.Equal(t, 1, updated.focusedField)

--- a/internal/tui/select_field.go
+++ b/internal/tui/select_field.go
@@ -56,22 +56,35 @@ func (d selectItemDelegate) Render(w io.Writer, m list.Model, index int, listIte
 	_, _ = io.WriteString(w, style.Render(item.label))
 }
 
+// maxSelectFieldHeight is the tallest a SelectField list will grow before scrolling.
+const maxSelectFieldHeight = 8
+
 // NewSelectField creates a new select field with the given items.
 // selected is the index to pre-select (-1 for none).
+// The list height is sized to fit the items (up to maxSelectFieldHeight) so
+// there is no blank padding below the last item.
 func NewSelectField(title string, items []SelectItem, selected int) SelectField {
 	listItems := make([]list.Item, len(items))
 	for i, item := range items {
 		listItems[i] = item
 	}
 
+	h := len(listItems)
+	if h < 1 {
+		h = 1
+	}
+	if h > maxSelectFieldHeight {
+		h = maxSelectFieldHeight
+	}
+
 	delegate := selectItemDelegate{}
-	// Height 8 matches the original huh config
-	l := list.New(listItems, delegate, 40, 8)
+	l := list.New(listItems, delegate, 40, h)
 	l.SetShowTitle(false)
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(true)
 	l.SetShowFilter(false) // Only show filter input when actively filtering
 	l.SetShowHelp(false)
+	l.SetShowPagination(false)
 	l.Styles.TitleBar = lipgloss.NewStyle()
 
 	// Configure filter input styles
@@ -90,7 +103,7 @@ func NewSelectField(title string, items []SelectItem, selected int) SelectField 
 		list:   l,
 		title:  title,
 		width:  40,
-		height: 8,
+		height: h,
 	}
 }
 

--- a/pkg/tmpl/tmpl.go
+++ b/pkg/tmpl/tmpl.go
@@ -46,12 +46,14 @@ func (c Config) scriptPath(name string) string {
 
 // Renderer renders Go templates with shell-oriented helper functions.
 type Renderer struct {
+	cfg   Config
 	funcs template.FuncMap
 }
 
 // New creates a Renderer with the given config baked into template functions.
 func New(cfg Config) *Renderer {
 	return &Renderer{
+		cfg: cfg,
 		funcs: template.FuncMap{
 			"shq":          shellQuote,
 			"join":         strings.Join,
@@ -72,6 +74,16 @@ func NewValidation() *Renderer {
 		AgentCommand: "claude",
 		AgentWindow:  "claude",
 	})
+}
+
+// WithAgent returns a new Renderer with the agent values overridden.
+// All other config (script paths etc.) is inherited from the receiver.
+func (r *Renderer) WithAgent(command, window, flags string) *Renderer {
+	cfg := r.cfg
+	cfg.AgentCommand = command
+	cfg.AgentWindow = window
+	cfg.AgentFlags = flags
+	return New(cfg)
 }
 
 // Render executes a Go template string with the given data.


### PR DESCRIPTION
## Purpose

Adds an opt-in `agents.agent_selector: true` config option that surfaces a compact inline agent picker at the top of the new session form, letting users choose which agent profile to use per session.

## Proposed Changes

  - `agents.agent_selector` config field — when true and multiple profiles are configured, the new session form shows the picker
  - Compact inline picker renders `Agent / claude  ·  opencode  ·  pi` with left/right to cycle; default profile is pre-selected so the normal flow is unaffected
  - Selected agent key flows through `CreateOptions.AgentKey` → `SessionService` → spawn, which builds a per-session `tmpl.Renderer` variant via `Renderer.WithAgent`
  - `SelectField` paginator dots removed and list height now hugs content instead of padding to a fixed 8 lines

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)