### PR TITLE
Add agent field to rules configuration

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -38,6 +38,9 @@ rules:
       - name: shell
     commands:
       - hive ctx init
+
+  - pattern: ".*/data-team/.*"
+    agent: aider
 ```
 
 !!! tip
@@ -56,7 +59,7 @@ rules:
 
 ## Agents
 
-Agent profiles define the AI tools available for spawning in sessions. The `default` key selects which profile to use when creating a new session.
+Agent profiles define the AI tools available for spawning in sessions. The `default` key selects which profile to use when creating a new session unless a matching rule sets `agent` or the session is created with `--agent`.
 
 | Option                    | Type       | Default        | Description                                                                    |
 | ------------------------- | ---------- | -------------- | ------------------------------------------------------------------------------ |
@@ -65,7 +68,7 @@ Agent profiles define the AI tools available for spawning in sessions. The `defa
 | `agents.<name>.command`   | `string`   | profile name   | CLI binary to run (defaults to profile name if empty)                          |
 | `agents.<name>.flags`     | `[]string` | `[]`           | Extra CLI args appended to the command on spawn                                |
 
-Sessions can run multiple agents by opening additional tmux windows — use `tmux.preview_window_matcher` to control which windows the TUI monitors.
+Agent resolution order is: CLI `--agent`, then the last matching `rules[].agent`, then `agents.default`. Sessions can run multiple agents by opening additional tmux windows — use `tmux.preview_window_matcher` to control which windows the TUI monitors.
 
 ## Tmux
 

--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -4,7 +4,7 @@ icon: lucide/regex
 
 # Rules
 
-Rules match repositories by regex pattern against the remote URL and configure how sessions are created, recycled, and set up. Rules are evaluated in order — the last matching rule with spawn/windows config wins. An empty pattern (`""`) matches all repositories.
+Rules match repositories by regex pattern against the remote URL and configure how sessions are created, recycled, and set up. Rules are evaluated in order — the last matching rule with spawn/windows config wins, and the last matching `agent` selects the agent profile. An empty pattern (`""`) matches all repositories.
 
 ```yaml
 rules:
@@ -19,11 +19,12 @@ rules:
     commands:
       - hive ctx init
 
-  # Override for work repos — custom agent flags
+  # Override for work repos — use the aider profile
   - pattern: ".*/my-org/.*"
+    agent: aider
     windows:
-      - name: claude
-        command: "claude --model opus"
+      - name: "{{ agentWindow }}"
+        command: "{{ agentCommand }} {{ agentFlags }}"
         focus: true
       - name: tests
         command: "npm run test:watch"
@@ -35,7 +36,7 @@ rules:
 ```
 
 !!! info "Last match wins"
-    Rules are evaluated in order — the **last** matching rule with spawn/windows config wins. Place general patterns before specific ones.
+    Rules are evaluated in order — the **last** matching rule with spawn/windows config wins, and the **last** matching rule with `agent` selects the agent profile. Place general patterns before specific ones.
 
 ## Rule Fields
 
@@ -44,6 +45,7 @@ rules:
 | `pattern`          | string         | `""`                         | Regex pattern to match remote URL                 |
 | `clone_strategy`   | string         | —                            | Override clone strategy for matching repos: `full` or `worktree` |
 | `branch_template`  | string         | `hive/{{ .Slug }}-{{ .ID }}` | Go template for the git branch name (worktree only). Variables: `.Name`, `.Slug`, `.Owner`, `.Repo`, `.ID`. The rendered value must be a valid git branch name (no spaces, colons, `~`, `^`, etc.) — session creation fails with a clear error if it isn't. |
+| `agent`            | string         | —                            | Agent profile override for matching repos. Must match a key under `agents`. |
 | `windows`          | []WindowConfig | see below                    | Declarative tmux window layout (recommended)      |
 | `spawn`            | []string       | —                            | Shell commands run after session creation (legacy) |
 | `batch_spawn`      | []string       | —                            | Shell commands for batch session creation (legacy) |
@@ -53,7 +55,45 @@ rules:
 | `max_recycled`     | *int           | `5`                          | Maximum recycled sessions to keep (0 = unlimited) |
 
 !!! warning "`windows` vs `spawn`/`batch_spawn`"
-    A rule must use either `windows` or `spawn`/`batch_spawn`, not both. If neither is set, the default window layout is used (agent window + shell window).
+    A rule must use either `windows` or `spawn`/`batch_spawn`, not both. If neither is set, the default window layout is used (agent window + shell window). A rule can set `agent` with or without custom `windows`/`spawn` config.
+
+## Agent Overrides
+
+Use `agent` to select a configured agent profile for repositories matching a rule. The value must match a profile under `agents`.
+
+```yaml
+agents:
+  default: claude
+  claude:
+    command: claude
+    flags: ["--model", "opus"]
+  aider:
+    command: aider
+    flags: ["--model", "sonnet"]
+
+rules:
+  - pattern: ""
+    max_recycled: 5
+
+  # Uses the default window layout, rendered with the aider profile.
+  - pattern: ".*/data-team/.*"
+    agent: aider
+
+  # Custom windows can still use the selected profile through template functions.
+  - pattern: ".*/infra/.*"
+    agent: aider
+    windows:
+      - name: "{{ agentWindow }}"
+        command: "{{ agentCommand }} {{ agentFlags }}"
+        focus: true
+      - name: shell
+```
+
+Agent resolution order is:
+
+1. CLI `--agent` flag
+2. Last matching rule with `agent`
+3. `agents.default`
 
 ## Window Configuration
 
@@ -70,7 +110,7 @@ The `windows` field defines tmux windows declaratively. Each window has:
 !!! warning "`command` vs `panes`"
     A window must use either `command` or `panes`, not both. Use `command` for a single-pane window. Use `panes` when you need splits inside the window.
 
-**Default window layout** (used when no rule specifies `windows` or `spawn`):
+**Default window layout** (used when no rule specifies `windows` or `spawn`). The template functions render from the resolved agent profile:
 
 ```yaml
 windows:
@@ -86,8 +126,8 @@ windows:
 
 ```yaml
 windows:
-  - name: claude
-    command: "claude"
+  - name: "{{ agentWindow }}"
+    command: "{{ agentCommand }} {{ agentFlags }}"
     focus: true
   - name: shell
 ```
@@ -96,8 +136,8 @@ windows:
 
 ```yaml
 windows:
-  - name: claude
-    command: "claude --model opus"
+  - name: "{{ agentWindow }}"
+    command: "{{ agentCommand }} {{ agentFlags }}"
     focus: true
   - name: tests
     command: "npm run test:watch"
@@ -108,8 +148,8 @@ windows:
 
 ```yaml
 windows:
-  - name: claude
-    command: "claude"
+  - name: "{{ agentWindow }}"
+    command: "{{ agentCommand }} {{ agentFlags }}"
     focus: true
   - name: aider
     command: "aider --model sonnet"
@@ -120,10 +160,10 @@ windows:
 
 ```yaml
 windows:
-  - name: agent
+  - name: "{{ agentWindow }}"
     focus: true
     panes:
-      - command: "claude"
+      - command: "{{ agentCommand }} {{ agentFlags }}"
       - command: "npm test -- --watch"
         split: horizontal
         size: 30%
@@ -188,6 +228,6 @@ If `.Name` renders to an invalid git branch name (e.g. contains a space), hive w
 | `join`      | Join string slice with separator              |
 | `hiveTmux`  | Path to bundled `hive-tmux` script            |
 | `agentSend` | Path to bundled `agent-send` script           |
-| `agentCommand` | Default agent command from `agents.default` profile |
-| `agentWindow`  | Default agent window/profile name (use for targets like `session:{{ agentWindow }}`) |
-| `agentFlags`   | Default agent flags from `agents.default` profile |
+| `agentCommand` | Command from the resolved agent profile |
+| `agentWindow`  | Resolved agent profile name/window name (use for targets like `session:{{ agentWindow }}`) |
+| `agentFlags`   | Flags from the resolved agent profile |

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -620,6 +620,8 @@ type WindowConfig struct {
 type Rule struct {
 	// Pattern matches against remote URL (regex). Empty = matches all.
 	Pattern string `json:"pattern" yaml:"pattern"`
+	// Agent selects the agent profile used for matching repositories.
+	Agent string `json:"agent,omitempty" yaml:"agent,omitempty"`
 	// Commands to run in the session directory after clone/recycle.
 	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty"`
 	// Copy are glob patterns to copy from source directory.
@@ -1058,12 +1060,21 @@ func (c *Config) validateMaxRecycled() error {
 	return errs.ToError()
 }
 
-// validateAgents checks that agents.default references an existing profile.
+// validateAgents checks that configured agent references point at existing profiles.
 func (c *Config) validateAgents() error {
+	var errs criterio.FieldErrorsBuilder
 	if _, ok := c.Agents.Profiles[c.Agents.Default]; !ok {
-		return criterio.NewFieldErrors("agents.default", fmt.Errorf("profile %q not found in agents config", c.Agents.Default))
+		errs = errs.Append("agents.default", fmt.Errorf("profile %q not found in agents config", c.Agents.Default))
 	}
-	return nil
+	for i, rule := range c.Rules {
+		if rule.Agent == "" {
+			continue
+		}
+		if _, ok := c.Agents.Profiles[rule.Agent]; !ok {
+			errs = errs.Append(fmt.Sprintf("rules[%d].agent", i), fmt.Errorf("profile %q not found in agents config", rule.Agent))
+		}
+	}
+	return errs.ToError()
 }
 
 // validateTheme checks that the configured theme name is a valid built-in theme.
@@ -1249,6 +1260,7 @@ func ValidateCloneStrategy(s string) error {
 type SpawnStrategy struct {
 	Windows  []WindowConfig
 	Commands []string
+	Agent    string
 }
 
 // IsWindows returns true if the strategy uses declarative window config.
@@ -1264,17 +1276,23 @@ func ResolveSpawn(rules []Rule, remote string, batch bool) SpawnStrategy {
 		if !rule.Matches(remote) {
 			continue
 		}
+		if rule.Agent != "" {
+			strategy.Agent = rule.Agent
+		}
 		switch {
 		case len(rule.Windows) > 0:
-			strategy = SpawnStrategy{Windows: rule.Windows}
+			strategy.Windows = rule.Windows
+			strategy.Commands = nil
 		case batch && len(rule.BatchSpawn) > 0:
-			strategy = SpawnStrategy{Commands: rule.BatchSpawn}
+			strategy.Windows = nil
+			strategy.Commands = rule.BatchSpawn
 		case !batch && len(rule.Spawn) > 0:
-			strategy = SpawnStrategy{Commands: rule.Spawn}
+			strategy.Windows = nil
+			strategy.Commands = rule.Spawn
 		}
 	}
 	if !strategy.IsWindows() && len(strategy.Commands) == 0 {
-		return SpawnStrategy{Windows: DefaultWindows()}
+		strategy.Windows = DefaultWindows()
 	}
 	return strategy
 }

--- a/internal/core/config/validate_test.go
+++ b/internal/core/config/validate_test.go
@@ -1227,6 +1227,20 @@ func TestValidate_AgentsDefaultValid(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidate_RuleAgentMissing(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.Agents = AgentsConfig{
+		Default:  "claude",
+		Profiles: map[string]AgentProfile{"claude": {}},
+	}
+	cfg.Rules = []Rule{{Pattern: "", Agent: "aider"}}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rules[0].agent")
+	assert.Contains(t, err.Error(), "aider")
+}
+
 func TestApplyDefaults_AgentsEmpty(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.DataDir = t.TempDir()
@@ -1283,6 +1297,7 @@ func TestResolveSpawn(t *testing.T) {
 		batch        bool
 		wantWindows  bool
 		wantCommands []string
+		wantAgent    string
 	}{
 		{
 			name:        "no rules returns default windows",
@@ -1378,6 +1393,25 @@ func TestResolveSpawn(t *testing.T) {
 			remote:      "https://gitlab.com/some/repo",
 			wantWindows: true,
 		},
+		{
+			name: "agent-only matching rule uses default windows",
+			rules: []Rule{
+				{Pattern: "", Agent: "aider"},
+			},
+			remote:      "https://github.com/foo/bar",
+			wantWindows: true,
+			wantAgent:   "aider",
+		},
+		{
+			name: "last matching agent wins independently of windows",
+			rules: []Rule{
+				{Pattern: "", Agent: "claude", Windows: []WindowConfig{{Name: "default"}}},
+				{Pattern: "github.com/foo/.*", Agent: "aider"},
+			},
+			remote:      "https://github.com/foo/bar",
+			wantWindows: true,
+			wantAgent:   "aider",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1387,6 +1421,7 @@ func TestResolveSpawn(t *testing.T) {
 
 			strategy := ResolveSpawn(cfg.Rules, tt.remote, tt.batch)
 			assert.Equal(t, tt.wantWindows, strategy.IsWindows(), "IsWindows mismatch")
+			assert.Equal(t, tt.wantAgent, strategy.Agent)
 
 			if tt.wantCommands != nil {
 				assert.Equal(t, tt.wantCommands, strategy.Commands)

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -338,19 +338,11 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	}
 
 	if !opts.SkipSpawn {
-		renderer := s.renderer
-		if opts.AgentKey != "" {
-			profile, ok := s.config.Agents.Profiles[opts.AgentKey]
-			if !ok {
-				return nil, fmt.Errorf("unknown agent %q", opts.AgentKey)
-			}
-			renderer = s.renderer.WithAgent(
-				profile.CommandOrDefault(opts.AgentKey),
-				opts.AgentKey,
-				profile.ShellFlags(),
-			)
-		}
 		strategy := config.ResolveSpawn(s.config.Rules, remote, opts.UseBatchSpawn)
+		renderer, err := s.rendererForAgent(firstNonEmpty(opts.AgentKey, strategy.Agent))
+		if err != nil {
+			return nil, err
+		}
 		switch {
 		case strategy.IsWindows():
 			if err := s.spawner.SpawnWindowsWith(ctx, strategy.Windows, data, opts.UseBatchSpawn || opts.Background, renderer); err != nil {
@@ -747,7 +739,36 @@ func (s *SessionService) OpenTmuxSession(ctx context.Context, name, path, remote
 		Repo:       repo,
 	}
 
-	return s.spawner.OpenWindows(ctx, strategy.Windows, data, background, targetWindow)
+	renderer, err := s.rendererForAgent(strategy.Agent)
+	if err != nil {
+		return err
+	}
+
+	return s.spawner.OpenWindowsWith(ctx, strategy.Windows, data, background, targetWindow, renderer)
+}
+
+func (s *SessionService) rendererForAgent(agentKey string) (*tmpl.Renderer, error) {
+	if agentKey == "" {
+		return s.renderer, nil
+	}
+	profile, ok := s.config.Agents.Profiles[agentKey]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent %q", agentKey)
+	}
+	return s.renderer.WithAgent(
+		profile.CommandOrDefault(agentKey),
+		agentKey,
+		profile.ShellFlags(),
+	), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // Git returns the git client for use in background operations.

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -284,6 +284,68 @@ func TestCreateSession_AgentKeyOverridesSpawnRenderer(t *testing.T) {
 	assert.Equal(t, "aider-bin|aider|--yes --model sonnet", exec.streamCommands[0])
 }
 
+func TestCreateSession_RuleAgentOverridesSpawnRenderer(t *testing.T) {
+	store := newMockStore()
+	exec := &capturingStreamExec{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+		Agents: config.AgentsConfig{
+			Default: "claude",
+			Profiles: map[string]config.AgentProfile{
+				"claude": {Command: "claude"},
+				"aider":  {Command: "aider-bin", Flags: []string{"--model", "sonnet"}},
+			},
+		},
+		Rules: []config.Rule{
+			{Pattern: "", Agent: "aider", Spawn: []string{"{{ agentCommand }}|{{ agentWindow }}|{{ agentFlags }}"}},
+		},
+	}
+	log := zerolog.New(io.Discard)
+	renderer := tmpl.New(tmpl.Config{AgentCommand: "claude", AgentWindow: "claude"})
+	svc := NewSessionService(store, &mockGit{}, cfg, testbus.New(t).EventBus, exec, renderer, log, io.Discard, io.Discard)
+
+	_, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:   "rule agent override",
+		Remote: testRemote,
+	})
+	require.NoError(t, err)
+	require.Len(t, exec.streamCommands, 1)
+	assert.Equal(t, "aider-bin|aider|--model sonnet", exec.streamCommands[0])
+}
+
+func TestCreateSession_AgentKeyOverridesRuleAgent(t *testing.T) {
+	store := newMockStore()
+	exec := &capturingStreamExec{}
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+		Agents: config.AgentsConfig{
+			Default: "claude",
+			Profiles: map[string]config.AgentProfile{
+				"claude": {Command: "claude"},
+				"aider":  {Command: "aider-bin"},
+				"codex":  {Command: "codex-bin", Flags: []string{"--fast"}},
+			},
+		},
+		Rules: []config.Rule{
+			{Pattern: "", Agent: "aider", Spawn: []string{"{{ agentCommand }}|{{ agentWindow }}|{{ agentFlags }}"}},
+		},
+	}
+	log := zerolog.New(io.Discard)
+	renderer := tmpl.New(tmpl.Config{AgentCommand: "claude", AgentWindow: "claude"})
+	svc := NewSessionService(store, &mockGit{}, cfg, testbus.New(t).EventBus, exec, renderer, log, io.Discard, io.Discard)
+
+	_, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:     "cli agent override",
+		Remote:   testRemote,
+		AgentKey: "codex",
+	})
+	require.NoError(t, err)
+	require.Len(t, exec.streamCommands, 1)
+	assert.Equal(t, "codex-bin|codex|--fast", exec.streamCommands[0])
+}
+
 func TestCreateSession_UnknownAgentKey(t *testing.T) {
 	store := newMockStore()
 	cfg := &config.Config{

--- a/internal/hive/spawner.go
+++ b/internal/hive/spawner.go
@@ -104,7 +104,12 @@ func (s *Spawner) SpawnWindowsWith(ctx context.Context, windows []config.WindowC
 // OpenWindows renders window templates and opens (or creates) a tmux session.
 // If the session already exists, it attaches to it (optionally selecting targetWindow).
 func (s *Spawner) OpenWindows(ctx context.Context, windows []config.WindowConfig, data SpawnData, background bool, targetWindow string) error {
-	rendered, err := RenderWindows(s.renderer, windows, data)
+	return s.OpenWindowsWith(ctx, windows, data, background, targetWindow, s.renderer)
+}
+
+// OpenWindowsWith renders window templates using the given renderer and opens (or creates) a tmux session.
+func (s *Spawner) OpenWindowsWith(ctx context.Context, windows []config.WindowConfig, data SpawnData, background bool, targetWindow string, renderer *tmpl.Renderer) error {
+	rendered, err := RenderWindows(renderer, windows, data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #207

## Purpose

Allow repository rules to select an agent profile without hardcoding agent commands in window or spawn templates.

## Proposed Changes

  - Add `rules[].agent` validation and last-match-wins spawn resolution
  - Render spawn commands and tmux windows with the resolved rule agent unless CLI `--agent` is set
  - Document rule-level agent overrides and resolution order
  - Add tests for rule agent validation, resolution, and CLI precedence

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
