### PR TITLE
fix(tui): respect default agent in new session form

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1662,7 +1662,9 @@ func (m Model) openNewSessionForm() (tea.Model, tea.Cmd) {
 		}
 	}
 
-	m.modals.NewSession = NewNewSessionForm(m.sessionsView.DiscoveredRepos(), preselectedRemote, existingNames, agentKeys)
+	newSessionForm := NewNewSessionForm(m.sessionsView.DiscoveredRepos(), preselectedRemote, existingNames, agentKeys)
+	newSessionForm.selectAgent(m.cfg.Agents.Default)
+	m.modals.NewSession = newSessionForm
 	m.state = stateCreatingSession
 	return m, m.modals.NewSession.Init()
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -72,6 +74,57 @@ func newKeybindingPrecedenceModel(t *testing.T, mutate func(*config.Config)) Mod
 	}, Opts{})
 
 	return m
+}
+
+func TestOpenNewSessionFormUsesEnvironmentDefaultAgent(t *testing.T) {
+	dataDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`agents:
+  agent_selector: true
+  default: claude
+  claude: {}
+  pi: {}
+`), 0o600))
+	t.Setenv(config.EnvDefaultAgent, "pi")
+
+	cfg, err := config.Load(configPath, dataDir)
+	require.NoError(t, err)
+	require.Equal(t, "pi", cfg.Agents.Default)
+
+	database, err := db.Open(dataDir, db.DefaultOpenOptions())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, database.Close())
+	})
+
+	tb := testbus.New(t)
+	commandSet := plugins.NewCommandSet(config.DefaultUserCommands(), cfg.UserCommands)
+	pluginManager := plugins.NewManager(plugins.NewWorkerPool(0), commandSet)
+	todoService := hive.NewTodoService(
+		stores.NewTodoStore(database),
+		tb.EventBus,
+		cfg,
+		zerolog.New(io.Discard),
+	)
+
+	m := New(Deps{
+		Config:          cfg,
+		Service:         newMouseTestSessionService(t),
+		Renderer:        testRenderer,
+		TerminalManager: terminal.NewManager(nil),
+		PluginManager:   pluginManager,
+		CommandSet:      commandSet,
+		TodoService:     todoService,
+		DB:              database,
+		Bus:             tb.EventBus,
+	}, Opts{})
+
+	model, _ := m.openNewSessionForm()
+	opened := model.(Model)
+	require.NotNil(t, opened.modals.NewSession)
+	require.True(t, opened.modals.NewSession.hasAgentSelector)
+	require.NotEmpty(t, opened.modals.NewSession.agent.keys)
+	assert.Equal(t, "pi", opened.modals.NewSession.agent.keys[opened.modals.NewSession.agent.selected])
 }
 
 func keyPressMsg(key string) tea.KeyPressMsg {

--- a/internal/tui/new_session_form.go
+++ b/internal/tui/new_session_form.go
@@ -146,6 +146,18 @@ func NewNewSessionForm(repos []workspace.DiscoveredRepo, preselectedRemote strin
 }
 
 // repoIdx returns the focusedField value for the repo field.
+func (f *NewSessionForm) selectAgent(key string) {
+	if !f.hasAgentSelector || key == "" {
+		return
+	}
+	for i, agentKey := range f.agent.keys {
+		if agentKey == key {
+			f.agent.selected = i
+			return
+		}
+	}
+}
+
 func (f *NewSessionForm) repoIdx() int {
 	if f.hasAgentSelector {
 		return repoFieldWithAgent

--- a/internal/tui/new_session_form_test.go
+++ b/internal/tui/new_session_form_test.go
@@ -125,4 +125,14 @@ func TestNewNewSessionForm(t *testing.T) {
 		updated, _ := form.Update(keyPress(tea.KeyEnter))
 		assert.Equal(t, 1, updated.focusedField)
 	})
+
+	t.Run("selectAgent chooses configured default even when not first", func(t *testing.T) {
+		form := NewNewSessionForm(repos, "", nil, []string{"claude", "codex", "pi"})
+		form.selectAgent("pi")
+		form.nameInput.SetValue("my-session")
+		form.submitted = true
+
+		result := form.Result()
+		assert.Equal(t, "pi", result.AgentKey)
+	})
 }


### PR DESCRIPTION
Fixes #

## Purpose

Ensure the TUI new-session agent selector preselects the resolved default agent, including when `HIVE_DEFAULT_AGENT` overrides `agents.default`.

## Proposed Changes

  - Select the default agent by key after constructing the new-session form.
  - Add regression tests for env-resolved default agent selection.
  - Add form-level coverage for selecting a default that is not first in the displayed list.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)