### PR TITLE
feat: show all tmux windows and panes in sessions tree

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -73,6 +73,7 @@ Sessions can run multiple agents by opening additional tmux windows — use `tmu
 | ----------------------------- | ---------- | ----------------------------------- | ------------------------------------- |
 | `tmux.poll_interval`          | `duration` | `1.5s`                              | Status check frequency                |
 | `tmux.preview_window_matcher` | `[]string` | `["claude", "aider", "codex", ...]` | Regex patterns for agent window names |
+| `tmux.port_discovery`         | `bool`     | `true`                              | Discover listening TCP ports for non-agent panes (uses `lsof`); set `false` to opt out |
 
 ## TUI
 
@@ -128,6 +129,7 @@ View-specific settings (keybindings, layout, behavior) are configured per-view u
 | `views.sessions.preview_title`      | `string`   |               | Go template for preview panel title          |
 | `views.sessions.preview_status`     | `string`   |               | Go template for preview status line          |
 | `views.sessions.group_by`           | `string`   | `repo`        | Tree view grouping: `repo` or `group`        |
+| `views.sessions.tmux_items`         | `string`   | `all`         | Panes shown in tree: `agents` (agent panes only) or `all` (every tmux window/pane) |
 
 ### Tasks View
 

--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -81,7 +81,8 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 
 	// Create terminal integration manager (tmux always enabled)
 	termMgr := terminal.NewManager([]string{"tmux"})
-	tmuxIntegration := tmux.NewFromPreviewMatchers(cmd.app.Config.Tmux.PreviewWindowMatcher)
+	tmuxIntegration := tmux.NewFromPreviewMatchers(cmd.app.Config.Tmux.PreviewWindowMatcher).
+		WithPortDiscovery(cmd.app.Config.Tmux.IsPortDiscoveryEnabled())
 	if tmuxIntegration.Available() {
 		termMgr.Register(tmuxIntegration)
 	}

--- a/internal/commands/cmd_x_pick.go
+++ b/internal/commands/cmd_x_pick.go
@@ -453,7 +453,7 @@ func refreshStatusCmd(mgr *terminal.Manager, items []pickItem) tea.Cmd {
 			var allInfos []*terminal.SessionInfo
 			var dErr error
 			if disc, ok := integration.(terminal.AllPanesDiscoverer); ok {
-				allInfos, dErr = disc.DiscoverAllPanes(ctx, item.Session.Slug, metadata)
+				allInfos, dErr = disc.DiscoverAllPanes(ctx, item.Session.Slug, metadata, false)
 			} else {
 				statuses[item.Session.ID] = status
 				expanded = append(expanded, item)

--- a/internal/commands/cmd_x_pick.go
+++ b/internal/commands/cmd_x_pick.go
@@ -561,7 +561,8 @@ func (cmd *ExperimentalCmd) pickCmd() *cli.Command {
 
 			// Create terminal manager (same as TUI) since cmd.app.Terminal is nil at app level
 			termMgr := terminal.NewManager([]string{"tmux"})
-			tmuxIntegration := terminaltmux.NewFromPreviewMatchers(cmd.app.Config.Tmux.PreviewWindowMatcher)
+			tmuxIntegration := terminaltmux.NewFromPreviewMatchers(cmd.app.Config.Tmux.PreviewWindowMatcher).
+				WithPortDiscovery(cmd.app.Config.Tmux.IsPortDiscoveryEnabled())
 			if tmuxIntegration.Available() {
 				termMgr.Register(tmuxIntegration)
 			}

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -547,6 +547,13 @@ type MessagingConfig struct {
 type TmuxConfig struct {
 	PollInterval         time.Duration `json:"poll_interval"          yaml:"poll_interval"`          // status check frequency, default 1.5s
 	PreviewWindowMatcher []string      `json:"preview_window_matcher" yaml:"preview_window_matcher"` // regex patterns for preferred window names (e.g., ["claude", "aider"])
+	PortDiscovery        *bool         `json:"port_discovery"         yaml:"port_discovery"`         // discover listening TCP ports for non-agent panes; nil/true = enabled (default), false = opt-out
+}
+
+// IsPortDiscoveryEnabled reports whether lsof-based port discovery is enabled.
+// Port discovery is on by default; set tmux.port_discovery: false to opt out.
+func (t TmuxConfig) IsPortDiscoveryEnabled() bool {
+	return t.PortDiscovery == nil || *t.PortDiscovery
 }
 
 // PluginsConfig holds configuration for the plugin system.

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -1074,7 +1074,6 @@ func (c *Config) validateGroupBy() error {
 	return criterio.Run("views.sessions.group_by", c.Views.Sessions.GroupBy, criterio.StrOneOf(ValidGroupByModes...))
 }
 
-// validateTmuxItems checks that the configured tmux_items value is valid.
 func (c *Config) validateTmuxItems() error {
 	return criterio.Run("views.sessions.tmux_items", c.Views.Sessions.TmuxItems, criterio.StrOneOf(ValidTmuxItemsModes...))
 }

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -513,6 +513,14 @@ const (
 // ValidGroupByModes lists all valid group_by values.
 var ValidGroupByModes = []string{GroupByRepo, GroupByGroup}
 
+const (
+	TmuxItemsAgents = "agents" // Show only detected agent panes in the sessions tree.
+	TmuxItemsAll    = "all"    // Show all tmux windows and panes tied to a hive session.
+)
+
+// ValidTmuxItemsModes lists all valid tmux_items values.
+var ValidTmuxItemsModes = []string{TmuxItemsAgents, TmuxItemsAll}
+
 // TUIConfig holds TUI-related configuration.
 type TUIConfig struct {
 	Theme         string `json:"theme"          yaml:"theme"`          // built-in theme name (default: "tokyo-night")
@@ -738,6 +746,7 @@ func DefaultConfig() Config {
 			Sessions: SessionsViewConfig{
 				RefreshInterval: 15 * time.Second,
 				PreviewEnabled:  true,
+				TmuxItems:       TmuxItemsAll,
 			},
 		},
 		Messaging: MessagingConfig{
@@ -836,6 +845,9 @@ func (c *Config) applyDefaults() {
 	if c.Views.Sessions.GroupBy == "" {
 		c.Views.Sessions.GroupBy = GroupByRepo
 	}
+	if c.Views.Sessions.TmuxItems == "" {
+		c.Views.Sessions.TmuxItems = TmuxItemsAll
+	}
 	if c.CopyCommand == "" {
 		c.CopyCommand = defaultCopyCommand()
 	}
@@ -918,6 +930,7 @@ func (c *Config) Validate() error {
 		criterio.Run("database.busy_timeout", c.Database.BusyTimeout, criterio.Min(0)),
 		c.validateTheme(),
 		c.validateGroupBy(),
+		c.validateTmuxItems(),
 		c.validateKeybindingsBasic(),
 		c.validateUserCommandsBasic(),
 		c.validateMaxRecycled(),
@@ -1059,6 +1072,11 @@ func (c *Config) validateTheme() error {
 // validateGroupBy checks that the configured group_by value is valid.
 func (c *Config) validateGroupBy() error {
 	return criterio.Run("views.sessions.group_by", c.Views.Sessions.GroupBy, criterio.StrOneOf(ValidGroupByModes...))
+}
+
+// validateTmuxItems checks that the configured tmux_items value is valid.
+func (c *Config) validateTmuxItems() error {
+	return criterio.Run("views.sessions.tmux_items", c.Views.Sessions.TmuxItems, criterio.StrOneOf(ValidTmuxItemsModes...))
 }
 
 // validateKeybindingsBasic performs basic keybinding validation for the Validate() method.

--- a/internal/core/config/config_views.go
+++ b/internal/core/config/config_views.go
@@ -30,6 +30,7 @@ type SessionsViewConfig struct {
 	PreviewTitle    string                `json:"preview_title"    yaml:"preview_title"`
 	PreviewStatus   string                `json:"preview_status"   yaml:"preview_status"`
 	GroupBy         string                `json:"group_by"         yaml:"group_by"`
+	TmuxItems       string                `json:"tmux_items"       yaml:"tmux_items"`
 }
 
 // SplitRatioOrDefault returns the configured split ratio, or the given default if unset or invalid.
@@ -166,6 +167,7 @@ func mergeViewsConfig(defaults, user ViewsConfig) ViewsConfig {
 			PreviewTitle:    firstNonEmpty(user.Sessions.PreviewTitle, defaults.Sessions.PreviewTitle),
 			PreviewStatus:   firstNonEmpty(user.Sessions.PreviewStatus, defaults.Sessions.PreviewStatus),
 			GroupBy:         firstNonEmpty(user.Sessions.GroupBy, defaults.Sessions.GroupBy),
+			TmuxItems:       firstNonEmpty(user.Sessions.TmuxItems, defaults.Sessions.TmuxItems),
 		},
 		Tasks: TasksViewConfig{
 			Keybindings: mergeKeybindingMaps(defaults.Tasks.Keybindings, user.Tasks.Keybindings),

--- a/internal/core/config/validate_test.go
+++ b/internal/core/config/validate_test.go
@@ -22,7 +22,7 @@ func validConfig(t *testing.T) *Config {
 		DataDir: t.TempDir(),
 		Git:     GitConfig{StatusWorkers: 1},
 		TUI:     TUIConfig{Theme: styles.DefaultTheme},
-		Views:   ViewsConfig{Sessions: SessionsViewConfig{GroupBy: GroupByRepo}},
+		Views:   ViewsConfig{Sessions: SessionsViewConfig{GroupBy: GroupByRepo, TmuxItems: TmuxItemsAll}},
 		Agents: AgentsConfig{
 			Default:  "claude",
 			Profiles: map[string]AgentProfile{"claude": {}},
@@ -1530,6 +1530,27 @@ func TestValidate_GroupByValidModes(t *testing.T) {
 		t.Run(mode, func(t *testing.T) {
 			cfg := validConfig(t)
 			cfg.Views.Sessions.GroupBy = mode
+
+			err := cfg.Validate()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidate_TmuxItemsInvalid(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.Views.Sessions.TmuxItems = "invalid"
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "views.sessions.tmux_items")
+}
+
+func TestValidate_TmuxItemsValidModes(t *testing.T) {
+	for _, mode := range ValidTmuxItemsModes {
+		t.Run(mode, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.Views.Sessions.TmuxItems = mode
 
 			err := cfg.Validate()
 			assert.NoError(t, err)

--- a/internal/core/config/validate_test.go
+++ b/internal/core/config/validate_test.go
@@ -1558,6 +1558,26 @@ func TestValidate_TmuxItemsValidModes(t *testing.T) {
 	}
 }
 
+func TestIsPortDiscoveryEnabled(t *testing.T) {
+	true_ := true
+	false_ := false
+
+	tests := []struct {
+		name string
+		cfg  TmuxConfig
+		want bool
+	}{
+		{name: "nil (default)", cfg: TmuxConfig{PortDiscovery: nil}, want: true},
+		{name: "explicitly true", cfg: TmuxConfig{PortDiscovery: &true_}, want: true},
+		{name: "explicitly false", cfg: TmuxConfig{PortDiscovery: &false_}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.IsPortDiscoveryEnabled())
+		})
+	}
+}
+
 func TestGetCloneStrategy(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/core/styles/status.go
+++ b/internal/core/styles/status.go
@@ -9,6 +9,7 @@ const (
 	StatusIndicatorReady    = "[>]"
 	StatusIndicatorMissing  = "[?]"
 	StatusIndicatorRecycled = "[○]"
+	StatusIndicatorNeutral  = "[·]"
 )
 
 // RenderStatusIndicator returns a colored status indicator string for the given terminal status.
@@ -20,6 +21,8 @@ func RenderStatusIndicator(status terminal.Status) string {
 		return TextWarningStyle.Render(StatusIndicatorApproval)
 	case terminal.StatusReady:
 		return TextSecondaryStyle.Render(StatusIndicatorReady)
+	case terminal.StatusNeutral:
+		return TextMutedStyle.Render(StatusIndicatorNeutral)
 	case terminal.StatusMissing:
 		return TextMutedStyle.Render(StatusIndicatorMissing)
 	default:

--- a/internal/core/styles/status_test.go
+++ b/internal/core/styles/status_test.go
@@ -15,6 +15,7 @@ func TestRenderStatusIndicator(t *testing.T) {
 		{terminal.StatusActive, StatusIndicatorActive},
 		{terminal.StatusApproval, StatusIndicatorApproval},
 		{terminal.StatusReady, StatusIndicatorReady},
+		{terminal.StatusNeutral, StatusIndicatorNeutral},
 		{terminal.StatusMissing, StatusIndicatorMissing},
 		{terminal.Status("unknown"), StatusIndicatorMissing},
 	}
@@ -33,6 +34,7 @@ func TestRenderStatusIndicator_AllStatusesCovered(t *testing.T) {
 		terminal.StatusActive,
 		terminal.StatusApproval,
 		terminal.StatusReady,
+		terminal.StatusNeutral,
 		terminal.StatusMissing,
 	}
 

--- a/internal/core/terminal/terminal.go
+++ b/internal/core/terminal/terminal.go
@@ -23,7 +23,8 @@ type SessionInfo struct {
 	PaneTitle    string // pane title (for non-agent display)
 	Status       Status // current detected status
 	DetectedTool string // detected AI tool (claude, gemini, etc.)
-	IsAgent      bool   // true when this pane is a detected agent
+	IsAgent      bool   // true when an AI agent was detected in this pane
+	Ports        []int  // listening TCP ports owned by pane processes
 	PaneContent  string // captured pane content for preview
 }
 

--- a/internal/core/terminal/terminal.go
+++ b/internal/core/terminal/terminal.go
@@ -10,6 +10,7 @@ const (
 	StatusActive   Status = "active"   // agent is actively working (spinner/busy indicator)
 	StatusApproval Status = "approval" // agent needs permission (Yes/No dialog)
 	StatusReady    Status = "ready"    // agent finished, waiting for next input (❯ prompt)
+	StatusNeutral  Status = "neutral"  // terminal exists but is not an agent pane
 	StatusMissing  Status = "missing"  // terminal session not found
 )
 
@@ -19,8 +20,10 @@ type SessionInfo struct {
 	WindowIndex  string // tmux window index (e.g., "0", "1")
 	PaneID       string // tmux pane ID in %N format
 	WindowName   string // window name (for display and template data)
+	PaneTitle    string // pane title (for non-agent display)
 	Status       Status // current detected status
 	DetectedTool string // detected AI tool (claude, gemini, etc.)
+	IsAgent      bool   // true when this pane is a detected agent
 	PaneContent  string // captured pane content for preview
 }
 
@@ -44,7 +47,7 @@ type Integration interface {
 	GetStatus(ctx context.Context, info *SessionInfo) (Status, error)
 }
 
-// AllPanesDiscoverer is implemented by integrations that can return all agent panes.
+// AllPanesDiscoverer is implemented by integrations that can return session panes.
 type AllPanesDiscoverer interface {
-	DiscoverAllPanes(ctx context.Context, slug string, metadata map[string]string) ([]*SessionInfo, error)
+	DiscoverAllPanes(ctx context.Context, slug string, metadata map[string]string, includeNonAgents bool) ([]*SessionInfo, error)
 }

--- a/internal/core/terminal/tmux/ports.go
+++ b/internal/core/terminal/tmux/ports.go
@@ -1,0 +1,81 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// PortLister returns listening TCP ports keyed by owning PID.
+type PortLister interface {
+	ListListeningPorts(ctx context.Context, pids []int) (map[int][]int, error)
+}
+
+type LsofPortLister struct{}
+
+func (LsofPortLister) ListListeningPorts(ctx context.Context, pids []int) (map[int][]int, error) {
+	pids = uniquePositiveInts(pids)
+	if len(pids) == 0 {
+		return nil, nil
+	}
+	pidArgs := make([]string, len(pids))
+	for i, pid := range pids {
+		pidArgs[i] = strconv.Itoa(pid)
+	}
+	out, err := exec.CommandContext(ctx, "lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", strings.Join(pidArgs, ",")).Output()
+	if err != nil {
+		return nil, fmt.Errorf("lsof listening ports: %w", err)
+	}
+	return parseLsofListeningPorts(string(out)), nil
+}
+
+var lsofPortPattern = regexp.MustCompile(`:(\d+)\s+\(LISTEN\)$`)
+
+func parseLsofListeningPorts(output string) map[int][]int {
+	portsByPID := make(map[int][]int)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] == "COMMAND" {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[1])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		matches := lsofPortPattern.FindStringSubmatch(line)
+		if len(matches) != 2 {
+			continue
+		}
+		port, err := strconv.Atoi(matches[1])
+		if err != nil || port <= 0 {
+			continue
+		}
+		portsByPID[pid] = append(portsByPID[pid], port)
+	}
+	for pid, ports := range portsByPID {
+		portsByPID[pid] = uniqueSortedPorts(ports)
+	}
+	return portsByPID
+}
+
+func uniquePositiveInts(values []int) []int {
+	seen := make(map[int]bool, len(values))
+	out := make([]int, 0, len(values))
+	for _, value := range values {
+		if value <= 0 || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func uniqueSortedPorts(values []int) []int {
+	return uniquePositiveInts(values)
+}

--- a/internal/core/terminal/tmux/ports_test.go
+++ b/internal/core/terminal/tmux/ports_test.go
@@ -1,0 +1,25 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLsofListeningPorts(t *testing.T) {
+	output := `COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+node     1234 hayden 21u  IPv6 0xabc            0t0  TCP *:3000 (LISTEN)
+python   1234 hayden 22u  IPv4 0xdef            0t0  TCP 127.0.0.1:8000 (LISTEN)
+postgres 5678 hayden 10u  IPv6 0xghi            0t0  TCP [::1]:5432 (LISTEN)
+node     1234 hayden 23u  IPv6 0xabc            0t0  TCP *:3000 (LISTEN)
+`
+
+	got := parseLsofListeningPorts(output)
+
+	assert.Equal(t, []int{3000, 8000}, got[1234])
+	assert.Equal(t, []int{5432}, got[5678])
+}
+
+func TestUniquePositiveInts(t *testing.T) {
+	assert.Equal(t, []int{1, 2, 3}, uniquePositiveInts([]int{3, 1, 2, 2, 0, -1}))
+}

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -51,18 +51,18 @@ type cachedPane struct {
 	state  paneState
 }
 
-// agentPanes returns panes classified as agents.
-func (sc *sessionCache) agentPanes() []cachedPane {
+// matchingPanes returns panes eligible for tree expansion.
+func (sc *sessionCache) matchingPanes(includeNonAgents bool) []cachedPane {
 	if sc == nil {
 		return nil
 	}
-	agents := make([]cachedPane, 0, len(sc.panes))
+	panes := make([]cachedPane, 0, len(sc.panes))
 	for _, pane := range sc.panes {
-		if pane.result.IsAgent {
-			agents = append(agents, pane)
+		if includeNonAgents || pane.result.IsAgent {
+			panes = append(panes, pane)
 		}
 	}
-	return agents
+	return panes
 }
 
 // findPane returns the pane matching paneID.
@@ -392,7 +392,9 @@ func sessionInfoFromPane(sessionName string, pane *cachedPane) *terminal.Session
 		WindowIndex:  pane.input.WindowIndex,
 		PaneID:       pane.input.PaneID,
 		WindowName:   pane.input.WindowName,
+		PaneTitle:    pane.input.PaneTitle,
 		DetectedTool: pane.result.Tool,
+		IsAgent:      pane.result.IsAgent,
 	}
 }
 
@@ -498,8 +500,8 @@ func (t *Integration) updatePaneState(sessionName, paneID string, update func(*p
 	}
 }
 
-// DiscoverAllPanes returns a SessionInfo for every classified agent pane.
-func (t *Integration) DiscoverAllPanes(_ context.Context, slug string, metadata map[string]string) ([]*terminal.SessionInfo, error) {
+// DiscoverAllPanes returns SessionInfo values for panes tied to a hive session.
+func (t *Integration) DiscoverAllPanes(_ context.Context, slug string, metadata map[string]string, includeNonAgents bool) ([]*terminal.SessionInfo, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
@@ -512,13 +514,13 @@ func (t *Integration) DiscoverAllPanes(_ context.Context, slug string, metadata 
 		return nil, nil
 	}
 
-	agents := sc.agentPanes()
-	if len(agents) == 0 {
+	panes := sc.matchingPanes(includeNonAgents)
+	if len(panes) == 0 {
 		return nil, nil
 	}
-	infos := make([]*terminal.SessionInfo, 0, len(agents))
-	for i := range agents {
-		infos = append(infos, sessionInfoFromPane(sessionName, &agents[i]))
+	infos := make([]*terminal.SessionInfo, 0, len(panes))
+	for i := range panes {
+		infos = append(infos, sessionInfoFromPane(sessionName, &panes[i]))
 	}
 	return infos, nil
 }

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -37,6 +37,7 @@ type Integration struct {
 	processReader   process.ProcessReader
 	lister          PaneLister
 	capture         classifier.ContentCapture
+	portLister      PortLister
 }
 
 // sessionCache holds all panes for a single tmux session.
@@ -49,6 +50,7 @@ type cachedPane struct {
 	input  classifier.PaneInput
 	result classifier.Result
 	state  paneState
+	ports  []int
 }
 
 // matchingPanes returns panes eligible for tree expansion.
@@ -156,6 +158,7 @@ func NewWithReader(cls *classifier.Classifier, lister PaneLister, reader process
 		processReader:   reader,
 		lister:          lister,
 		capture:         capture,
+		portLister:      LsofPortLister{},
 	}
 }
 
@@ -187,8 +190,9 @@ func (t *Integration) RefreshCache() {
 	defer t.refreshMu.Unlock()
 
 	// Build a process-tree snapshot once for this refresh cycle so all pane
-	// classifications share one OS call instead of one per pane.
-	snapshotCls := t.classifier.WithReader(process.NewSnapshotReader(t.processReader))
+	// classifications and port discovery share one OS call instead of one per pane.
+	snapshotReader := process.NewSnapshotReader(t.processReader)
+	snapshotCls := t.classifier.WithReader(snapshotReader)
 
 	panes, err := t.lister.ListAllPanes()
 	if err != nil {
@@ -205,11 +209,16 @@ func (t *Integration) RefreshCache() {
 	type paneSnapshot struct {
 		pid   int64
 		state paneState
+		ports []int
 	}
 	oldStates := make(map[string]paneSnapshot)
 	for sessionName, sc := range t.cache {
 		for _, pane := range sc.panes {
-			oldStates[paneKey(sessionName, pane.input.PaneID)] = paneSnapshot{pid: pane.input.PanePID, state: pane.state}
+			oldStates[paneKey(sessionName, pane.input.PaneID)] = paneSnapshot{
+				pid:   pane.input.PanePID,
+				state: pane.state,
+				ports: append([]int(nil), pane.ports...),
+			}
 		}
 	}
 	t.mu.RUnlock()
@@ -217,6 +226,12 @@ func (t *Integration) RefreshCache() {
 	newCache := make(map[string]*sessionCache)
 	activePaneIDs := make(map[string]bool, len(panes))
 	activeKeys := make(map[string]bool, len(panes))
+	type panePortsInput struct {
+		key  string
+		pids []int
+	}
+	var portInputs []panePortsInput
+	var portPIDs []int
 	for _, input := range panes {
 		if input.SessionName == "" || input.PaneID == "" {
 			continue
@@ -243,16 +258,41 @@ func (t *Integration) RefreshCache() {
 		}
 
 		var state paneState
+		var ports []int
 		if snapshot, ok := oldStates[key]; ok && snapshot.pid == input.PanePID {
 			state = snapshot.state
+			ports = append([]int(nil), snapshot.ports...)
 		}
-		entry := cachedPane{input: input, result: result, state: state}
+		entry := cachedPane{input: input, result: result, state: state, ports: ports}
+		if !result.IsAgent {
+			pids := processPIDsForPane(input.PanePID, snapshotReader)
+			if len(pids) > 0 {
+				portInputs = append(portInputs, panePortsInput{key: key, pids: pids})
+				portPIDs = append(portPIDs, pids...)
+			}
+		}
 		sc := newCache[input.SessionName]
 		if sc == nil {
 			sc = &sessionCache{}
 			newCache[input.SessionName] = sc
 		}
 		sc.panes = append(sc.panes, entry)
+	}
+
+	portsByPID, portsOK := t.listPortsByPID(portPIDs)
+	if portsOK {
+		portsByPane := make(map[string][]int, len(portInputs))
+		for _, input := range portInputs {
+			portsByPane[input.key] = portsForPIDs(input.pids, portsByPID)
+		}
+		for sessionName, sc := range newCache {
+			for i := range sc.panes {
+				key := paneKey(sessionName, sc.panes[i].input.PaneID)
+				if ports, ok := portsByPane[key]; ok {
+					sc.panes[i].ports = ports
+				}
+			}
+		}
 	}
 
 	t.classCache.Prune(activePaneIDs)
@@ -289,6 +329,44 @@ func (t *Integration) processFingerprint(panePID int64) int64 {
 		return int64(foregroundPID)
 	}
 	return panePID
+}
+
+func (t *Integration) listPortsByPID(pids []int) (map[int][]int, bool) {
+	pids = uniquePositiveInts(pids)
+	if len(pids) == 0 || t.portLister == nil {
+		return nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	portsByPID, err := t.portLister.ListListeningPorts(ctx, pids)
+	if err != nil {
+		log.Debug().Err(err).Msg("tmux listening port discovery failed")
+		return nil, false
+	}
+	return portsByPID, true
+}
+
+func processPIDsForPane(panePID int64, reader process.ProcessReader) []int {
+	if panePID <= 0 {
+		return nil
+	}
+	candidates, err := process.Candidates(int(panePID), reader)
+	if err != nil || candidates == nil {
+		return nil
+	}
+	pids := []int{candidates.Foreground.PID}
+	for _, child := range candidates.Children {
+		pids = append(pids, child.PID)
+	}
+	return uniquePositiveInts(pids)
+}
+
+func portsForPIDs(pids []int, portsByPID map[int][]int) []int {
+	var ports []int
+	for _, pid := range pids {
+		ports = append(ports, portsByPID[pid]...)
+	}
+	return uniqueSortedPorts(ports)
 }
 
 func (t *Integration) prunePaneKeysLocked(activeKeys map[string]bool) {
@@ -395,6 +473,7 @@ func sessionInfoFromPane(sessionName string, pane *cachedPane) *terminal.Session
 		PaneTitle:    pane.input.PaneTitle,
 		DetectedTool: pane.result.Tool,
 		IsAgent:      pane.result.IsAgent,
+		Ports:        append([]int(nil), pane.ports...),
 	}
 }
 

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -162,6 +162,15 @@ func NewWithReader(cls *classifier.Classifier, lister PaneLister, reader process
 	}
 }
 
+// WithPortDiscovery enables or disables lsof-based port discovery for non-agent
+// panes. Disabled when the caller sets tmux.port_discovery: false in config.
+func (t *Integration) WithPortDiscovery(enabled bool) *Integration {
+	if !enabled {
+		t.portLister = nil
+	}
+	return t
+}
+
 // Classifier returns the pane classifier used by this integration.
 func (t *Integration) Classifier() *classifier.Classifier { return t.classifier }
 

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -305,6 +305,27 @@ func TestDiscoverAllPanes(t *testing.T) {
 	assert.Equal(t, "%3", infos[1].PaneID)
 }
 
+func TestRefreshCache_AttachesPortsToNonAgentPanes(t *testing.T) {
+	reader := &fakeProcessReader{tpgid: 200, comm: map[int]string{200: "zsh"}}
+	lister := &fakePaneLister{panes: []classifier.PaneInput{{
+		SessionName: "sess",
+		PaneID:      "%1",
+		PanePID:     100,
+		WindowIndex: "0",
+		WindowName:  "shell",
+	}}}
+	integ := NewWithReader(nil, lister, reader)
+	integ.portLister = fakePortLister{ports: map[int][]int{200: {3000, 8000}}}
+
+	integ.RefreshCache()
+	infos, err := integ.DiscoverAllPanes(context.Background(), "sess", nil, true)
+
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.False(t, infos[0].IsAgent)
+	assert.Equal(t, []int{3000, 8000}, infos[0].Ports)
+}
+
 func TestDiscoverAllPanes_IncludesNonAgentsWhenRequested(t *testing.T) {
 	integ := New(nil, nil)
 	integ.cache = map[string]*sessionCache{"multi-sess": {panes: []cachedPane{
@@ -486,6 +507,12 @@ func agentCachedPane(paneID, windowIndex, tool string) cachedPane {
 type fakePaneLister struct{ panes []classifier.PaneInput }
 
 func (f *fakePaneLister) ListAllPanes() ([]classifier.PaneInput, error) { return f.panes, nil }
+
+type fakePortLister struct{ ports map[int][]int }
+
+func (f fakePortLister) ListListeningPorts(_ context.Context, _ []int) (map[int][]int, error) {
+	return f.ports, nil
+}
 
 type blockingPaneLister struct {
 	listFn func() ([]classifier.PaneInput, error)

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -572,3 +572,17 @@ func (f *fakeScorer) Score(content string) (int, int, string) {
 	score := f.scores[content]
 	return score.score, score.categories, score.tool
 }
+
+func TestWithPortDiscovery_DisabledNilsPortLister(t *testing.T) {
+	integ := New(nil, nil)
+	assert.NotNil(t, integ.portLister, "port discovery should be on by default")
+
+	integ.WithPortDiscovery(false)
+	assert.Nil(t, integ.portLister, "port discovery should be disabled")
+}
+
+func TestWithPortDiscovery_EnabledKeepsPortLister(t *testing.T) {
+	integ := New(nil, nil)
+	integ.WithPortDiscovery(true)
+	assert.NotNil(t, integ.portLister, "port discovery should remain enabled")
+}

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -297,11 +297,28 @@ func TestDiscoverAllPanes(t *testing.T) {
 	}}}
 	integ.cacheTime = time.Now()
 
-	infos, err := integ.DiscoverAllPanes(context.Background(), "multi-sess", nil)
+	infos, err := integ.DiscoverAllPanes(context.Background(), "multi-sess", nil, false)
 	require.NoError(t, err)
 	require.Len(t, infos, 2)
 	assert.Equal(t, "%1", infos[0].PaneID)
+	assert.True(t, infos[0].IsAgent)
 	assert.Equal(t, "%3", infos[1].PaneID)
+}
+
+func TestDiscoverAllPanes_IncludesNonAgentsWhenRequested(t *testing.T) {
+	integ := New(nil, nil)
+	integ.cache = map[string]*sessionCache{"multi-sess": {panes: []cachedPane{
+		{input: classifier.PaneInput{PaneID: "%1", WindowIndex: "0", WindowName: testToolClaude}, result: classifier.Result{IsAgent: true, Tool: testToolClaude}},
+		{input: classifier.PaneInput{PaneID: "%2", WindowIndex: "0", WindowName: "shell", PaneTitle: "zsh"}, result: classifier.Result{IsAgent: false}},
+	}}}
+	integ.cacheTime = time.Now()
+
+	infos, err := integ.DiscoverAllPanes(context.Background(), "multi-sess", nil, true)
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+	assert.Equal(t, "%2", infos[1].PaneID)
+	assert.Equal(t, "zsh", infos[1].PaneTitle)
+	assert.False(t, infos[1].IsAgent)
 }
 
 func TestDiscoverAllPanes_Matching(t *testing.T) {
@@ -320,27 +337,27 @@ func TestDiscoverAllPanes_Matching(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("unknown session returns nil", func(t *testing.T) {
-		infos, err := integ.DiscoverAllPanes(ctx, "nonexistent", nil)
+		infos, err := integ.DiscoverAllPanes(ctx, "nonexistent", nil, false)
 		require.NoError(t, err)
 		assert.Nil(t, infos)
 	})
 
 	t.Run("stale cache returns nil", func(t *testing.T) {
 		integ.cacheTime = time.Now().Add(-5 * time.Second)
-		infos, err := integ.DiscoverAllPanes(ctx, "multi-sess", nil)
+		infos, err := integ.DiscoverAllPanes(ctx, "multi-sess", nil, false)
 		require.NoError(t, err)
 		assert.Nil(t, infos)
 		integ.cacheTime = time.Now()
 	})
 
 	t.Run("similar slug does not cross match", func(t *testing.T) {
-		infos, err := integ.DiscoverAllPanes(ctx, "foo", nil)
+		infos, err := integ.DiscoverAllPanes(ctx, "foo", nil, false)
 		require.NoError(t, err)
 		assert.Nil(t, infos, "slug foo must not match tmux session foo-bar")
 	})
 
 	t.Run("hyphenated exact slug still found", func(t *testing.T) {
-		infos, err := integ.DiscoverAllPanes(ctx, "foo-bar", nil)
+		infos, err := integ.DiscoverAllPanes(ctx, "foo-bar", nil, false)
 		require.NoError(t, err)
 		require.Len(t, infos, 1)
 		assert.Equal(t, "foo-bar", infos[0].Name)
@@ -348,7 +365,7 @@ func TestDiscoverAllPanes_Matching(t *testing.T) {
 	})
 
 	t.Run("metadata tmux_session match returns named session", func(t *testing.T) {
-		infos, err := integ.DiscoverAllPanes(ctx, "myslug", map[string]string{"tmux_session": "multi-sess"})
+		infos, err := integ.DiscoverAllPanes(ctx, "myslug", map[string]string{"tmux_session": "multi-sess"}, false)
 		require.NoError(t, err)
 		require.Len(t, infos, 2)
 		assert.Equal(t, "multi-sess", infos[0].Name)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1673,10 +1673,12 @@ func tmuxTargetForTerminalStatus(status sessions.TerminalStatus) string {
 		return ""
 	}
 	window := status.Windows[0]
+	// Prefer the globally-unique pane ID when there is exactly one pane; a bare
+	// window index is ambiguous in multi-session tmux environments.
 	if len(window.Panes) == 1 && window.Panes[0].PaneID != "" {
 		return window.Panes[0].PaneID
 	}
-	return window.WindowIndex
+	return ""
 }
 
 // selectedTreeItem returns the currently selected tree item, or nil if none.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -256,7 +256,7 @@ func New(deps Deps, opts Opts) Model {
 	// Wire handler lookups through sessions view stores
 	handler.SetTmuxWindowLookup(func(sessionID string) string {
 		if status, ok := sessionsView.TerminalStatuses().Get(sessionID); ok {
-			return status.WindowName
+			return tmuxTargetForTerminalStatus(status)
 		}
 		return ""
 	})
@@ -1663,6 +1663,20 @@ func (m Model) openNewSessionForm() (tea.Model, tea.Cmd) {
 	m.modals.NewSession = NewNewSessionForm(m.sessionsView.DiscoveredRepos(), preselectedRemote, existingNames, agentKeys)
 	m.state = stateCreatingSession
 	return m, m.modals.NewSession.Init()
+}
+
+func tmuxTargetForTerminalStatus(status sessions.TerminalStatus) string {
+	if status.WindowName != "" {
+		return status.WindowName
+	}
+	if len(status.Windows) != 1 {
+		return ""
+	}
+	window := status.Windows[0]
+	if len(window.Panes) == 1 && window.Panes[0].PaneID != "" {
+		return window.Panes[0].PaneID
+	}
+	return window.WindowIndex
 }
 
 // selectedTreeItem returns the currently selected tree item, or nil if none.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -546,3 +546,22 @@ func TestModalDismissalQIgnoresNormalModeOverride(t *testing.T) {
 		})
 	}
 }
+
+func TestTmuxTargetForTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status sessions.TerminalStatus
+		want   string
+	}{
+		{name: "direct window name", status: sessions.TerminalStatus{WindowName: "pi"}, want: "pi"},
+		{name: "single pane fallback", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "0", Panes: []sessions.PaneStatus{{PaneID: "%7"}}}}}, want: "%7"},
+		{name: "single window fallback", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "2"}}}, want: "2"},
+		{name: "ambiguous windows", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "0"}, {WindowIndex: "1"}}}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tmuxTargetForTerminalStatus(tt.status))
+		})
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -555,7 +555,7 @@ func TestTmuxTargetForTerminalStatus(t *testing.T) {
 	}{
 		{name: "direct window name", status: sessions.TerminalStatus{WindowName: "pi"}, want: "pi"},
 		{name: "single pane fallback", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "0", Panes: []sessions.PaneStatus{{PaneID: "%7"}}}}}, want: "%7"},
-		{name: "single window fallback", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "2"}}}, want: "2"},
+		{name: "single window no panes", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "2"}}}, want: ""},
 		{name: "ambiguous windows", status: sessions.TerminalStatus{Windows: []sessions.WindowStatus{{WindowIndex: "0"}, {WindowIndex: "1"}}}, want: ""},
 	}
 

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -3,6 +3,9 @@ package sessions
 import (
 	"context"
 	"maps"
+	"os"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +21,21 @@ import (
 
 const terminalStatusTimeout = 2 * time.Second
 
+// resolvedHostname caches os.Hostname() so the per-pane hot path avoids
+// repeated syscalls. Hostname is constant for the lifetime of the process.
+var (
+	hostnameOnce     sync.Once
+	resolvedHostname string
+)
+
+func getHostname() string {
+	hostnameOnce.Do(func() {
+		h, _ := os.Hostname()
+		resolvedHostname = strings.ToLower(strings.TrimSpace(h))
+	})
+	return resolvedHostname
+}
+
 // PaneStatus holds per-pane terminal status for agent panes.
 type PaneStatus struct {
 	PaneID      string
@@ -25,6 +43,7 @@ type PaneStatus struct {
 	Tool        string
 	PaneContent string
 	IsAgent     bool
+	Ports       []int
 }
 
 // WindowStatus holds per-window terminal status for multi-window sessions.
@@ -35,6 +54,7 @@ type WindowStatus struct {
 	Tool        string
 	PaneContent string
 	HasAgent    bool
+	Ports       []int
 	Panes       []PaneStatus
 }
 
@@ -44,6 +64,7 @@ type TerminalStatus struct {
 	Tool        string
 	WindowName  string
 	PaneContent string
+	Ports       []int
 	IsLoading   bool
 	Error       error
 	Windows     []WindowStatus // per-window statuses (populated only for multi-window sessions)
@@ -61,6 +82,9 @@ type TerminalPollTickMsg struct{}
 func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int, tmuxItems string) tea.Cmd {
 	if len(sessions) == 0 || !mgr.HasEnabledIntegrations() {
 		return nil
+	}
+	if workers <= 0 {
+		workers = 1
 	}
 
 	return func() tea.Msg {
@@ -129,6 +153,7 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 			windows := discoverAllWindows(ctx, mgr, sess.Slug, metadata)
 			if len(windows) > 0 {
 				status.Status = terminal.StatusNeutral
+				status.Ports = portsForWindows(windows)
 				status.Windows = windows
 			}
 		}
@@ -147,6 +172,7 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 	status.Tool = info.DetectedTool
 	status.WindowName = info.WindowName
 	status.PaneContent = info.PaneContent
+	status.Ports = append([]int(nil), info.Ports...)
 
 	// Discover all panes/windows if the integration supports it.
 	var allInfos []*terminal.SessionInfo
@@ -159,6 +185,7 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 			log.Debug().Err(discErr).Str("session", sess.Slug).Msg("multi-window discovery failed, using single-window mode")
 		} else if len(allInfos) > 0 {
 			windows := groupPaneStatuses(ctx, integration, sess.Slug, allInfos)
+			status.Ports = mergePorts(status.Ports, portsForWindows(windows))
 			if shouldExposeWindowsForMode(windows, tmuxItems) {
 				status.Windows = windows
 			}
@@ -207,6 +234,7 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 			Tool:        paneLabel(wi),
 			PaneContent: wi.PaneContent,
 			IsAgent:     wi.IsAgent,
+			Ports:       append([]int(nil), wi.Ports...),
 		}
 
 		// \x1f is an ASCII Unit Separator, which avoids collisions with printable tmux window names.
@@ -222,15 +250,19 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 				Tool:        wi.DetectedTool,
 				PaneContent: wi.PaneContent,
 				HasAgent:    wi.IsAgent,
+				Ports:       append([]int(nil), wi.Ports...),
 			})
-		} else if wi.IsAgent {
-			windows[idx].Status = aggregateStatus(windows[idx].Status, paneStatus)
-			windows[idx].HasAgent = true
-			if windows[idx].Tool == "" {
-				windows[idx].Tool = wi.DetectedTool
-			}
-			if windows[idx].PaneContent == "" {
-				windows[idx].PaneContent = wi.PaneContent
+		} else {
+			windows[idx].Ports = mergePorts(windows[idx].Ports, wi.Ports)
+			if wi.IsAgent {
+				windows[idx].Status = aggregateStatus(windows[idx].Status, paneStatus)
+				windows[idx].HasAgent = true
+				if windows[idx].Tool == "" {
+					windows[idx].Tool = wi.DetectedTool
+				}
+				if windows[idx].PaneContent == "" {
+					windows[idx].PaneContent = wi.PaneContent
+				}
 			}
 		}
 		windows[idx].Panes = append(windows[idx].Panes, pane)
@@ -238,26 +270,56 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 	return windows
 }
 
+// shouldExposeWindowsForMode reports whether the windows list should be
+// expanded into child rows in the session tree.
+//
+// In "agents" mode (default), windows are only shown when there are multiple
+// windows or multiple panes within a single window — the agent must be
+// identifiable among siblings. In "all" mode the same threshold applies
+// because a single-pane, single-window session has no hierarchy to show.
 func shouldExposeWindowsForMode(windows []WindowStatus, tmuxItems string) bool {
+	_ = tmuxItems // both modes share the same threshold today
 	if len(windows) == 0 {
 		return false
 	}
-	if tmuxItems == config.TmuxItemsAll {
-		return shouldExposeAllTmuxItems(windows)
-	}
 	if len(windows) > 1 {
 		return true
 	}
-	return len(windows) == 1 && len(windows[0].Panes) > 1
+	return len(windows[0].Panes) > 1
 }
 
-func shouldExposeAllTmuxItems(windows []WindowStatus) bool {
-	if len(windows) > 1 {
-		return true
+func portsForWindows(windows []WindowStatus) []int {
+	var ports []int
+	for _, window := range windows {
+		ports = mergePorts(ports, window.Ports)
+		for _, pane := range window.Panes {
+			ports = mergePorts(ports, pane.Ports)
+		}
 	}
-	return len(windows) == 1 && len(windows[0].Panes) > 1
+	return ports
 }
 
+func mergePorts(a, b []int) []int {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	seen := make(map[int]bool, len(a)+len(b))
+	merged := make([]int, 0, len(a)+len(b))
+	for _, port := range append(append([]int(nil), a...), b...) {
+		if port <= 0 || seen[port] {
+			continue
+		}
+		seen[port] = true
+		merged = append(merged, port)
+	}
+	slices.Sort(merged)
+	return merged
+}
+
+// paneLabel returns the display label for a pane.
+// Priority: detected AI tool > custom pane title (non-default) > window name > "terminal".
+// Default pane titles (hostname, ".local" suffix) are suppressed so users see
+// meaningful names rather than OS-generated noise.
 func paneLabel(info *terminal.SessionInfo) string {
 	if info == nil {
 		return ""
@@ -265,10 +327,37 @@ func paneLabel(info *terminal.SessionInfo) string {
 	if info.DetectedTool != "" {
 		return info.DetectedTool
 	}
-	if info.PaneTitle != "" {
+	if info.PaneTitle != "" && !isDefaultPaneTitle(info.PaneTitle) {
 		return info.PaneTitle
 	}
+	if info.WindowName != "" {
+		return info.WindowName
+	}
 	return "terminal"
+}
+
+// isDefaultPaneTitle reports whether title is the default tmux pane title that
+// tmux sets automatically (process name or hostname). These should be suppressed
+// in favour of the window name so users see meaningful labels.
+func isDefaultPaneTitle(title string) bool {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return false
+	}
+	lowerTitle := strings.ToLower(title)
+	// tmux often sets the pane title to "hostname.local" on macOS.
+	if strings.HasSuffix(lowerTitle, ".local") {
+		return true
+	}
+	lowerHost := getHostname()
+	if lowerHost == "" {
+		return false
+	}
+	if lowerTitle == lowerHost {
+		return true
+	}
+	shortHost, _, _ := strings.Cut(lowerHost, ".")
+	return shortHost != "" && lowerTitle == shortHost
 }
 
 func aggregateStatus(current, next terminal.Status) terminal.Status {

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/colonyops/hive/internal/core/config"
+
 	tea "charm.land/bubbletea/v2"
 	"github.com/rs/zerolog/log"
 
@@ -32,6 +34,7 @@ type WindowStatus struct {
 	Status      terminal.Status
 	Tool        string
 	PaneContent string
+	HasAgent    bool
 	Panes       []PaneStatus
 }
 
@@ -55,7 +58,7 @@ type TerminalStatusBatchCompleteMsg struct {
 type TerminalPollTickMsg struct{}
 
 // FetchTerminalStatusBatch returns a command that fetches terminal status for multiple sessions.
-func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int) tea.Cmd {
+func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int, tmuxItems string) tea.Cmd {
 	if len(sessions) == 0 || !mgr.HasEnabledIntegrations() {
 		return nil
 	}
@@ -86,7 +89,7 @@ func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session
 				ctx, cancel := context.WithTimeout(context.Background(), terminalStatusTimeout)
 				defer cancel()
 
-				status := fetchTerminalStatusForSession(ctx, mgr, s)
+				status := fetchTerminalStatusForSession(ctx, mgr, s, tmuxItems)
 
 				mu.Lock()
 				results[s.ID] = status
@@ -100,7 +103,7 @@ func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session
 }
 
 // fetchTerminalStatusForSession fetches terminal status for a single session.
-func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, sess *session.Session) TerminalStatus {
+func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, sess *session.Session, tmuxItems string) TerminalStatus {
 	status := TerminalStatus{
 		Status: terminal.StatusMissing,
 	}
@@ -122,6 +125,13 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 	}
 
 	if info == nil || integration == nil {
+		if tmuxItems == config.TmuxItemsAll {
+			windows := discoverAllWindows(ctx, mgr, sess.Slug, metadata)
+			if len(windows) > 0 {
+				status.Status = terminal.StatusNeutral
+				status.Windows = windows
+			}
+		}
 		return status
 	}
 
@@ -142,14 +152,14 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 	var allInfos []*terminal.SessionInfo
 	var discErr error
 	if disc, ok := integration.(terminal.AllPanesDiscoverer); ok {
-		allInfos, discErr = disc.DiscoverAllPanes(ctx, sess.Slug, metadata)
+		allInfos, discErr = disc.DiscoverAllPanes(ctx, sess.Slug, metadata, tmuxItems == config.TmuxItemsAll)
 	}
 	if allInfos != nil || discErr != nil {
 		if discErr != nil {
 			log.Debug().Err(discErr).Str("session", sess.Slug).Msg("multi-window discovery failed, using single-window mode")
 		} else if len(allInfos) > 0 {
 			windows := groupPaneStatuses(ctx, integration, sess.Slug, allInfos)
-			if shouldExposeWindows(windows) {
+			if shouldExposeWindowsForMode(windows, tmuxItems) {
 				status.Windows = windows
 			}
 		}
@@ -158,22 +168,45 @@ func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, s
 	return status
 }
 
+func discoverAllWindows(ctx context.Context, mgr *terminal.Manager, slug string, metadata map[string]string) []WindowStatus {
+	for _, integration := range mgr.EnabledIntegrations() {
+		disc, ok := integration.(terminal.AllPanesDiscoverer)
+		if !ok {
+			continue
+		}
+		infos, err := disc.DiscoverAllPanes(ctx, slug, metadata, true)
+		if err != nil {
+			log.Debug().Err(err).Str("session", slug).Msg("all tmux item discovery failed")
+			continue
+		}
+		windows := groupPaneStatuses(ctx, integration, slug, infos)
+		if len(windows) > 0 {
+			return windows
+		}
+	}
+	return nil
+}
+
 func groupPaneStatuses(ctx context.Context, integration terminal.Integration, slug string, infos []*terminal.SessionInfo) []WindowStatus {
 	windows := make([]WindowStatus, 0, len(infos))
 	byWindow := make(map[string]int, len(infos))
 	for _, wi := range infos {
-		paneStatus, wErr := integration.GetStatus(ctx, wi)
-		if wErr != nil {
-			log.Debug().Err(wErr).Str("session", slug).Str("window", wi.WindowIndex).Str("pane", wi.PaneID).Msg("per-pane status failed, marking missing")
-			paneStatus = terminal.StatusMissing
+		paneStatus := terminal.Status("")
+		if wi.IsAgent {
+			var wErr error
+			paneStatus, wErr = integration.GetStatus(ctx, wi)
+			if wErr != nil {
+				log.Debug().Err(wErr).Str("session", slug).Str("window", wi.WindowIndex).Str("pane", wi.PaneID).Msg("per-pane status failed, marking missing")
+				paneStatus = terminal.StatusMissing
+			}
 		}
 
 		pane := PaneStatus{
 			PaneID:      wi.PaneID,
 			Status:      paneStatus,
-			Tool:        wi.DetectedTool,
+			Tool:        paneLabel(wi),
 			PaneContent: wi.PaneContent,
-			IsAgent:     true,
+			IsAgent:     wi.IsAgent,
 		}
 
 		// \x1f is an ASCII Unit Separator, which avoids collisions with printable tmux window names.
@@ -188,9 +221,11 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 				Status:      paneStatus,
 				Tool:        wi.DetectedTool,
 				PaneContent: wi.PaneContent,
+				HasAgent:    wi.IsAgent,
 			})
-		} else {
+		} else if wi.IsAgent {
 			windows[idx].Status = aggregateStatus(windows[idx].Status, paneStatus)
+			windows[idx].HasAgent = true
 			if windows[idx].Tool == "" {
 				windows[idx].Tool = wi.DetectedTool
 			}
@@ -203,11 +238,37 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 	return windows
 }
 
-func shouldExposeWindows(windows []WindowStatus) bool {
+func shouldExposeWindowsForMode(windows []WindowStatus, tmuxItems string) bool {
+	if len(windows) == 0 {
+		return false
+	}
+	if tmuxItems == config.TmuxItemsAll {
+		return shouldExposeAllTmuxItems(windows)
+	}
 	if len(windows) > 1 {
 		return true
 	}
 	return len(windows) == 1 && len(windows[0].Panes) > 1
+}
+
+func shouldExposeAllTmuxItems(windows []WindowStatus) bool {
+	if len(windows) > 1 {
+		return true
+	}
+	return len(windows) == 1 && len(windows[0].Panes) > 1
+}
+
+func paneLabel(info *terminal.SessionInfo) string {
+	if info == nil {
+		return ""
+	}
+	if info.DetectedTool != "" {
+		return info.DetectedTool
+	}
+	if info.PaneTitle != "" {
+		return info.PaneTitle
+	}
+	return "terminal"
 }
 
 func aggregateStatus(current, next terminal.Status) terminal.Status {

--- a/internal/tui/views/sessions/terminalstatus_test.go
+++ b/internal/tui/views/sessions/terminalstatus_test.go
@@ -16,9 +16,9 @@ func TestGroupPaneStatuses(t *testing.T) {
 		"%3": terminal.StatusActive,
 	}}
 	infos := []*terminal.SessionInfo{
-		{WindowIndex: "0", WindowName: "main", PaneID: "%1", DetectedTool: "claude", PaneContent: "ready"},
-		{WindowIndex: "0", WindowName: "main", PaneID: "%2", DetectedTool: "codex", PaneContent: "approval"},
-		{WindowIndex: "1", WindowName: "main", PaneID: "%3", DetectedTool: "aider", PaneContent: "active"},
+		{WindowIndex: "0", WindowName: "main", PaneID: "%1", DetectedTool: "claude", IsAgent: true, PaneContent: "ready"},
+		{WindowIndex: "0", WindowName: "main", PaneID: "%2", DetectedTool: "codex", IsAgent: true, PaneContent: "approval"},
+		{WindowIndex: "1", WindowName: "main", PaneID: "%3", DetectedTool: "aider", IsAgent: true, PaneContent: "active"},
 	}
 
 	got := groupPaneStatuses(context.Background(), integration, "sess", infos)
@@ -29,6 +29,26 @@ func TestGroupPaneStatuses(t *testing.T) {
 	assert.Len(t, got[0].Panes, 2)
 	assert.Equal(t, "1", got[1].WindowIndex)
 	assert.Equal(t, terminal.StatusActive, got[1].Status)
+}
+
+func TestGroupPaneStatuses_NonAgentDoesNotAffectWindowStatus(t *testing.T) {
+	integration := &fakeTerminalIntegration{statuses: map[string]terminal.Status{
+		"%1": terminal.StatusReady,
+	}}
+	infos := []*terminal.SessionInfo{
+		{WindowIndex: "0", WindowName: "main", PaneID: "%1", DetectedTool: "claude", IsAgent: true},
+		{WindowIndex: "0", WindowName: "main", PaneID: "%2", PaneTitle: "zsh", IsAgent: false},
+	}
+
+	got := groupPaneStatuses(context.Background(), integration, "sess", infos)
+
+	require.Len(t, got, 1)
+	assert.True(t, got[0].HasAgent)
+	assert.Equal(t, terminal.StatusReady, got[0].Status)
+	require.Len(t, got[0].Panes, 2)
+	assert.False(t, got[0].Panes[1].IsAgent)
+	assert.Equal(t, terminal.Status(""), got[0].Panes[1].Status)
+	assert.Equal(t, "zsh", got[0].Panes[1].Tool)
 }
 
 func TestAggregateStatus(t *testing.T) {

--- a/internal/tui/views/sessions/terminalstatus_test.go
+++ b/internal/tui/views/sessions/terminalstatus_test.go
@@ -3,7 +3,9 @@ package sessions
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,6 +77,44 @@ func TestStatusRank(t *testing.T) {
 	assert.Greater(t, statusRank(terminal.StatusActive), statusRank(terminal.StatusMissing))
 	assert.Greater(t, statusRank(terminal.StatusMissing), statusRank(terminal.StatusReady))
 	assert.Zero(t, statusRank(terminal.Status("unknown")))
+}
+
+func TestPaneLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		info *terminal.SessionInfo
+		want string
+	}{
+		{name: "detected tool wins", info: &terminal.SessionInfo{DetectedTool: "pi", WindowName: "agent", PaneTitle: "host.local"}, want: "pi"},
+		{name: "custom title", info: &terminal.SessionInfo{WindowName: "Python", PaneTitle: "worker"}, want: "worker"},
+		{name: "local host title falls back to window", info: &terminal.SessionInfo{WindowName: "Python", PaneTitle: "Haydens-MacBook-Pro-2.local"}, want: "Python"},
+		{name: "empty title falls back to window", info: &terminal.SessionInfo{WindowName: "shell"}, want: "shell"},
+		{name: "empty fields", info: &terminal.SessionInfo{}, want: "terminal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, paneLabel(tt.info))
+		})
+	}
+}
+
+func TestFetchTerminalStatusBatch_DefaultsInvalidWorkerCount(t *testing.T) {
+	mgr := terminal.NewManager([]string{"fake"})
+	mgr.Register(&fakeTerminalIntegration{})
+	cmd := FetchTerminalStatusBatch(mgr, []*session.Session{{ID: "s1", Slug: "s1", State: session.StateActive}}, 0, "")
+	require.NotNil(t, cmd)
+
+	done := make(chan struct{})
+	go func() {
+		_ = cmd()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("terminal status batch deadlocked with zero workers")
+	}
 }
 
 type fakeTerminalIntegration struct {

--- a/internal/tui/views/sessions/tree_items_test.go
+++ b/internal/tui/views/sessions/tree_items_test.go
@@ -67,7 +67,7 @@ func TestRenderPanePrefixContinuesParentWindowLine(t *testing.T) {
 		IsLastWindow: false,
 	}, false))
 
-	wantPrefix := "│   │   ├─"
+	wantPrefix := "  │  ├─"
 	if got[:len(wantPrefix)] != wantPrefix {
 		t.Fatalf("renderPane prefix = %q, want prefix %q", got, wantPrefix)
 	}
@@ -85,7 +85,7 @@ func TestRenderPanePrefixStopsAtLastWindow(t *testing.T) {
 		IsLastWindow: true,
 	}, false))
 
-	wantPrefix := "│       ├─"
+	wantPrefix := "     ├─"
 	if got[:len(wantPrefix)] != wantPrefix {
 		t.Fatalf("renderPane prefix = %q, want prefix %q", got, wantPrefix)
 	}

--- a/internal/tui/views/sessions/tree_items_test.go
+++ b/internal/tui/views/sessions/tree_items_test.go
@@ -1,11 +1,13 @@
 package sessions
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/list"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/pkg/kv"
 )
 
 func TestIsSession(t *testing.T) {
@@ -67,7 +69,8 @@ func TestRenderPanePrefixContinuesParentWindowLine(t *testing.T) {
 		IsLastWindow: false,
 	}, false))
 
-	wantPrefix := "  │  ├─"
+	// Session not last → "│   "; window not last → "│   "; then connector.
+	wantPrefix := "│   │   ├─"
 	if got[:len(wantPrefix)] != wantPrefix {
 		t.Fatalf("renderPane prefix = %q, want prefix %q", got, wantPrefix)
 	}
@@ -85,9 +88,43 @@ func TestRenderPanePrefixStopsAtLastWindow(t *testing.T) {
 		IsLastWindow: true,
 	}, false))
 
-	wantPrefix := "     ├─"
+	// Session not last → "│   "; window last → "    "; then connector.
+	wantPrefix := "│       ├─"
 	if got[:len(wantPrefix)] != wantPrefix {
 		t.Fatalf("renderPane prefix = %q, want prefix %q", got, wantPrefix)
+	}
+}
+
+func TestRenderSessionDoesNotShowAggregatePorts(t *testing.T) {
+	statuses := kv.New[string, TerminalStatus]()
+	statuses.Set("s1", TerminalStatus{Status: terminal.StatusReady, Ports: []int{3000, 8080}})
+	delegate := NewTreeDelegate()
+	delegate.TerminalStatuses = statuses
+	delegate.PreviewMode = true
+	item := TreeItem{Session: session.Session{ID: "s1", Name: "alpha", State: session.StateActive}}
+	model := list.New([]list.Item{item}, delegate, 80, 24)
+
+	got := terminal.StripANSI(delegate.renderSession(item, false, model, 0))
+	if strings.Contains(got, ":3000") || strings.Contains(got, ":8080") {
+		t.Fatalf("session row should not show aggregate ports: %q", got)
+	}
+}
+
+func TestRenderWindowAndPaneShowPorts(t *testing.T) {
+	statuses := kv.New[string, TerminalStatus]()
+	statuses.Set("s1", TerminalStatus{Windows: []WindowStatus{{WindowIndex: "0", WindowName: "main", Status: terminal.StatusReady, HasAgent: true, Ports: []int{3000}}}})
+	delegate := NewTreeDelegate()
+	delegate.TerminalStatuses = statuses
+	parent := session.Session{ID: "s1", Name: "alpha", State: session.StateActive}
+
+	window := terminal.StripANSI(delegate.renderWindow(TreeItem{IsWindowItem: true, WindowIndex: "0", WindowName: "main", ParentSession: parent}, false))
+	pane := terminal.StripANSI(delegate.renderPane(TreeItem{IsPaneItem: true, PaneID: "%2", PaneTool: "zsh", Ports: []int{8080}}, false))
+
+	if !strings.Contains(window, ":3000") {
+		t.Fatalf("window row should show ports: %q", window)
+	}
+	if !strings.Contains(pane, ":8080") {
+		t.Fatalf("pane row should show ports: %q", pane)
 	}
 }
 

--- a/internal/tui/views/sessions/tree_items_test.go
+++ b/internal/tui/views/sessions/tree_items_test.go
@@ -5,6 +5,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/core/terminal"
 )
 
 func TestIsSession(t *testing.T) {
@@ -51,6 +52,42 @@ func TestTreeItemsAll(t *testing.T) {
 	}
 	if !got[2].IsRecycledPlaceholder {
 		t.Error("third item should be recycled placeholder")
+	}
+}
+
+func TestRenderPanePrefixContinuesParentWindowLine(t *testing.T) {
+	delegate := NewTreeDelegate()
+	got := terminal.StripANSI(delegate.renderPane(TreeItem{
+		IsPaneItem:   true,
+		PaneID:       "%2",
+		PaneTool:     "claude",
+		PaneStatus:   terminal.StatusReady,
+		PaneIsAgent:  true,
+		IsLastInRepo: false,
+		IsLastWindow: false,
+	}, false))
+
+	wantPrefix := "│   │   ├─"
+	if got[:len(wantPrefix)] != wantPrefix {
+		t.Fatalf("renderPane prefix = %q, want prefix %q", got, wantPrefix)
+	}
+}
+
+func TestRenderPanePrefixStopsAtLastWindow(t *testing.T) {
+	delegate := NewTreeDelegate()
+	got := terminal.StripANSI(delegate.renderPane(TreeItem{
+		IsPaneItem:   true,
+		PaneID:       "%2",
+		PaneTool:     "claude",
+		PaneStatus:   terminal.StatusReady,
+		PaneIsAgent:  true,
+		IsLastInRepo: false,
+		IsLastWindow: true,
+	}, false))
+
+	wantPrefix := "│       ├─"
+	if got[:len(wantPrefix)] != wantPrefix {
+		t.Fatalf("renderPane prefix = %q, want prefix %q", got, wantPrefix)
 	}
 }
 

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -139,6 +139,7 @@ type TreeItem struct {
 	PaneTool     string
 	PaneStatus   terminal.Status
 	PaneIsAgent  bool
+	Ports        []int
 	ParentWindow string
 	IsLastPane   bool
 }
@@ -399,9 +400,14 @@ func (d TreeDelegate) renderRecycledPlaceholder(item TreeItem, isSelected bool) 
 
 // renderSession renders a session entry.
 func (d TreeDelegate) renderSession(item TreeItem, isSelected bool, m list.Model, index int) string {
-	// Session rows sit directly below the repo header; child tmux rows
-	// indent one level further to keep hierarchy clear.
-	prefixStyled := d.Styles.TreeLine.Render("")
+	// Tree prefix
+	var prefix string
+	if item.IsLastInRepo {
+		prefix = treeLast
+	} else {
+		prefix = treeBranch
+	}
+	prefixStyled := d.Styles.TreeLine.Render(prefix)
 
 	// Get terminal status if available
 	var termStatus *TerminalStatus
@@ -484,12 +490,18 @@ func (d TreeDelegate) renderPane(item TreeItem, isSelected bool) string {
 		connector = treeBranch
 	}
 
-	sessionLine := "  "
+	// Continue the parent session's line, then the parent window's line.
+	var sessionLine string
+	if item.IsLastInRepo {
+		sessionLine = "    " // session used └─
+	} else {
+		sessionLine = "│   " // session used ├─
+	}
 	var windowLine string
 	if item.IsLastWindow {
-		windowLine = "   "
+		windowLine = "    "
 	} else {
-		windowLine = "│  "
+		windowLine = "│   "
 	}
 	prefixStyled := d.Styles.TreeLine.Render(sessionLine + windowLine + connector)
 
@@ -512,8 +524,24 @@ func (d TreeDelegate) renderPane(item TreeItem, isSelected bool) string {
 	if item.PaneTool != "" {
 		name += " " + nameStyle.Render(item.PaneTool)
 	}
+	name += renderPorts(item.Ports)
 
 	return fmt.Sprintf("%s %s %s", prefixStyled, statusStr, name)
+}
+
+func renderPorts(ports []int) string {
+	if len(ports) == 0 {
+		return ""
+	}
+	limit := min(len(ports), 2)
+	parts := make([]string, 0, limit+1)
+	for _, port := range ports[:limit] {
+		parts = append(parts, fmt.Sprintf(":%d", port))
+	}
+	if extra := len(ports) - limit; extra > 0 {
+		parts = append(parts, fmt.Sprintf("+%d", extra))
+	}
+	return styles.TextWarningStyle.Render(" " + strings.Join(parts, " "))
 }
 
 func displayPaneID(paneID string) string {
@@ -532,7 +560,15 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 		connector = treeBranch
 	}
 
-	prefixStyled := d.Styles.TreeLine.Render("  " + connector)
+	// Continue the parent session's vertical line when it is not the last
+	// sibling in the repo group.
+	var parentLine string
+	if item.IsLastInRepo {
+		parentLine = "    " // parent used └─, no continuation
+	} else {
+		parentLine = "│   " // parent used ├─, line continues
+	}
+	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
 
 	// Get per-window terminal status from the delegate's store
 	var windowStatus *WindowStatus
@@ -584,8 +620,12 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 	if showIndex {
 		indexStr = d.Styles.SessionBranch.Render(fmt.Sprintf(" #%s", item.WindowIndex))
 	}
+	ports := ""
+	if windowStatus != nil {
+		ports = renderPorts(windowStatus.Ports)
+	}
 
-	return fmt.Sprintf("%s %s %s%s", prefixStyled, statusStr, name, indexStr)
+	return fmt.Sprintf("%s %s %s%s%s", prefixStyled, statusStr, name, indexStr, ports)
 }
 
 // renderGitStatus returns the formatted git status for a session path.

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -399,14 +399,9 @@ func (d TreeDelegate) renderRecycledPlaceholder(item TreeItem, isSelected bool) 
 
 // renderSession renders a session entry.
 func (d TreeDelegate) renderSession(item TreeItem, isSelected bool, m list.Model, index int) string {
-	// Tree prefix
-	var prefix string
-	if item.IsLastInRepo {
-		prefix = treeLast
-	} else {
-		prefix = treeBranch
-	}
-	prefixStyled := d.Styles.TreeLine.Render(prefix)
+	// Session rows sit directly below the repo header; child tmux rows
+	// indent one level further to keep hierarchy clear.
+	prefixStyled := d.Styles.TreeLine.Render("")
 
 	// Get terminal status if available
 	var termStatus *TerminalStatus
@@ -489,17 +484,12 @@ func (d TreeDelegate) renderPane(item TreeItem, isSelected bool) string {
 		connector = treeBranch
 	}
 
-	var sessionLine string
-	if item.IsLastInRepo {
-		sessionLine = "    "
-	} else {
-		sessionLine = "│   "
-	}
+	sessionLine := "  "
 	var windowLine string
 	if item.IsLastWindow {
-		windowLine = "    "
+		windowLine = "   "
 	} else {
-		windowLine = "│   "
+		windowLine = "│  "
 	}
 	prefixStyled := d.Styles.TreeLine.Render(sessionLine + windowLine + connector)
 
@@ -534,7 +524,7 @@ func displayPaneID(paneID string) string {
 }
 
 func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
-	// Deeper indent: "│     ├─" or "│     └─" depending on position
+	// Window rows sit one level under the session row.
 	var connector string
 	if item.IsLastWindow {
 		connector = treeLast
@@ -542,14 +532,7 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 		connector = treeBranch
 	}
 
-	// The parent session's tree line continues vertically
-	var parentLine string
-	if item.IsLastInRepo {
-		parentLine = "    " // parent was └─, no continuing line
-	} else {
-		parentLine = "│   " // parent was ├─, line continues
-	}
-	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
+	prefixStyled := d.Styles.TreeLine.Render("  " + connector)
 
 	// Get per-window terminal status from the delegate's store
 	var windowStatus *WindowStatus

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -73,6 +73,8 @@ func renderStatusIndicator(state session.State, termStatus *TerminalStatus, tree
 			return treeStyles.StatusApproval.Render(styles.StatusIndicatorApproval)
 		case terminal.StatusReady:
 			return treeStyles.StatusReady.Render(styles.StatusIndicatorReady)
+		case terminal.StatusNeutral:
+			return treeStyles.StatusUnknown.Render(styles.StatusIndicatorNeutral)
 		case terminal.StatusMissing:
 			return treeStyles.StatusUnknown.Render(styles.StatusIndicatorMissing)
 		}
@@ -136,6 +138,7 @@ type TreeItem struct {
 	PaneID       string
 	PaneTool     string
 	PaneStatus   terminal.Status
+	PaneIsAgent  bool
 	ParentWindow string
 	IsLastPane   bool
 }
@@ -486,18 +489,30 @@ func (d TreeDelegate) renderPane(item TreeItem, isSelected bool) string {
 		connector = treeBranch
 	}
 
-	var parentLine string
+	var sessionLine string
 	if item.IsLastInRepo {
-		parentLine = "        "
+		sessionLine = "    "
 	} else {
-		parentLine = "│       "
+		sessionLine = "│   "
 	}
-	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
+	var windowLine string
+	if item.IsLastWindow {
+		windowLine = "    "
+	} else {
+		windowLine = "│   "
+	}
+	prefixStyled := d.Styles.TreeLine.Render(sessionLine + windowLine + connector)
 
-	termStatus := &TerminalStatus{Status: item.PaneStatus}
-	statusStr := renderStatusIndicator(session.StateActive, termStatus, d.Styles, d.AnimationFrame)
+	statusStr := renderStatusIndicator(session.StateActive, &TerminalStatus{Status: terminal.StatusNeutral}, d.Styles, d.AnimationFrame)
+	if item.PaneIsAgent {
+		termStatus := &TerminalStatus{Status: item.PaneStatus}
+		statusStr = renderStatusIndicator(session.StateActive, termStatus, d.Styles, d.AnimationFrame)
+	}
 
 	nameStyle := d.Styles.SessionName
+	if !item.PaneIsAgent {
+		nameStyle = d.Styles.SessionID
+	}
 	if isSelected {
 		nameStyle = d.Styles.Selected
 	}
@@ -551,10 +566,13 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 
 	// Status indicator
 	var statusStr string
-	if windowStatus != nil {
+	switch {
+	case windowStatus != nil && windowStatus.HasAgent:
 		termStatus := &TerminalStatus{Status: windowStatus.Status}
 		statusStr = renderStatusIndicator(session.StateActive, termStatus, d.Styles, d.AnimationFrame)
-	} else {
+	case windowStatus != nil:
+		statusStr = renderStatusIndicator(session.StateActive, &TerminalStatus{Status: terminal.StatusNeutral}, d.Styles, d.AnimationFrame)
+	default:
 		statusStr = d.Styles.StatusUnknown.Render(styles.StatusIndicatorMissing)
 	}
 

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -291,7 +291,7 @@ func (v *View) handleSessionsLoaded(msg sessionsLoadedMsg) tea.Cmd {
 		for i := range v.allSessions {
 			sessPtrs[i] = &v.allSessions[i]
 		}
-		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.tmuxItemsMode()))
 	}
 	return tea.Batch(cmds...)
 }
@@ -344,7 +344,7 @@ func (v *View) handleTerminalPollTick() tea.Cmd {
 	for i := range allSess {
 		sessPtrs[i] = &v.allSessions[i]
 	}
-	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.tmuxItemsMode()))
 	if v.terminalManager.HasEnabledIntegrations() {
 		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
 	}
@@ -750,7 +750,7 @@ func (v *View) rebuildWindowItems() {
 		if !ti.IsSession() {
 			continue
 		}
-		if ts, ok := v.terminalStatuses.Get(ti.Session.ID); ok && shouldExposeWindows(ts.Windows) {
+		if ts, ok := v.terminalStatuses.Get(ti.Session.ID); ok && shouldExposeWindowsForMode(ts.Windows, v.tmuxItemsMode()) {
 			for _, w := range ts.Windows {
 				expected["w\x1f"+ti.Session.ID+"\x1f"+w.WindowIndex+"\x1f"+w.WindowName] = struct{}{}
 				if len(w.Panes) > 1 {
@@ -807,7 +807,7 @@ func (v *View) expandWindowItems(items []list.Item) []list.Item {
 		}
 
 		ts, ok := v.terminalStatuses.Get(treeItem.Session.ID)
-		if !ok || !shouldExposeWindows(ts.Windows) {
+		if !ok || !shouldExposeWindowsForMode(ts.Windows, v.tmuxItemsMode()) {
 			continue
 		}
 
@@ -829,6 +829,7 @@ func (v *View) expandWindowItems(items []list.Item) []list.Item {
 						PaneID:        p.PaneID,
 						PaneTool:      p.Tool,
 						PaneStatus:    p.Status,
+						PaneIsAgent:   p.IsAgent,
 						ParentWindow:  w.WindowIndex,
 						ParentSession: treeItem.Session,
 						IsLastPane:    j == len(w.Panes)-1,
@@ -1515,6 +1516,13 @@ func (v *View) ToggleGroupBy() tea.Cmd {
 // GroupBy returns the current tree view grouping mode.
 func (v *View) GroupBy() string {
 	return v.groupBy
+}
+
+func (v *View) tmuxItemsMode() string {
+	if v.cfg == nil || v.cfg.Views.Sessions.TmuxItems == "" {
+		return config.TmuxItemsAgents
+	}
+	return v.cfg.Views.Sessions.TmuxItems
 }
 
 // ApplyTheme resets delegate styles and clears cached animation colors for a theme change.

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -74,11 +74,12 @@ type View struct {
 	gitWorkers  int
 
 	// Terminal integration
-	terminalManager    *terminal.Manager
-	terminalStatuses   *kv.Store[string, TerminalStatus]
-	previewEnabled     bool
-	previewTemplates   *PreviewTemplates
-	currentTmuxSession string
+	terminalManager      *terminal.Manager
+	terminalStatuses     *kv.Store[string, TerminalStatus]
+	terminalPollInFlight bool
+	previewEnabled       bool
+	previewTemplates     *PreviewTemplates
+	currentTmuxSession   string
 
 	// Plugin integration
 	pluginManager      *plugins.Manager
@@ -286,12 +287,8 @@ func (v *View) handleSessionsLoaded(msg sessionsLoadedMsg) tea.Cmd {
 	}
 	// Immediately fetch terminal status so newly created sessions are detected
 	// without waiting for the next scheduled poll tick (up to 1500ms delay).
-	if v.terminalManager != nil && v.terminalManager.HasEnabledIntegrations() && len(v.allSessions) > 0 {
-		sessPtrs := make([]*session.Session, len(v.allSessions))
-		for i := range v.allSessions {
-			sessPtrs[i] = &v.allSessions[i]
-		}
-		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.tmuxItemsMode()))
+	if cmd := v.startTerminalStatusBatch(); cmd != nil {
+		cmds = append(cmds, cmd)
 	}
 	return tea.Batch(cmds...)
 }
@@ -303,6 +300,7 @@ func (v *View) handleGitStatusComplete(msg GitStatusBatchCompleteMsg) tea.Cmd {
 }
 
 func (v *View) handleTerminalStatusComplete(msg TerminalStatusBatchCompleteMsg) tea.Cmd {
+	v.terminalPollInFlight = false
 	if v.terminalStatuses != nil {
 		for sessionID, newStatus := range msg.Results {
 			if newStatus.Error != nil {
@@ -339,16 +337,33 @@ func (v *View) handleTerminalStatusComplete(msg TerminalStatusBatchCompleteMsg) 
 
 func (v *View) handleTerminalPollTick() tea.Cmd {
 	var cmds []tea.Cmd
+	if cmd := v.startTerminalStatusBatch(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	if v.terminalManager != nil && v.terminalManager.HasEnabledIntegrations() {
+		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
+	}
+	return tea.Batch(cmds...)
+}
+
+// startTerminalStatusBatch dispatches a terminal status fetch for all sessions.
+// The terminalPollInFlight guard prevents overlapping fetches from queuing up
+// during slow poll cycles — only one batch runs at a time.
+func (v *View) startTerminalStatusBatch() tea.Cmd {
+	if v.terminalPollInFlight || v.terminalManager == nil || !v.terminalManager.HasEnabledIntegrations() || len(v.allSessions) == 0 {
+		return nil
+	}
 	allSess := v.allSessions
 	sessPtrs := make([]*session.Session, len(allSess))
 	for i := range allSess {
 		sessPtrs[i] = &v.allSessions[i]
 	}
-	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.tmuxItemsMode()))
-	if v.terminalManager.HasEnabledIntegrations() {
-		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
+	cmd := FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers, v.tmuxItemsMode())
+	if cmd == nil {
+		return nil
 	}
-	return tea.Batch(cmds...)
+	v.terminalPollInFlight = true
+	return cmd
 }
 
 func (v *View) handlePluginWorkerStarted(msg pluginWorkerStartedMsg) tea.Cmd {
@@ -830,6 +845,7 @@ func (v *View) expandWindowItems(items []list.Item) []list.Item {
 						PaneTool:      p.Tool,
 						PaneStatus:    p.Status,
 						PaneIsAgent:   p.IsAgent,
+						Ports:         append([]int(nil), p.Ports...),
 						ParentWindow:  w.WindowIndex,
 						ParentSession: treeItem.Session,
 						IsLastPane:    j == len(w.Panes)-1,
@@ -1539,9 +1555,11 @@ func (v *View) LocalRemote() string {
 
 // --- Package-level utility functions ---
 
-// isActiveStatus returns true for any session with a live terminal (not missing).
+// isActiveStatus returns true for any session with a live agent terminal.
+// StatusNeutral is excluded because it indicates only non-agent (shell) panes,
+// which are not considered "active" for navigation purposes.
 func isActiveStatus(s terminal.Status) bool {
-	return s != terminal.StatusMissing && s != ""
+	return s != terminal.StatusMissing && s != "" && s != terminal.StatusNeutral
 }
 
 // IsFilterAction returns true if the action type is a filter action.

--- a/internal/tui/views/sessions/view_test.go
+++ b/internal/tui/views/sessions/view_test.go
@@ -464,6 +464,30 @@ func TestHandleSessionsLoaded_NoTerminalPollWithoutIntegrations(t *testing.T) {
 	assert.Equal(t, sessions, v.allSessions)
 }
 
+func TestStartTerminalStatusBatch_SkipsWhileInFlight(t *testing.T) {
+	sessions := []session.Session{
+		{ID: "s1", Name: "session", State: session.StateActive},
+	}
+	v := newViewWithTerminalMgr(sessions)
+
+	cmd := v.startTerminalStatusBatch()
+	assert.NotNil(t, cmd)
+	assert.True(t, v.terminalPollInFlight)
+
+	cmd = v.startTerminalStatusBatch()
+	assert.Nil(t, cmd, "must not start overlapping terminal status batches")
+}
+
+func TestHandleTerminalStatusComplete_ClearsInFlight(t *testing.T) {
+	v := newViewWithTerminalMgr(nil)
+	v.terminalPollInFlight = true
+
+	cmd := v.handleTerminalStatusComplete(TerminalStatusBatchCompleteMsg{})
+
+	assert.Nil(t, cmd)
+	assert.False(t, v.terminalPollInFlight)
+}
+
 func TestApplyFilter_GroupByGroup(t *testing.T) {
 	sessions := []session.Session{
 		{ID: "s1", Name: "alpha", Metadata: map[string]string{"group": "backend"}},

--- a/internal/tui/views/sessions/view_test.go
+++ b/internal/tui/views/sessions/view_test.go
@@ -111,6 +111,37 @@ func TestExpandWindowItems_OneWindow(t *testing.T) {
 	assert.Len(t, got, 1, "session with 1 window should not be expanded (threshold is >1)")
 }
 
+func TestExpandWindowItems_AllTmuxItemsKeepsSinglePaneCollapsed(t *testing.T) {
+	tests := []struct {
+		name string
+		pane PaneStatus
+	}{
+		{name: "shell", pane: PaneStatus{PaneID: "%1", Tool: "zsh", Status: terminal.StatusNeutral}},
+		{name: "agent", pane: PaneStatus{PaneID: "%1", Tool: "claude", Status: terminal.StatusReady, IsAgent: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := kv.New[string, TerminalStatus]()
+			ts.Set("s1", TerminalStatus{
+				Windows: []WindowStatus{{
+					WindowIndex: "0",
+					WindowName:  "main",
+					HasAgent:    tt.pane.IsAgent,
+					Panes:       []PaneStatus{tt.pane},
+				}},
+			})
+			cfg := config.DefaultConfig()
+			cfg.Views.Sessions.TmuxItems = config.TmuxItemsAll
+			v := &View{terminalStatuses: ts, cfg: &cfg}
+
+			items := []list.Item{TreeItem{Session: session.Session{ID: "s1"}}}
+			got := v.expandWindowItems(items)
+			assert.Len(t, got, 1, "all tmux items should keep a single pane collapsed")
+		})
+	}
+}
+
 func TestExpandWindowItems_OneWindowMultiplePanes(t *testing.T) {
 	ts := kv.New[string, TerminalStatus]()
 	ts.Set("s1", TerminalStatus{
@@ -188,6 +219,28 @@ func TestExpandWindowItems_MultipleWindows(t *testing.T) {
 	w1 := got[2].(TreeItem)
 	assert.True(t, w1.IsWindowItem)
 	assert.True(t, w1.IsLastWindow, "last window should be marked")
+}
+
+func TestExpandWindowItems_AllTmuxItemsMultipleSinglePaneWindowsDoesNotShowPanes(t *testing.T) {
+	ts := kv.New[string, TerminalStatus]()
+	ts.Set("s1", TerminalStatus{
+		Windows: []WindowStatus{
+			{WindowIndex: "0", WindowName: "pi", HasAgent: true, Panes: []PaneStatus{{PaneID: "%1", Tool: "pi", IsAgent: true, Status: terminal.StatusReady}}},
+			{WindowIndex: "1", WindowName: "shell", Panes: []PaneStatus{{PaneID: "%2", Tool: "zsh", Status: terminal.StatusNeutral}}},
+		},
+	})
+	cfg := config.DefaultConfig()
+	cfg.Views.Sessions.TmuxItems = config.TmuxItemsAll
+	v := &View{terminalStatuses: ts, cfg: &cfg}
+
+	items := []list.Item{TreeItem{Session: session.Session{ID: "s1"}, RepoPrefix: "repo"}}
+	got := v.expandWindowItems(items)
+
+	assert.Len(t, got, 3, "single-pane windows should render as window rows only")
+	for _, item := range got {
+		ti := item.(TreeItem)
+		assert.False(t, ti.IsPaneItem)
+	}
 }
 
 func TestExpandWindowItems_NonSessionPassthrough(t *testing.T) {


### PR DESCRIPTION
## Purpose

Add a `tmux_items` config option (`agents` | `all`) that controls what appears in the sessions tree. In `all` mode, every tmux window and pane tied to a hive session is visible — not just panes where an agent was detected. Non-agent panes are displayed with a neutral indicator and their listening ports are surfaced.

## Proposed Changes

  - New `views.sessions.tmux_items` config field; default is `all`
  - `StatusNeutral` for panes that exist but have no detected agent
  - Port discovery for non-agent panes via `lsof` (batched per refresh cycle, 500ms timeout)
  - Port display (`:3000 :8080 +N`) on window and pane rows
  - In-flight guard on terminal status polling to prevent overlapping fetches
  - Smarter tmux target resolution when opening a pane via the window lookup

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)