### PR TITLE
Add agent selection for session creation

### DIFF
--- a/internal/commands/cmd_batch.go
+++ b/internal/commands/cmd_batch.go
@@ -19,6 +19,7 @@ type BatchCmd struct {
 	flags *Flags
 	app   *hive.App
 	fr    *iojson.FileReader[BatchInput]
+	agent string
 }
 
 func NewBatchCmd(flags *Flags, app *hive.App) *BatchCmd {
@@ -39,7 +40,10 @@ Read from stdin:
   echo '{"sessions":[{"name":"task1","prompt":"Do something"}]}' | hive batch
 
 Read from file:
-  hive batch -f sessions.json`,
+  hive batch -f sessions.json
+
+Use an agent profile for sessions without a per-session agent:
+  hive batch --agent claude -f sessions.json`,
 		Description: `Creates multiple agent sessions from a JSON specification.
 
 Each session in the input array is created sequentially. A terminal is
@@ -71,14 +75,23 @@ Fields:
   agent      - Optional. Agent profile key from agents config.
 
 Config example (in ~/.config/hive/config.yaml):
-  commands:
-    spawn:        # Used by hive new
-      - "wezterm cli spawn --cwd {{.Path}}"
-    batch_spawn:  # Used by hive batch (supports {{.Prompt}})
-      - "wezterm cli spawn --cwd {{.Path}} -- claude --prompt '{{.Prompt}}'"
+  rules:
+    - windows:
+        - name: "{{ agentWindow }}"
+          command: "{{ agentCommand }} {{ agentFlags }}{{- if .Prompt }} {{ .Prompt | shq }}{{ end }}"
+          focus: true
+        - name: shell
 
 Output is JSON with a batch ID, log file path, and results for each session.`,
-		Flags:  []cli.Flag{cmd.fr.Flag()},
+		Flags: []cli.Flag{
+			cmd.fr.Flag(),
+			&cli.StringFlag{
+				Name:        "agent",
+				Aliases:     []string{"a"},
+				Usage:       "default agent profile key for sessions without an agent field",
+				Destination: &cmd.agent,
+			},
+		},
 		Action: cmd.run,
 	})
 
@@ -159,6 +172,12 @@ func (cmd *BatchCmd) run(ctx context.Context, c *cli.Command) error {
 
 func (cmd *BatchCmd) validateAgents(input BatchInput) error {
 	var errs criterio.FieldErrorsBuilder
+	if cmd.agent != "" {
+		if _, ok := cmd.app.Config.Agents.Profiles[cmd.agent]; !ok {
+			errs = errs.Append("agent", fmt.Errorf("unknown agent %q", cmd.agent))
+		}
+	}
+
 	for i, sess := range input.Sessions {
 		if sess.Agent == "" {
 			continue
@@ -193,7 +212,7 @@ func (cmd *BatchCmd) createSession(ctx context.Context, sess BatchSession) Batch
 		Source:        source,
 		UseBatchSpawn: true,
 		CloneStrategy: sess.CloneStrategy,
-		AgentKey:      sess.Agent,
+		AgentKey:      cmd.agentForSession(sess),
 	}
 
 	created, err := cmd.app.Sessions.CreateSession(ctx, opts)
@@ -219,6 +238,13 @@ const (
 	StatusSkipped = "skipped" // StatusSkipped indicates the session was not attempted due to failure threshold.
 	maxFailures   = 3         // maxFailures is the number of failures before stopping batch processing.
 )
+
+func (cmd *BatchCmd) agentForSession(sess BatchSession) string {
+	if sess.Agent != "" {
+		return sess.Agent
+	}
+	return cmd.agent
+}
 
 // BatchInput is the JSON input schema for batch session creation.
 type BatchInput struct {

--- a/internal/commands/cmd_batch_test.go
+++ b/internal/commands/cmd_batch_test.go
@@ -132,10 +132,12 @@ func TestBatchCmd_validateAgents(t *testing.T) {
 				Agents: config.AgentsConfig{
 					Profiles: map[string]config.AgentProfile{
 						"claude": {},
+						"aider":  {},
 					},
 				},
 			},
 		},
+		agent: "aider",
 	}
 
 	require.NoError(t, cmd.validateAgents(BatchInput{Sessions: []BatchSession{
@@ -149,6 +151,19 @@ func TestBatchCmd_validateAgents(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sessions[0].agent")
 	assert.Contains(t, err.Error(), `unknown agent "missing"`)
+
+	cmd.agent = "missing-default"
+	err = cmd.validateAgents(BatchInput{Sessions: []BatchSession{{Name: "task1"}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent")
+	assert.Contains(t, err.Error(), `unknown agent "missing-default"`)
+}
+
+func TestBatchCmd_agentForSession(t *testing.T) {
+	cmd := &BatchCmd{agent: "aider"}
+
+	assert.Equal(t, "aider", cmd.agentForSession(BatchSession{Name: "task1"}))
+	assert.Equal(t, "claude", cmd.agentForSession(BatchSession{Name: "task1", Agent: "claude"}))
 }
 
 func TestBatchOutput_JSON(t *testing.T) {

--- a/internal/commands/cmd_doc.go
+++ b/internal/commands/cmd_doc.go
@@ -423,15 +423,15 @@ views:
 		Migration: `- Add "batch_spawn" to your config if you need prompt support
 - The "spawn" command no longer supports the "{{.Prompt}}" template variable`,
 		Before: `# config.yaml (old - spawn with prompt)
-commands:
-  spawn:
-    - "wezterm cli spawn --cwd {{.Path}} -- claude --prompt '{{.Prompt}}'"`,
+rules:
+  - spawn:
+      - "tmux new-session -d -c {{.Path | shq}} -- claude --prompt {{.Prompt | shq}}"`,
 		After: `# config.yaml (new - separate commands)
-commands:
-  spawn:        # For hive new (no prompt)
-    - "wezterm cli spawn --cwd {{.Path}}"
-  batch_spawn:  # For hive batch (with prompt)
-    - "wezterm cli spawn --cwd {{.Path}} -- claude --prompt '{{.Prompt}}'"`,
+rules:
+  - spawn:       # For hive new (no prompt)
+      - "tmux new-session -d -c {{.Path | shq}} -- claude"
+    batch_spawn: # For hive batch (with prompt)
+      - "tmux new-session -d -c {{.Path | shq}} -- claude --prompt {{.Prompt | shq}}"`,
 	},
 	{
 		Version:     "0.2.0",

--- a/internal/commands/cmd_new.go
+++ b/internal/commands/cmd_new.go
@@ -17,6 +17,7 @@ type NewCmd struct {
 	source        string
 	background    bool
 	cloneStrategy string
+	agent         string
 }
 
 // NewNewCmd creates a new new command
@@ -40,6 +41,7 @@ command launches a terminal with the AI tool.
 
 Example:
   hive new Fix Auth Bug
+  hive new --agent claude Refactor Utils
   hive new bugfix --source /some/path`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -65,6 +67,12 @@ Example:
 				Usage:       "clone strategy: full or worktree",
 				Destination: &cmd.cloneStrategy,
 			},
+			&cli.StringFlag{
+				Name:        "agent",
+				Aliases:     []string{"a"},
+				Usage:       "agent profile key from agents config",
+				Destination: &cmd.agent,
+			},
 		},
 		Action: cmd.run,
 	})
@@ -78,6 +86,12 @@ func (cmd *NewCmd) run(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("session name required\n\nUsage: hive new <name...>\n\nExample: hive new Fix Auth Bug")
 	}
 	name := strings.Join(args, " ")
+
+	if cmd.agent != "" {
+		if _, ok := cmd.app.Config.Agents.Profiles[cmd.agent]; !ok {
+			return fmt.Errorf("unknown agent %q", cmd.agent)
+		}
+	}
 
 	source := cmd.source
 	if source == "" {
@@ -94,6 +108,7 @@ func (cmd *NewCmd) run(ctx context.Context, c *cli.Command) error {
 		Source:        source,
 		Background:    cmd.background,
 		CloneStrategy: cmd.cloneStrategy,
+		AgentKey:      cmd.agent,
 	}
 
 	sess, err := cmd.app.Sessions.CreateSession(ctx, opts)

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -340,13 +340,15 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	if !opts.SkipSpawn {
 		renderer := s.renderer
 		if opts.AgentKey != "" {
-			if profile, ok := s.config.Agents.Profiles[opts.AgentKey]; ok {
-				renderer = s.renderer.WithAgent(
-					profile.CommandOrDefault(opts.AgentKey),
-					opts.AgentKey,
-					profile.ShellFlags(),
-				)
+			profile, ok := s.config.Agents.Profiles[opts.AgentKey]
+			if !ok {
+				return nil, fmt.Errorf("unknown agent %q", opts.AgentKey)
 			}
+			renderer = s.renderer.WithAgent(
+				profile.CommandOrDefault(opts.AgentKey),
+				opts.AgentKey,
+				profile.ShellFlags(),
+			)
 		}
 		strategy := config.ResolveSpawn(s.config.Rules, remote, opts.UseBatchSpawn)
 		switch {

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -253,6 +253,82 @@ func (c *capturingExec) RunDirStream(_ context.Context, _ string, _ io.Writer, _
 	return nil
 }
 
+func TestCreateSession_AgentKeyOverridesSpawnRenderer(t *testing.T) {
+	store := newMockStore()
+	exec := &capturingStreamExec{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+		Agents: config.AgentsConfig{
+			Default: "claude",
+			Profiles: map[string]config.AgentProfile{
+				"claude": {Command: "claude"},
+				"aider":  {Command: "aider-bin", Flags: []string{"--yes", "--model", "sonnet"}},
+			},
+		},
+		Rules: []config.Rule{
+			{Pattern: "", Spawn: []string{"{{ agentCommand }}|{{ agentWindow }}|{{ agentFlags }}"}},
+		},
+	}
+	log := zerolog.New(io.Discard)
+	renderer := tmpl.New(tmpl.Config{AgentCommand: "claude", AgentWindow: "claude"})
+	svc := NewSessionService(store, &mockGit{}, cfg, testbus.New(t).EventBus, exec, renderer, log, io.Discard, io.Discard)
+
+	_, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:     "agent override",
+		Remote:   testRemote,
+		AgentKey: "aider",
+	})
+	require.NoError(t, err)
+	require.Len(t, exec.streamCommands, 1)
+	assert.Equal(t, "aider-bin|aider|--yes --model sonnet", exec.streamCommands[0])
+}
+
+func TestCreateSession_UnknownAgentKey(t *testing.T) {
+	store := newMockStore()
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+		Agents: config.AgentsConfig{
+			Default:  "claude",
+			Profiles: map[string]config.AgentProfile{"claude": {Command: "claude"}},
+		},
+		Rules: []config.Rule{{Pattern: "", Spawn: []string{"{{ agentCommand }}"}}},
+	}
+	svc := newTestService(t, store, cfg)
+
+	_, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:     "missing agent",
+		Remote:   testRemote,
+		AgentKey: "missing",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown agent "missing"`)
+}
+
+type capturingStreamExec struct {
+	streamCommands []string
+}
+
+func (c *capturingStreamExec) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (c *capturingStreamExec) RunDir(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (c *capturingStreamExec) RunStream(_ context.Context, _ io.Writer, _ io.Writer, cmd string, args ...string) error {
+	if cmd == "sh" && len(args) == 2 && args[0] == "-c" {
+		c.streamCommands = append(c.streamCommands, args[1])
+	}
+	return nil
+}
+
+func (c *capturingStreamExec) RunDirStream(_ context.Context, _ string, _ io.Writer, _ io.Writer, _ string, _ ...string) error {
+	return nil
+}
+
 func TestEnforceMaxRecycled(t *testing.T) {
 	intPtr := func(n int) *int { return &n }
 


### PR DESCRIPTION
Fixes #205

## Purpose

Allow users to select an agent profile when creating sessions from `hive new` or `hive batch`, without changing the default config.

## Proposed Changes

  - Add `--agent/-a` to `hive new` and `hive batch` with profile validation
  - Apply batch CLI agent as a default while preserving per-session overrides
  - Pass selected profiles through session creation to spawn template rendering

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)