### PR TITLE
Add pane support to window configs

### DIFF
--- a/docs/configuration/commands.md
+++ b/docs/configuration/commands.md
@@ -122,12 +122,22 @@ The `windows` field opens one or more tmux windows in the current session after 
 
 ### Window Fields
 
+| Field     | Type         | Description                                             |
+| --------- | ------------ | ------------------------------------------------------- |
+| `name`    | string       | Window name (required, template string)                 |
+| `command` | string       | Command to run in a single-pane window (template string). Mutually exclusive with `panes`. |
+| `dir`     | string       | Working directory override (template string)            |
+| `focus`   | bool         | Select this window after creation                       |
+| `panes`   | []PaneConfig | Panes to create in the window. Mutually exclusive with `command`. |
+
+### Pane Fields
+
 | Field     | Type   | Description                                             |
 | --------- | ------ | ------------------------------------------------------- |
-| `name`    | string | Window name (required, template string)                 |
-| `command` | string | Command to run in the window (template string)          |
+| `command` | string | Command to run in the pane (template string)            |
 | `dir`     | string | Working directory override (template string)            |
-| `focus`   | bool   | Select this window after creation                       |
+| `size`    | string | Size passed to `tmux split-window -l` (for example `30%`) |
+| `split`   | string | Split direction: `horizontal` or `vertical` (default `vertical`) |
 
 ### Options Fields
 

--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -59,12 +59,16 @@ rules:
 
 The `windows` field defines tmux windows declaratively. Each window has:
 
-| Field     | Type   | Required | Default       | Description                                    |
-| --------- | ------ | -------- | ------------- | ---------------------------------------------- |
-| `name`    | string | yes      | —             | Window name (supports templates)               |
-| `command` | string | no       | default shell | Command to run in the window (supports templates) |
-| `dir`     | string | no       | session path  | Working directory override (supports templates) |
-| `focus`   | bool   | no       | `false`       | Select this window after creation              |
+| Field     | Type         | Required | Default       | Description                                    |
+| --------- | ------------ | -------- | ------------- | ---------------------------------------------- |
+| `name`    | string       | yes      | —             | Window name (supports templates)               |
+| `command` | string       | no       | default shell | Command to run in the window (supports templates). Mutually exclusive with `panes`. |
+| `dir`     | string       | no       | session path  | Working directory override (supports templates) |
+| `focus`   | bool         | no       | `false`       | Select this window after creation              |
+| `panes`   | []PaneConfig | no       | single pane   | Panes to create in the window. Mutually exclusive with `command`. |
+
+!!! warning "`command` vs `panes`"
+    A window must use either `command` or `panes`, not both. Use `command` for a single-pane window. Use `panes` when you need splits inside the window.
 
 **Default window layout** (used when no rule specifies `windows` or `spawn`):
 
@@ -112,13 +116,38 @@ windows:
   - name: shell
 ```
 
+**Split panes inside a window:**
+
+```yaml
+windows:
+  - name: agent
+    focus: true
+    panes:
+      - command: "claude"
+      - command: "npm test -- --watch"
+        split: horizontal
+        size: 30%
+  - name: shell
+```
+
+## Pane Configuration
+
+The `panes` field defines tmux panes inside a window. The first pane becomes the initial pane for the window. Additional panes are created with `tmux split-window`.
+
+| Field     | Type   | Required | Default       | Description                                    |
+| --------- | ------ | -------- | ------------- | ---------------------------------------------- |
+| `command` | string | no       | default shell | Command to run in the pane (supports templates) |
+| `dir`     | string | no       | window/session path | Working directory override (supports templates) |
+| `size`    | string | no       | tmux default  | Size passed to `tmux split-window -l` (for example `30%`) |
+| `split`   | string | no       | `vertical`    | Split direction: `horizontal` or `vertical` |
+
 ## Template Variables
 
 Commands support Go templates with `{{ .Variable }}` syntax and `{{ .Variable | shq }}` for shell-safe quoting.
 
 | Context                | Variables                                                           |
 | ---------------------- | ------------------------------------------------------------------- |
-| `rules[].windows`      | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo`, `.Prompt` (batch) |
+| `rules[].windows` / `panes` | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo`, `.Prompt` (batch) |
 | `rules[].spawn`        | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo`         |
 | `rules[].batch_spawn`  | Same as spawn, plus `.Prompt`                                       |
 | `rules[].commands`     | `.Path`, `.Name`, `.Slug`, `.ContextDir`, `.Owner`, `.Repo`, `.ID` |

--- a/internal/core/action/action.go
+++ b/internal/core/action/action.go
@@ -1,5 +1,13 @@
 package action
 
+// PaneSpec is a fully-rendered pane definition carried in a SpawnWindows action.
+type PaneSpec struct {
+	Command string
+	Dir     string
+	Size    string
+	Split   string
+}
+
 // WindowSpec is a fully-rendered window definition carried in a SpawnWindows action.
 // Fields mirror coretmux.RenderedWindow to avoid a cross-package dependency on the tmux layer.
 type WindowSpec struct {
@@ -7,6 +15,7 @@ type WindowSpec struct {
 	Command string
 	Dir     string
 	Focus   bool
+	Panes   []PaneSpec
 }
 
 // NewSessionRequest carries parameters for creating a new Hive session before spawning windows.

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -599,12 +599,21 @@ type GitConfig struct {
 	StatusWorkers int `json:"status_workers" yaml:"status_workers"`
 }
 
-// WindowConfig defines a tmux window to create when spawning a session.
-type WindowConfig struct {
-	Name    string `json:"name"              yaml:"name"`              // Window name (template string, required)
+// PaneConfig defines a tmux pane to create inside a window.
+type PaneConfig struct {
 	Command string `json:"command,omitempty" yaml:"command,omitempty"` // Command to run (template string, empty = shell)
 	Dir     string `json:"dir,omitempty"     yaml:"dir,omitempty"`     // Working directory override (template string)
-	Focus   bool   `json:"focus,omitempty"   yaml:"focus,omitempty"`   // Select this window after creation
+	Size    string `json:"size,omitempty"    yaml:"size,omitempty"`    // Pane size passed to tmux -l (for example "30%")
+	Split   string `json:"split,omitempty"   yaml:"split,omitempty"`   // Split direction: horizontal or vertical (default vertical)
+}
+
+// WindowConfig defines a tmux window to create when spawning a session.
+type WindowConfig struct {
+	Name    string       `json:"name"              yaml:"name"`              // Window name (template string, required)
+	Command string       `json:"command,omitempty" yaml:"command,omitempty"` // Command to run (template string, empty = shell); mutually exclusive with Panes
+	Dir     string       `json:"dir,omitempty"     yaml:"dir,omitempty"`     // Working directory override (template string)
+	Focus   bool         `json:"focus,omitempty"   yaml:"focus,omitempty"`   // Select this window after creation
+	Panes   []PaneConfig `json:"panes,omitempty"   yaml:"panes,omitempty"`   // Panes to create in this window; mutually exclusive with Command
 }
 
 // Rule defines actions to take for matching repositories.
@@ -1017,10 +1026,19 @@ func (c *Config) validateWindowsBasic() error {
 			errs = errs.Append(fmt.Sprintf("rules[%d]", i), fmt.Errorf("cannot have both windows and batch_spawn"))
 		}
 
-		// Each window must have a name
+		// Each window must have a name and cannot mix command with panes.
 		for j, w := range rule.Windows {
+			field := fmt.Sprintf("rules[%d].windows[%d]", i, j)
 			if w.Name == "" {
-				errs = errs.Append(fmt.Sprintf("rules[%d].windows[%d].name", i, j), fmt.Errorf("is required"))
+				errs = errs.Append(field+".name", fmt.Errorf("is required"))
+			}
+			if w.Command != "" && len(w.Panes) > 0 {
+				errs = errs.Append(field, fmt.Errorf("command and panes are mutually exclusive"))
+			}
+			for k, p := range w.Panes {
+				if p.Split != "" && p.Split != "horizontal" && p.Split != "vertical" {
+					errs = errs.Append(fmt.Sprintf("%s.panes[%d].split", field, k), fmt.Errorf("must be one of: horizontal, vertical"))
+				}
 			}
 		}
 	}

--- a/internal/core/config/usercommand_validation.go
+++ b/internal/core/config/usercommand_validation.go
@@ -38,6 +38,14 @@ func ValidateUserCommandBasic(field, name string, cmd UserCommand) criterio.Fiel
 		if w.Name == "" {
 			errs = errs.Append(wfield, fmt.Errorf("name is required"))
 		}
+		if w.Command != "" && len(w.Panes) > 0 {
+			errs = errs.Append(wfield, fmt.Errorf("command and panes are mutually exclusive"))
+		}
+		for j, p := range w.Panes {
+			if p.Split != "" && p.Split != "horizontal" && p.Split != "vertical" {
+				errs = errs.Append(fmt.Sprintf("%s.panes[%d].split", wfield, j), fmt.Errorf("must be one of: horizontal, vertical"))
+			}
+		}
 	}
 
 	if cmd.Options.Remote != "" && cmd.Options.SessionName == "" {
@@ -115,6 +123,21 @@ func ValidateUserCommandTemplates(field string, cmd UserCommand) criterio.FieldE
 			}
 			if err := validateTemplate(tmplStr, testData); err != nil {
 				errs = errs.Append(wfield+tname, err)
+			}
+		}
+		for j, p := range w.Panes {
+			pfield := fmt.Sprintf("%s.panes[%d]", wfield, j)
+			for tname, tmplStr := range map[string]string{
+				".command": p.Command,
+				".dir":     p.Dir,
+				".size":    p.Size,
+			} {
+				if tmplStr == "" {
+					continue
+				}
+				if err := validateTemplate(tmplStr, testData); err != nil {
+					errs = errs.Append(pfield+tname, err)
+				}
 			}
 		}
 	}

--- a/internal/core/config/validate.go
+++ b/internal/core/config/validate.go
@@ -211,6 +211,24 @@ func (c *Config) validateRules() error {
 					errs = errs.Append(prefix+".dir", fmt.Errorf("template error: %w", err))
 				}
 			}
+			for k, p := range w.Panes {
+				panePrefix := fmt.Sprintf("%s.panes[%d]", prefix, k)
+				if p.Command != "" {
+					if err := validateTemplate(p.Command, BatchSpawnTemplateData{}); err != nil {
+						errs = errs.Append(panePrefix+".command", fmt.Errorf("template error: %w", err))
+					}
+				}
+				if p.Dir != "" {
+					if err := validateTemplate(p.Dir, BatchSpawnTemplateData{}); err != nil {
+						errs = errs.Append(panePrefix+".dir", fmt.Errorf("template error: %w", err))
+					}
+				}
+				if p.Size != "" {
+					if err := validateTemplate(p.Size, BatchSpawnTemplateData{}); err != nil {
+						errs = errs.Append(panePrefix+".size", fmt.Errorf("template error: %w", err))
+					}
+				}
+			}
 		}
 		// Validate branch_template
 		if rule.BranchTemplate != "" {

--- a/internal/core/config/validate_test.go
+++ b/internal/core/config/validate_test.go
@@ -552,6 +552,36 @@ func TestValidate_UserCommandWindowsOnly(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidate_UserCommandWindowCommandAndPanes(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.UserCommands = map[string]UserCommand{
+		"spawn": {
+			Windows: []WindowConfig{{Name: "agent", Command: "claude", Panes: []PaneConfig{{Command: "npm test"}}}},
+		},
+	}
+
+	err := cfg.Validate()
+	var fieldErrs criterio.FieldErrors
+	require.ErrorAs(t, err, &fieldErrs)
+	assert.Contains(t, fieldErrs[0].Field, "windows[0]")
+	assert.Contains(t, fieldErrs[0].Err.Error(), "command and panes are mutually exclusive")
+}
+
+func TestValidate_UserCommandWindowInvalidPaneSplit(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.UserCommands = map[string]UserCommand{
+		"spawn": {
+			Windows: []WindowConfig{{Name: "agent", Panes: []PaneConfig{{Split: "diagonal"}}}},
+		},
+	}
+
+	err := cfg.Validate()
+	var fieldErrs criterio.FieldErrors
+	require.ErrorAs(t, err, &fieldErrs)
+	assert.Contains(t, fieldErrs[0].Field, "windows[0].panes[0].split")
+	assert.Contains(t, fieldErrs[0].Err.Error(), "must be one of: horizontal, vertical")
+}
+
 func TestValidate_UserCommandWindowsMissingName(t *testing.T) {
 	cfg := validConfig(t)
 	cfg.UserCommands = map[string]UserCommand{
@@ -617,8 +647,15 @@ func TestValidateDeep_UserCommandWindowTemplates(t *testing.T) {
 		cfg.UserCommands = map[string]UserCommand{
 			"spawn": {
 				Windows: []WindowConfig{
-					{Name: "{{ .Name }}-agent", Command: "claude --session {{ .ID }}"},
+					{
+						Name: "{{ .Name }}-agent",
+						Panes: []PaneConfig{
+							{Command: "claude --session {{ .ID }}"},
+							{Command: "npm test {{ .Form.target }}", Size: "30%"},
+						},
+					},
 				},
+				Form: []FormField{{Variable: "target", Label: "Target", Type: "text"}},
 			},
 		}
 
@@ -1390,6 +1427,29 @@ func TestValidate_WindowsMutualExclusive(t *testing.T) {
 			},
 		},
 		{
+			name: "window command and panes",
+			rule: Rule{
+				Pattern: "",
+				Windows: []WindowConfig{{
+					Name:    "agent",
+					Command: "claude",
+					Panes:   []PaneConfig{{Command: "npm test"}},
+				}},
+			},
+			wantErr: "command and panes are mutually exclusive",
+		},
+		{
+			name: "invalid pane split",
+			rule: Rule{
+				Pattern: "",
+				Windows: []WindowConfig{{
+					Name:  "agent",
+					Panes: []PaneConfig{{Command: "npm test", Split: "diagonal"}},
+				}},
+			},
+			wantErr: "must be one of: horizontal, vertical",
+		},
+		{
 			name: "spawn only is valid",
 			rule: Rule{
 				Pattern: "",
@@ -1440,7 +1500,14 @@ func TestValidateDeep_WindowTemplates(t *testing.T) {
 				Pattern: "",
 				Windows: []WindowConfig{
 					{Name: "claude", Command: "claude {{ .Name }}", Focus: true},
-					{Name: "shell", Dir: "{{ .Path }}"},
+					{
+						Name: "shell",
+						Dir:  "{{ .Path }}",
+						Panes: []PaneConfig{
+							{Command: "npm test {{ .Prompt }}", Size: "{{ .Name }}", Split: "horizontal"},
+							{Dir: "{{ .ContextDir }}"},
+						},
+					},
 				},
 			},
 		}
@@ -1498,6 +1565,23 @@ func TestValidateDeep_WindowTemplates(t *testing.T) {
 		var fieldErrs criterio.FieldErrors
 		require.ErrorAs(t, err, &fieldErrs)
 		assert.Contains(t, fieldErrs[0].Field, "windows[0].dir")
+	})
+
+	t.Run("invalid pane template", func(t *testing.T) {
+		cfg := validConfig(t)
+		cfg.Rules = []Rule{
+			{
+				Pattern: "",
+				Windows: []WindowConfig{
+					{Name: "agent", Panes: []PaneConfig{{Command: "{{ .Missing }}"}}},
+				},
+			},
+		}
+
+		err := cfg.ValidateDeep("")
+		var fieldErrs criterio.FieldErrors
+		require.ErrorAs(t, err, &fieldErrs)
+		assert.Contains(t, fieldErrs[0].Field, "windows[0].panes[0].command")
 	})
 
 	t.Run("Prompt template valid in windows", func(t *testing.T) {

--- a/internal/core/tmux/client.go
+++ b/internal/core/tmux/client.go
@@ -14,12 +14,21 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// RenderedPane is a fully-resolved tmux pane definition (no templates).
+type RenderedPane struct {
+	Command string // Command to run (empty = default shell)
+	Dir     string // Working directory (empty = window/session default)
+	Size    string // Pane size passed to tmux -l (empty = tmux default)
+	Split   string // Split direction: horizontal or vertical (default vertical)
+}
+
 // RenderedWindow is a fully-resolved tmux window definition (no templates).
 type RenderedWindow struct {
-	Name    string // Window name
-	Command string // Command to run (empty = default shell)
-	Dir     string // Working directory (empty = session default)
-	Focus   bool   // Select this window after creation
+	Name    string         // Window name
+	Command string         // Command to run (empty = default shell); ignored when Panes is non-empty
+	Dir     string         // Working directory (empty = session default)
+	Focus   bool           // Select this window after creation
+	Panes   []RenderedPane // Panes to create in this window; mutually exclusive with Command
 }
 
 // Client creates and manages tmux sessions from window definitions.
@@ -50,12 +59,7 @@ func (c *Client) CreateSession(ctx context.Context, name, workDir string, window
 	// Create session with the first window.
 	first := windows[0]
 	args := []string{"new-session", "-d", "-s", name, "-n", first.Name}
-	if dir := windowDir(first, workDir); dir != "" {
-		args = append(args, "-c", dir)
-	}
-	if first.Command != "" {
-		args = append(args, "--", "sh", "-c", first.Command)
-	}
+	args = appendInitialPaneArgs(args, first, workDir)
 
 	c.log.Debug().Strs("args", args).Msg("tmux new-session")
 	if out, err := c.exec.Run(ctx, "tmux", args...); err != nil {
@@ -70,22 +74,17 @@ func (c *Client) CreateSession(ctx context.Context, name, workDir string, window
 	// windows are created programmatically.
 	c.suppressInteractiveHooks(ctx, name)
 
+	if err := c.splitAdditionalPanes(ctx, name, workDir, first); err != nil {
+		_, _ = c.exec.Run(ctx, "tmux", "kill-session", "-t", name)
+		return err
+	}
+
 	// Create additional windows. On failure, kill the partial session.
 	for _, w := range windows[1:] {
-		args := []string{"new-window", "-t", name, "-n", w.Name}
-		if dir := windowDir(w, workDir); dir != "" {
-			args = append(args, "-c", dir)
-		}
-		if w.Command != "" {
-			args = append(args, "--", "sh", "-c", w.Command)
-		}
-
-		c.log.Debug().Strs("args", args).Msg("tmux new-window")
-		if out, err := c.exec.Run(ctx, "tmux", args...); err != nil {
+		if err := c.createWindow(ctx, name, workDir, w); err != nil {
 			_, _ = c.exec.Run(ctx, "tmux", "kill-session", "-t", name)
-			return fmt.Errorf("tmux new-window %q: %w; output: %s", w.Name, err, strings.TrimSpace(string(out)))
+			return err
 		}
-		c.tagPanesWithSession(ctx, name+":"+w.Name, name)
 	}
 
 	// Select the focused window (default to first).
@@ -113,17 +112,9 @@ func (c *Client) CreateSession(ctx context.Context, name, workDir string, window
 func (c *Client) AddWindows(ctx context.Context, name, workDir string, windows []RenderedWindow) error {
 	c.suppressInteractiveHooks(ctx, name)
 	for _, w := range windows {
-		args := []string{"new-window", "-t", name, "-n", w.Name}
-		if dir := windowDir(w, workDir); dir != "" {
-			args = append(args, "-c", dir)
+		if err := c.createWindow(ctx, name, workDir, w); err != nil {
+			return err
 		}
-		if w.Command != "" {
-			args = append(args, "--", "sh", "-c", w.Command)
-		}
-		if _, err := c.exec.Run(ctx, "tmux", args...); err != nil {
-			return fmt.Errorf("tmux new-window %q: %w", w.Name, err)
-		}
-		c.tagPanesWithSession(ctx, name+":"+w.Name, name)
 	}
 	for _, w := range windows {
 		if w.Focus {
@@ -219,6 +210,79 @@ func (c *Client) suppressInteractiveHooks(ctx context.Context, session string) {
 			c.log.Debug().Err(err).Str("hook", h).Msg("failed to suppress hook")
 		}
 	}
+}
+
+func (c *Client) createWindow(ctx context.Context, sessionName, workDir string, w RenderedWindow) error {
+	args := []string{"new-window", "-t", sessionName, "-n", w.Name}
+	args = appendInitialPaneArgs(args, w, workDir)
+
+	c.log.Debug().Strs("args", args).Msg("tmux new-window")
+	if out, err := c.exec.Run(ctx, "tmux", args...); err != nil {
+		return fmt.Errorf("tmux new-window %q: %w; output: %s", w.Name, err, strings.TrimSpace(string(out)))
+	}
+	c.tagPanesWithSession(ctx, sessionName+":"+w.Name, sessionName)
+	return c.splitAdditionalPanes(ctx, sessionName, workDir, w)
+}
+
+func (c *Client) splitAdditionalPanes(ctx context.Context, sessionName, workDir string, w RenderedWindow) error {
+	windowTarget := sessionName + ":" + w.Name
+	for _, pane := range additionalPanes(w) {
+		args := splitPaneArgs(windowTarget, pane, windowDir(w, workDir))
+		c.log.Debug().Strs("args", args).Msg("tmux split-window")
+		if out, err := c.exec.Run(ctx, "tmux", args...); err != nil {
+			return fmt.Errorf("tmux split-window %q: %w; output: %s", w.Name, err, strings.TrimSpace(string(out)))
+		}
+		c.tagPanesWithSession(ctx, windowTarget, sessionName)
+	}
+	return nil
+}
+
+func appendInitialPaneArgs(args []string, w RenderedWindow, sessionDir string) []string {
+	command := w.Command
+	dir := windowDir(w, sessionDir)
+	if len(w.Panes) > 0 {
+		command = w.Panes[0].Command
+		if w.Panes[0].Dir != "" {
+			dir = w.Panes[0].Dir
+		}
+	}
+	if dir != "" {
+		args = append(args, "-c", dir)
+	}
+	if command != "" {
+		args = append(args, "--", "sh", "-c", command)
+	}
+	return args
+}
+
+func splitPaneArgs(target string, p RenderedPane, fallbackDir string) []string {
+	args := []string{"split-window", "-t", target}
+	if p.Split == "horizontal" {
+		args = append(args, "-h")
+	} else {
+		args = append(args, "-v")
+	}
+	if p.Size != "" {
+		args = append(args, "-l", p.Size)
+	}
+	dir := p.Dir
+	if dir == "" {
+		dir = fallbackDir
+	}
+	if dir != "" {
+		args = append(args, "-c", dir)
+	}
+	if p.Command != "" {
+		args = append(args, "--", "sh", "-c", p.Command)
+	}
+	return args
+}
+
+func additionalPanes(w RenderedWindow) []RenderedPane {
+	if len(w.Panes) <= 1 {
+		return nil
+	}
+	return w.Panes[1:]
 }
 
 // windowDir returns the working directory for a window, falling back to the session default.

--- a/internal/core/tmux/client_test.go
+++ b/internal/core/tmux/client_test.go
@@ -69,6 +69,32 @@ func TestClient_CreateSession(t *testing.T) {
 		assert.Equal(t, []string{"select-window", "-t", "sess:agent"}, rec.Commands[6].Args)
 	})
 
+	t.Run("window with panes", func(t *testing.T) {
+		rec := &executil.RecordingExecutor{}
+		c := New(rec, nopLog)
+
+		err := c.CreateSession(context.Background(), "sess", "/work", []RenderedWindow{
+			{
+				Name:  "agent",
+				Focus: true,
+				Panes: []RenderedPane{
+					{Command: "claude"},
+					{Command: "npm test", Size: "30%", Split: "horizontal"},
+					{Dir: "/logs", Split: "vertical"},
+				},
+			},
+		}, true)
+		require.NoError(t, err)
+
+		require.Len(t, rec.Commands, 9)
+		assert.Equal(t, []string{"new-session", "-d", "-s", "sess", "-n", "agent", "-c", "/work", "--", "sh", "-c", "claude"}, rec.Commands[0].Args)
+		assert.Equal(t, []string{"split-window", "-t", "sess:agent", "-h", "-l", "30%", "-c", "/work", "--", "sh", "-c", "npm test"}, rec.Commands[4].Args)
+		assert.Equal(t, []string{"set-option", "-p", "-t", "sess:agent", "@hive-session", "sess"}, rec.Commands[5].Args)
+		assert.Equal(t, []string{"split-window", "-t", "sess:agent", "-v", "-c", "/logs"}, rec.Commands[6].Args)
+		assert.Equal(t, []string{"set-option", "-p", "-t", "sess:agent", "@hive-session", "sess"}, rec.Commands[7].Args)
+		assert.Equal(t, []string{"select-window", "-t", "sess:agent"}, rec.Commands[8].Args)
+	})
+
 	t.Run("three windows with dir override", func(t *testing.T) {
 		rec := &executil.RecordingExecutor{}
 		c := New(rec, nopLog)

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -950,11 +950,7 @@ func (s *SessionService) enforceMaxRecycled(ctx context.Context, remote, cloneSt
 // AddWindowsToTmuxSession adds windows to an existing tmux session, converting action.WindowSpec
 // to coretmux.RenderedWindow. Satisfies the command.WindowSpawner interface.
 func (s *SessionService) AddWindowsToTmuxSession(ctx context.Context, tmuxName, workDir string, windows []action.WindowSpec, background bool) error {
-	rendered := make([]coretmux.RenderedWindow, len(windows))
-	for i, w := range windows {
-		rendered[i] = coretmux.RenderedWindow{Name: w.Name, Command: w.Command, Dir: w.Dir, Focus: w.Focus}
-	}
-	return s.spawner.AddWindowsToTmuxSession(ctx, tmuxName, workDir, rendered, background)
+	return s.spawner.AddWindowsToTmuxSession(ctx, tmuxName, workDir, renderedWindowsFromSpecs(windows), background)
 }
 
 // CreateSessionWithWindows creates a new Hive session, optionally runs shCmd in its directory,
@@ -983,13 +979,23 @@ func (s *SessionService) CreateSessionWithWindows(ctx context.Context, req actio
 		}
 	}
 
-	rendered := make([]coretmux.RenderedWindow, len(windows))
-	for i, w := range windows {
-		rendered[i] = coretmux.RenderedWindow{Name: w.Name, Command: w.Command, Dir: w.Dir, Focus: w.Focus}
-	}
-	if err := s.spawner.tmux.CreateSession(ctx, sess.Slug, sess.Path, rendered, background); err != nil {
+	if err := s.spawner.tmux.CreateSession(ctx, sess.Slug, sess.Path, renderedWindowsFromSpecs(windows), background); err != nil {
 		cleanup()
 		return fmt.Errorf("create tmux session: %w", err)
 	}
 	return nil
+}
+
+func renderedWindowsFromSpecs(windows []action.WindowSpec) []coretmux.RenderedWindow {
+	rendered := make([]coretmux.RenderedWindow, len(windows))
+	for i, w := range windows {
+		rendered[i] = coretmux.RenderedWindow{Name: w.Name, Command: w.Command, Dir: w.Dir, Focus: w.Focus}
+		if len(w.Panes) > 0 {
+			rendered[i].Panes = make([]coretmux.RenderedPane, len(w.Panes))
+			for j, p := range w.Panes {
+				rendered[i].Panes[j] = coretmux.RenderedPane{Command: p.Command, Dir: p.Dir, Size: p.Size, Split: p.Split}
+			}
+		}
+	}
+	return rendered
 }

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -157,7 +157,55 @@ func renderWindowCommon(w config.WindowConfig, render func(string) (string, erro
 		}
 	}
 
-	return coretmux.RenderedWindow{Name: name, Command: command, Dir: dir, Focus: w.Focus}, nil
+	panes, err := renderPanes(w.Panes, render)
+	if err != nil {
+		return coretmux.RenderedWindow{}, err
+	}
+
+	return coretmux.RenderedWindow{Name: name, Command: command, Dir: dir, Focus: w.Focus, Panes: panes}, nil
+}
+
+func renderPanes(panes []config.PaneConfig, render func(string) (string, error)) ([]coretmux.RenderedPane, error) {
+	rendered := make([]coretmux.RenderedPane, 0, len(panes))
+	for i, p := range panes {
+		rp, err := renderPane(p, render)
+		if err != nil {
+			return nil, fmt.Errorf("panes[%d]: %w", i, err)
+		}
+		rendered = append(rendered, rp)
+	}
+	return rendered, nil
+}
+
+func renderPane(p config.PaneConfig, render func(string) (string, error)) (coretmux.RenderedPane, error) {
+	var command string
+	if p.Command != "" {
+		rendered, err := render(p.Command)
+		if err != nil {
+			return coretmux.RenderedPane{}, fmt.Errorf("command template: %w", err)
+		}
+		command = strings.TrimSpace(rendered)
+	}
+
+	var dir string
+	if p.Dir != "" {
+		rendered, err := render(p.Dir)
+		if err != nil {
+			return coretmux.RenderedPane{}, fmt.Errorf("dir template: %w", err)
+		}
+		dir = rendered
+	}
+
+	var size string
+	if p.Size != "" {
+		rendered, err := render(p.Size)
+		if err != nil {
+			return coretmux.RenderedPane{}, fmt.Errorf("size template: %w", err)
+		}
+		size = strings.TrimSpace(rendered)
+	}
+
+	return coretmux.RenderedPane{Command: command, Dir: dir, Size: size, Split: p.Split}, nil
 }
 
 // renderWindow renders a single WindowConfig against SpawnData.

--- a/internal/hive/spawner_test.go
+++ b/internal/hive/spawner_test.go
@@ -28,6 +28,28 @@ func TestRenderWindowCommon(t *testing.T) {
 	assert.True(t, rw.Focus)
 }
 
+func TestRenderWindowCommon_Panes(t *testing.T) {
+	r := testRenderer()
+	w := config.WindowConfig{
+		Name: "agent",
+		Dir:  "{{ .Path }}",
+		Panes: []config.PaneConfig{
+			{Command: "claude --session {{ .Name }}"},
+			{Command: "npm test", Dir: "/tmp/tests", Size: "30%", Split: "horizontal"},
+		},
+	}
+
+	rw, err := renderWindow(r, w, SpawnData{Name: "test-session", Path: "/tmp/test"})
+	require.NoError(t, err)
+	require.Len(t, rw.Panes, 2)
+	assert.Equal(t, "/tmp/test", rw.Dir)
+	assert.Equal(t, "claude --session test-session", rw.Panes[0].Command)
+	assert.Equal(t, "npm test", rw.Panes[1].Command)
+	assert.Equal(t, "/tmp/tests", rw.Panes[1].Dir)
+	assert.Equal(t, "30%", rw.Panes[1].Size)
+	assert.Equal(t, "horizontal", rw.Panes[1].Split)
+}
+
 func TestRenderUserCommandWindows(t *testing.T) {
 	r := testRenderer()
 	windows := []config.WindowConfig{

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -193,6 +193,12 @@ func renderUserCommandWindows(renderer *tmpl.Renderer, windows []config.WindowCo
 	specs := make([]action.WindowSpec, len(rws))
 	for i, rw := range rws {
 		specs[i] = action.WindowSpec{Name: rw.Name, Command: rw.Command, Dir: rw.Dir, Focus: rw.Focus}
+		if len(rw.Panes) > 0 {
+			specs[i].Panes = make([]action.PaneSpec, len(rw.Panes))
+			for j, p := range rw.Panes {
+				specs[i].Panes[j] = action.PaneSpec{Command: p.Command, Dir: p.Dir, Size: p.Size, Split: p.Split}
+			}
+		}
 	}
 	return specs, nil
 }

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -146,6 +146,17 @@ func assertTmuxWindowNames(t *testing.T, session string, wantNames []string) {
 	}, 5*time.Second, 200*time.Millisecond)
 }
 
+// assertTmuxPaneCount waits for a tmux window to have exactly the expected number of panes.
+func assertTmuxPaneCount(t *testing.T, target string, want int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		out, err := exec.Command("tmux", "list-panes", "-t", target, "-F", "#{pane_id}").CombinedOutput()
+		assert.NoError(c, err, "tmux list-panes: %s", out)
+		got := strings.Fields(strings.TrimSpace(string(out)))
+		assert.Len(c, got, want)
+	}, 5*time.Second, 200*time.Millisecond)
+}
+
 // cleanupTmuxSession registers a t.Cleanup to kill a named tmux session.
 func cleanupTmuxSession(t *testing.T, name string) {
 	t.Helper()

--- a/test/integration/tmux_test.go
+++ b/test/integration/tmux_test.go
@@ -188,6 +188,36 @@ rules:
 	}
 }
 
+func TestTmuxWindowPanes(t *testing.T) {
+	config := `version: "0.2.4"
+git_path: git
+agents:
+  default: testbash
+  testbash:
+    command: bash
+rules:
+  - windows:
+      - name: agent
+        focus: true
+        panes:
+          - command: bash
+          - command: bash
+            split: horizontal
+            size: 30%
+      - name: shell
+`
+	h := NewHarness(t).WithConfig(config)
+	repo := createBareRepo(t, "tmux-pane-repo")
+	cleanupTmuxSession(t, "tmux-pane-test")
+
+	_, err := h.Run("new", "--background", "--remote", repo, "tmux-pane-test")
+	require.NoError(t, err)
+
+	assertTmuxWindowNames(t, "tmux-pane-test", []string{"agent", "shell"})
+	assertTmuxPaneCount(t, "tmux-pane-test:agent", 2)
+	assertTmuxPaneCount(t, "tmux-pane-test:shell", 1)
+}
+
 func TestTmuxListAll(t *testing.T) {
 	h := NewHarness(t)
 	repo := createBareRepo(t, "tmux-list-repo")


### PR DESCRIPTION
Fixes #175

## Purpose

Allow declarative window configs to define tmux pane splits without falling back to custom spawn commands.

## Proposed Changes

  - Add pane configuration/rendering for rule and usercommand windows
  - Create additional panes with tmux split-window
  - Document command/panes mutual exclusivity and add validation/tests

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)