### PR TITLE
docs: redesign landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -122,9 +122,7 @@ brew install colonyops/tap/hive</code></pre>
       </div>
       <div class="hive-preview-pane">
         <div class="hive-preview-coming-soon">
-          <span>Coming soon</span>
-          <strong>Terminal preview in progress</strong>
-          <em>A short capture will show sessions, live agent status, tmux previews, and coordination flows.</em>
+          <span>Demo coming soon</span>
         </div>
       </div>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,14 +19,14 @@ brew install colonyops/tap/hive</code></pre>
     </div>
   </div>
 
-  <div class="hive-terminal-demo" aria-label="Animated terminal demo of creating Hive sessions">
-    <div class="hive-terminal-demo__bar">
+  <div class="hive-terminal-demo" role="img" aria-label="Animated terminal demo of creating Hive sessions">
+    <div class="hive-terminal-demo__bar" aria-hidden="true">
       <span></span><span></span><span></span>
       <strong>hive</strong>
     </div>
-    <div class="hive-terminal-demo__screen">
+    <div class="hive-terminal-demo__screen" aria-hidden="true">
       <div class="term-shell">
-        <div class="term-line term-command term-command--one"><span class="term-prompt">$</span> <span class="term-typed">hive new auth-refactor --remote github.com/acme/app --background</span></div>
+        <div class="term-line term-command term-command--one"><span class="term-prompt">$</span> <span class="term-typed">hive new auth-refactor --remote https://github.com/acme/app.git --background</span></div>
         <div class="term-line term-output term-output--one">hook [1/2] mise install</div>
         <div class="term-line term-output term-output--two">mise all tools are installed</div>
         <div class="term-line term-output term-output--three">hook [2/2] hive ctx init</div>
@@ -97,12 +97,12 @@ brew install colonyops/tap/hive</code></pre>
   <h2>See What Hive Actually Is</h2>
   <p>Hive is a tmux-native command center for local agents, isolated git workspaces, project commands, and interactive terminals. It keeps your stack visible and gives Claude Code, Codex, Pi, and the rest of your tools one shared control surface.</p>
 
-  <div class="hive-preview-terminal" aria-label="Hive terminal UI preview coming soon">
-    <div class="hive-preview-terminal__nav">
+  <div class="hive-preview-terminal" role="img" aria-label="Hive terminal UI preview coming soon">
+    <div class="hive-preview-terminal__nav" aria-hidden="true">
       <strong>Sessions</strong><span>|</span><span>Tasks</span><span>|</span><span>Docs</span><span>|</span><span>Messages</span>
       <em><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 5h8"/><path d="M13 12h8"/><path d="M13 19h8"/><path d="m3 5 2 2 4-4"/><path d="m3 12 2 2 4-4"/><path d="m3 19 2 2 4-4"/></svg>2</em><b>Hive</b>
     </div>
-    <div class="hive-preview-terminal__body">
+    <div class="hive-preview-terminal__body" aria-hidden="true">
       <div class="hive-preview-tree" aria-label="Hive session tree preview">
         <div class="hive-preview-tree__repo">hive <span>◆</span></div>
         <div class="hive-preview-tree__line">├─ <b>[&gt;]</b> init-command <em>#ek3p</em></div>
@@ -128,7 +128,7 @@ brew install colonyops/tap/hive</code></pre>
         </div>
       </div>
     </div>
-    <div class="hive-preview-terminal__footer">j/k navigate · / filter · enter select · ? help</div>
+    <div class="hive-preview-terminal__footer" aria-hidden="true">j/k navigate · / filter · enter select · ? help</div>
   </div>
 </section>
 
@@ -147,7 +147,7 @@ brew install colonyops/tap/hive</code></pre>
     <a class="hive-feature-card" href="getting-started/sessions/#status-indicators">
       <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M12 19h8M4 17l6-6-6-6"/></svg></span>
       <strong>Terminal Integration</strong>
-      <p>Monitor Claude Code, Codex, Pi, shell windows, test watchers, and dev servers through tmux-backed status detection.</p>
+      <p>Track Claude Code and Codex status alongside shell, test, and dev-server tmux windows.</p>
     </a>
     <a class="hive-feature-card" href="getting-started/task-tracking/">
       <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M13 5h8"/><path d="M13 12h8"/><path d="M13 19h8"/><path d="m3 5 2 2 4-4"/><path d="m3 12 2 2 4-4"/><path d="m3 19 2 2 4-4"/></svg></span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,124 +1,188 @@
 ---
 icon: fontawesome/brands/hive
+hide:
+  - toc
 ---
 
-<div align="center">
-  <img src="assets/favicon.svg" alt="Hive" width="100">
-  <h1 style="margin-top: 0.5em; margin-bottom: 0.5em;">Hive</h1>
-</div>
+<section class="hive-hero">
+  <div class="hive-hero__copy">
+    <div class="hive-eyebrow">Tmux-native metaharness</div>
+    <h1>The layer above your coding agents.</h1>
+    <p class="hive-lede">Hive does not replace <a href="https://docs.anthropic.com/en/docs/claude-code/overview" target="_blank" rel="noopener noreferrer">Claude Code</a>, <a href="https://openai.com/codex/" target="_blank" rel="noopener noreferrer">Codex</a>, <a href="https://pi.dev" target="_blank" rel="noopener noreferrer">Pi</a>, or your shell. It gives them a shared tmux command center with isolated git workspaces or worktrees, live status, repo context, task coordination, and inter-agent messaging.</p>
+    <div class="hive-hero__actions">
+      <a class="md-button md-button--primary" href="getting-started/">Get started</a>
+      <a class="md-button" href="https://github.com/colonyops/hive" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+    </div>
+    <div class="hive-install">
+      <pre><code>brew install tmux
+brew install colonyops/tap/hive</code></pre>
+    </div>
+  </div>
 
-Hive manages isolated git sessions for running AI agents in parallel. Instead of manually managing git worktrees or directories, hive handles cloning, recycling, and spawning terminal sessions with your preferred AI tool (Claude, Aider, Codex). Each session is a complete git clone with its own terminal environment, tracked through a lifecycle (active → recycled → deleted) and reusable to save time and disk space.
+  <div class="hive-terminal-demo" aria-label="Animated terminal demo of creating Hive sessions">
+    <div class="hive-terminal-demo__bar">
+      <span></span><span></span><span></span>
+      <strong>hive</strong>
+    </div>
+    <div class="hive-terminal-demo__screen">
+      <div class="term-shell">
+        <div class="term-line term-command term-command--one"><span class="term-prompt">$</span> <span class="term-typed">hive new auth-refactor --remote github.com/acme/app --background</span></div>
+        <div class="term-line term-output term-output--one">hook [1/2] mise install</div>
+        <div class="term-line term-output term-output--two">mise all tools are installed</div>
+        <div class="term-line term-output term-output--three">hook [2/2] hive ctx init</div>
+        <div class="term-line term-output term-output--four">Created symlink: .hive -&gt; ~/.local/share/hive/context/acme/app</div>
+        <div class="term-line term-output term-output--five">Session created</div>
+        <div class="term-line term-output term-output--six">  ~/.local/share/hive/repos/app-a1b2c3</div>
+        <div class="term-line term-command term-command--two"><span class="term-prompt">$</span> <span class="term-typed">hive</span></div>
+      </div>
+      <div class="term-tui">
+        <div class="term-line term-output term-ui">colonyops/hive</div>
+        <div class="term-line term-output term-ui term-line--status">  <b>[●]</b> docs-landing-page</div>
+        <div class="term-line term-output term-ui term-line--status">      ├─ <b>[●]</b> claude</div>
+        <div class="term-line term-output term-ui term-line--status">      └─ <b>[&gt;]</b> shell</div>
+        <div class="term-line term-output term-ui">  [!] ci-fix</div>
+        <div class="term-line term-output term-ui">      └─ [!] codex</div>
+        <div class="term-line term-output term-ui">acme/app</div>
+        <div class="term-line term-output term-ui term-line--status">  <b>[●]</b> auth-refactor</div>
+        <div class="term-line term-output term-ui term-line--status">      ├─ <b>[●]</b> claude</div>
+        <div class="term-line term-output term-ui term-line--status">      └─ <b>[&gt;]</b> shell</div>
+        <div class="term-line term-output term-ui">  [?] payment-tests</div>
+      </div>
+    </div>
+  </div>
+</section>
 
-## Key Features
+<section class="hive-strip">
+  <div><strong>Bring your harness</strong><span>Use Claude Code, Codex, Pi, or any terminal agent.</span></div>
+  <div><strong>Give each task a room</strong><span>Run work in isolated clones or worktrees with their own tmux sessions.</span></div>
+  <div><strong>Coordinate above it</strong><span>Share status, context, tasks, notes, and messages through Hive.</span></div>
+</section>
 
-<div class="grid cards" markdown>
+<section class="hive-metaharness-section">
+  <div class="hive-metaharness-section__inner">
+    <h2>The Metaharness Layer</h2>
+    <p>Coding tools already have strong harnesses: prompts, permissions, tool calls, auth, and terminal behavior. Hive leaves those loops alone. It sits above tmux to manage sessions, show what is happening, and help agents communicate.</p>
 
-- :lucide-layers: __Session Management__
+    <div class="hive-layer-diagram" aria-label="Hive layered above tmux sessions and agents">
+      <div class="hive-layer hive-layer--hive">
+        <strong>Hive</strong>
+        <span>command center · status · context · tasks · messaging</span>
+      </div>
+      <div class="hive-layer hive-layer--tmux">
+        <strong>tmux</strong>
+        <span>terminal sessions and windows</span>
+      </div>
+      <div class="hive-session-row">
+        <div class="hive-session-card">
+          <strong>session</strong>
+          <span class="hive-session-item"><span class="hive-session-icon hive-session-icon--agent" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="m4.714 15.956 4.718-2.648.079-.23-.08-.128h-.23l-.79-.048-2.695-.073-2.337-.097-2.265-.122-.57-.121-.535-.704.055-.353.48-.321.685.06 1.518.104 2.277.157 1.651.098 2.447.255h.389l.054-.158-.133-.097-.103-.098-2.356-1.596-2.55-1.688-1.336-.972-.722-.491L2 6.223l-.158-1.008.656-.722.88.06.224.061.893.686 1.906 1.476 2.49 1.833.364.304.146-.104.018-.072-.164-.274-1.354-2.446-1.445-2.49-.644-1.032-.17-.619a3 3 0 0 1-.103-.729L6.287.133 6.7 0l.995.134.42.364.619 1.415L9.735 4.14l1.555 3.03.455.898.243.832.09.255h.159V9.01l.127-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.583.28.48.685-.067.444-.286 1.851-.558 2.903-.365 1.942h.213l.243-.242.983-1.306 1.652-2.064.728-.82.85-.904.547-.431h1.032l.759 1.129-.34 1.166-1.063 1.347-.88 1.142-1.263 1.7-.79 1.36.074.11.188-.02 2.853-.606 1.542-.28 1.84-.315.832.388.09.395-.327.807-1.967.486-2.307.462-3.436.813-.043.03.049.061 1.548.146.662.036h1.62l3.018.225.79.522.473.638-.08.485-1.213.62-1.64-.389-3.825-.91-1.31-.329h-.183v.11l1.093 1.068 2.003 1.81 2.508 2.33.127.578-.321.455-.34-.049-2.204-1.657-.85-.747-1.925-1.62h-.127v.17l.443.649 2.343 3.521.122 1.08-.17.353-.607.213-.668-.122-1.372-1.924-1.415-2.168-1.141-1.943-.14.08-.674 7.254-.316.37-.728.28-.607-.461-.322-.747.322-1.476.388-1.924.316-1.53.285-1.9.17-.632-.012-.042-.14.018-1.432 1.967-2.18 2.945-1.724 1.845-.413.164-.716-.37.066-.662.401-.589 2.386-3.036 1.439-1.882.929-1.086-.006-.158h-.055L4.138 18.56l-1.13.146-.485-.456.06-.746.231-.243 1.907-1.312Z"/></svg></span>Claude Code</span>
+          <span class="hive-session-item"><span class="hive-session-icon hive-session-icon--terminal" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M12 19h8M4 17l6-6-6-6"/></svg></span>shell</span>
+        </div>
+        <div class="hive-session-card">
+          <strong>session</strong>
+          <span class="hive-session-item"><span class="hive-session-icon hive-session-icon--agent" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M196.4 185.8v-48.6c0-4.1 1.5-7.2 5.1-9.2l97.8-56.3c13.3-7.7 29.2-11.3 45.6-11.3 61.4 0 100.4 47.6 100.4 98.3 0 3.6 0 7.7-.5 11.8l-101.5-59.4c-6.1-3.6-12.3-3.6-18.4 0zm228.3 189.4V259c0-7.2-3.1-12.3-9.2-15.9L287 168.4l42-24.1c3.6-2 6.7-2 10.2 0l97.8 56.4c28.2 16.4 47.1 51.2 47.1 85 0 38.9-23 74.8-59.4 89.6zM166.2 272.8l-42-24.6c-3.6-2-5.1-5.1-5.1-9.2V126.4c0-54.8 42-96.3 98.8-96.3 21.5 0 41.5 7.2 58.4 20l-100.9 58.4c-6.1 3.6-9.2 8.7-9.2 15.9v148.5zm90.4 52.2-60.2-33.8v-71.7l60.2-33.8 60.2 33.8v71.7zm38.7 155.7c-21.5 0-41.5-7.2-58.4-20l100.9-58.4c6.1-3.6 9.2-8.7 9.2-15.9V237.9l42.5 24.6c3.6 2 5.1 5.1 5.1 9.2v112.6c0 54.8-42.5 96.3-99.3 96.3zM173.8 366.5l-97.7-56.3C47.9 293.8 29 259 29 225.2c0-39.4 23.6-74.8 59.9-89.6v116.7c0 7.2 3.1 12.3 9.2 15.9l128 74.2-42 24.1c-3.6 2-6.7 2-10.2 0zm-5.6 84c-57.9 0-100.4-43.5-100.4-97.3 0-4.1.5-8.2 1-12.3l100.9 58.4c6.1 3.6 12.3 3.6 18.4 0l128.5-74.2v48.6c0 4.1-1.5 7.2-5.1 9.2l-97.8 56.3c-13.3 7.7-29.2 11.3-45.6 11.3zm127 60.9c62 0 113.7-44 125.4-102.4 57.3-14.9 94.2-68.6 94.2-123.4 0-35.8-15.4-70.7-43-95.7 2.6-10.8 4.1-21.5 4.1-32.3 0-73.2-59.4-128-128-128-13.8 0-27.1 2-40.4 6.7-23-22.5-54.8-36.9-89.6-36.9-62 0-113.7 44-125.4 102.4-57.3 14.8-94.2 68.6-94.2 123.4 0 35.8 15.4 70.7 43 95.7-2.6 10.8-4.1 21.5-4.1 32.3 0 73.2 59.4 128 128 128 13.8 0 27.1-2 40.4-6.7 23 22.5 54.8 36.9 89.6 36.9"/></svg></span>Codex</span>
+          <span class="hive-session-item"><span class="hive-session-icon hive-session-icon--terminal" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M12 19h8M4 17l6-6-6-6"/></svg></span>tests</span>
+        </div>
+        <div class="hive-session-card">
+          <strong>session</strong>
+          <span class="hive-session-item"><span class="hive-session-icon hive-session-icon--agent" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M9 4v16M4 7c0-1.7 1.3-3 3-3h13"/><path d="M18 20c-1.7 0-3-1.3-3-3V4"/></svg></span>Pi</span>
+          <span class="hive-session-item"><span class="hive-session-icon hive-session-icon--terminal" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M12 19h8M4 17l6-6-6-6"/></svg></span>dev server</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
-    ---
+<section class="hive-preview-section">
+  <h2>See What Hive Actually Is</h2>
+  <p>Hive is a tmux-native command center for local agents, isolated git workspaces, project commands, and interactive terminals. It keeps your stack visible and gives Claude Code, Codex, Pi, and the rest of your tools one shared control surface.</p>
 
-    Create, recycle, and prune isolated git clones
+  <div class="hive-preview-terminal" aria-label="Hive terminal UI preview coming soon">
+    <div class="hive-preview-terminal__nav">
+      <strong>Sessions</strong><span>|</span><span>Tasks</span><span>|</span><span>Docs</span><span>|</span><span>Messages</span>
+      <em><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M13 5h8"/><path d="M13 12h8"/><path d="M13 19h8"/><path d="m3 5 2 2 4-4"/><path d="m3 12 2 2 4-4"/><path d="m3 19 2 2 4-4"/></svg>2</em><b>Hive</b>
+    </div>
+    <div class="hive-preview-terminal__body">
+      <div class="hive-preview-tree" aria-label="Hive session tree preview">
+        <div class="hive-preview-tree__repo">hive <span>◆</span></div>
+        <div class="hive-preview-tree__line">├─ <b>[&gt;]</b> init-command <em>#ek3p</em></div>
+        <div class="hive-preview-tree__line">└─ <b>[&gt;]</b> website-homepage <em>#cwc3</em></div>
+        <div class="hive-preview-tree__space"></div>
+        <div class="hive-preview-tree__repo">haykot.dev</div>
+        <div class="hive-preview-tree__line">└─ <b>[&gt;]</b> website <em>#1egd</em></div>
+        <div class="hive-preview-tree__line hive-preview-tree__line--child">├─ <b>[&gt;]</b> pi</div>
+        <div class="hive-preview-tree__line hive-preview-tree__line--child">└─ <b>[&gt;]</b> claude</div>
+        <div class="hive-preview-tree__space"></div>
+        <div class="hive-preview-tree__repo">infrastructure</div>
+        <div class="hive-preview-tree__line">└─ <b>[&gt;]</b> infra-general <em>#d3mw</em></div>
+        <div class="hive-preview-tree__space"></div>
+        <div class="hive-preview-tree__repo">colonyops/hive</div>
+        <div class="hive-preview-tree__line hive-preview-tree__line--active">├─ <b>[●]</b> docs-landing-page <em>#a1b2</em></div>
+        <div class="hive-preview-tree__line hive-preview-tree__line--waiting">└─ <b>[!]</b> ci-fix <em>#f9e8</em></div>
+      </div>
+      <div class="hive-preview-pane">
+        <div class="hive-preview-coming-soon">
+          <span>Coming soon</span>
+          <strong>Terminal preview in progress</strong>
+          <em>A short capture will show sessions, live agent status, tmux previews, and coordination flows.</em>
+        </div>
+      </div>
+    </div>
+    <div class="hive-preview-terminal__footer">j/k navigate · / filter · enter select · ? help</div>
+  </div>
+</section>
 
-- :lucide-terminal: __Terminal Integration__
+<section class="hive-features-section">
+  <div class="hive-section-heading">
+    <h2>The Layer Above Your Agent Tools</h2>
+    <p>Hive gives terminal agents the shared room they are missing: isolated workspaces, live visibility, shared memory, and coordination primitives.</p>
+  </div>
 
-    ---
+  <div class="hive-feature-grid">
+    <a class="hive-feature-card" href="getting-started/sessions/">
+      <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="m12 3-8 4.5 8 4.5 8-4.5Z"/><path d="m4 12 8 4.5 8-4.5"/><path d="m4 16.5 8 4.5 8-4.5"/></svg></span>
+      <strong>Workspace Management</strong>
+      <p>Create and manage isolated git workspaces — full clones by default, worktrees when you prefer shared object storage.</p>
+    </a>
+    <a class="hive-feature-card" href="getting-started/sessions/#status-indicators">
+      <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M12 19h8M4 17l6-6-6-6"/></svg></span>
+      <strong>Terminal Integration</strong>
+      <p>Monitor Claude Code, Codex, Pi, shell windows, test watchers, and dev servers through tmux-backed status detection.</p>
+    </a>
+    <a class="hive-feature-card" href="getting-started/task-tracking/">
+      <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M13 5h8"/><path d="M13 12h8"/><path d="M13 19h8"/><path d="m3 5 2 2 4-4"/><path d="m3 12 2 2 4-4"/><path d="m3 19 2 2 4-4"/></svg></span>
+      <strong>Task Tracking</strong>
+      <p>Use built-in epics, tasks, blockers, comments, and assignment to coordinate work across agents.</p>
+    </a>
+    <a class="hive-feature-card" href="getting-started/context/">
+      <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M12 10v6"/><path d="M9 13h6"/><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg></span>
+      <strong>Shared Context</strong>
+      <p>Keep plans, research, notes, and handoffs in a repo-scoped `.hive` context directory agents can share.</p>
+    </a>
+    <a class="hive-feature-card" href="getting-started/messaging/">
+      <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"/><rect x="2" y="4" width="20" height="16" rx="2"/></svg></span>
+      <strong>Inter-agent Messaging</strong>
+      <p>Send direct or broadcast messages between sessions using Hive's pub/sub inboxes.</p>
+    </a>
+    <a class="hive-feature-card" href="configuration/commands/">
+      <span class="hive-feature-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"><path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3"/></svg></span>
+      <strong>Custom Workflows</strong>
+      <p>Bind keys and commands to your own scripts, review flows, dev servers, test runners, and agent tools.</p>
+    </a>
+  </div>
+</section>
 
-    Real-time status monitoring of AI agents in tmux (works out of the box)
+## Start Building With Hive
 
-- :lucide-message-circle: __Inter-agent Messaging__
-
-    ---
-
-    Pub/sub communication between sessions
-
-- :lucide-folder-symlink: __Context Sharing__
-
-    ---
-
-    Shared storage per repository via `.hive` symlinks
-
-- :lucide-list-checks: __Task Tracking__
-
-    ---
-
-    Built-in epics and tasks for multi-agent coordination — no external tracker needed
-
-- :lucide-keyboard: __Custom Keybindings__
-
-    ---
-
-    Bind keys to user-defined or system commands
-
-- :lucide-command: __Command Palette__
-
-    ---
-
-    Vim-style command palette for custom commands (`:` key)
-
-</div>
-
-## Installation
-
-```bash
-brew install tmux
-brew install colonyops/tap/hive
-```
-
-Or install directly with Go:
-
-```bash
-go install github.com/colonyops/hive@latest
-```
-
-Pre-built binaries are also available on the [GitHub Releases](https://github.com/colonyops/hive/releases) page.
-
-!!! tip "Claude Code Plugin"
-    Hive provides a [Claude Code plugin](https://github.com/colonyops/hive/tree/main/claude-plugin/hive) for inter-agent messaging, session management, and workflow coordination. Install it with:
-
-    ```bash
-    claude plugin add github:colonyops/hive/claude-plugin/hive
-    ```
-
-## Status Indicators
-
-The TUI shows real-time agent status:
-
-| Indicator | Color            | Meaning                         |
-| --------- | ---------------- | ------------------------------- |
-| `[●]`     | Green (animated) | Agent actively working          |
-| `[!]`     | Yellow           | Agent needs approval/permission |
-| `[>]`     | Cyan             | Agent ready for input           |
-| `[?]`     | Dim              | Terminal session not found      |
-| `[○]`     | Gray             | Session recycled                |
-
-## Next Steps
-
-<div class="grid cards" markdown>
-
-- :lucide-rocket: __[Getting Started](getting-started/)__
-
-    ---
-
-    Quick start and first session
-
-- :lucide-box: __[Sessions](getting-started/sessions.md)__
-
-    ---
-
-    How sessions, agents, and lifecycle work
-
-- :lucide-list-checks: __[Task Tracking](getting-started/task-tracking.md)__
-
-    ---
-
-    Built-in epics and tasks for multi-agent coordination
-
-- :lucide-settings: __[Configuration](configuration/)__
-
-    ---
-
-    Config file, rules, templates, and options
-
+<div class="hive-cta">
+  <div>
+    <h2>Install Hive and give your terminal agents a shared room to work in.</h2>
+    <p>Prefer a deeper walkthrough? Start with the getting started guide.</p>
+  </div>
+  <div class="hive-cta__actions">
+    <a class="md-button md-button--primary" href="getting-started/">Getting Started</a>
+    <a class="md-button" href="configuration/">Configuration</a>
+  </div>
 </div>
 
 ---

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -293,9 +293,6 @@
 }
 
 .md-typeset .hive-strip div,
-.md-typeset .hive-media-placeholder,
-.md-typeset .hive-demo-flow > div,
-.md-typeset .hive-status-demo,
 .md-typeset .hive-cta {
   border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 24%, var(--md-default-fg-color--lightest));
   border-radius: 0.9rem;
@@ -809,98 +806,8 @@
   line-height: 1.6;
 }
 
-.md-typeset .hive-demo-flow {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin: 1rem 0 2.5rem;
-}
-
-.md-typeset .hive-demo-flow > div {
-  padding: 1rem;
-}
-
-.md-typeset .hive-demo-flow span {
-  display: inline-grid;
-  place-items: center;
-  width: 1.8rem;
-  height: 1.8rem;
-  border-radius: 50%;
-  background: var(--md-accent-fg-color);
-  color: var(--md-accent-bg-color);
-  font-weight: 800;
-}
-
-.md-typeset .hive-demo-flow h3,
-.md-typeset .hive-media-placeholder h3 {
-  margin-top: 0.9rem;
-}
-
-.md-typeset .hive-demo-flow p,
-.md-typeset .hive-media-placeholder p,
 .md-typeset .hive-cta p {
   color: var(--md-default-fg-color--light);
-}
-
-.md-typeset .hive-status-demo {
-  max-width: 46rem;
-  margin: 1rem 0 2.5rem;
-  overflow: hidden;
-  font-family: var(--md-code-font-family), ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-.md-typeset .hive-status-demo__header,
-.md-typeset .hive-status-row {
-  display: grid;
-  grid-template-columns: 4.2rem minmax(0, 1fr) minmax(9rem, 0.75fr);
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.75rem 0.95rem;
-}
-
-.md-typeset .hive-status-demo__header {
-  grid-template-columns: minmax(0, 1fr) auto;
-  border-bottom: 1px solid var(--md-default-fg-color--lightest);
-  color: var(--md-default-fg-color--light);
-  font-family: var(--md-text-font-family);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.md-typeset .hive-status-row {
-  border-bottom: 1px solid color-mix(in srgb, var(--md-default-fg-color--lightest) 72%, transparent);
-}
-
-.md-typeset .hive-status-row:last-child {
-  border-bottom: 0;
-}
-
-.md-typeset .hive-status-row strong {
-  font-weight: 700;
-}
-
-.md-typeset .hive-status-row em {
-  color: var(--md-default-fg-color--light);
-  font-style: normal;
-}
-
-.md-typeset .hive-status-icon {
-  font-weight: 800;
-}
-
-.md-typeset .hive-status-row--active .hive-status-icon {
-  color: #a6e3a1;
-  animation: hive-active-pulse 1s ease-in-out infinite;
-}
-
-.md-typeset .hive-status-row--waiting .hive-status-icon { color: #f6c177; }
-.md-typeset .hive-status-row--ready .hive-status-icon { color: #9ccfd8; }
-.md-typeset .hive-status-row--missing .hive-status-icon { color: var(--md-default-fg-color--light); }
-
-@keyframes hive-active-pulse {
-  0%, 100% { opacity: 0.55; }
-  50% { opacity: 1; }
 }
 
 .md-typeset .hive-cta {
@@ -918,8 +825,6 @@
 
 @media screen and (max-width: 960px) {
   .md-typeset .hive-hero,
-  .md-typeset .hive-showcase,
-  .md-typeset .hive-demo-flow,
   .md-typeset .hive-strip,
   .md-typeset .hive-session-row,
   .md-typeset .hive-section-heading,
@@ -966,8 +871,7 @@
   .md-typeset .term-command--one .term-typed,
   .md-typeset .term-command--two,
   .md-typeset .term-command--two .term-typed,
-  .md-typeset .term-output,
-  .md-typeset .hive-status-row--active .hive-status-icon {
+  .md-typeset .term-output {
     animation: none;
   }
 
@@ -984,4 +888,18 @@
     width: auto;
     border-right: 0;
   }
+
+  .md-typeset .hive-layer,
+  .md-typeset .hive-session-card,
+  .md-typeset .hive-feature-card {
+    transition: none;
+  }
+
+  .md-typeset .hive-layer:hover { transform: none; }
+  .md-typeset .hive-layer--hive { transform: translateY(0.1rem); }
+  .md-typeset .hive-layer--hive:hover { transform: translateY(0.1rem); }
+  .md-typeset .hive-session-card:nth-child(1):hover { transform: translateY(0.35rem) rotate(-0.7deg); }
+  .md-typeset .hive-session-card:nth-child(2):hover { transform: translateY(-0.2rem); }
+  .md-typeset .hive-session-card:nth-child(3):hover { transform: translateY(0.4rem) rotate(0.7deg); }
+  .md-typeset .hive-feature-card:hover { transform: none; }
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -6,6 +6,11 @@
   max-width: min(94vw, 86rem);
 }
 
+html:has(.hive-hero) .md-header .md-grid,
+html:has(.hive-hero) .md-tabs .md-grid {
+  max-width: min(94vw, 86rem);
+}
+
 .md-main__inner:has(.hive-hero) > .md-sidebar {
   display: none;
 }
@@ -28,8 +33,8 @@
   display: grid;
   grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
   gap: 2.4rem;
-  align-items: center;
-  margin: 2.4rem 0 2rem;
+  align-items: start;
+  margin: 0.8rem 0 2rem;
 }
 
 .md-typeset .hive-eyebrow {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,987 @@
 .md-header__button.md-logo img,.md-header__button.md-logo svg  {
   color: var(--md-accent-fg-color) !important;
 }
+
+.md-main__inner:has(.hive-hero) {
+  max-width: min(94vw, 86rem);
+}
+
+.md-main__inner:has(.hive-hero) > .md-sidebar {
+  display: none;
+}
+
+.md-main__inner:has(.hive-hero) > .md-content {
+  margin-inline: 0;
+  max-width: none;
+}
+
+.md-content__inner:has(.hive-hero) {
+  margin-inline: 0;
+  max-width: none;
+}
+
+.md-content__inner:has(.hive-hero)::before {
+  display: none;
+}
+
+.md-typeset .hive-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+  gap: 2.4rem;
+  align-items: center;
+  margin: 2.4rem 0 2rem;
+}
+
+.md-typeset .hive-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.8rem;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 38%, transparent);
+  border-radius: 999px;
+  color: var(--md-accent-fg-color);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.md-typeset .hive-hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.25rem);
+  line-height: 0.95;
+  letter-spacing: -0.055em;
+}
+
+.md-typeset .hive-lede {
+  max-width: 42rem;
+  margin: 1.1rem 0 1.4rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.md-typeset .hive-lede a {
+  color: var(--md-accent-fg-color);
+  text-decoration-color: color-mix(in srgb, var(--md-accent-fg-color) 45%, transparent);
+}
+
+.md-typeset .hive-lede a:hover {
+  color: color-mix(in srgb, var(--md-accent-fg-color) 82%, white);
+}
+
+.md-typeset .hive-hero__actions,
+.md-typeset .hive-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin: 1rem 0;
+}
+
+.md-typeset .hive-hero__actions .md-button,
+.md-typeset .hive-cta__actions .md-button {
+  border-color: color-mix(in srgb, var(--md-accent-fg-color) 48%, transparent);
+  border-radius: 999px;
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-hero__actions .md-button--primary,
+.md-typeset .hive-cta__actions .md-button--primary {
+  background: var(--md-accent-fg-color);
+  border-color: var(--md-accent-fg-color);
+  color: var(--md-accent-bg-color);
+}
+
+.md-typeset .hive-hero__actions .md-button:not(.md-button--primary) {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 10%, transparent);
+}
+
+.md-typeset .hive-hero__actions .md-button:hover,
+.md-typeset .hive-cta__actions .md-button:hover {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 86%, white);
+  border-color: color-mix(in srgb, var(--md-accent-fg-color) 86%, white);
+  color: var(--md-accent-bg-color);
+}
+
+.md-typeset .hive-install {
+  max-width: 30rem;
+  margin-top: 1.2rem;
+}
+
+.md-typeset .hive-terminal-demo {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 34%, var(--md-default-fg-color--lightest));
+  border-radius: 1.1rem;
+  background: linear-gradient(145deg, color-mix(in srgb, var(--md-accent-fg-color) 13%, #15171c), #111318 42%);
+  box-shadow: 0 1.2rem 3.5rem rgba(0, 0, 0, 0.28);
+}
+
+.md-typeset .hive-terminal-demo__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.md-typeset .hive-terminal-demo__bar span {
+  width: 0.68rem;
+  height: 0.68rem;
+  border-radius: 50%;
+  background: #ff5f57;
+}
+
+.md-typeset .hive-terminal-demo__bar span:nth-child(2) { background: #ffbd2e; }
+.md-typeset .hive-terminal-demo__bar span:nth-child(3) { background: #28c840; }
+
+.md-typeset .hive-terminal-demo__bar strong {
+  margin-left: auto;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.md-typeset .hive-terminal-demo__screen {
+  position: relative;
+  min-height: 25rem;
+  padding: 1rem;
+  color: #d7f8dc;
+  font-family: var(--md-code-font-family), ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: clamp(0.66rem, 1.45vw, 0.78rem);
+  line-height: 1.85;
+}
+
+.md-typeset .term-line {
+  min-height: 1.35rem;
+  opacity: 0;
+  white-space: nowrap;
+}
+
+.md-typeset .term-shell,
+.md-typeset .term-tui {
+  position: absolute;
+  inset: 1rem;
+}
+
+.md-typeset .term-shell {
+  animation: hive-shell-screen 24s linear infinite;
+}
+
+.md-typeset .term-tui {
+  opacity: 0;
+  animation: hive-tui-screen 24s linear infinite;
+}
+
+.md-typeset .term-prompt { color: #f6c177; }
+.md-typeset .term-output { color: rgba(215, 248, 220, 0.66); }
+.md-typeset .term-line--status { color: #9ccfd8; }
+.md-typeset .term-line--status b { color: #a6e3a1; }
+
+.md-typeset .term-typed {
+  display: inline-block;
+  overflow: hidden;
+  width: 0;
+  border-right: 0.55rem solid #f6c177;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.md-typeset .term-command--one,
+.md-typeset .term-command--one .term-typed,
+.md-typeset .term-command--two,
+.md-typeset .term-command--two .term-typed,
+.md-typeset .term-shell .term-output {
+  animation-duration: 24s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+.md-typeset .term-tui .term-line {
+  opacity: 1;
+}
+
+.md-typeset .term-command--one { animation-name: hive-line-one; }
+.md-typeset .term-command--one .term-typed { animation-name: hive-type-one; animation-timing-function: steps(64, end); }
+.md-typeset .term-command--two { animation-name: hive-line-two; }
+.md-typeset .term-command--two .term-typed { animation-name: hive-type-two; animation-timing-function: steps(4, end); }
+.md-typeset .term-ui { color: rgba(232, 235, 241, 0.78); }
+.md-typeset .term-output--one { animation-name: hive-output-one; }
+.md-typeset .term-output--two { animation-name: hive-output-two; }
+.md-typeset .term-output--three { animation-name: hive-output-three; }
+.md-typeset .term-output--four { animation-name: hive-output-four; }
+.md-typeset .term-output--five { animation-name: hive-output-five; }
+.md-typeset .term-output--six { animation-name: hive-output-six; }
+
+@keyframes hive-shell-screen {
+  0%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-tui-screen {
+  0%, 49% { opacity: 0; }
+  51%, 94% { opacity: 1; }
+  96%, 100% { opacity: 0; }
+}
+
+@keyframes hive-line-one {
+  0%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-type-one {
+  0%, 3% { width: 0; border-right-color: #f6c177; }
+  20%, 36% { width: 64ch; border-right-color: #f6c177; }
+  37%, 48% { width: 64ch; border-right-color: transparent; }
+  50%, 100% { width: 64ch; border-right-color: transparent; }
+}
+
+@keyframes hive-output-one {
+  0%, 21% { opacity: 0; }
+  23%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-output-two {
+  0%, 25% { opacity: 0; }
+  27%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-output-three {
+  0%, 29% { opacity: 0; }
+  31%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-output-four {
+  0%, 33% { opacity: 0; }
+  35%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-output-five {
+  0%, 37% { opacity: 0; }
+  39%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-output-six {
+  0%, 39% { opacity: 0; }
+  41%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-line-two {
+  0%, 40% { opacity: 0; }
+  42%, 48% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes hive-type-two {
+  0%, 42% { width: 0; border-right-color: #f6c177; }
+  46%, 48% { width: 4.8ch; border-right-color: #f6c177; }
+  50%, 100% { width: 4.8ch; border-right-color: transparent; }
+}
+
+.md-typeset .hive-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin: 2rem 0 3rem;
+}
+
+.md-typeset .hive-strip div,
+.md-typeset .hive-media-placeholder,
+.md-typeset .hive-demo-flow > div,
+.md-typeset .hive-status-demo,
+.md-typeset .hive-cta {
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 24%, var(--md-default-fg-color--lightest));
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, var(--md-default-bg-color) 92%, var(--md-accent-fg-color) 8%);
+}
+
+.md-typeset .hive-strip div {
+  padding: 1rem;
+}
+
+.md-typeset .hive-strip strong,
+.md-typeset .hive-strip span {
+  display: block;
+}
+
+.md-typeset .hive-strip span {
+  margin-top: 0.25rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.82rem;
+}
+
+.md-typeset .hive-metaharness-section {
+  position: relative;
+  left: 50%;
+  width: 100vw;
+  margin: 3rem 0 3.2rem -50vw;
+  padding: 3.2rem max(1.2rem, calc((100vw - 86rem) / 2)) 3.6rem;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 18%, color-mix(in srgb, var(--md-accent-fg-color) 16%, transparent), transparent 28%),
+    radial-gradient(circle at 78% 38%, color-mix(in srgb, #9ccfd8 16%, transparent), transparent 30%),
+    radial-gradient(circle at 55% 80%, color-mix(in srgb, var(--md-accent-fg-color) 9%, transparent), transparent 34%),
+    linear-gradient(180deg, transparent, color-mix(in srgb, var(--md-accent-fg-color) 5%, transparent) 28%, transparent);
+}
+
+.md-typeset .hive-metaharness-section::before {
+  position: absolute;
+  inset: 1.2rem 0 auto;
+  height: 18rem;
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--md-accent-fg-color) 10%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--md-accent-fg-color) 10%, transparent) 1px, transparent 1px);
+  background-size: 4.5rem 4.5rem;
+  content: "";
+  mask-image: radial-gradient(ellipse at center, black, transparent 68%);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.md-typeset .hive-metaharness-section__inner {
+  position: relative;
+  z-index: 1;
+  max-width: 86rem;
+  margin-inline: auto;
+}
+
+.md-typeset .hive-metaharness-section h2 {
+  margin-top: 0;
+}
+
+.md-typeset .hive-metaharness-section p {
+  max-width: 72rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.md-typeset .hive-layer-diagram {
+  position: relative;
+  display: grid;
+  gap: 1.7rem;
+  margin: 2.1rem 0 0;
+  padding: 1.8rem 0.4rem 0.8rem;
+}
+
+.md-typeset .hive-layer-diagram::before,
+.md-typeset .hive-layer-diagram::after {
+  position: absolute;
+  inset: 3.9rem 13% auto;
+  height: 10.4rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 18%, transparent);
+  border-top: 0;
+  border-radius: 0 0 999px 999px;
+  content: "";
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.md-typeset .hive-layer-diagram::after {
+  inset-inline: 25%;
+  top: 7.8rem;
+  height: 6.7rem;
+  opacity: 0.38;
+}
+
+.md-typeset .hive-layer {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  width: min(100%, 42rem);
+  margin-inline: auto;
+  padding: 1rem 1.15rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 20%, transparent);
+  border-radius: 1.05rem;
+  background: color-mix(in srgb, var(--md-default-bg-color) 72%, transparent);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.14);
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.md-typeset .hive-layer:hover {
+  border-color: color-mix(in srgb, var(--md-accent-fg-color) 42%, transparent);
+  box-shadow: 0 1.25rem 3.4rem rgba(0, 0, 0, 0.18), 0 0 2.2rem color-mix(in srgb, var(--md-accent-fg-color) 10%, transparent);
+  transform: translateY(-0.08rem);
+}
+
+.md-typeset .hive-layer strong,
+.md-typeset .hive-session-card strong {
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.md-typeset .hive-layer span,
+.md-typeset .hive-session-card span {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+}
+
+.md-typeset .hive-layer--hive {
+  width: min(100%, 40rem);
+  transform: translateY(0.1rem);
+  border-color: color-mix(in srgb, var(--md-accent-fg-color) 34%, transparent);
+  background: color-mix(in srgb, var(--md-default-bg-color) 62%, var(--md-accent-fg-color) 10%);
+}
+
+.md-typeset .hive-layer--hive:hover {
+  transform: translateY(-0.12rem);
+}
+
+.md-typeset .hive-layer--hive strong {
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-layer--tmux {
+  width: min(100%, 33rem);
+}
+
+.md-typeset .hive-layer--hive::after {
+  position: absolute;
+  top: calc(100% + 0.05rem);
+  left: 50%;
+  width: 1px;
+  height: 1.55rem;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--md-accent-fg-color) 34%, transparent), transparent);
+  content: "";
+  transform: translateX(-50%);
+}
+
+.md-typeset .hive-session-row {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1.65rem;
+}
+
+.md-typeset .hive-session-row::before {
+  position: absolute;
+  top: -1.28rem;
+  left: 16.5%;
+  right: 16.5%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--md-accent-fg-color) 32%, transparent), transparent);
+  content: "";
+  pointer-events: none;
+}
+
+.md-typeset .hive-session-row::after {
+  position: absolute;
+  top: -2.95rem;
+  left: 50%;
+  width: 1px;
+  height: 1.8rem;
+  background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--md-accent-fg-color) 34%, transparent));
+  content: "";
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+
+.md-typeset .hive-session-card {
+  position: relative;
+  display: grid;
+  gap: 0.35rem;
+  min-height: 7rem;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 16%, transparent);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--md-default-bg-color) 74%, transparent);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 0.9rem 2.4rem rgba(0, 0, 0, 0.1);
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.md-typeset .hive-session-card::before {
+  position: absolute;
+  bottom: calc(100% + 1px);
+  left: 50%;
+  width: 1px;
+  height: 1.28rem;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--md-accent-fg-color) 28%, transparent), transparent);
+  content: "";
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+
+.md-typeset .hive-session-card:hover {
+  border-color: color-mix(in srgb, var(--md-accent-fg-color) 36%, transparent);
+  box-shadow: 0 1.15rem 2.8rem rgba(0, 0, 0, 0.16), 0 0 2rem color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
+}
+
+.md-typeset .hive-session-item {
+  display: inline-flex;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.md-typeset .hive-session-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.45rem;
+  height: 1.45rem;
+  flex: 0 0 auto;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 22%, transparent);
+  border-radius: 0.45rem;
+  color: var(--md-default-fg-color);
+  line-height: 1;
+}
+
+.md-typeset .hive-session-icon svg {
+  display: block;
+  width: 0.82rem;
+  height: 0.82rem;
+}
+
+.md-typeset .hive-session-icon--agent {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 12%, transparent);
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-session-icon--terminal {
+  background: color-mix(in srgb, var(--md-default-fg-color) 8%, transparent);
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .hive-session-card:nth-child(1) { transform: translateY(0.35rem) rotate(-0.7deg); }
+.md-typeset .hive-session-card:nth-child(1):hover { transform: translateY(0.05rem) rotate(-0.35deg); }
+.md-typeset .hive-session-card:nth-child(2) { transform: translateY(-0.2rem); }
+.md-typeset .hive-session-card:nth-child(2):hover { transform: translateY(-0.5rem); }
+.md-typeset .hive-session-card:nth-child(3) { transform: translateY(0.4rem) rotate(0.7deg); }
+.md-typeset .hive-session-card:nth-child(3):hover { transform: translateY(0.1rem) rotate(0.35deg); }
+
+.md-typeset .hive-preview-section {
+  margin: 3rem 0 3.4rem;
+  padding: 0;
+}
+
+.md-typeset .hive-preview-section h2 {
+  max-width: 52rem;
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: -0.045em;
+}
+
+.md-typeset .hive-preview-section p {
+  max-width: 68rem;
+  margin-bottom: 2.2rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.md-typeset .hive-preview-terminal {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 34%, transparent);
+  border-radius: 0.45rem;
+  background: #17191f;
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.28);
+  color: #d8e6dc;
+  font-family: var(--md-code-font-family), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.md-typeset .hive-preview-terminal__nav {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+  min-height: 3rem;
+  padding: 0 0.9rem;
+  border-block: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 20%, transparent);
+  color: rgba(216, 230, 220, 0.48);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.md-typeset .hive-preview-terminal__nav strong {
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-preview-terminal__nav em {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+  margin-left: auto;
+  color: var(--md-accent-fg-color);
+  font-style: normal;
+}
+
+.md-typeset .hive-preview-terminal__nav em svg {
+  width: 0.82rem;
+  height: 0.82rem;
+}
+
+.md-typeset .hive-preview-terminal__nav b {
+  padding: 0.18rem 0.45rem;
+  background: color-mix(in srgb, var(--md-accent-fg-color) 18%, transparent);
+  color: #d8e6dc;
+  font-weight: 700;
+}
+
+.md-typeset .hive-preview-terminal__body {
+  display: grid;
+  grid-template-columns: minmax(16rem, 24rem) minmax(0, 1fr);
+  min-height: 32rem;
+}
+
+.md-typeset .hive-preview-tree {
+  min-height: 100%;
+  padding: 1rem 1.1rem;
+  overflow: hidden;
+  border-right: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 24%, transparent);
+  color: #d8e6dc;
+  font-size: clamp(0.68rem, 1.25vw, 0.86rem);
+  line-height: 1.58;
+  white-space: nowrap;
+}
+
+.md-typeset .hive-preview-tree__repo {
+  color: #d8e6dc;
+  font-weight: 800;
+}
+
+.md-typeset .hive-preview-tree__repo span {
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-preview-tree__line {
+  padding-left: 0.35rem;
+  color: rgba(216, 230, 220, 0.72);
+}
+
+.md-typeset .hive-preview-tree__line--child {
+  padding-left: 2rem;
+}
+
+.md-typeset .hive-preview-tree__line b {
+  color: #9ccfd8;
+  font-weight: 800;
+}
+
+.md-typeset .hive-preview-tree__line em {
+  color: color-mix(in srgb, var(--md-accent-fg-color) 70%, white);
+  font-style: normal;
+}
+
+.md-typeset .hive-preview-tree__line--active b {
+  color: #a6e3a1;
+}
+
+.md-typeset .hive-preview-tree__line--waiting b {
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-preview-tree__space {
+  height: 0.45rem;
+}
+
+.md-typeset .hive-preview-pane {
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent), transparent 34%);
+}
+
+.md-typeset .hive-preview-coming-soon {
+  display: grid;
+  gap: 0.55rem;
+  max-width: 26rem;
+  padding: 1.4rem;
+  text-align: center;
+}
+
+.md-typeset .hive-preview-coming-soon span {
+  width: fit-content;
+  margin-inline: auto;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 38%, transparent);
+  border-radius: 999px;
+  color: var(--md-accent-fg-color);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.md-typeset .hive-preview-coming-soon strong {
+  color: #d8e6dc;
+  font-size: 1.2rem;
+}
+
+.md-typeset .hive-preview-coming-soon em {
+  color: rgba(216, 230, 220, 0.58);
+  font-style: normal;
+  line-height: 1.55;
+}
+
+.md-typeset .hive-preview-terminal__footer {
+  padding: 0.7rem 0.9rem;
+  border-top: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 20%, transparent);
+  color: rgba(216, 230, 220, 0.48);
+  font-size: 0.78rem;
+}
+
+.md-typeset .hive-features-section {
+  margin: 3.2rem 0;
+}
+
+.md-typeset .hive-section-heading {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 58rem;
+  margin-bottom: 1.2rem;
+}
+
+.md-typeset .hive-section-heading h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+  letter-spacing: -0.04em;
+}
+
+.md-typeset .hive-section-heading p {
+  margin: 0;
+  color: var(--md-default-fg-color--light);
+  line-height: 1.65;
+}
+
+.md-typeset .hive-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.md-typeset .hive-feature-card {
+  display: grid;
+  gap: 0.7rem;
+  min-height: 13rem;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 18%, var(--md-default-fg-color--lightest));
+  border-radius: 1rem;
+  background:
+    radial-gradient(circle at top right, color-mix(in srgb, var(--md-accent-fg-color) 9%, transparent), transparent 36%),
+    color-mix(in srgb, var(--md-default-bg-color) 94%, var(--md-accent-fg-color) 6%);
+  color: var(--md-default-fg-color);
+  text-decoration: none;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.md-typeset .hive-feature-card:hover {
+  border-color: color-mix(in srgb, var(--md-accent-fg-color) 38%, transparent);
+  box-shadow: 0 1rem 2.6rem rgba(0, 0, 0, 0.12), 0 0 2rem color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
+  transform: translateY(-0.12rem);
+}
+
+.md-typeset .hive-feature-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 2.8rem;
+  height: 2.8rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 30%, transparent);
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .hive-feature-icon svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  stroke-width: 1.8;
+}
+
+.md-typeset .hive-feature-card strong {
+  font-size: 1rem;
+}
+
+.md-typeset .hive-feature-card p {
+  margin: 0;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.86rem;
+  line-height: 1.6;
+}
+
+.md-typeset .hive-demo-flow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 2.5rem;
+}
+
+.md-typeset .hive-demo-flow > div {
+  padding: 1rem;
+}
+
+.md-typeset .hive-demo-flow span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: var(--md-accent-fg-color);
+  color: var(--md-accent-bg-color);
+  font-weight: 800;
+}
+
+.md-typeset .hive-demo-flow h3,
+.md-typeset .hive-media-placeholder h3 {
+  margin-top: 0.9rem;
+}
+
+.md-typeset .hive-demo-flow p,
+.md-typeset .hive-media-placeholder p,
+.md-typeset .hive-cta p {
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .hive-status-demo {
+  max-width: 46rem;
+  margin: 1rem 0 2.5rem;
+  overflow: hidden;
+  font-family: var(--md-code-font-family), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.md-typeset .hive-status-demo__header,
+.md-typeset .hive-status-row {
+  display: grid;
+  grid-template-columns: 4.2rem minmax(0, 1fr) minmax(9rem, 0.75fr);
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 0.95rem;
+}
+
+.md-typeset .hive-status-demo__header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  color: var(--md-default-fg-color--light);
+  font-family: var(--md-text-font-family);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.md-typeset .hive-status-row {
+  border-bottom: 1px solid color-mix(in srgb, var(--md-default-fg-color--lightest) 72%, transparent);
+}
+
+.md-typeset .hive-status-row:last-child {
+  border-bottom: 0;
+}
+
+.md-typeset .hive-status-row strong {
+  font-weight: 700;
+}
+
+.md-typeset .hive-status-row em {
+  color: var(--md-default-fg-color--light);
+  font-style: normal;
+}
+
+.md-typeset .hive-status-icon {
+  font-weight: 800;
+}
+
+.md-typeset .hive-status-row--active .hive-status-icon {
+  color: #a6e3a1;
+  animation: hive-active-pulse 1s ease-in-out infinite;
+}
+
+.md-typeset .hive-status-row--waiting .hive-status-icon { color: #f6c177; }
+.md-typeset .hive-status-row--ready .hive-status-icon { color: #9ccfd8; }
+.md-typeset .hive-status-row--missing .hive-status-icon { color: var(--md-default-fg-color--light); }
+
+@keyframes hive-active-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+.md-typeset .hive-cta {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin: 2rem 0;
+  padding: 1.3rem;
+}
+
+.md-typeset .hive-cta h2 {
+  margin: 0;
+}
+
+@media screen and (max-width: 960px) {
+  .md-typeset .hive-hero,
+  .md-typeset .hive-showcase,
+  .md-typeset .hive-demo-flow,
+  .md-typeset .hive-strip,
+  .md-typeset .hive-session-row,
+  .md-typeset .hive-section-heading,
+  .md-typeset .hive-feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .md-typeset .hive-layer {
+    align-items: flex-start;
+    border-radius: 1.1rem;
+    flex-direction: column;
+  }
+
+  .md-typeset .hive-session-card:nth-child(1),
+  .md-typeset .hive-session-card:nth-child(2),
+  .md-typeset .hive-session-card:nth-child(3) {
+    transform: none;
+  }
+
+  .md-typeset .hive-preview-terminal__body {
+    grid-template-columns: 1fr;
+  }
+
+  .md-typeset .hive-preview-tree {
+    max-height: 16rem;
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 24%, transparent);
+  }
+
+  .md-typeset .hive-preview-pane {
+    min-height: 18rem;
+  }
+
+  .md-typeset .hive-cta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .md-typeset .term-shell,
+  .md-typeset .term-tui,
+  .md-typeset .term-command--one,
+  .md-typeset .term-command--one .term-typed,
+  .md-typeset .term-command--two,
+  .md-typeset .term-command--two .term-typed,
+  .md-typeset .term-output,
+  .md-typeset .hive-status-row--active .hive-status-icon {
+    animation: none;
+  }
+
+  .md-typeset .term-shell {
+    display: none;
+  }
+
+  .md-typeset .term-tui,
+  .md-typeset .term-line {
+    opacity: 1;
+  }
+
+  .md-typeset .term-typed {
+    width: auto;
+    border-right: 0;
+  }
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -715,16 +715,6 @@ html:has(.hive-hero) .md-tabs .md-grid {
   text-transform: uppercase;
 }
 
-.md-typeset .hive-preview-coming-soon strong {
-  color: #d8e6dc;
-  font-size: 1.2rem;
-}
-
-.md-typeset .hive-preview-coming-soon em {
-  color: rgba(216, 230, 220, 0.58);
-  font-style: normal;
-  line-height: 1.55;
-}
 
 .md-typeset .hive-preview-terminal__footer {
   padding: 0.7rem 0.9rem;


### PR DESCRIPTION
## Purpose

Reposition the docs landing page around Hive as a tmux-native metaharness for terminal coding agents.

## Proposed Changes

  - Redesign the landing page hero, metaharness diagram, TUI preview, feature cards, and CTA
  - Link feature cards to the relevant documentation pages
  - Add landing-page-specific CSS for responsive marketing sections

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
