### PR TITLE
fix(worktree): create new branch when reusing recycled worktree session

### DIFF
--- a/internal/core/git/executor.go
+++ b/internal/core/git/executor.go
@@ -226,6 +226,20 @@ func (e *Executor) WorktreeReset(ctx context.Context, bareDir, worktreePath stri
 	return nil
 }
 
+func (e *Executor) CheckoutNewBranch(ctx context.Context, dir, branch string) error {
+	if _, err := e.exec.RunDir(ctx, dir, e.gitPath, "checkout", "-b", branch); err != nil {
+		return fmt.Errorf("git checkout -b %s: %w", branch, err)
+	}
+	return nil
+}
+
+func (e *Executor) DeleteBranch(ctx context.Context, dir, branch string) error {
+	if _, err := e.exec.RunDir(ctx, dir, e.gitPath, "branch", "-D", branch); err != nil {
+		return fmt.Errorf("git branch -D %s: %w", branch, err)
+	}
+	return nil
+}
+
 func (e *Executor) HasUnpushedCommits(ctx context.Context, dir string) (bool, error) {
 	// Try the upstream tracking branch first (set via "git push -u" or "git branch --set-upstream-to").
 	out, err := e.exec.RunDir(ctx, dir, e.gitPath, "--no-optional-locks", "rev-list", "--count", "@{upstream}..HEAD")

--- a/internal/core/git/git.go
+++ b/internal/core/git/git.go
@@ -37,6 +37,10 @@ type Git interface {
 	// WorktreeReset resets the worktree at worktreePath to origin's default branch.
 	// It fetches the default branch ref from bareDir, then resets the worktree.
 	WorktreeReset(ctx context.Context, bareDir, worktreePath string) error
+	// CheckoutNewBranch creates and switches to a new branch from the current HEAD in dir.
+	CheckoutNewBranch(ctx context.Context, dir, branch string) error
+	// DeleteBranch force-deletes a branch in dir.
+	DeleteBranch(ctx context.Context, dir, branch string) error
 	// Fetch fetches all remotes in dir.
 	Fetch(ctx context.Context, dir string) error
 	// HasUnpushedCommits returns true if there are local commits not yet pushed to a remote.

--- a/internal/core/workspace/scanner_test.go
+++ b/internal/core/workspace/scanner_test.go
@@ -27,6 +27,8 @@ func (m *mockGit) CloneBare(context.Context, string, string) error              
 func (m *mockGit) WorktreeAdd(context.Context, string, string, string) error    { return nil }
 func (m *mockGit) WorktreeRemove(context.Context, string, string, string) error { return nil }
 func (m *mockGit) WorktreeReset(context.Context, string, string) error          { return nil }
+func (m *mockGit) CheckoutNewBranch(context.Context, string, string) error      { return nil }
+func (m *mockGit) DeleteBranch(context.Context, string, string) error           { return nil }
 func (m *mockGit) Fetch(context.Context, string) error                          { return nil }
 func (m *mockGit) HasUnpushedCommits(context.Context, string) (bool, error)     { return false, nil }
 func (m *mockGit) RemoteURL(_ context.Context, dir string) (string, error) {

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -214,6 +214,26 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 				s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("worktree reset failed, marking corrupted")
 				s.markCorrupted(ctx, recyclable)
 				recyclable = nil
+			} else {
+				// Create a fresh branch for the new session; the worktree is still on the old branch.
+				dirID = generateID()
+				branch, err := s.worktreeBranchName(remote, opts.Name, slug, dirID)
+				if err != nil {
+					return nil, err
+				}
+				writeProgressf(progress, "Creating branch %s...", branch)
+				if err := s.git.CheckoutNewBranch(ctx, recyclable.Path, branch); err != nil {
+					s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("branch creation failed, marking corrupted")
+					s.markCorrupted(ctx, recyclable)
+					recyclable = nil
+				} else {
+					if old := recyclable.GetMeta(session.MetaWorktreeBranch); old != "" && old != branch {
+						if err := s.git.DeleteBranch(ctx, bareDir, old); err != nil {
+							s.log.Debug().Err(err).Str("branch", old).Msg("failed to delete old worktree branch")
+						}
+					}
+					recyclable.SetMeta(session.MetaWorktreeBranch, branch)
+				}
 			}
 		} else {
 			// Pull latest changes before running hooks
@@ -274,23 +294,9 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 				return nil, fmt.Errorf("ensure bare clone: %w", err)
 			}
 			writeProgressf(progress, "Adding worktree...")
-			branch := "hive/" + slug + "-" + dirID
-			if tmplStr := s.config.GetBranchTemplate(remote); tmplStr != "" {
-				owner, repo := git.ExtractOwnerRepo(remote)
-				rendered, err := s.renderer.Render(tmplStr, config.BranchTemplateData{
-					Name:  opts.Name,
-					Slug:  slug,
-					Owner: owner,
-					Repo:  repo,
-					ID:    dirID,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("branch_template render failed: %w", err)
-				}
-				if err := git.ValidateBranchName(rendered); err != nil {
-					return nil, fmt.Errorf("branch_template %q rendered to invalid git branch name %q: %w", tmplStr, rendered, err)
-				}
-				branch = rendered
+			branch, err := s.worktreeBranchName(remote, opts.Name, slug, dirID)
+			if err != nil {
+				return nil, err
 			}
 			if err := s.git.WorktreeAdd(ctx, bareDir, path, branch); err != nil {
 				return nil, fmt.Errorf("worktree add: %w", err)
@@ -367,6 +373,32 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 	s.bus.PublishSessionCreated(eventbus.SessionCreatedPayload{Session: &sess})
 
 	return &sess, nil
+}
+
+// worktreeBranchName returns the branch name for a worktree session, applying
+// the configured branch template for the remote when one is set.
+func (s *SessionService) worktreeBranchName(remote, name, slug, dirID string) (string, error) {
+	branch := "hive/" + slug + "-" + dirID
+	tmplStr := s.config.GetBranchTemplate(remote)
+	if tmplStr == "" {
+		return branch, nil
+	}
+
+	owner, repo := git.ExtractOwnerRepo(remote)
+	rendered, err := s.renderer.Render(tmplStr, config.BranchTemplateData{
+		Name:  name,
+		Slug:  slug,
+		Owner: owner,
+		Repo:  repo,
+		ID:    dirID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("branch_template render failed: %w", err)
+	}
+	if err := git.ValidateBranchName(rendered); err != nil {
+		return "", fmt.Errorf("branch_template %q rendered to invalid git branch name %q: %w", tmplStr, rendered, err)
+	}
+	return rendered, nil
 }
 
 // writeProgressf writes a formatted progress line when w is non-nil.

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -73,6 +73,8 @@ func (m *mockGit) CloneBare(_ context.Context, _, _ string) error               
 func (m *mockGit) WorktreeAdd(_ context.Context, _, _, _ string) error          { return nil }
 func (m *mockGit) WorktreeRemove(_ context.Context, _, _, _ string) error       { return nil }
 func (m *mockGit) WorktreeReset(_ context.Context, _, _ string) error           { return nil }
+func (m *mockGit) CheckoutNewBranch(_ context.Context, _, _ string) error       { return nil }
+func (m *mockGit) DeleteBranch(_ context.Context, _, _ string) error            { return nil }
 func (m *mockGit) Fetch(_ context.Context, _ string) error                      { return nil }
 func (m *mockGit) HasUnpushedCommits(_ context.Context, _ string) (bool, error) { return false, nil }
 func (m *mockGit) DefaultBranch(_ context.Context, _ string) (string, error) {
@@ -1261,15 +1263,78 @@ func TestCreateSession_BranchTemplate(t *testing.T) {
 	})
 }
 
+func TestCreateSession_RecycledWorktreeCreatesNewBranch(t *testing.T) {
+	store := newMockStore()
+	remote := "https://github.com/example/repo.git"
+	store.sessions["wt-1"] = session.Session{
+		ID:            "wt-1",
+		Name:          "old-session",
+		Slug:          "old-session",
+		Remote:        remote,
+		State:         session.StateRecycled,
+		CloneStrategy: config.CloneStrategyWorktree,
+		Path:          t.TempDir(),
+		Metadata:      map[string]string{session.MetaWorktreeBranch: "hive/old-session-abc123"},
+	}
+
+	var newBranch, deletedBranch string
+	spy := &capturingMockGit{}
+	spy.CheckoutNewBranchFn = func(_ context.Context, _, branch string) error {
+		newBranch = branch
+		return nil
+	}
+	spy.DeleteBranchFn = func(_ context.Context, _, branch string) error {
+		deletedBranch = branch
+		return nil
+	}
+
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		GitPath: "git",
+		Rules:   []config.Rule{{Pattern: "", CloneStrategy: config.CloneStrategyWorktree}},
+	}
+	log := zerolog.New(io.Discard)
+	renderer := tmpl.New(tmpl.Config{})
+	svc := NewSessionService(store, spy, cfg, testbus.New(t).EventBus, &executiltest.Exec{}, renderer, log, io.Discard, io.Discard)
+
+	sess, err := svc.CreateSession(context.Background(), CreateOptions{
+		Name:      "new-feature",
+		Remote:    remote,
+		SkipSpawn: true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "wt-1", sess.ID, "recycled session should be reused")
+	assert.Regexp(t, `^hive/new-feature-[a-z0-9]+$`, newBranch)
+	assert.Equal(t, newBranch, sess.GetMeta(session.MetaWorktreeBranch))
+	assert.Equal(t, "hive/old-session-abc123", deletedBranch, "old branch should be deleted")
+}
+
 // capturingMockGit extends mockGit with optional function overrides for capturing calls.
 type capturingMockGit struct {
 	mockGit
-	WorktreeAddFn func(ctx context.Context, repoDir, path, branch string) error
+	WorktreeAddFn       func(ctx context.Context, repoDir, path, branch string) error
+	CheckoutNewBranchFn func(ctx context.Context, dir, branch string) error
+	DeleteBranchFn      func(ctx context.Context, dir, branch string) error
 }
 
 func (m *capturingMockGit) WorktreeAdd(ctx context.Context, repoDir, path, branch string) error {
 	if m.WorktreeAddFn != nil {
 		return m.WorktreeAddFn(ctx, repoDir, path, branch)
+	}
+	return nil
+}
+
+func (m *capturingMockGit) CheckoutNewBranch(ctx context.Context, dir, branch string) error {
+	if m.CheckoutNewBranchFn != nil {
+		return m.CheckoutNewBranchFn(ctx, dir, branch)
+	}
+	return nil
+}
+
+func (m *capturingMockGit) DeleteBranch(ctx context.Context, dir, branch string) error {
+	if m.DeleteBranchFn != nil {
+		return m.DeleteBranchFn(ctx, dir, branch)
 	}
 	return nil
 }

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -50,6 +50,8 @@ func (g *mouseTestGit) CloneBare(_ context.Context, _, _ string) error          
 func (g *mouseTestGit) WorktreeAdd(_ context.Context, _, _, _ string) error       { return nil }
 func (g *mouseTestGit) WorktreeRemove(_ context.Context, _, _, _ string) error    { return nil }
 func (g *mouseTestGit) WorktreeReset(_ context.Context, _, _ string) error        { return nil }
+func (g *mouseTestGit) CheckoutNewBranch(_ context.Context, _, _ string) error    { return nil }
+func (g *mouseTestGit) DeleteBranch(_ context.Context, _, _ string) error         { return nil }
 func (g *mouseTestGit) Fetch(_ context.Context, _ string) error                   { return nil }
 func (g *mouseTestGit) HasUnpushedCommits(_ context.Context, _ string) (bool, error) {
 	return false, nil

--- a/test/integration/worktree_test.go
+++ b/test/integration/worktree_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,40 @@ func TestWorktreeBareRootCreated(t *testing.T) {
 	headPath := filepath.Join(bareDir, "HEAD")
 	_, err = os.Stat(headPath)
 	require.NoError(t, err, "bare root must contain HEAD at %s", headPath)
+}
+
+func TestWorktreeRecycleReuseCreatesNewBranch(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "wt-recycle-repo")
+
+	out, err := h.Run("new", "--clone-strategy", "worktree", "--remote", repo, "first-session")
+	require.NoError(t, err, "first session: %s", out)
+	path := parseCreatedSessionPath(t, out)
+
+	oldBranch := strings.TrimSpace(runInDir(t, path, "git", "branch", "--show-current"))
+	require.Contains(t, oldBranch, "first-session", "worktree should start on the first session's branch")
+
+	lines, err := h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	require.Len(t, lines, 1)
+	id := lines[0]["id"].(string)
+
+	_, err = h.Run("session", "recycle", id)
+	require.NoError(t, err)
+
+	out, err = h.Run("new", "--clone-strategy", "worktree", "--remote", repo, "second-session")
+	require.NoError(t, err, "second session: %s", out)
+	reusedPath := parseCreatedSessionPath(t, out)
+	require.Equal(t, path, reusedPath, "recycled worktree session should be reused")
+
+	newBranch := strings.TrimSpace(runInDir(t, reusedPath, "git", "branch", "--show-current"))
+	assert.Contains(t, newBranch, "second-session", "reused worktree must be on a fresh branch for the new session")
+	assert.NotEqual(t, oldBranch, newBranch)
+
+	bareDir := worktreeBareDir(t, reusedPath)
+	branches := runInDir(t, bareDir, "git", "branch", "--list")
+	assert.NotContains(t, branches, oldBranch, "old session branch should be deleted from the bare repo")
+	assert.Contains(t, branches, newBranch)
 }
 
 func TestWorktreeTwoSessionsSameBare(t *testing.T) {


### PR DESCRIPTION
## Purpose

Recycling a worktree session and creating a new one from the TUI left the reused worktree on the previous session's branch — no new branch was ever created. Branch creation only happened in the brand-new-session path via `worktree add -b`.

## Proposed Changes

  - Create a fresh branch (honoring `branch_template`) after resetting a reused recycled worktree, and update `MetaWorktreeBranch`
  - Delete the old session's branch from the bare repo to avoid branch leaks
  - Add `CheckoutNewBranch` / `DeleteBranch` to the `Git` interface

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)