### PR TITLE
feat(sources): multi-select in source picker to spawn many sessions

### DIFF
--- a/docs/configuration/sources.md
+++ b/docs/configuration/sources.md
@@ -83,6 +83,13 @@ returns to navigate, keeping the filter), `O` opens the highlighted item in
 your browser, and enter creates a session from it using the source's configured
 templates.
 
+Space marks items for batch spawning: enter then creates one session per
+marked item instead of the highlighted one. Marks survive filtering, tab
+switches, and re-searches, and are capped at 10 across all tabs. Session
+creation runs on a single background stream; if some items fail (e.g. a
+template error), the rest still spawn and the completion notice reports how
+many failed.
+
 Custom commands can pin a source id and scope via preset `args`, and keybindings
 can reference those commands. This is how the built-in `SourceIssues`/`SourcePRs`
 commands are defined:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -598,10 +598,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Source picker
 	case sourcepicker.Msg:
 		model, cmd = m.forwardSourcePickerMsg(msg)
-	case sourceSelectionErrorMsg:
-		m.state = stateNormal
-		m.notifyErrorf("source %q: %v", msg.SourceID, msg.Err)
-		model, cmd = m, nil
 
 	// Review delegation
 	case review.DocumentChangeMsg:

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -1011,7 +1011,7 @@ func (m Model) startSourceCreate(results []sourcepicker.Result, scope sourcePick
 // batch, or a partial-failure summary otherwise. The first created
 // session is written to firstID/firstName for post-completion selection.
 func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.Result, scope sourcePickerScope, out chan<- string, firstID, firstName *string) error {
-	failed := 0
+	var failedIDs []string
 	var firstErr error
 	for i, result := range results {
 		if err := ctx.Err(); err != nil {
@@ -1031,7 +1031,7 @@ func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.
 		if ctx.Err() != nil {
 			return err
 		}
-		failed++
+		failedIDs = append(failedIDs, result.Item.ID)
 		if firstErr == nil {
 			firstErr = err
 		}
@@ -1041,12 +1041,15 @@ func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.
 	}
 
 	switch {
-	case failed == 0:
+	case len(failedIDs) == 0:
 		return nil
 	case len(results) == 1:
 		return firstErr
 	default:
-		return fmt.Errorf("%d of %d sessions failed", failed, len(results))
+		// Name the failed items (IDs are short — issue/PR numbers) so the
+		// completion notification tells the user what to retry; full causes
+		// stay in the log.
+		return fmt.Errorf("%d of %d sessions failed (#%s)", len(failedIDs), len(results), strings.Join(failedIDs, ", #"))
 	}
 }
 

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -934,10 +934,6 @@ func (m Model) handleSourcePickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // stream. Detail fetches and template rendering run inside the stream so a
 // slow `gh` call never blocks the UI.
 func (m Model) handleSourceSelection(results []sourcepicker.Result) (tea.Model, tea.Cmd) {
-	if len(results) == 0 {
-		m.state = stateNormal
-		return m, nil
-	}
 	if m.modals.BgStreamDone != nil {
 		m.state = stateNormal
 		m.notifyErrorf("already running in background: %s", m.modals.BgStreamTitle)
@@ -969,8 +965,10 @@ func fetchSourceDetail(ctx context.Context, result sourcepicker.Result, scope st
 }
 
 // startSourceCreate starts one background stream that creates a session
-// for every result in order. Per-item failures are reported on the stream
-// and summarized in the completion error; remaining items still spawn.
+// for every result in order. Background stream output is discarded (see
+// listenForBgStreamComplete), so the user-visible record of per-item
+// failures is the summarized completion error plus the log; remaining
+// items still spawn.
 func (m Model) startSourceCreate(results []sourcepicker.Result, scope sourcePickerScope) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1005,11 +1003,13 @@ func (m Model) startSourceCreate(results []sourcepicker.Result, scope sourcePick
 	}
 }
 
-// createSourceSessions renders and creates one session per result,
-// streaming progress lines into out. A failed item is reported on the
-// stream and logged, then the loop moves on; only cancellation aborts the
+// createSourceSessions renders and creates one session per result, writing
+// progress lines to out (discarded while the stream runs in background —
+// the summary error and the log are the user-visible record). A failed
+// item is logged, then the loop moves on; only cancellation aborts the
 // batch. The returned error is the lone item's error for a single-item
-// batch, or a partial-failure summary otherwise.
+// batch, or a partial-failure summary otherwise. The first created
+// session is written to firstID/firstName for post-completion selection.
 func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.Result, scope sourcePickerScope, out chan<- string, firstID, firstName *string) error {
 	failed := 0
 	var firstErr error
@@ -1020,8 +1020,12 @@ func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.
 		if len(results) > 1 {
 			streamLine(ctx, out, fmt.Sprintf("[%d/%d] %s", i+1, len(results), result.Item.Title))
 		}
-		err := m.createSourceSession(ctx, result, scope, out, firstID, firstName)
+		id, name, err := m.createSourceSession(ctx, result, scope, out)
 		if err == nil {
+			if *firstID == "" {
+				*firstID = id
+				*firstName = name
+			}
 			continue
 		}
 		if ctx.Err() != nil {
@@ -1048,13 +1052,14 @@ func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.
 
 // createSourceSession fetches the item's detail (best-effort), renders the
 // source's session templates, and creates the session, forwarding its
-// creation output onto the shared stream.
-func (m Model) createSourceSession(ctx context.Context, result sourcepicker.Result, scope sourcePickerScope, out chan<- string, firstID, firstName *string) error {
+// creation output onto the shared stream. It returns the created session's
+// ID and name.
+func (m Model) createSourceSession(ctx context.Context, result sourcepicker.Result, scope sourcePickerScope, out chan<- string) (id, name string, err error) {
 	detail := fetchSourceDetail(ctx, result, scope.Search)
 
 	rendered, err := sources.RenderSessionTemplates(result.Templates, result.Item, detail)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	exec := m.cmdService.NewCreateExecutor(hive.CreateOptions{
@@ -1073,13 +1078,9 @@ func (m Model) createSourceSession(ctx context.Context, result sourcepicker.Resu
 		streamLine(ctx, out, line)
 	}
 	if err := <-done; err != nil {
-		return err
+		return "", "", err
 	}
-	if *firstID == "" {
-		*firstID = exec.ResultSessionID
-		*firstName = exec.ResultSessionName
-	}
-	return nil
+	return exec.ResultSessionID, exec.ResultSessionName, nil
 }
 
 // streamLine sends a line to a stream output channel without blocking past

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -921,34 +921,30 @@ func (m Model) handleSourcePickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if result, ok := picker.Selected(); ok {
+	if results, ok := picker.Selected(); ok {
 		m.modals.SourcePicker = nil
-		return m.handleSourceSelection(result)
+		return m.handleSourceSelection(results)
 	}
 
 	return m, cmd
 }
 
-// handleSourceSelection fetches the selected item's detail (best-effort,
-// capability-gated), renders the source's session templates against the
-// item, and creates a session via the same UseBatchSpawn:true path used
-// by `hive batch`. The detail fetch and render run inside the returned
-// command so a slow `gh` call never blocks the UI.
-func (m Model) handleSourceSelection(result sourcepicker.Result) (tea.Model, tea.Cmd) {
+// handleSourceSelection spawns one session per selected item via the same
+// UseBatchSpawn:true path used by `hive batch`, all on a single background
+// stream. Detail fetches and template rendering run inside the stream so a
+// slow `gh` call never blocks the UI.
+func (m Model) handleSourceSelection(results []sourcepicker.Result) (tea.Model, tea.Cmd) {
+	if len(results) == 0 {
+		m.state = stateNormal
+		return m, nil
+	}
 	if m.modals.BgStreamDone != nil {
 		m.state = stateNormal
 		m.notifyErrorf("already running in background: %s", m.modals.BgStreamTitle)
 		return m, nil
 	}
 
-	return m, m.startSourceCreate(result, m.pendingSourceScope)
-}
-
-// sourceSelectionErrorMsg reports an async template-render failure from
-// startSourceCreate back to the model.
-type sourceSelectionErrorMsg struct {
-	SourceID string
-	Err      error
+	return m, m.startSourceCreate(results, m.pendingSourceScope)
 }
 
 // fetchSourceDetail returns the item's detail for template rendering.
@@ -972,37 +968,126 @@ func fetchSourceDetail(ctx context.Context, result sourcepicker.Result, scope st
 	return fetched
 }
 
-func (m Model) startSourceCreate(result sourcepicker.Result, scope sourcePickerScope) tea.Cmd {
+// startSourceCreate starts one background stream that creates a session
+// for every result in order. Per-item failures are reported on the stream
+// and summarized in the completion error; remaining items still spawn.
+func (m Model) startSourceCreate(results []sourcepicker.Result, scope sourcePickerScope) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
-		detail := fetchSourceDetail(ctx, result, scope.Search)
+		ctx, cancel := context.WithCancel(context.Background())
+		output := make(chan string, 100)
+		done := make(chan error, 1)
 
-		rendered, err := sources.RenderSessionTemplates(result.Templates, result.Item, detail)
-		if err != nil {
-			return sourceSelectionErrorMsg{SourceID: result.SourceID, Err: err}
+		// Populated with the first created session before done fires, for
+		// post-completion selection (same contract as CreateExecutor).
+		firstID := new(string)
+		firstName := new(string)
+
+		go func() {
+			defer close(output)
+			defer close(done)
+			done <- m.createSourceSessions(ctx, results, scope, output, firstID, firstName)
+		}()
+
+		title := "Creating session..."
+		if len(results) > 1 {
+			title = fmt.Sprintf("Creating %d sessions...", len(results))
 		}
-
-		exec := m.cmdService.NewCreateExecutor(hive.CreateOptions{
-			Name:          rendered.Name,
-			Prompt:        rendered.Prompt,
-			Remote:        scope.Remote,
-			Source:        scope.Source,
-			UseBatchSpawn: true,
-			Background:    true,
-			Tags:          rendered.Tags,
-		})
-
-		output, done, cancel := exec.Execute(ctx)
 		return bgStreamStartedMsg{
-			title:  "Creating session...",
+			title:  title,
 			output: output,
 			done:   done,
 			cancel: cancel,
 			result: streamResult{
-				sessionID:   &exec.ResultSessionID,
-				sessionName: &exec.ResultSessionName,
+				sessionID:   firstID,
+				sessionName: firstName,
 			},
 		}
+	}
+}
+
+// createSourceSessions renders and creates one session per result,
+// streaming progress lines into out. A failed item is reported on the
+// stream and logged, then the loop moves on; only cancellation aborts the
+// batch. The returned error is the lone item's error for a single-item
+// batch, or a partial-failure summary otherwise.
+func (m Model) createSourceSessions(ctx context.Context, results []sourcepicker.Result, scope sourcePickerScope, out chan<- string, firstID, firstName *string) error {
+	failed := 0
+	var firstErr error
+	for i, result := range results {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if len(results) > 1 {
+			streamLine(ctx, out, fmt.Sprintf("[%d/%d] %s", i+1, len(results), result.Item.Title))
+		}
+		err := m.createSourceSession(ctx, result, scope, out, firstID, firstName)
+		if err == nil {
+			continue
+		}
+		if ctx.Err() != nil {
+			return err
+		}
+		failed++
+		if firstErr == nil {
+			firstErr = err
+		}
+		streamLine(ctx, out, fmt.Sprintf("[%d/%d] failed: %v", i+1, len(results), err))
+		log.Warn().Err(err).Str("source", result.SourceID).Str("item", result.Item.ID).
+			Msg("source picker: session create failed")
+	}
+
+	switch {
+	case failed == 0:
+		return nil
+	case len(results) == 1:
+		return firstErr
+	default:
+		return fmt.Errorf("%d of %d sessions failed", failed, len(results))
+	}
+}
+
+// createSourceSession fetches the item's detail (best-effort), renders the
+// source's session templates, and creates the session, forwarding its
+// creation output onto the shared stream.
+func (m Model) createSourceSession(ctx context.Context, result sourcepicker.Result, scope sourcePickerScope, out chan<- string, firstID, firstName *string) error {
+	detail := fetchSourceDetail(ctx, result, scope.Search)
+
+	rendered, err := sources.RenderSessionTemplates(result.Templates, result.Item, detail)
+	if err != nil {
+		return err
+	}
+
+	exec := m.cmdService.NewCreateExecutor(hive.CreateOptions{
+		Name:          rendered.Name,
+		Prompt:        rendered.Prompt,
+		Remote:        scope.Remote,
+		Source:        scope.Source,
+		UseBatchSpawn: true,
+		Background:    true,
+		Tags:          rendered.Tags,
+	})
+
+	output, done, cancel := exec.Execute(ctx)
+	defer cancel()
+	for line := range output {
+		streamLine(ctx, out, line)
+	}
+	if err := <-done; err != nil {
+		return err
+	}
+	if *firstID == "" {
+		*firstID = exec.ResultSessionID
+		*firstName = exec.ResultSessionName
+	}
+	return nil
+}
+
+// streamLine sends a line to a stream output channel without blocking past
+// cancellation.
+func streamLine(ctx context.Context, out chan<- string, line string) {
+	select {
+	case out <- line:
+	case <-ctx.Done():
 	}
 }
 

--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -720,20 +720,23 @@ func (m Model) handleBgStreamComplete(msg bgStreamCompleteMsg) (tea.Model, tea.C
 		m.modals.BgStreamTitle = ""
 	}
 
-	if msg.err == nil {
-		if active {
+	if active {
+		if msg.err == nil {
 			m.publishNotificationf(notify.LevelInfo, "Complete: %s", msg.title)
+		} else {
+			m.publishNotificationf(notify.LevelError, "Failed: %s — %v", msg.title, msg.err)
 		}
-		if msg.result.sessionID != nil && *msg.result.sessionID != "" {
-			m.sessionsView.SelectOnNextRefresh(*msg.result.sessionID)
-		}
-		return m, m.refreshSessions()
 	}
 
-	if active {
-		m.publishNotificationf(notify.LevelError, "Failed: %s — %v", msg.title, msg.err)
+	// A batch can fail partially: an error with a populated session ID means
+	// some sessions were still created, so they must appear (and be
+	// selected) without waiting for a manual or periodic refresh.
+	if msg.result.sessionID != nil && *msg.result.sessionID != "" {
+		m.sessionsView.SelectOnNextRefresh(*msg.result.sessionID)
+	} else if msg.err != nil {
+		return m, nil
 	}
-	return m, nil
+	return m, m.refreshSessions()
 }
 
 // --- Review delegation ---

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -164,6 +165,37 @@ func TestHandleBgStreamCompleteIgnoresStaleCompletion(t *testing.T) {
 	assert.Equal(t, secondDone, next.modals.BgStreamDone)
 	assert.NotNil(t, next.modals.BgStreamCancel)
 	assert.Equal(t, "second", next.modals.BgStreamTitle)
+}
+
+func TestHandleBgStreamCompletePartialFailureStillRefreshes(t *testing.T) {
+	var done <-chan error = make(chan error)
+	m := Model{modals: NewModalCoordinator(), sessionsView: &sessions.View{}}
+	m.modals.BgStreamDone = done
+
+	id, name := "sess-1", "sess-one"
+	_, cmd := m.handleBgStreamComplete(bgStreamCompleteMsg{
+		title:  "Creating 3 sessions...",
+		done:   done,
+		err:    errors.New("1 of 3 sessions failed (#2)"),
+		result: streamResult{sessionID: &id, sessionName: &name},
+	})
+
+	// A partial failure still created sessions: the completion must trigger
+	// a refresh so they appear without manual action.
+	require.NotNil(t, cmd)
+	assert.IsType(t, sessions.RefreshSessionsMsg{}, cmd())
+
+	// A failed batch that created nothing keeps the old no-refresh behavior.
+	m2 := Model{modals: NewModalCoordinator()}
+	m2.modals.BgStreamDone = done
+	empty := ""
+	_, cmd = m2.handleBgStreamComplete(bgStreamCompleteMsg{
+		title:  "Creating session...",
+		done:   done,
+		err:    errors.New("boom"),
+		result: streamResult{sessionID: &empty, sessionName: &empty},
+	})
+	assert.Nil(t, cmd)
 }
 
 func TestHandleStreamingModalKeyDoesNotOverwriteActiveBackgroundStream(t *testing.T) {

--- a/internal/tui/source_wiring_test.go
+++ b/internal/tui/source_wiring_test.go
@@ -166,7 +166,8 @@ func TestCreateSourceSessions_PartialFailureContinues(t *testing.T) {
 	var firstID, firstName string
 	err := m.createSourceSessions(context.Background(), results, sourcePickerScope{}, out, &firstID, &firstName)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "1 of 3 sessions failed")
+	assert.Contains(t, err.Error(), "1 of 3 sessions failed (#2)",
+		"summary names the failed items so the user knows what to retry")
 
 	require.Len(t, creator.created, 2, "items after a failure must still spawn")
 	assert.Equal(t, "session-1", creator.created[0].Name)

--- a/internal/tui/source_wiring_test.go
+++ b/internal/tui/source_wiring_test.go
@@ -2,13 +2,17 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/hive"
 	"github.com/colonyops/hive/internal/sources"
+	"github.com/colonyops/hive/internal/tui/command"
 	"github.com/colonyops/hive/internal/tui/sourcepicker"
 )
 
@@ -106,6 +110,90 @@ func sourcepickerResult(src sources.Source, manifest sources.Manifest) sourcepic
 		Source:   src,
 		Manifest: manifest,
 	}
+}
+
+// fakeSessionCreator records CreateSession calls for fan-out tests.
+type fakeSessionCreator struct {
+	created []hive.CreateOptions
+}
+
+func (f *fakeSessionCreator) CreateSession(_ context.Context, opts hive.CreateOptions) (*session.Session, error) {
+	f.created = append(f.created, opts)
+	return &session.Session{ID: fmt.Sprintf("id-%d", len(f.created)), Slug: opts.Name}, nil
+}
+
+func multiResult(id, nameTemplate string) sourcepicker.Result {
+	return sourcepicker.Result{
+		Item:      sources.Item{ID: id, Title: "item " + id},
+		SourceID:  "issues",
+		Source:    stubSource{id: "issues"},
+		Templates: sources.TemplateConfig{Name: nameTemplate},
+	}
+}
+
+func TestCreateSourceSessions_FanOut(t *testing.T) {
+	creator := &fakeSessionCreator{}
+	m := Model{cmdService: command.NewService(nil, nil, nil, nil, creator)}
+	out := make(chan string, 100)
+
+	results := []sourcepicker.Result{
+		multiResult("1", "session-{{ .ID }}"),
+		multiResult("2", "session-{{ .ID }}"),
+	}
+
+	var firstID, firstName string
+	err := m.createSourceSessions(context.Background(), results, sourcePickerScope{}, out, &firstID, &firstName)
+	require.NoError(t, err)
+
+	require.Len(t, creator.created, 2, "every selected item spawns a session")
+	assert.Equal(t, "session-1", creator.created[0].Name)
+	assert.Equal(t, "session-2", creator.created[1].Name)
+	assert.Equal(t, "id-1", firstID, "first created session is recorded for selection")
+	assert.Equal(t, "session-1", firstName)
+}
+
+func TestCreateSourceSessions_PartialFailureContinues(t *testing.T) {
+	creator := &fakeSessionCreator{}
+	m := Model{cmdService: command.NewService(nil, nil, nil, nil, creator)}
+	out := make(chan string, 100)
+
+	results := []sourcepicker.Result{
+		multiResult("1", "session-{{ .ID }}"),
+		multiResult("2", "{{ .Nope }}"), // render failure
+		multiResult("3", "session-{{ .ID }}"),
+	}
+
+	var firstID, firstName string
+	err := m.createSourceSessions(context.Background(), results, sourcePickerScope{}, out, &firstID, &firstName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 of 3 sessions failed")
+
+	require.Len(t, creator.created, 2, "items after a failure must still spawn")
+	assert.Equal(t, "session-1", creator.created[0].Name)
+	assert.Equal(t, "session-3", creator.created[1].Name)
+
+	close(out)
+	var lines []string
+	for line := range out {
+		lines = append(lines, line)
+	}
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "[2/3] failed:", "per-item failure is reported on the stream")
+}
+
+func TestCreateSourceSessions_SingleItemErrorPassesThrough(t *testing.T) {
+	creator := &fakeSessionCreator{}
+	m := Model{cmdService: command.NewService(nil, nil, nil, nil, creator)}
+	out := make(chan string, 100)
+
+	var firstID, firstName string
+	err := m.createSourceSessions(context.Background(),
+		[]sourcepicker.Result{multiResult("1", "{{ .Nope }}")},
+		sourcePickerScope{}, out, &firstID, &firstName)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name template", "single-item batches surface the underlying error")
+	assert.Empty(t, creator.created)
 }
 
 func TestSourcePickerScopeForSelection(t *testing.T) {

--- a/internal/tui/source_wiring_test.go
+++ b/internal/tui/source_wiring_test.go
@@ -178,7 +178,7 @@ func TestCreateSourceSessions_PartialFailureContinues(t *testing.T) {
 		lines = append(lines, line)
 	}
 	joined := strings.Join(lines, "\n")
-	assert.Contains(t, joined, "[2/3] failed:", "per-item failure is reported on the stream")
+	assert.Contains(t, joined, "[2/3] failed:", "per-item failure is written to the stream (discarded while backgrounded)")
 }
 
 func TestCreateSourceSessions_SingleItemErrorPassesThrough(t *testing.T) {

--- a/internal/tui/sourcepicker/picker.go
+++ b/internal/tui/sourcepicker/picker.go
@@ -39,7 +39,18 @@ const (
 	// rowsPerItemCard is the terminal-row height of one card item: the
 	// title line plus the status strip beneath it.
 	rowsPerItemCard = 2
+	// markCellWidth is the fixed multi-select gutter at the start of every
+	// card row. Reserving it unconditionally keeps rows aligned whether or
+	// not anything is marked.
+	markCellWidth = 2
+	// maxMarkedItems caps how many items can be marked for batch spawning
+	// across all tabs, so one enter can't fan out an unbounded number of
+	// session creations.
+	maxMarkedItems = 10
 )
+
+// markGlyph indicates a marked (multi-selected) row in the mark gutter.
+const markGlyph = "✓"
 
 // defaultSearchDebounce is used when a remote-search manifest does not
 // set its own DebounceMS: long enough to coalesce normal typing, short
@@ -73,6 +84,20 @@ type tabState struct {
 	cursor       int
 	scrollOffset int
 	filterQuery  string
+
+	// marked holds the items toggled for batch spawning, in toggle order.
+	// Full items (not indexes) so marks survive re-filtering and remote
+	// re-searching that replace filteredItems.
+	marked []sources.Item
+}
+
+func (t *tabState) isMarked(id string) bool {
+	for i := range t.marked {
+		if t.marked[i].ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // Picker is a tabbed, searchable modal for browsing external sources.
@@ -343,7 +368,7 @@ func (p Picker) handleKey(msg tea.KeyPressMsg) (Picker, tea.Cmd) {
 		return p, nil
 	case "enter":
 		tab := p.activeState()
-		if len(tab.filteredItems) > 0 && tab.cursor < len(tab.filteredItems) {
+		if p.totalMarked() > 0 || (len(tab.filteredItems) > 0 && tab.cursor < len(tab.filteredItems)) {
 			p.selected = true
 		}
 		return p, nil
@@ -398,6 +423,8 @@ func (p Picker) handleNavigateKey(msg tea.KeyPressMsg) (Picker, tea.Cmd) {
 		return p.moveCursor(1), nil
 	case "k":
 		return p.moveCursor(-1), nil
+	case "space":
+		return p.toggleMark(), nil
 	case "/":
 		p.searchMode = true
 		return p, p.input.Focus()
@@ -405,6 +432,38 @@ func (p Picker) handleNavigateKey(msg tea.KeyPressMsg) (Picker, tea.Cmd) {
 		return p, p.openCurrentItemURL()
 	}
 	return p, nil
+}
+
+// toggleMark toggles multi-select on the cursor item. Marking is refused
+// past maxMarkedItems; the filter line renders the count in a warning
+// style at the cap so the refusal is visible.
+func (p Picker) toggleMark() Picker {
+	tab := p.activeState()
+	if tab.cursor < 0 || tab.cursor >= len(tab.filteredItems) {
+		return p
+	}
+	item := tab.filteredItems[tab.cursor]
+	for i := range tab.marked {
+		if tab.marked[i].ID == item.ID {
+			tab.marked = append(tab.marked[:i], tab.marked[i+1:]...)
+			return p
+		}
+	}
+	if p.totalMarked() >= maxMarkedItems {
+		log.Debug().Int("max", maxMarkedItems).Msg("source picker: mark limit reached")
+		return p
+	}
+	tab.marked = append(tab.marked, item)
+	return p
+}
+
+// totalMarked counts marked items across all tabs.
+func (p Picker) totalMarked() int {
+	n := 0
+	for i := range p.tabs {
+		n += len(p.tabs[i].marked)
+	}
+	return n
 }
 
 func (p Picker) switchTab(delta int) (Picker, tea.Cmd) {
@@ -562,22 +621,40 @@ func (p Picker) itemCapacity() int {
 	return max(p.listHeight()/rowsPerItemCard, 1)
 }
 
-// Selected returns the highlighted item if the user pressed enter.
-func (p Picker) Selected() (Result, bool) {
+// Selected returns the items to spawn if the user pressed enter: every
+// marked item across all tabs (in toggle order, tab by tab), or the
+// highlighted item when nothing is marked.
+func (p Picker) Selected() ([]Result, bool) {
 	if !p.selected {
-		return Result{}, false
+		return nil, false
 	}
+
+	var results []Result
+	for i := range p.tabs {
+		tab := &p.tabs[i]
+		for _, item := range tab.marked {
+			results = append(results, tabResult(tab, item))
+		}
+	}
+	if len(results) > 0 {
+		return results, true
+	}
+
 	tab := p.activeState()
 	if tab.cursor < 0 || tab.cursor >= len(tab.filteredItems) {
-		return Result{}, false
+		return nil, false
 	}
+	return []Result{tabResult(tab, tab.filteredItems[tab.cursor])}, true
+}
+
+func tabResult(tab *tabState, item sources.Item) Result {
 	return Result{
-		Item:      tab.filteredItems[tab.cursor],
+		Item:      item,
 		SourceID:  tab.tab.ID,
 		Source:    tab.tab.Source,
 		Manifest:  tab.tab.Manifest,
 		Templates: tab.tab.Templates,
-	}, true
+	}
 }
 
 // Cancelled reports whether the user dismissed the picker.
@@ -740,6 +817,16 @@ func (p Picker) renderFilterLine(tab *tabState) string {
 	}
 
 	countStr := styles.TextMutedStyle.Render(fmt.Sprintf("%d", len(tab.filteredItems)))
+	// Surface the marked total (across tabs) next to the item count; at
+	// the cap it turns warning-colored since further marks are refused.
+	if n := p.totalMarked(); n > 0 {
+		markStyle := styles.TextSuccessStyle
+		if n >= maxMarkedItems {
+			markStyle = styles.TextWarningStyle
+		}
+		countStr = markStyle.Render(fmt.Sprintf("%s %d", markGlyph, n)) +
+			" " + styles.TextMutedStyle.Render("·") + " " + countStr
+	}
 
 	gap := max(p.innerWidth-lipgloss.Width(placeholder)-lipgloss.Width(countStr), 1)
 	return placeholder + strings.Repeat(" ", gap) + countStr
@@ -758,7 +845,7 @@ func (p Picker) renderList(tab *tabState) string {
 		item := tab.filteredItems[idx]
 		selected := idx == tab.cursor
 		// Each card row is two lines joined by "\n".
-		lines = append(lines, p.renderRow(item, selected, numWidth))
+		lines = append(lines, p.renderRow(item, selected, tab.isMarked(item.ID), numWidth))
 	}
 
 	// Pad with blank lines so the body box keeps a fixed height. Each
@@ -778,9 +865,9 @@ func (p Picker) renderList(tab *tabState) string {
 // only the trailing padding is highlighted. Do not "restore" per-cell
 // styling on selected rows unless every cell and every padding space
 // carries the highlight background itself.
-func (p Picker) renderRow(item sources.Item, selected bool, numWidth int) string {
+func (p Picker) renderRow(item sources.Item, selected, marked bool, numWidth int) string {
 	innerWidth := max(p.innerWidth-2, 10) // account for the left border+space / padding
-	content := p.renderCardContent(item, !selected, innerWidth, numWidth)
+	content := p.renderCardContent(item, !selected, marked, innerWidth, numWidth)
 	if selected {
 		return p.selectedCardStyle.Render(content)
 	}
@@ -800,17 +887,32 @@ func numberColumnWidth(items []sources.Item) int {
 	return widest
 }
 
-// renderCardContent composes a two-line card row. Line 1 is the number and
-// title (left) with the author right-aligned; line 2 is the metadata strip
-// (left, aligned under the title) with labels right-aligned. When styled is
-// false the result carries no ANSI (used for selected rows — see the
-// comment on renderRow).
-func (p Picker) renderCardContent(item sources.Item, styled bool, innerWidth, numWidth int) string {
-	line1 := p.renderCardLine1(item, styled, innerWidth, numWidth)
+// renderCardContent composes a two-line card row. Line 1 leads with the
+// multi-select mark gutter, then the number and title (left) with the
+// author right-aligned; line 2 is the metadata strip (left, aligned under
+// the title) with labels right-aligned. When styled is false the result
+// carries no ANSI (used for selected rows — see the comment on renderRow).
+func (p Picker) renderCardContent(item sources.Item, styled, marked bool, innerWidth, numWidth int) string {
+	bodyWidth := max(innerWidth-markCellWidth, 10)
+	line1 := p.markCell(marked, styled) + p.renderCardLine1(item, styled, bodyWidth, numWidth)
 
 	indent := numWidth + 1 // align the meta strip under the title, past "#<n> "
-	line2 := strings.Repeat(" ", indent) + p.renderCardLine2(item, styled, max(innerWidth-indent, 1))
+	line2 := strings.Repeat(" ", markCellWidth+indent) + p.renderCardLine2(item, styled, max(bodyWidth-indent, 1))
 	return line1 + "\n" + line2
+}
+
+// markCell renders the fixed-width multi-select gutter: a mark glyph for
+// marked rows, blank space otherwise. On cursor rows (styled=false) the
+// glyph stays plain so the card highlight paints it.
+func (p Picker) markCell(marked, styled bool) string {
+	if !marked {
+		return strings.Repeat(" ", markCellWidth)
+	}
+	glyph := markGlyph
+	if styled {
+		glyph = styles.TextSuccessStyle.Render(glyph)
+	}
+	return glyph + " "
 }
 
 // renderCardLine1 renders "#<number> <title>" on the left with the author
@@ -1018,11 +1120,17 @@ func (p Picker) helpText() string {
 			components.HelpEntry{Key: "esc", Desc: "done"},
 		)
 	}
+	enterDesc := "select"
+	if n := p.totalMarked(); n > 0 {
+		enterDesc = fmt.Sprintf("spawn %d", n)
+	}
+	// No nav hint here: j/k/arrows are the expected defaults, and the help
+	// line must stay a single row at the modal's minimum width.
 	return components.KeyHints(
 		components.HelpEntry{Key: "tab", Desc: "switch source"},
 		components.HintFilter,
-		components.HintNav,
-		components.HelpEntry{Key: "enter", Desc: "select"},
+		components.HelpEntry{Key: "space", Desc: "mark"},
+		components.HelpEntry{Key: "enter", Desc: enterDesc},
 		components.HelpEntry{Key: "O", Desc: "open"},
 		components.HelpEntry{Key: "esc", Desc: "close"},
 	)

--- a/internal/tui/sourcepicker/picker_row_test.go
+++ b/internal/tui/sourcepicker/picker_row_test.go
@@ -12,8 +12,10 @@ import (
 func TestRowWidthsMatchSelectedVsUnselected(t *testing.T) {
 	p := newTestPicker(newFakeTUISource(fakeManifest(), nil), fakeManifest(), "test-repo", 90, 24)
 	item := sources.Item{ID: "1", Title: "First reference item", Fields: map[string]any{"number": 1278, "author": "alice"}}
-	sel := p.renderRow(item, true, 5)
-	unsel := p.renderRow(item, false, 5)
-	assert.Equal(t, lipgloss.Width(unsel), lipgloss.Width(sel), "selected and unselected rows must have identical width")
-	assert.Equal(t, p.innerWidth, lipgloss.Width(sel))
+	for _, marked := range []bool{false, true} {
+		sel := p.renderRow(item, true, marked, 5)
+		unsel := p.renderRow(item, false, marked, 5)
+		assert.Equal(t, lipgloss.Width(unsel), lipgloss.Width(sel), "selected and unselected rows must have identical width (marked=%v)", marked)
+		assert.Equal(t, p.innerWidth, lipgloss.Width(sel))
+	}
 }

--- a/internal/tui/sourcepicker/picker_test.go
+++ b/internal/tui/sourcepicker/picker_test.go
@@ -243,9 +243,10 @@ func TestPicker_SelectionAndCancel(t *testing.T) {
 	next, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	p = drainPicker(t, next, cmd)
 
-	result, ok := p.Selected()
+	results, ok := p.Selected()
 	require.True(t, ok)
-	assert.Equal(t, "1", result.Item.ID)
+	require.Len(t, results, 1, "enter without marks selects the cursor item")
+	assert.Equal(t, "1", results[0].Item.ID)
 	assert.False(t, p.Cancelled())
 
 	// Cancel test
@@ -256,6 +257,165 @@ func TestPicker_SelectionAndCancel(t *testing.T) {
 	assert.True(t, p2.Cancelled())
 	_, ok = p2.Selected()
 	assert.False(t, ok)
+}
+
+// pressSpace toggles the mark on the cursor item.
+func pressSpace(t *testing.T, p Picker) Picker {
+	t.Helper()
+	next, cmd := p.Update(tea.KeyPressMsg{Text: " ", Code: tea.KeySpace})
+	return drainPicker(t, next, cmd)
+}
+
+func TestPicker_SpaceTogglesMark(t *testing.T) {
+	items := []sources.Item{
+		{ID: "1", Title: "alpha"},
+		{ID: "2", Title: "beta"},
+	}
+	fake := newFakeTUISource(fakeManifest(), items)
+	p := newTestPicker(fake, fakeManifest(), "", 80, 24)
+	p = drainPicker(t, p, p.Init())
+
+	p = pressSpace(t, p)
+	tab := activeTab(p)
+	require.Len(t, tab.marked, 1)
+	assert.Equal(t, "1", tab.marked[0].ID)
+	assert.Equal(t, 0, tab.cursor, "marking must not move the cursor")
+
+	// Mark the second item, then move back and unmark the first.
+	p = p.moveCursor(1)
+	p = pressSpace(t, p)
+	require.Len(t, activeTab(p).marked, 2)
+
+	p = p.moveCursor(-1)
+	p = pressSpace(t, p)
+	tab = activeTab(p)
+	require.Len(t, tab.marked, 1)
+	assert.Equal(t, "2", tab.marked[0].ID, "unmarking removes only the toggled item")
+}
+
+func TestPicker_EnterSpawnsMarkedItems(t *testing.T) {
+	items := []sources.Item{
+		{ID: "1", Title: "alpha"},
+		{ID: "2", Title: "beta"},
+		{ID: "3", Title: "gamma"},
+	}
+	fake := newFakeTUISource(fakeManifest(), items)
+	p := newTestPicker(fake, fakeManifest(), "", 80, 24)
+	p = drainPicker(t, p, p.Init())
+
+	p = pressSpace(t, p)
+	p = p.moveCursor(1)
+	p = pressSpace(t, p)
+
+	next, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	p = drainPicker(t, next, cmd)
+
+	results, ok := p.Selected()
+	require.True(t, ok)
+	require.Len(t, results, 2, "enter returns every marked item, not the cursor item")
+	assert.Equal(t, "1", results[0].Item.ID)
+	assert.Equal(t, "2", results[1].Item.ID)
+}
+
+func TestPicker_MarksSurviveRemoteSearch(t *testing.T) {
+	items := []sources.Item{
+		{ID: "1", Title: "alpha"},
+		{ID: "2", Title: "beta"},
+	}
+	fake := newFakeTUISource(remoteManifest(), items)
+	p := newTestPicker(fake, remoteManifest(), "o/r", 80, 24)
+	p = drainPicker(t, p, p.Init())
+
+	p = pressSpace(t, p) // mark "alpha"
+
+	// Search narrows the list to "beta"; the mark on "alpha" must survive.
+	p = enterSearch(t, p)
+	p = typeKey(t, p, "beta")
+	require.Len(t, activeTab(p).filteredItems, 1)
+
+	next, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	p = drainPicker(t, next, cmd)
+
+	results, ok := p.Selected()
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	assert.Equal(t, "1", results[0].Item.ID, "marked item spawns even when filtered out of view")
+}
+
+func TestPicker_MarksAcrossTabs(t *testing.T) {
+	m1 := fakeManifest()
+	m1.ID = "prs"
+	m2 := fakeManifest()
+	m2.ID = "issues"
+
+	tabs := []TabSource{
+		{ID: "prs", Source: newFakeTUISource(m1, []sources.Item{{ID: "p1", Title: "PR one"}}), Manifest: m1},
+		{ID: "issues", Source: newFakeTUISource(m2, []sources.Item{{ID: "i1", Title: "Issue one"}}), Manifest: m2},
+	}
+	p := New(tabs, "prs", "", 80, 24)
+	p = drainPicker(t, p, p.Init())
+
+	p = pressSpace(t, p)
+
+	next, cmd := p.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	p = drainPicker(t, next, cmd)
+	p = pressSpace(t, p)
+
+	next, cmd = p.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	p = drainPicker(t, next, cmd)
+
+	results, ok := p.Selected()
+	require.True(t, ok)
+	require.Len(t, results, 2)
+	assert.Equal(t, "prs", results[0].SourceID)
+	assert.Equal(t, "p1", results[0].Item.ID)
+	assert.Equal(t, "issues", results[1].SourceID)
+	assert.Equal(t, "i1", results[1].Item.ID)
+}
+
+func TestPicker_MarkCapRefusesFurtherMarks(t *testing.T) {
+	items := make([]sources.Item, maxMarkedItems+2)
+	for i := range items {
+		items[i] = sources.Item{ID: fmt.Sprintf("%d", i+1), Title: fmt.Sprintf("item %d", i+1)}
+	}
+	fake := newFakeTUISource(fakeManifest(), items)
+	p := newTestPicker(fake, fakeManifest(), "", 80, 40)
+	p = drainPicker(t, p, p.Init())
+
+	for range items {
+		p = pressSpace(t, p)
+		p = p.moveCursor(1)
+	}
+	assert.Equal(t, maxMarkedItems, p.totalMarked(), "marks stop at the cap")
+
+	// Unmarking below the cap frees a slot.
+	activeTab(p).cursor = 0
+	p = pressSpace(t, p) // unmark first item
+	assert.Equal(t, maxMarkedItems-1, p.totalMarked())
+}
+
+func TestPicker_MarkedRowRendersGlyphAndCount(t *testing.T) {
+	items := []sources.Item{
+		{ID: "1", Title: "alpha"},
+		{ID: "2", Title: "beta"},
+	}
+	fake := newFakeTUISource(fakeManifest(), items)
+	p := newTestPicker(fake, fakeManifest(), "", 80, 24)
+	p = drainPicker(t, p, p.Init())
+
+	p = pressSpace(t, p)
+
+	list := terminal.StripANSI(p.renderList(activeTab(p)))
+	require.Contains(t, list, markGlyph, "marked row must show the mark glyph")
+	firstLine := strings.SplitN(list, "\n", 2)[0]
+	assert.Less(t, strings.Index(firstLine, markGlyph), strings.Index(firstLine, "alpha"),
+		"mark glyph sits in the gutter before the title")
+
+	filterLine := terminal.StripANSI(p.renderFilterLine(activeTab(p)))
+	assert.Contains(t, filterLine, markGlyph+" 1", "filter line shows the marked count")
+
+	help := terminal.StripANSI(p.helpText())
+	assert.Contains(t, help, "spawn 1", "enter hint reflects the marked count")
 }
 
 func TestPicker_EmptyResultsShowsEmptyState(t *testing.T) {
@@ -478,8 +638,8 @@ func TestNumberColumnWidth_AlignsShortAndLongNumbers(t *testing.T) {
 	// The card title line pads "#<number>" to the shared width, so titles
 	// start at the same column regardless of number width.
 	p := newTestPicker(newFakeTUISource(fakeManifest(), nil), fakeManifest(), "test-repo", 90, 24)
-	short := strings.SplitN(p.renderCardContent(items[0], false, 60, w), "\n", 2)[0]
-	long := strings.SplitN(p.renderCardContent(items[1], false, 60, w), "\n", 2)[0]
+	short := strings.SplitN(p.renderCardContent(items[0], false, false, 60, w), "\n", 2)[0]
+	long := strings.SplitN(p.renderCardContent(items[1], false, false, 60, w), "\n", 2)[0]
 	assert.Equal(t, strings.Index(short, "Short"), strings.Index(long, "Long"),
 		"titles must start at the same column regardless of number width")
 }
@@ -555,9 +715,11 @@ func TestPicker_CardRowIsTwoLines(t *testing.T) {
 
 	numWidth := numberColumnWidth([]sources.Item{item})
 	for _, selected := range []bool{true, false} {
-		row := p.renderRow(item, selected, numWidth)
-		assert.Equal(t, rowsPerItemCard, lipgloss.Height(row),
-			"card row must render as exactly two lines (selected=%v)", selected)
+		for _, marked := range []bool{true, false} {
+			row := p.renderRow(item, selected, marked, numWidth)
+			assert.Equal(t, rowsPerItemCard, lipgloss.Height(row),
+				"card row must render as exactly two lines (selected=%v marked=%v)", selected, marked)
+		}
 	}
 }
 
@@ -570,8 +732,8 @@ func TestRenderCardContent_PlainIsANSIFree(t *testing.T) {
 		"assignee": "bob", "assignee_count": 2,
 	}}
 
-	plain := p.renderCardContent(item, false, 60, 5)
-	styled := p.renderCardContent(item, true, 60, 5)
+	plain := p.renderCardContent(item, false, false, 60, 5)
+	styled := p.renderCardContent(item, true, false, 60, 5)
 
 	assert.Equal(t, plain, terminal.StripANSI(plain), "plain card row must be ANSI-free")
 	assert.Equal(t, plain, terminal.StripANSI(styled), "styled and plain must match once ANSI is stripped")

--- a/internal/tui/sourcepicker/testdata/TestPickerGolden_CardLayout.golden
+++ b/internal/tui/sourcepicker/testdata/TestPickerGolden_CardLayout.golden
@@ -3,12 +3,12 @@
 │────────────────────────────────────────────────────────────────────────────────│
 │ / filter fake pull requests…                                                 3 │
 │────────────────────────────────────────────────────────────────────────────────│
-│ ┃ #366 feat: connectors vertical slice with a title long enough to t… @hay-kot │
-│ ┃       · draft · 3w ·  #342 ·  @hay-kot                    [tui] [sources] │
-│   #359 fix: stop KV filter from swallowing keys on other views        @hay-kot │
-│         · approved · 5d                                                 [bug] │
-│   #351 refactor: source registry ordering                         @contributor │
-│         · changes requested · 2d ·  @alice +2                                │
+│ ┃   #366 feat: connectors vertical slice with a title long enough to… @hay-kot │
+│ ┃         · draft · 3w ·  #342 ·  @hay-kot                  [tui] [sources] │
+│     #359 fix: stop KV filter from swallowing keys on other views      @hay-kot │
+│           · approved · 5d                                               [bug] │
+│     #351 refactor: source registry ordering                       @contributor │
+│           · changes requested · 2d ·  @alice +2                              │
 │                                                                                │
 │                                                                                │
 │                                                                                │
@@ -18,5 +18,5 @@
 │                                                                                │
 │                                                                                │
 │                                                                                │
-│ tab switch source • / filter • j/k navigate • enter select • O open • esc close│
+│ tab switch source • / filter • space mark • enter select • O open • esc close  │
 ╰────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/sourcepicker/testdata/TestPickerGolden_EmptyResults.golden
+++ b/internal/tui/sourcepicker/testdata/TestPickerGolden_EmptyResults.golden
@@ -18,5 +18,5 @@
 │                                                                                │
 │                                                                                │
 │                                                                                │
-│ tab switch source • / filter • j/k navigate • enter select • O open • esc close│
+│ tab switch source • / filter • space mark • enter select • O open • esc close  │
 ╰────────────────────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Fixes #373

## Purpose

Bulk workflows (triaging several issues, spinning up review sessions for multiple PRs) required reopening the picker once per item. The picker now supports marking multiple items and spawning a session for each in one action.

## Proposed Changes

  - `space` toggles a mark on the cursor row (cursor stays put); marks are stored as full items so they survive re-filtering, remote re-searches, and tab switches, and are capped at 10 across all tabs (count turns warning-colored at the cap).
  - Every card row reserves a 2-column gutter that renders a `✓` for marked rows; the filter line shows the marked total and the enter hint becomes `spawn N`.
  - `Picker.Selected()` returns `[]Result` — all marks across tabs, or the cursor item when nothing is marked — and enter fans out on a single background stream: per item detail fetch → template render → create. Per-item failures don't stop the batch; the completion toast names the failed items (`2 of 5 sessions failed (#359, #366)`) with full causes in the log, and sessions created before a failure are refreshed and selected rather than left invisible.
  - Dropped the `j/k navigate` entry from the picker help line to keep it a single row at the modal's minimum width (search-mode help still shows it).
  - Post-review cleanup from a rethink pass (`.hive/reviews/2026-07-05-rethink-source-picker-multi-select.md`): simplified fan-out contracts, deleted an unreachable guard, honest comments about background stream output being discarded.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)