### PR TITLE
feat: add session delete/recycle CLI commands and fix tmux kill on delete

### DIFF
--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -44,6 +44,8 @@ Use 'hive session info' to get details about the current session.`,
 			Commands: []*cli.Command{
 				lsCommand,
 				cmd.infoCmd(),
+				cmd.deleteCmd(),
+				cmd.recycleCmd(),
 			},
 		},
 		// Top-level alias: "hive ls" -> "hive session list"
@@ -235,6 +237,58 @@ func (cmd *SessionCmd) runLs(ctx context.Context, c *cli.Command) error {
 		fmt.Fprintf(os.Stderr, "Run 'hive prune' to clean up\n")
 	}
 
+	return nil
+}
+
+func (cmd *SessionCmd) deleteCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "delete",
+		Usage:     "Delete a session and its directory",
+		UsageText: "hive session delete <id>",
+		Description: `Permanently removes a session, its cloned directory, and any associated tmux session.
+
+This action cannot be undone. Use 'hive session recycle' to preserve the directory for reuse.`,
+		Action: cmd.runDelete,
+	}
+}
+
+func (cmd *SessionCmd) runDelete(ctx context.Context, c *cli.Command) error {
+	id := c.Args().First()
+	if id == "" {
+		return fmt.Errorf("session ID required")
+	}
+
+	if err := cmd.app.Sessions.DeleteSession(ctx, id); err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Session %s deleted\n", id)
+	return nil
+}
+
+func (cmd *SessionCmd) recycleCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "recycle",
+		Usage:     "Recycle a session back to the pool",
+		UsageText: "hive session recycle <id>",
+		Description: `Marks a session as recycled so it can be reused for a new task.
+
+Runs any configured recycle commands (e.g. git reset) and kills the associated tmux session.`,
+		Action: cmd.runRecycle,
+	}
+}
+
+func (cmd *SessionCmd) runRecycle(ctx context.Context, c *cli.Command) error {
+	id := c.Args().First()
+	if id == "" {
+		return fmt.Errorf("session ID required")
+	}
+
+	if err := cmd.app.Sessions.RecycleSession(ctx, id, os.Stderr); err != nil {
+		return fmt.Errorf("recycle session: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Session %s recycled\n", id)
 	return nil
 }
 

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -599,6 +599,11 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string) error {
 		}
 	}
 
+	// Kill associated tmux session (best-effort)
+	if _, err := s.executor.Run(ctx, "tmux", "kill-session", "-t", sess.Slug); err != nil {
+		s.log.Debug().Err(err).Str("session", sess.Slug).Msg("no tmux session to kill")
+	}
+
 	// Remove directory
 	if err := os.RemoveAll(sess.Path); err != nil {
 		return fmt.Errorf("remove directory: %w", err)

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -68,3 +68,58 @@ func TestSessionLsJSON(t *testing.T) {
 	assert.Contains(t, entry, "repo")
 	assert.Contains(t, entry, "inbox")
 }
+
+func TestSessionDelete(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "delete-repo")
+
+	_, err := h.Run("new", "--remote", repo, "to-delete")
+	require.NoError(t, err)
+
+	lines, err := h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	require.Len(t, lines, 1)
+	id := lines[0]["id"].(string)
+
+	_, err = h.Run("session", "delete", id)
+	require.NoError(t, err)
+
+	lines, err = h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, lines, "session should be gone after delete")
+}
+
+func TestSessionDeleteMissingID(t *testing.T) {
+	h := NewHarness(t)
+
+	_, err := h.Run("session", "delete")
+	require.Error(t, err, "delete without ID should fail")
+}
+
+func TestSessionRecycle(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "recycle-repo")
+
+	_, err := h.Run("new", "--remote", repo, "to-recycle")
+	require.NoError(t, err)
+
+	lines, err := h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	require.Len(t, lines, 1)
+	id := lines[0]["id"].(string)
+
+	_, err = h.Run("session", "recycle", id)
+	require.NoError(t, err)
+
+	lines, err = h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	require.Len(t, lines, 1)
+	assert.Equal(t, "recycled", lines[0]["state"], "session state should be recycled")
+}
+
+func TestSessionRecycleMissingID(t *testing.T) {
+	h := NewHarness(t)
+
+	_, err := h.Run("session", "recycle")
+	require.Error(t, err, "recycle without ID should fail")
+}


### PR DESCRIPTION
## Summary

- Add `hive session delete <id>` and `hive session recycle <id>` subcommands under the existing `session` command group
- Fix bug where `DeleteSession()` did not kill the associated tmux session before removing the directory — `RecycleSession()` already did this correctly via `tmux kill-session -t <slug>`
- The fix automatically covers `Prune()` and the TUI delete executor, both of which call through `DeleteSession()`

## Changes

- `internal/hive/service.go` — add best-effort `tmux kill-session` call in `DeleteSession()` before `os.RemoveAll`, matching the pattern already used in `RecycleSession()`
- `internal/commands/cmd_session.go` — add `deleteCmd()` / `recycleCmd()` following the existing `lsCmd` / `infoCmd` pattern; `recycle` pipes output to `os.Stderr` so recycle script output is visible
- `test/integration/session_test.go` — integration tests for both new commands plus missing-ID error cases

## Test plan

- [ ] `mise run test` passes (unit tests)
- [ ] `mise run test -- -tags integration` passes (integration tests including new delete/recycle cases)
- [ ] `mise run lint` passes
- [ ] `hive session delete <id>` removes session from `hive ls` output
- [ ] `hive session recycle <id>` shows session as `recycled` in `hive ls` output
- [ ] Deleting a session with an active tmux session kills that tmux session (`tmux ls` before/after)