### PR TITLE
fix(sources): truncate long session names from source item titles

### DIFF
--- a/internal/sources/templates.go
+++ b/internal/sources/templates.go
@@ -86,18 +86,36 @@ func RenderSessionTemplates(cfg TemplateConfig, item Item, detail Detail) (Rende
 	}, nil
 }
 
+// maxSessionNameLength caps sanitized session names so long issue/PR titles
+// don't produce unwieldy directory, branch, and tmux session names.
+const maxSessionNameLength = 60
+
 // sanitizeSessionName rewrites a rendered session Name into kebab-case (via
 // session.Slugify) so it passes hive's session name validation and remains
-// predictable for issue titles. If nothing usable remains, it falls back to
-// the item's ID.
+// predictable for issue titles. Long names are truncated at a word boundary
+// to maxSessionNameLength. If nothing usable remains, it falls back to the
+// item's ID.
 func sanitizeSessionName(name, fallbackID string) string {
 	if normalized := session.Slugify(name); normalized != "" {
-		return normalized
+		return truncateSlug(normalized, maxSessionNameLength)
 	}
 	if normalized := session.Slugify(fallbackID); normalized != "" {
-		return "session-" + normalized
+		return truncateSlug("session-"+normalized, maxSessionNameLength)
 	}
 	return "session-item"
+}
+
+// truncateSlug shortens a kebab-case slug to at most max characters,
+// preferring to cut at a hyphen boundary so words aren't split mid-way.
+func truncateSlug(slug string, max int) string {
+	if len(slug) <= max {
+		return slug
+	}
+	truncated := slug[:max]
+	if idx := strings.LastIndex(truncated, "-"); idx > 0 {
+		truncated = truncated[:idx]
+	}
+	return strings.Trim(truncated, "-")
 }
 
 // detailText returns a plain-text representation of a Detail for use as the

--- a/internal/sources/templates_test.go
+++ b/internal/sources/templates_test.go
@@ -95,6 +95,37 @@ func TestRenderSessionTemplates(t *testing.T) {
 			wantTags:   []string{},
 		},
 		{
+			name: "truncates long names at a word boundary",
+			cfg: sources.TemplateConfig{
+				Name:   "gh-{{ .Fields.number }}-{{ .Title }}",
+				Prompt: "ok",
+			},
+			item: sources.Item{
+				ID:    "1",
+				Title: "Add support for configuring session name truncation behavior when creating sessions from external sources",
+				Fields: map[string]any{
+					"number": 1234,
+				},
+			},
+			wantName:   "gh-1234-add-support-for-configuring-session-name-truncation",
+			wantPrompt: "ok",
+			wantTags:   []string{},
+		},
+		{
+			name: "truncates hard at limit when no hyphen boundary exists",
+			cfg: sources.TemplateConfig{
+				Name:   "{{ .Title }}",
+				Prompt: "ok",
+			},
+			item: sources.Item{
+				ID:    "1",
+				Title: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			wantName:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"[:60],
+			wantPrompt: "ok",
+			wantTags:   []string{},
+		},
+		{
 			name: "renders detail content",
 			cfg: sources.TemplateConfig{
 				Name:   "{{ .ID }}",


### PR DESCRIPTION
## Purpose

Long issue/PR titles from sources (GitHub, Gitea, custom CLI) produced unwieldy directory, branch, and tmux session names.

## Proposed Changes

- Cap sanitized source session names at 60 characters
- Truncate at a hyphen boundary when possible so words aren't split

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)