### PR TITLE
fix(logutils): append to log file instead of truncating on start

### DIFF
--- a/pkg/logutils/logger.go
+++ b/pkg/logutils/logger.go
@@ -31,7 +31,7 @@ func New(level string, file string) (zerolog.Logger, func(), error) {
 			return zerolog.Logger{}, closer, fmt.Errorf("create logs dir: %w", err)
 		}
 
-		osFile, err := os.Create(file)
+		osFile, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return zerolog.Logger{}, closer, err
 		}


### PR DESCRIPTION
## Summary

`os.Create` truncates the log file on every hive startup, meaning logs from previous sessions are lost. Switch to `os.OpenFile` with append flags so logs accumulate across sessions.