### PR TITLE
fix(tui): stop KV filter from swallowing keys on other views

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -700,8 +700,10 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleRepoPickerKey(msg)
 	}
 
-	// When filtering in either list, pass most keys except quit
-	if m.sessionsView.IsSettingFilter() || m.kvView.IsFiltering() || m.sessionsView.FocusMode() {
+	// When filtering in either list, pass most keys except quit. The KV
+	// filter only captures keys while the Store view is active so it cannot
+	// swallow keys on other views.
+	if m.sessionsView.IsSettingFilter() || (m.activeView == ViewStore && m.kvView.IsFiltering()) || m.sessionsView.FocusMode() {
 		return m.handleFilteringKey(msg, keyStr)
 	}
 

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -1142,6 +1142,9 @@ func (m Model) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 // (tab bar click).
 func (m Model) switchToView(view ViewType) (tea.Model, tea.Cmd) {
 	m.lastClickTime = time.Time{} // reset double-click state across view changes
+	if m.activeView == ViewStore && view != ViewStore && m.kvView.IsFiltering() {
+		m.kvView.CancelFilter() // don't leave stale KV filter state behind
+	}
 	m.activeView = view
 	m.handler.SetActiveView(view)
 	m.sessionsView.SetActive(view == ViewSessions)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -455,6 +455,45 @@ func TestFilterModeSwallowsKeys(t *testing.T) {
 	assert.Equal(t, stateNormal, m.state)
 }
 
+func TestKVFilterDoesNotLeakAcrossViews(t *testing.T) {
+	newModel := func(t *testing.T) Model {
+		return newKeybindingPrecedenceModel(t, func(cfg *config.Config) {
+			cfg.UserCommands["SentinelTodoPanel"] = config.UserCommand{
+				Action: act.TypeTodoPanel,
+				Help:   "sentinel todo panel",
+				Scope:  []string{"sessions"},
+			}
+			cfg.Views.Sessions.Keybindings["g"] = config.Keybinding{Cmd: "SentinelTodoPanel"}
+		})
+	}
+
+	t.Run("switching away from store cancels the filter", func(t *testing.T) {
+		m := newModel(t)
+		m = switchTestView(t, m, ViewStore)
+		m.kvView.StartFilter()
+		require.True(t, m.kvView.IsFiltering())
+
+		m = switchTestView(t, m, ViewSessions)
+		assert.False(t, m.kvView.IsFiltering())
+
+		// Keybindings resolve normally on the sessions view after switching.
+		m = driveKeyUpdate(t, m, "g")
+		assert.Equal(t, stateShowingTodos, m.state)
+	})
+
+	t.Run("active kv filter does not capture keys on other views", func(t *testing.T) {
+		m := newModel(t)
+		m = switchTestView(t, m, ViewSessions)
+
+		// Simulate stale KV filter state while another view is active.
+		m.kvView.StartFilter()
+		require.True(t, m.kvView.IsFiltering())
+
+		m = driveKeyUpdate(t, m, "g")
+		assert.Equal(t, stateShowingTodos, m.state, "key must resolve via keybindings, not the KV filter")
+	})
+}
+
 func TestUnknownCommandDoesNotFallBack(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

The Store (KV) view's filter state leaked across tabs. `Model.handleKey` routed keys to `handleFilteringKey` whenever `m.kvView.IsFiltering()` was true, regardless of the active view.

**Repro:** open the Store tab, press `/` to start the KV filter, then mouse-click the Sessions tab (keyboard `tab` is swallowed by the filter handler). On the Sessions view, keys like `ctrl+d` (TmuxKill) and `d` (Delete) do nothing — they are routed into the invisible KV filter input until `esc` unsticks it.

## Fix

- `Model.handleKey` only routes to the KV filter handler when the Store view is active (`m.activeView == ViewStore && m.kvView.IsFiltering()`).
- `switchToView` cancels the KV filter when leaving the Store tab, so no stale filter state lingers.

## Testing

- New regression test `TestKVFilterDoesNotLeakAcrossViews` covering both cases: filter cancelled on view switch, and keys resolving via keybindings (not the filter) even with stale filter state. Both subtests fail without the fix.
- `mise run fmt`, `mise run lint` (0 issues), `mise run test` (all 43 packages pass).