### PR TITLE
fix: delete worktree sessions on recycle

### DIFF
--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -49,10 +49,10 @@ rules:
 | `windows`          | []WindowConfig | see below                    | Declarative tmux window layout (recommended)      |
 | `spawn`            | []string       | —                            | Shell commands run after session creation (legacy) |
 | `batch_spawn`      | []string       | —                            | Shell commands for batch session creation (legacy) |
-| `recycle`          | []string       | git fetch/checkout/reset/clean | Commands run when recycling a session           |
+| `recycle`          | []string       | git fetch/checkout/reset/clean | Commands run when recycling a full-clone session; worktree sessions are deleted |
 | `commands`         | []string       | `[]`                         | Setup commands run after clone                    |
 | `copy`             | []string       | `[]`                         | Glob patterns for files to copy from parent repo  |
-| `max_recycled`     | *int           | `5`                          | Maximum recycled sessions to keep (0 = unlimited) |
+| `max_recycled`     | *int           | `5`                          | Maximum recycled full-clone sessions to keep (0 = unlimited) |
 
 !!! warning "`windows` vs `spawn`/`batch_spawn`"
     A rule must use either `windows` or `spawn`/`batch_spawn`, not both. If neither is set, the default window layout is used (agent window + shell window). A rule can set `agent` with or without custom `windows`/`spawn` config.

--- a/docs/getting-started/sessions.md
+++ b/docs/getting-started/sessions.md
@@ -96,19 +96,19 @@ rules:
 ```
 
 !!! note
-    Recycled worktree sessions are reset by fetching from the bare clone and resetting the worktree branch. Worktree sessions cannot be recycled into full-clone sessions or vice versa — hive only reuses sessions with a matching strategy.
+    Recycling a worktree session removes its checkout and session record, just like deleting it. The next session gets a fresh path and branch while continuing to reuse the shared bare clone. This keeps the usual recycle workflow without retaining stale worktree state.
 
 ## Session Lifecycle
 
 Sessions move through a managed lifecycle:
 
 1. **Create** — A new session starts as `active`. Hive clones the repository (or reuses a recycled clone) and spawns a tmux session.
-2. **Recycle** — When you're done, recycle the session instead of deleting it. Recycling resets the git repository to a clean state and makes it available for reuse. The next `hive new` for the same repository will reuse a recycled session, avoiding a fresh clone.
+2. **Recycle** — When you're done, recycle the session instead of deleting it. Full-clone sessions are reset and retained for reuse. Worktree sessions are removed because the shared bare clone already makes the next worktree inexpensive to create.
 3. **Delete** — Permanently removes the session directory and all associated data.
 4. **Corrupted** — If hive detects an invalid state (e.g., missing directory, broken git repo), the session is marked corrupted and can only be deleted.
 
 !!! tip "Prefer recycling over deleting"
-    Recycled sessions are reused on the next `hive new`, skipping a fresh `git clone`. This saves time and disk I/O, especially for large repositories.
+    You can use the same recycle workflow with either clone strategy. Full-clone sessions are retained to avoid another clone; worktree sessions are deleted while their shared bare clone remains available for fast future sessions.
 
 ## Status Indicators
 

--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -288,9 +288,9 @@ func (cmd *SessionCmd) recycleCmd() *cli.Command {
 		Name:      "recycle",
 		Usage:     "Recycle a session back to the pool",
 		UsageText: "hive session recycle <id>",
-		Description: `Marks a session as recycled so it can be reused for a new task.
+		Description: `Recycles a full-clone session so its checkout can be reused for a new task.
 
-Runs any configured recycle commands (e.g. git reset) and kills the associated tmux session.`,
+For worktree sessions, removes the checkout and session record while retaining the shared bare clone. This keeps future worktree creation fast without retaining stale session state.`,
 		Action: cmd.runRecycle,
 	}
 }

--- a/internal/core/git/executor.go
+++ b/internal/core/git/executor.go
@@ -202,40 +202,13 @@ func (e *Executor) WorktreeRemove(ctx context.Context, repoDir, path, branch str
 	if _, err := e.exec.RunDir(ctx, repoDir, e.gitPath, "worktree", "remove", "--force", path); err != nil {
 		errs = append(errs, fmt.Sprintf("git worktree remove: %v", err))
 	}
-	if _, err := e.exec.RunDir(ctx, repoDir, e.gitPath, "branch", "-D", branch); err != nil {
-		errs = append(errs, fmt.Sprintf("git branch -D: %v", err))
+	if branch != "" {
+		if _, err := e.exec.RunDir(ctx, repoDir, e.gitPath, "branch", "-D", branch); err != nil {
+			errs = append(errs, fmt.Sprintf("git branch -D: %v", err))
+		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
-	}
-	return nil
-}
-
-func (e *Executor) WorktreeReset(ctx context.Context, bareDir, worktreePath string) error {
-	out, err := e.exec.RunDir(ctx, bareDir, e.gitPath, "--no-optional-locks", "symbolic-ref", "HEAD", "--short")
-	if err != nil {
-		return fmt.Errorf("get bare default branch: %w", err)
-	}
-	ref := strings.TrimSpace(string(out)) // e.g., "main"
-	if _, err := e.exec.RunDir(ctx, worktreePath, e.gitPath, "reset", "--hard", ref); err != nil {
-		return fmt.Errorf("git reset --hard %s: %w", ref, err)
-	}
-	if _, err := e.exec.RunDir(ctx, worktreePath, e.gitPath, "clean", "-fdx"); err != nil {
-		return fmt.Errorf("git clean: %w", err)
-	}
-	return nil
-}
-
-func (e *Executor) CheckoutNewBranch(ctx context.Context, dir, branch string) error {
-	if _, err := e.exec.RunDir(ctx, dir, e.gitPath, "checkout", "-b", branch); err != nil {
-		return fmt.Errorf("git checkout -b %s: %w", branch, err)
-	}
-	return nil
-}
-
-func (e *Executor) DeleteBranch(ctx context.Context, dir, branch string) error {
-	if _, err := e.exec.RunDir(ctx, dir, e.gitPath, "branch", "-D", branch); err != nil {
-		return fmt.Errorf("git branch -D %s: %w", branch, err)
 	}
 	return nil
 }

--- a/internal/core/git/executor_test.go
+++ b/internal/core/git/executor_test.go
@@ -201,35 +201,40 @@ func TestExecutor_DefaultBranch(t *testing.T) {
 	}
 }
 
-func TestExecutor_WorktreeResetUsesBareDefaultBranch(t *testing.T) {
-	var calls []string
-	mock := &mockExecutor{
-		runDirFunc: func(ctx context.Context, dir, cmd string, args ...string) ([]byte, error) {
-			calls = append(calls, dir+" "+cmd+" "+strings.Join(args, " "))
-			switch len(calls) {
-			case 1:
-				assert.Equal(t, "/bare", dir)
-				assert.Equal(t, []string{"--no-optional-locks", "symbolic-ref", "HEAD", "--short"}, args)
-				return []byte("main\n"), nil
-			case 2:
-				assert.Equal(t, "/worktree", dir)
-				assert.Equal(t, []string{"reset", "--hard", "main"}, args)
-				return nil, nil
-			case 3:
-				assert.Equal(t, "/worktree", dir)
-				assert.Equal(t, []string{"clean", "-fdx"}, args)
-				return nil, nil
-			default:
-				return nil, fmt.Errorf("unexpected call %d", len(calls))
-			}
-		},
+func TestExecutor_WorktreeRemove(t *testing.T) {
+	tests := []struct {
+		name       string
+		branch     string
+		wantCalls  int
+		wantBranch bool
+	}{
+		{name: "removes worktree and branch", branch: "hive/session", wantCalls: 2, wantBranch: true},
+		{name: "removes worktree without branch metadata", wantCalls: 1},
 	}
 
-	e := NewExecutor("git", mock)
-	err := e.WorktreeReset(context.Background(), "/bare", "/worktree")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls [][]string
+			mock := &mockExecutor{
+				runDirFunc: func(_ context.Context, dir, cmd string, args ...string) ([]byte, error) {
+					require.Equal(t, "/bare", dir)
+					require.Equal(t, "git", cmd)
+					calls = append(calls, args)
+					return nil, nil
+				},
+			}
 
-	require.NoError(t, err)
-	assert.Len(t, calls, 3)
+			e := NewExecutor("git", mock)
+			err := e.WorktreeRemove(context.Background(), "/bare", "/worktree", tt.branch)
+
+			require.NoError(t, err)
+			require.Len(t, calls, tt.wantCalls)
+			assert.Equal(t, []string{"worktree", "remove", "--force", "/worktree"}, calls[0])
+			if tt.wantBranch {
+				assert.Equal(t, []string{"branch", "-D", tt.branch}, calls[1])
+			}
+		})
+	}
 }
 
 func TestExecutor_Fetch(t *testing.T) {

--- a/internal/core/git/git.go
+++ b/internal/core/git/git.go
@@ -32,15 +32,8 @@ type Git interface {
 	CloneBare(ctx context.Context, url, dest string) error
 	// WorktreeAdd creates a new worktree at path on a new branch named branch.
 	WorktreeAdd(ctx context.Context, repoDir, path, branch string) error
-	// WorktreeRemove removes the worktree at path and deletes the branch from repoDir.
+	// WorktreeRemove removes the worktree at path and deletes branch from repoDir when provided.
 	WorktreeRemove(ctx context.Context, repoDir, path, branch string) error
-	// WorktreeReset resets the worktree at worktreePath to origin's default branch.
-	// It fetches the default branch ref from bareDir, then resets the worktree.
-	WorktreeReset(ctx context.Context, bareDir, worktreePath string) error
-	// CheckoutNewBranch creates and switches to a new branch from the current HEAD in dir.
-	CheckoutNewBranch(ctx context.Context, dir, branch string) error
-	// DeleteBranch force-deletes a branch in dir.
-	DeleteBranch(ctx context.Context, dir, branch string) error
 	// Fetch fetches all remotes in dir.
 	Fetch(ctx context.Context, dir string) error
 	// HasUnpushedCommits returns true if there are local commits not yet pushed to a remote.

--- a/internal/core/workspace/scanner_test.go
+++ b/internal/core/workspace/scanner_test.go
@@ -26,9 +26,6 @@ func (m *mockGit) IsValidRepo(context.Context, string) error                    
 func (m *mockGit) CloneBare(context.Context, string, string) error              { return nil }
 func (m *mockGit) WorktreeAdd(context.Context, string, string, string) error    { return nil }
 func (m *mockGit) WorktreeRemove(context.Context, string, string, string) error { return nil }
-func (m *mockGit) WorktreeReset(context.Context, string, string) error          { return nil }
-func (m *mockGit) CheckoutNewBranch(context.Context, string, string) error      { return nil }
-func (m *mockGit) DeleteBranch(context.Context, string, string) error           { return nil }
 func (m *mockGit) Fetch(context.Context, string) error                          { return nil }
 func (m *mockGit) HasUnpushedCommits(context.Context, string) (bool, error)     { return false, nil }
 func (m *mockGit) RemoteURL(_ context.Context, dir string) (string, error) {

--- a/internal/hive/service.go
+++ b/internal/hive/service.go
@@ -193,58 +193,27 @@ func (s *SessionService) CreateSession(ctx context.Context, opts CreateOptions) 
 		}
 	}
 
-	// Try to find and validate a recyclable session with matching strategy
-	writeProgressf(progress, "Looking for recyclable session...")
-	recyclable := s.findValidRecyclable(ctx, remote, cloneStrategy)
+	// Full clones retain their checkout when recycled and can be reused. Worktree
+	// recycling deletes the checkout and session record because the shared bare
+	// clone already provides the performance benefit.
+	var recyclable *session.Session
+	if cloneStrategy == config.CloneStrategyFull {
+		writeProgressf(progress, "Looking for recyclable session...")
+		recyclable = s.findValidRecyclable(ctx, remote, cloneStrategy)
+	}
 
 	if recyclable != nil {
-		// Reuse existing recycled session (already cleaned up when marked for recycle)
 		s.log.Debug().Str("session_id", recyclable.ID).Msg("found valid recyclable session")
 		writeProgressf(progress, "Recycling session %s...", recyclable.ID)
 
-		if cloneStrategy == config.CloneStrategyWorktree {
-			// Worktrees are linked to a bare clone with no origin remote — use fetch+reset instead of pull.
-			bareDir := s.bareDirForRemote(remote)
-			writeProgressf(progress, "Fetching latest changes...")
-			if err := s.git.Fetch(ctx, bareDir); err != nil {
-				s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("fetch failed, marking corrupted")
-				s.markCorrupted(ctx, recyclable)
-				recyclable = nil
-			} else if err := s.git.WorktreeReset(ctx, bareDir, recyclable.Path); err != nil {
-				s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("worktree reset failed, marking corrupted")
-				s.markCorrupted(ctx, recyclable)
-				recyclable = nil
-			} else {
-				// Create a fresh branch for the new session; the worktree is still on the old branch.
-				dirID = generateID()
-				branch, err := s.worktreeBranchName(remote, opts.Name, slug, dirID)
-				if err != nil {
-					return nil, err
-				}
-				writeProgressf(progress, "Creating branch %s...", branch)
-				if err := s.git.CheckoutNewBranch(ctx, recyclable.Path, branch); err != nil {
-					s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("branch creation failed, marking corrupted")
-					s.markCorrupted(ctx, recyclable)
-					recyclable = nil
-				} else {
-					if old := recyclable.GetMeta(session.MetaWorktreeBranch); old != "" && old != branch {
-						if err := s.git.DeleteBranch(ctx, bareDir, old); err != nil {
-							s.log.Debug().Err(err).Str("branch", old).Msg("failed to delete old worktree branch")
-						}
-					}
-					recyclable.SetMeta(session.MetaWorktreeBranch, branch)
-				}
-			}
-		} else {
-			// Pull latest changes before running hooks
-			s.log.Debug().Str("path", recyclable.Path).Msg("pulling latest changes")
-			writeProgressf(progress, "Pulling latest changes...")
-			if err := s.git.Pull(ctx, recyclable.Path); err != nil {
-				// Pull failed - mark as corrupted and fall through to clone
-				s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("pull failed, marking corrupted")
-				s.markCorrupted(ctx, recyclable)
-				recyclable = nil
-			}
+		// Pull latest changes before running hooks.
+		s.log.Debug().Str("path", recyclable.Path).Msg("pulling latest changes")
+		writeProgressf(progress, "Pulling latest changes...")
+		if err := s.git.Pull(ctx, recyclable.Path); err != nil {
+			// Pull failed - mark as corrupted and fall through to clone.
+			s.log.Warn().Err(err).Str("session_id", recyclable.ID).Msg("pull failed, marking corrupted")
+			s.markCorrupted(ctx, recyclable)
+			recyclable = nil
 		}
 	}
 
@@ -433,7 +402,8 @@ func (s *SessionService) RecycleSession(ctx context.Context, id string, w io.Wri
 	}
 
 	if sess.CloneStrategy == config.CloneStrategyWorktree {
-		return s.recycleWorktreeSession(ctx, &sess)
+		s.log.Info().Str("session_id", id).Msg("deleting worktree session instead of retaining recycled state")
+		return s.DeleteSession(ctx, id)
 	}
 
 	// Full-clone recycle: validate, reset, and mark recycled.
@@ -478,43 +448,6 @@ func (s *SessionService) RecycleSession(ctx context.Context, id string, w io.Wri
 	s.log.Info().Str("session_id", id).Str("path", sess.Path).Msg("session recycled")
 
 	s.bus.PublishSessionRecycled(eventbus.SessionRecycledPayload{Session: &sess})
-
-	return nil
-}
-
-// recycleWorktreeSession resets the worktree to origin's default branch and marks the session recycled.
-// The worktree directory is kept on disk so it can be reused without re-cloning.
-func (s *SessionService) recycleWorktreeSession(ctx context.Context, sess *session.Session) error {
-	branch := sess.GetMeta(session.MetaWorktreeBranch)
-	if branch == "" {
-		s.log.Warn().Str("session_id", sess.ID).Msg("worktree session has no branch metadata, skipping git reset")
-	} else {
-		bareDir := s.bareDirForRemote(sess.Remote)
-		if err := s.git.WorktreeReset(ctx, bareDir, sess.Path); err != nil {
-			s.log.Warn().Err(err).Str("session_id", sess.ID).Msg("worktree reset failed during recycle")
-			// Continue — session is still marked recycled; findValidRecyclable will validate on reuse
-		}
-	}
-
-	// Kill associated tmux session (best-effort)
-	if _, err := s.executor.Run(ctx, "tmux", "kill-session", "-t", sess.Slug); err != nil {
-		s.log.Debug().Err(err).Str("session", sess.Slug).Msg("no tmux session to kill")
-	}
-
-	sess.MarkRecycled(time.Now())
-
-	if err := s.sessions.Save(ctx, *sess); err != nil {
-		return fmt.Errorf("save session: %w", err)
-	}
-
-	// Enforce max recycled limit
-	if err := s.enforceMaxRecycled(ctx, sess.Remote, sess.CloneStrategy); err != nil {
-		s.log.Warn().Err(err).Str("remote", sess.Remote).Msg("failed to enforce max recycled limit")
-	}
-
-	s.log.Info().Str("session_id", sess.ID).Str("path", sess.Path).Msg("worktree session recycled")
-
-	s.bus.PublishSessionRecycled(eventbus.SessionRecycledPayload{Session: sess})
 
 	return nil
 }
@@ -625,13 +558,9 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string) error {
 	// the bare repo's internal worktree tracking stays consistent.
 	if sess.CloneStrategy == config.CloneStrategyWorktree {
 		branch := sess.GetMeta(session.MetaWorktreeBranch)
-		if branch == "" {
-			s.log.Warn().Str("session_id", id).Msg("worktree session has no branch metadata, skipping git cleanup")
-		} else {
-			bareDir := s.bareDirForRemote(sess.Remote)
-			if err := s.git.WorktreeRemove(ctx, bareDir, sess.Path, branch); err != nil {
-				s.log.Warn().Err(err).Str("session_id", id).Msg("worktree remove failed during delete, proceeding with RemoveAll")
-			}
+		bareDir := s.bareDirForRemote(sess.Remote)
+		if err := s.git.WorktreeRemove(ctx, bareDir, sess.Path, branch); err != nil {
+			s.log.Warn().Err(err).Str("session_id", id).Msg("worktree remove failed during delete, proceeding with RemoveAll")
 		}
 	}
 

--- a/internal/hive/service_test.go
+++ b/internal/hive/service_test.go
@@ -72,9 +72,6 @@ func (m *mockGit) Branch(_ context.Context, _ string) (string, error)           
 func (m *mockGit) CloneBare(_ context.Context, _, _ string) error               { return nil }
 func (m *mockGit) WorktreeAdd(_ context.Context, _, _, _ string) error          { return nil }
 func (m *mockGit) WorktreeRemove(_ context.Context, _, _, _ string) error       { return nil }
-func (m *mockGit) WorktreeReset(_ context.Context, _, _ string) error           { return nil }
-func (m *mockGit) CheckoutNewBranch(_ context.Context, _, _ string) error       { return nil }
-func (m *mockGit) DeleteBranch(_ context.Context, _, _ string) error            { return nil }
 func (m *mockGit) Fetch(_ context.Context, _ string) error                      { return nil }
 func (m *mockGit) HasUnpushedCommits(_ context.Context, _ string) (bool, error) { return false, nil }
 func (m *mockGit) DefaultBranch(_ context.Context, _ string) (string, error) {
@@ -1031,67 +1028,56 @@ func TestSetSessionGroup_TrimWhitespace(t *testing.T) {
 	assert.Equal(t, "backend", updated.Group())
 }
 
-func TestRecycleWorktreeSession_KeepsPath(t *testing.T) {
-	store := newMockStore()
-	cfg := &config.Config{
-		DataDir: t.TempDir(),
-		GitPath: "git",
+func TestRecycleWorktreeSession_DeletesSession(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+	}{
+		{
+			name:     "with branch metadata",
+			metadata: map[string]string{session.MetaWorktreeBranch: "hive-abc123"},
+		},
+		{
+			name: "without branch metadata",
+		},
 	}
-	svc := newTestService(t, store, cfg)
 
-	sessDir := filepath.Join(cfg.ReposDir(), "repo-wt-abc123")
-	require.NoError(t, os.MkdirAll(sessDir, 0o755))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockStore()
+			tb := testbus.New(t)
+			cfg := &config.Config{
+				DataDir: t.TempDir(),
+				GitPath: "git",
+			}
+			svc := newTestServiceWithBus(t, store, cfg, tb.EventBus)
 
-	sess := session.Session{
-		ID:            "wt1",
-		Name:          "worktree-session",
-		Slug:          "worktree-session",
-		State:         session.StateActive,
-		Path:          sessDir,
-		Remote:        "https://github.com/example/repo.git",
-		CloneStrategy: config.CloneStrategyWorktree,
-		Metadata:      map[string]string{session.MetaWorktreeBranch: "hive-abc123"},
+			sessDir := filepath.Join(cfg.ReposDir(), "repo-wt-abc123")
+			require.NoError(t, os.MkdirAll(sessDir, 0o755))
+
+			sess := session.Session{
+				ID:            "wt1",
+				Name:          "worktree-session",
+				Slug:          "worktree-session",
+				State:         session.StateActive,
+				Path:          sessDir,
+				Remote:        "https://github.com/example/repo.git",
+				CloneStrategy: config.CloneStrategyWorktree,
+				Metadata:      tt.metadata,
+			}
+			require.NoError(t, store.Save(context.Background(), sess))
+
+			err := svc.RecycleSession(context.Background(), "wt1", io.Discard)
+			require.NoError(t, err)
+
+			_, err = store.Get(context.Background(), "wt1")
+			require.ErrorIs(t, err, session.ErrNotFound)
+			_, err = os.Stat(sessDir)
+			require.ErrorIs(t, err, os.ErrNotExist)
+			deleted := testbus.FindPayload[eventbus.SessionDeletedPayload](tb, t, eventbus.EventSessionDeleted)
+			assert.Equal(t, "wt1", deleted.SessionID)
+		})
 	}
-	require.NoError(t, store.Save(context.Background(), sess))
-
-	err := svc.RecycleSession(context.Background(), "wt1", io.Discard)
-	require.NoError(t, err)
-
-	recycled, err := store.Get(context.Background(), "wt1")
-	require.NoError(t, err)
-	assert.Equal(t, session.StateRecycled, recycled.State)
-	assert.Equal(t, sessDir, recycled.Path, "worktree path must be preserved on recycle")
-}
-
-func TestRecycleWorktreeSession_NoMetadata(t *testing.T) {
-	store := newMockStore()
-	cfg := &config.Config{
-		DataDir: t.TempDir(),
-		GitPath: "git",
-	}
-	svc := newTestService(t, store, cfg)
-
-	sessDir := filepath.Join(cfg.ReposDir(), "repo-wt-nometa")
-	require.NoError(t, os.MkdirAll(sessDir, 0o755))
-
-	sess := session.Session{
-		ID:            "wt-nometa",
-		Name:          "worktree-nometa",
-		Slug:          "worktree-nometa",
-		State:         session.StateActive,
-		Path:          sessDir,
-		Remote:        "https://github.com/example/repo.git",
-		CloneStrategy: config.CloneStrategyWorktree,
-		// No MetaWorktreeBranch
-	}
-	require.NoError(t, store.Save(context.Background(), sess))
-
-	err := svc.RecycleSession(context.Background(), "wt-nometa", io.Discard)
-	require.NoError(t, err)
-
-	recycled, err := store.Get(context.Background(), "wt-nometa")
-	require.NoError(t, err)
-	assert.Equal(t, session.StateRecycled, recycled.State)
 }
 
 func TestDeleteWorktreeSession(t *testing.T) {
@@ -1263,7 +1249,7 @@ func TestCreateSession_BranchTemplate(t *testing.T) {
 	})
 }
 
-func TestCreateSession_RecycledWorktreeCreatesNewBranch(t *testing.T) {
+func TestCreateSession_DoesNotReuseRecycledWorktree(t *testing.T) {
 	store := newMockStore()
 	remote := "https://github.com/example/repo.git"
 	store.sessions["wt-1"] = session.Session{
@@ -1277,14 +1263,10 @@ func TestCreateSession_RecycledWorktreeCreatesNewBranch(t *testing.T) {
 		Metadata:      map[string]string{session.MetaWorktreeBranch: "hive/old-session-abc123"},
 	}
 
-	var newBranch, deletedBranch string
+	var addedBranch string
 	spy := &capturingMockGit{}
-	spy.CheckoutNewBranchFn = func(_ context.Context, _, branch string) error {
-		newBranch = branch
-		return nil
-	}
-	spy.DeleteBranchFn = func(_ context.Context, _, branch string) error {
-		deletedBranch = branch
+	spy.WorktreeAddFn = func(_ context.Context, _, _, branch string) error {
+		addedBranch = branch
 		return nil
 	}
 
@@ -1304,37 +1286,20 @@ func TestCreateSession_RecycledWorktreeCreatesNewBranch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "wt-1", sess.ID, "recycled session should be reused")
-	assert.Regexp(t, `^hive/new-feature-[a-z0-9]+$`, newBranch)
-	assert.Equal(t, newBranch, sess.GetMeta(session.MetaWorktreeBranch))
-	assert.Equal(t, "hive/old-session-abc123", deletedBranch, "old branch should be deleted")
+	assert.NotEqual(t, "wt-1", sess.ID)
+	assert.Regexp(t, `^hive/new-feature-[a-z0-9]+$`, addedBranch)
+	assert.Equal(t, addedBranch, sess.GetMeta(session.MetaWorktreeBranch))
 }
 
 // capturingMockGit extends mockGit with optional function overrides for capturing calls.
 type capturingMockGit struct {
 	mockGit
-	WorktreeAddFn       func(ctx context.Context, repoDir, path, branch string) error
-	CheckoutNewBranchFn func(ctx context.Context, dir, branch string) error
-	DeleteBranchFn      func(ctx context.Context, dir, branch string) error
+	WorktreeAddFn func(ctx context.Context, repoDir, path, branch string) error
 }
 
 func (m *capturingMockGit) WorktreeAdd(ctx context.Context, repoDir, path, branch string) error {
 	if m.WorktreeAddFn != nil {
 		return m.WorktreeAddFn(ctx, repoDir, path, branch)
-	}
-	return nil
-}
-
-func (m *capturingMockGit) CheckoutNewBranch(ctx context.Context, dir, branch string) error {
-	if m.CheckoutNewBranchFn != nil {
-		return m.CheckoutNewBranchFn(ctx, dir, branch)
-	}
-	return nil
-}
-
-func (m *capturingMockGit) DeleteBranch(ctx context.Context, dir, branch string) error {
-	if m.DeleteBranchFn != nil {
-		return m.DeleteBranchFn(ctx, dir, branch)
 	}
 	return nil
 }

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -49,9 +49,6 @@ func (g *mouseTestGit) IsValidRepo(_ context.Context, _ string) error           
 func (g *mouseTestGit) CloneBare(_ context.Context, _, _ string) error            { return nil }
 func (g *mouseTestGit) WorktreeAdd(_ context.Context, _, _, _ string) error       { return nil }
 func (g *mouseTestGit) WorktreeRemove(_ context.Context, _, _, _ string) error    { return nil }
-func (g *mouseTestGit) WorktreeReset(_ context.Context, _, _ string) error        { return nil }
-func (g *mouseTestGit) CheckoutNewBranch(_ context.Context, _, _ string) error    { return nil }
-func (g *mouseTestGit) DeleteBranch(_ context.Context, _, _ string) error         { return nil }
 func (g *mouseTestGit) Fetch(_ context.Context, _ string) error                   { return nil }
 func (g *mouseTestGit) HasUnpushedCommits(_ context.Context, _ string) (bool, error) {
 	return false, nil

--- a/test/integration/worktree_test.go
+++ b/test/integration/worktree_test.go
@@ -162,13 +162,14 @@ func TestWorktreeBareRootCreated(t *testing.T) {
 	require.NoError(t, err, "bare root must contain HEAD at %s", headPath)
 }
 
-func TestWorktreeRecycleReuseCreatesNewBranch(t *testing.T) {
+func TestWorktreeRecycleDeletesSessionAndNextCreateIsFresh(t *testing.T) {
 	h := NewHarness(t)
 	repo := createBareRepo(t, "wt-recycle-repo")
 
 	out, err := h.Run("new", "--clone-strategy", "worktree", "--remote", repo, "first-session")
 	require.NoError(t, err, "first session: %s", out)
 	path := parseCreatedSessionPath(t, out)
+	bareDir := worktreeBareDir(t, path)
 
 	oldBranch := strings.TrimSpace(runInDir(t, path, "git", "branch", "--show-current"))
 	require.Contains(t, oldBranch, "first-session", "worktree should start on the first session's branch")
@@ -180,17 +181,22 @@ func TestWorktreeRecycleReuseCreatesNewBranch(t *testing.T) {
 
 	_, err = h.Run("session", "recycle", id)
 	require.NoError(t, err)
+	_, err = os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist, "recycling a worktree should remove its checkout")
+
+	lines, err = h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	require.Empty(t, lines, "recycling a worktree should delete its session record")
 
 	out, err = h.Run("new", "--clone-strategy", "worktree", "--remote", repo, "second-session")
 	require.NoError(t, err, "second session: %s", out)
-	reusedPath := parseCreatedSessionPath(t, out)
-	require.Equal(t, path, reusedPath, "recycled worktree session should be reused")
+	newPath := parseCreatedSessionPath(t, out)
+	require.NotEqual(t, path, newPath, "the next worktree session should use a fresh path")
 
-	newBranch := strings.TrimSpace(runInDir(t, reusedPath, "git", "branch", "--show-current"))
-	assert.Contains(t, newBranch, "second-session", "reused worktree must be on a fresh branch for the new session")
+	newBranch := strings.TrimSpace(runInDir(t, newPath, "git", "branch", "--show-current"))
+	assert.Contains(t, newBranch, "second-session", "the new worktree must use the new session branch")
 	assert.NotEqual(t, oldBranch, newBranch)
 
-	bareDir := worktreeBareDir(t, reusedPath)
 	branches := runInDir(t, bareDir, "git", "branch", "--list")
 	assert.NotContains(t, branches, oldBranch, "old session branch should be deleted from the bare repo")
 	assert.Contains(t, branches, newBranch)


### PR DESCRIPTION
## Purpose

Worktree recycling retained session and branch state even though the shared bare clone already provides fast subsequent creation. Treat recycle as deletion for worktree sessions to preserve the familiar workflow without stale branches or identity.

## Proposed Changes

- Delete worktree checkouts and session records when recycled while retaining the shared bare clone
- Always create fresh worktree sessions; keep full-clone recycling unchanged
- Document the strategy-specific behavior and update coverage

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
