### PR TITLE
fix(tui): read default agent when opening session dialog

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"sort"
@@ -1642,6 +1643,8 @@ func (m Model) openNewSessionForm() (tea.Model, tea.Cmd) {
 		existingNames[s.Name] = true
 	}
 
+	defaultAgent := m.defaultAgentKey()
+
 	var agentKeys []string
 	if m.cfg.Agents.AgentSelector && len(m.cfg.Agents.Profiles) > 1 {
 		// Sort alphabetically, then rotate so the configured default is first
@@ -1652,21 +1655,29 @@ func (m Model) openNewSessionForm() (tea.Model, tea.Cmd) {
 		}
 		sort.Strings(all)
 		// Put the default first so it is pre-selected.
-		def := m.cfg.Agents.Default
 		agentKeys = make([]string, 0, len(all))
-		agentKeys = append(agentKeys, def)
+		agentKeys = append(agentKeys, defaultAgent)
 		for _, k := range all {
-			if k != def {
+			if k != defaultAgent {
 				agentKeys = append(agentKeys, k)
 			}
 		}
 	}
 
 	newSessionForm := NewNewSessionForm(m.sessionsView.DiscoveredRepos(), preselectedRemote, existingNames, agentKeys)
-	newSessionForm.selectAgent(m.cfg.Agents.Default)
+	newSessionForm.selectAgent(defaultAgent)
 	m.modals.NewSession = newSessionForm
 	m.state = stateCreatingSession
 	return m, m.modals.NewSession.Init()
+}
+
+func (m Model) defaultAgentKey() string {
+	if envDefault := os.Getenv(config.EnvDefaultAgent); envDefault != "" {
+		if _, ok := m.cfg.Agents.Profiles[envDefault]; ok {
+			return envDefault
+		}
+	}
+	return m.cfg.Agents.Default
 }
 
 // selectedTreeItem returns the currently selected tree item, or nil if none.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -76,6 +76,25 @@ func newKeybindingPrecedenceModel(t *testing.T, mutate func(*config.Config)) Mod
 	return m
 }
 
+func TestOpenNewSessionFormReadsEnvironmentDefaultAgentAtOpen(t *testing.T) {
+	m := newKeybindingPrecedenceModel(t, func(cfg *config.Config) {
+		cfg.Agents.AgentSelector = true
+		cfg.Agents.Default = "claude"
+		cfg.Agents.Profiles = map[string]config.AgentProfile{
+			"claude": {},
+			"pi":     {},
+		}
+	})
+	t.Setenv(config.EnvDefaultAgent, "pi")
+
+	model, _ := m.openNewSessionForm()
+	opened := model.(Model)
+	require.NotNil(t, opened.modals.NewSession)
+	require.True(t, opened.modals.NewSession.hasAgentSelector)
+	require.NotEmpty(t, opened.modals.NewSession.agent.keys)
+	assert.Equal(t, "pi", opened.modals.NewSession.agent.keys[opened.modals.NewSession.agent.selected])
+}
+
 func TestOpenNewSessionFormUsesEnvironmentDefaultAgent(t *testing.T) {
 	dataDir := t.TempDir()
 	configPath := filepath.Join(t.TempDir(), "config.yaml")


### PR DESCRIPTION
Fixes #

## Purpose

Ensure the TUI new-session agent selector honors `HIVE_DEFAULT_AGENT` when the dialog opens, even if the config was already loaded before the environment override was set.

## Proposed Changes

  - Resolve the default agent from `HIVE_DEFAULT_AGENT` at dialog-open time when it matches a configured profile.
  - Add regression coverage for opening the form after setting the environment variable.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)