### PR TITLE
feat: add tags to sessions for external provider tracking

### DIFF
--- a/internal/commands/cmd_batch.go
+++ b/internal/commands/cmd_batch.go
@@ -61,7 +61,8 @@ Input JSON schema:
         "prompt": "optional task prompt",
         "remote": "optional-url",
         "source": "optional-path",
-        "agent": "optional-agent-key"
+        "agent": "optional-agent-key",
+        "tags": ["optional", "labels"]
       }
     ]
   }
@@ -73,6 +74,7 @@ Fields:
   remote     - Optional. Git remote URL (auto-detected from current dir if empty).
   source     - Optional. Directory to copy files from (per copy rules in config).
   agent      - Optional. Agent profile key from agents config.
+  tags       - Optional. Labels for external provider tracking (filterable via hive ls --tags).
 
 Config example (in ~/.config/hive/config.yaml):
   rules:
@@ -213,6 +215,7 @@ func (cmd *BatchCmd) createSession(ctx context.Context, sess BatchSession) Batch
 		UseBatchSpawn: true,
 		CloneStrategy: sess.CloneStrategy,
 		AgentKey:      cmd.agentForSession(sess),
+		Tags:          sess.Tags,
 	}
 
 	created, err := cmd.app.Sessions.CreateSession(ctx, opts)
@@ -296,13 +299,14 @@ func (b BatchInput) Validate() error {
 
 // BatchSession defines a single session to create.
 type BatchSession struct {
-	Name          string `json:"name"`
-	SessionID     string `json:"session_id,omitempty"`
-	Prompt        string `json:"prompt,omitempty"`
-	Remote        string `json:"remote,omitempty"`
-	Source        string `json:"source,omitempty"`
-	CloneStrategy string `json:"clone_strategy,omitempty"`
-	Agent         string `json:"agent,omitempty"`
+	Name          string   `json:"name"`
+	SessionID     string   `json:"session_id,omitempty"`
+	Prompt        string   `json:"prompt,omitempty"`
+	Remote        string   `json:"remote,omitempty"`
+	Source        string   `json:"source,omitempty"`
+	CloneStrategy string   `json:"clone_strategy,omitempty"`
+	Agent         string   `json:"agent,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
 }
 
 // BatchResult is the output for a single session creation attempt.

--- a/internal/commands/cmd_new.go
+++ b/internal/commands/cmd_new.go
@@ -18,6 +18,7 @@ type NewCmd struct {
 	background    bool
 	cloneStrategy string
 	agent         string
+	tags          []string
 }
 
 // NewNewCmd creates a new new command
@@ -73,6 +74,12 @@ Example:
 				Usage:       "agent profile key from agents config",
 				Destination: &cmd.agent,
 			},
+			&cli.StringSliceFlag{
+				Name:        "tags",
+				Aliases:     []string{"t"},
+				Usage:       "tags to attach to the session (repeatable)",
+				Destination: &cmd.tags,
+			},
 		},
 		Action: cmd.run,
 	})
@@ -109,6 +116,7 @@ func (cmd *NewCmd) run(ctx context.Context, c *cli.Command) error {
 		Background:    cmd.background,
 		CloneStrategy: cmd.cloneStrategy,
 		AgentKey:      cmd.agent,
+		Tags:          cmd.tags,
 	}
 
 	sess, err := cmd.app.Sessions.CreateSession(ctx, opts)

--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -22,6 +22,7 @@ type SessionCmd struct {
 	// per-subcommand flags
 	infoJSON bool
 	lsJSON   bool
+	lsTags   []string
 }
 
 // NewSessionCmd creates a new session command
@@ -75,6 +76,12 @@ Use --json for LLM-friendly output with additional fields like inbox topic and u
 				Usage:       "output as JSON lines with inbox info",
 				Destination: &cmd.lsJSON,
 			},
+			&cli.StringSliceFlag{
+				Name:        "tags",
+				Aliases:     []string{"t"},
+				Usage:       "filter sessions by tag (repeatable, all tags must match)",
+				Destination: &cmd.lsTags,
+			},
 		},
 		Action: cmd.runLs,
 	}
@@ -103,13 +110,14 @@ Example output (--json):
 
 // sessionInfoOutput is the JSON output format for hive session info.
 type sessionInfoOutput struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Repo   string `json:"repo"`
-	Remote string `json:"remote"`
-	Path   string `json:"path"`
-	Inbox  string `json:"inbox"`
-	State  string `json:"state"`
+	ID     string   `json:"id"`
+	Name   string   `json:"name"`
+	Repo   string   `json:"repo"`
+	Remote string   `json:"remote"`
+	Path   string   `json:"path"`
+	Inbox  string   `json:"inbox"`
+	State  string   `json:"state"`
+	Tags   []string `json:"tags,omitempty"`
 }
 
 func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
@@ -145,6 +153,7 @@ func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
 			Path:   sess.Path,
 			Inbox:  sess.InboxTopic(),
 			State:  string(sess.State),
+			Tags:   sess.Tags,
 		}
 		return iojson.WriteLine(out, info)
 	}
@@ -162,12 +171,13 @@ func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
 
 // lsSessionInfo is the JSON output format for hive session ls --json.
 type lsSessionInfo struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Repo   string `json:"repo"`
-	Inbox  string `json:"inbox"`
-	State  string `json:"state"`
-	Unread int    `json:"unread"`
+	ID     string   `json:"id"`
+	Name   string   `json:"name"`
+	Repo   string   `json:"repo"`
+	Inbox  string   `json:"inbox"`
+	State  string   `json:"state"`
+	Unread int      `json:"unread"`
+	Tags   []string `json:"tags,omitempty"`
 }
 
 func (cmd *SessionCmd) runLs(ctx context.Context, c *cli.Command) error {
@@ -183,14 +193,17 @@ func (cmd *SessionCmd) runLs(ctx context.Context, c *cli.Command) error {
 		return nil
 	}
 
-	// Separate normal and corrupted sessions
+	// Separate normal and corrupted sessions, applying tag filter if specified
 	var normal, corrupted []session.Session
 	for _, s := range sessions {
 		if s.State == session.StateCorrupted {
 			corrupted = append(corrupted, s)
-		} else {
-			normal = append(normal, s)
+			continue
 		}
+		if len(cmd.lsTags) > 0 && !sessionHasAllTags(s, cmd.lsTags) {
+			continue
+		}
+		normal = append(normal, s)
 	}
 
 	// Sort by repository name
@@ -246,6 +259,7 @@ func (cmd *SessionCmd) buildLsSessionInfo(ctx context.Context, s session.Session
 		Inbox:  s.InboxTopic(),
 		State:  string(s.State),
 		Unread: 0,
+		Tags:   s.Tags,
 	}
 
 	// Count unread inbox messages
@@ -254,4 +268,18 @@ func (cmd *SessionCmd) buildLsSessionInfo(ctx context.Context, s session.Session
 	}
 
 	return info
+}
+
+// sessionHasAllTags returns true if the session has every tag in required.
+func sessionHasAllTags(s session.Session, required []string) bool {
+	tagSet := make(map[string]struct{}, len(s.Tags))
+	for _, t := range s.Tags {
+		tagSet[t] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := tagSet[r]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -117,7 +117,7 @@ type sessionInfoOutput struct {
 	Path   string   `json:"path"`
 	Inbox  string   `json:"inbox"`
 	State  string   `json:"state"`
-	Tags   []string `json:"tags,omitempty"`
+	Tags   []string `json:"tags"`
 }
 
 func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
@@ -145,6 +145,10 @@ func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
 	out := c.Root().Writer
 
 	if cmd.infoJSON {
+		tags := sess.Tags
+		if tags == nil {
+			tags = []string{}
+		}
 		info := sessionInfoOutput{
 			ID:     sess.ID,
 			Name:   sess.Name,
@@ -153,7 +157,7 @@ func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
 			Path:   sess.Path,
 			Inbox:  sess.InboxTopic(),
 			State:  string(sess.State),
-			Tags:   sess.Tags,
+			Tags:   tags,
 		}
 		return iojson.WriteLine(out, info)
 	}
@@ -177,7 +181,7 @@ type lsSessionInfo struct {
 	Inbox  string   `json:"inbox"`
 	State  string   `json:"state"`
 	Unread int      `json:"unread"`
-	Tags   []string `json:"tags,omitempty"`
+	Tags   []string `json:"tags"`
 }
 
 func (cmd *SessionCmd) runLs(ctx context.Context, c *cli.Command) error {
@@ -252,6 +256,10 @@ func (cmd *SessionCmd) runLs(ctx context.Context, c *cli.Command) error {
 }
 
 func (cmd *SessionCmd) buildLsSessionInfo(ctx context.Context, s session.Session) lsSessionInfo {
+	tags := s.Tags
+	if tags == nil {
+		tags = []string{}
+	}
 	info := lsSessionInfo{
 		ID:     s.ID,
 		Name:   s.Name,
@@ -259,7 +267,7 @@ func (cmd *SessionCmd) buildLsSessionInfo(ctx context.Context, s session.Session
 		Inbox:  s.InboxTopic(),
 		State:  string(s.State),
 		Unread: 0,
-		Tags:   s.Tags,
+		Tags:   tags,
 	}
 
 	// Count unread inbox messages

--- a/internal/core/session/session.go
+++ b/internal/core/session/session.go
@@ -94,6 +94,7 @@ type Session struct {
 	Remote        string            `json:"remote"`
 	State         State             `json:"state"`
 	CloneStrategy string            `json:"clone_strategy,omitempty"` // "full" (default) or "worktree"
+	Tags          []string          `json:"tags,omitempty"`           // user-defined labels for external provider tracking
 	Metadata      map[string]string `json:"metadata,omitempty"`       // integration data (e.g., tmux session name)
 	CreatedAt     time.Time         `json:"created_at"`
 	UpdatedAt     time.Time         `json:"updated_at"`

--- a/internal/data/db/migrations/0012_add_session_tags.down.sql
+++ b/internal/data/db/migrations/0012_add_session_tags.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN tags;

--- a/internal/data/db/migrations/0012_add_session_tags.up.sql
+++ b/internal/data/db/migrations/0012_add_session_tags.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN tags TEXT;

--- a/internal/data/db/models.go
+++ b/internal/data/db/models.go
@@ -96,6 +96,7 @@ type Session struct {
 	CreatedAt     int64          `json:"created_at"`
 	UpdatedAt     int64          `json:"updated_at"`
 	CloneStrategy string         `json:"clone_strategy"`
+	Tags          sql.NullString `json:"tags"`
 }
 
 type TodoItem struct {

--- a/internal/data/db/queries.sql.go
+++ b/internal/data/db/queries.sql.go
@@ -353,7 +353,7 @@ func (q *Queries) GetReviewSessionByDocPathAndHash(ctx context.Context, arg GetR
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at, clone_strategy FROM sessions
+SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at, clone_strategy, tags FROM sessions
 WHERE id = ?
 `
 
@@ -371,6 +371,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.CloneStrategy,
+		&i.Tags,
 	)
 	return i, err
 }
@@ -650,7 +651,7 @@ func (q *Queries) ListReviewComments(ctx context.Context, sessionID string) ([]R
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at, clone_strategy FROM sessions
+SELECT id, name, slug, path, remote, state, metadata, created_at, updated_at, clone_strategy, tags FROM sessions
 ORDER BY created_at DESC
 `
 
@@ -674,6 +675,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.CloneStrategy,
+			&i.Tags,
 		); err != nil {
 			return nil, err
 		}
@@ -858,9 +860,9 @@ func (q *Queries) SaveReviewComment(ctx context.Context, arg SaveReviewCommentPa
 
 const saveSession = `-- name: SaveSession :exec
 INSERT INTO sessions (
-    id, name, slug, path, remote, state, clone_strategy, metadata,
+    id, name, slug, path, remote, state, clone_strategy, metadata, tags,
     created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     slug = excluded.slug,
@@ -869,6 +871,7 @@ ON CONFLICT(id) DO UPDATE SET
     state = excluded.state,
     clone_strategy = excluded.clone_strategy,
     metadata = excluded.metadata,
+    tags = excluded.tags,
     updated_at = excluded.updated_at
 `
 
@@ -881,6 +884,7 @@ type SaveSessionParams struct {
 	State         string         `json:"state"`
 	CloneStrategy string         `json:"clone_strategy"`
 	Metadata      sql.NullString `json:"metadata"`
+	Tags          sql.NullString `json:"tags"`
 	CreatedAt     int64          `json:"created_at"`
 	UpdatedAt     int64          `json:"updated_at"`
 }
@@ -895,6 +899,7 @@ func (q *Queries) SaveSession(ctx context.Context, arg SaveSessionParams) error 
 		arg.State,
 		arg.CloneStrategy,
 		arg.Metadata,
+		arg.Tags,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)

--- a/internal/data/db/queries/queries.sql
+++ b/internal/data/db/queries/queries.sql
@@ -8,9 +8,9 @@ WHERE id = ?;
 
 -- name: SaveSession :exec
 INSERT INTO sessions (
-    id, name, slug, path, remote, state, clone_strategy, metadata,
+    id, name, slug, path, remote, state, clone_strategy, metadata, tags,
     created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     slug = excluded.slug,
@@ -19,6 +19,7 @@ ON CONFLICT(id) DO UPDATE SET
     state = excluded.state,
     clone_strategy = excluded.clone_strategy,
     metadata = excluded.metadata,
+    tags = excluded.tags,
     updated_at = excluded.updated_at;
 
 -- name: DeleteSession :exec

--- a/internal/data/stores/store.go
+++ b/internal/data/stores/store.go
@@ -72,6 +72,16 @@ func (s *SessionStore) Save(ctx context.Context, sess session.Session) error {
 		metadataJSON = sql.NullString{String: string(data), Valid: true}
 	}
 
+	// Marshal tags to JSON
+	var tagsJSON sql.NullString
+	if len(sess.Tags) > 0 {
+		data, err := json.Marshal(sess.Tags)
+		if err != nil {
+			return fmt.Errorf("failed to marshal tags: %w", err)
+		}
+		tagsJSON = sql.NullString{String: string(data), Valid: true}
+	}
+
 	strategy := sess.CloneStrategy
 	if strategy == "" {
 		strategy = session.CloneStrategyFull
@@ -86,6 +96,7 @@ func (s *SessionStore) Save(ctx context.Context, sess session.Session) error {
 		State:         string(sess.State),
 		CloneStrategy: strategy,
 		Metadata:      metadataJSON,
+		Tags:          tagsJSON,
 		CreatedAt:     sess.CreatedAt.UnixNano(),
 		UpdatedAt:     sess.UpdatedAt.UnixNano(),
 	})
@@ -125,6 +136,14 @@ func rowToSession(row db.Session) (session.Session, error) {
 		}
 	}
 
+	// Unmarshal tags from JSON
+	var tags []string
+	if row.Tags.Valid {
+		if err := json.Unmarshal([]byte(row.Tags.String), &tags); err != nil {
+			return session.Session{}, fmt.Errorf("failed to unmarshal tags: %w", err)
+		}
+	}
+
 	return session.Session{
 		ID:            row.ID,
 		Name:          row.Name,
@@ -133,6 +152,7 @@ func rowToSession(row db.Session) (session.Session, error) {
 		Remote:        row.Remote,
 		State:         session.State(row.State),
 		CloneStrategy: row.CloneStrategy,
+		Tags:          tags,
 		Metadata:      metadata,
 		CreatedAt:     time.Unix(0, row.CreatedAt),
 		UpdatedAt:     time.Unix(0, row.UpdatedAt),

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -45,6 +45,8 @@ type CreateOptions struct {
 	// When non-empty, the spawn templates use that profile's command/flags instead
 	// of the process-wide default. Must match a key in config.Agents.Profiles.
 	AgentKey string
+	// Tags are user-defined labels attached to the session for external provider tracking.
+	Tags []string
 	// Progress receives human-readable progress lines during session creation.
 	// When non-nil, service output (hooks, file copies) is also redirected here.
 	Progress io.Writer
@@ -231,6 +233,7 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 		sess.Name = opts.Name
 		sess.Slug = slug
 		sess.State = session.StateActive
+		sess.Tags = opts.Tags
 		sess.UpdatedAt = time.Now()
 	} else {
 		// Create new session (either no recyclable found or it was corrupted)
@@ -260,6 +263,7 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 			Remote:        remote,
 			State:         session.StateActive,
 			CloneStrategy: cloneStrategy,
+			Tags:          opts.Tags,
 			CreatedAt:     now,
 			UpdatedAt:     now,
 		}


### PR DESCRIPTION
## Summary

Adds a `tags` field to sessions so external providers can label the sessions they create and filter them later. Tags are stored as a JSON array in a new SQLite column.

**Usage:**
- `hive new --tags foo --tags bar` (repeatable flag)
- Batch input: `"tags": ["foo", "bar"]` per session
- `hive ls --tags foo` filters to sessions with all specified tags (AND semantics)
- Tags appear in `--json` output for `hive ls` and `hive session info`