### PR TITLE
Add batch agent selection

### DIFF
--- a/internal/commands/cmd_batch.go
+++ b/internal/commands/cmd_batch.go
@@ -56,7 +56,8 @@ Input JSON schema:
         "session_id": "optional-id",
         "prompt": "optional task prompt",
         "remote": "optional-url",
-        "source": "optional-path"
+        "source": "optional-path",
+        "agent": "optional-agent-key"
       }
     ]
   }
@@ -67,6 +68,7 @@ Fields:
   prompt     - Optional. Task prompt passed to batch_spawn via {{.Prompt}} template.
   remote     - Optional. Git remote URL (auto-detected from current dir if empty).
   source     - Optional. Directory to copy files from (per copy rules in config).
+  agent      - Optional. Agent profile key from agents config.
 
 Config example (in ~/.config/hive/config.yaml):
   commands:
@@ -105,6 +107,11 @@ func (cmd *BatchCmd) run(ctx context.Context, c *cli.Command) error {
 
 	if err := input.Validate(); err != nil {
 		logger.Error().Err(err).Msg("input validation failed")
+		return iojson.WriteError(fmt.Sprintf("invalid input: %s", err), nil)
+	}
+
+	if err := cmd.validateAgents(input); err != nil {
+		logger.Error().Err(err).Msg("agent validation failed")
 		return iojson.WriteError(fmt.Sprintf("invalid input: %s", err), nil)
 	}
 
@@ -150,6 +157,20 @@ func (cmd *BatchCmd) run(ctx context.Context, c *cli.Command) error {
 	return iojson.Write(output)
 }
 
+func (cmd *BatchCmd) validateAgents(input BatchInput) error {
+	var errs criterio.FieldErrorsBuilder
+	for i, sess := range input.Sessions {
+		if sess.Agent == "" {
+			continue
+		}
+		if _, ok := cmd.app.Config.Agents.Profiles[sess.Agent]; !ok {
+			field := fmt.Sprintf("sessions[%d].agent", i)
+			errs = errs.Append(field, fmt.Errorf("unknown agent %q", sess.Agent))
+		}
+	}
+	return errs.ToError()
+}
+
 func (cmd *BatchCmd) createSession(ctx context.Context, sess BatchSession) BatchResult {
 	source := sess.Source
 	if source == "" {
@@ -172,6 +193,7 @@ func (cmd *BatchCmd) createSession(ctx context.Context, sess BatchSession) Batch
 		Source:        source,
 		UseBatchSpawn: true,
 		CloneStrategy: sess.CloneStrategy,
+		AgentKey:      sess.Agent,
 	}
 
 	created, err := cmd.app.Sessions.CreateSession(ctx, opts)
@@ -254,6 +276,7 @@ type BatchSession struct {
 	Remote        string `json:"remote,omitempty"`
 	Source        string `json:"source,omitempty"`
 	CloneStrategy string `json:"clone_strategy,omitempty"`
+	Agent         string `json:"agent,omitempty"`
 }
 
 // BatchResult is the output for a single session creation attempt.

--- a/internal/commands/cmd_batch_test.go
+++ b/internal/commands/cmd_batch_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/colonyops/hive/internal/core/config"
+	"github.com/colonyops/hive/internal/hive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,7 +106,7 @@ func TestBatchInput_Validate(t *testing.T) {
 func TestBatchInput_JSON(t *testing.T) {
 	jsonInput := `{
 		"sessions": [
-			{"name": "task1", "session_id": "abc123"},
+			{"name": "task1", "session_id": "abc123", "agent": "claude"},
 			{"name": "task2", "remote": "https://github.com/org/repo"}
 		]
 	}`
@@ -115,7 +117,38 @@ func TestBatchInput_JSON(t *testing.T) {
 	assert.Len(t, input.Sessions, 2, "expected 2 sessions, got %d", len(input.Sessions))
 	assert.Equal(t, "task1", input.Sessions[0].Name)
 	assert.Equal(t, "abc123", input.Sessions[0].SessionID)
+	assert.Equal(t, "claude", input.Sessions[0].Agent)
 	assert.Equal(t, "https://github.com/org/repo", input.Sessions[1].Remote)
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"agent":"claude"`)
+}
+
+func TestBatchCmd_validateAgents(t *testing.T) {
+	cmd := &BatchCmd{
+		app: &hive.App{
+			Config: &config.Config{
+				Agents: config.AgentsConfig{
+					Profiles: map[string]config.AgentProfile{
+						"claude": {},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, cmd.validateAgents(BatchInput{Sessions: []BatchSession{
+		{Name: "task1", Agent: "claude"},
+		{Name: "task2"},
+	}}))
+
+	err := cmd.validateAgents(BatchInput{Sessions: []BatchSession{
+		{Name: "task1", Agent: "missing"},
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sessions[0].agent")
+	assert.Contains(t, err.Error(), `unknown agent "missing"`)
 }
 
 func TestBatchOutput_JSON(t *testing.T) {


### PR DESCRIPTION
## Purpose

Allow batch JSON input to select a configured agent profile per session.

## Proposed Changes

  - Add an optional `agent` field to batch session input.
  - Validate agent keys before creating sessions.
  - Pass selected agents through to session creation.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)