### PR TITLE
feat(desktop): profiles and feeds as code — editor GUI, CRUD, toasts

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -102,49 +102,84 @@ re-reads counts and, when it is the active profile, items, and
 profiles-config reload.
 
 The feed service delegates to a `feed.Provider`: mock fixtures in
-`HIVE_DESKTOP_MOCK` modes, or the GitHub-backed `LiveProvider` (search-query
-feeds plus the notifications inbox, deduplicated by `repo#num`, 30s fetch
-cache, app-local read state under the hive data dir's `desktop/`
-subdirectory). In live mode a poller refreshes every profile each 60s and
-emits `feed:updated` on change; the titlebar's polling indicator reflects
-the active profile's unread count.
+`HIVE_DESKTOP_MOCK` modes, or the GitHub-backed `LiveProvider`. Live data is
+acquired per **source** (a search query or the notifications inbox) and
+cached by what is requested — kind + query + limit — so any number of feeds
+and profiles reading the same source share one request. Feeds are client-side
+filtered views over sources, deduplicated by `repo#num`, with app-local read
+state under the hive data dir's `desktop/` subdirectory. In live mode a
+poller refreshes the distinct source set across all profiles each 60s and
+emits `feed:updated` per profile whose sources changed; the titlebar's
+polling indicator reflects the active profile's unread count.
 
-## Profiles and feeds as code
+## Sources, profiles, and feeds as code
 
-Profiles ("workspaces") and their feeds are defined in a user-editable YAML
-file at `$XDG_CONFIG_HOME/hive/desktop/profiles.yaml` (`~/.config` fallback;
-`HIVE_DESKTOP_CONFIG` overrides the path) — deliberately in the config dir,
-not the data dir, so it can live in a dotfiles repo. App-local state
-(read-state) stays in the data dir.
+Sources, profiles ("workspaces"), and their feeds are defined in a
+user-editable YAML file at `$XDG_CONFIG_HOME/hive/desktop/profiles.yaml`
+(`~/.config` fallback; `HIVE_DESKTOP_CONFIG` overrides the path) —
+deliberately in the config dir, not the data dir, so it can live in a
+dotfiles repo. App-local state (read-state) stays in the data dir.
+
+Sources acquire data from the GitHub API; feeds are client-side filtered
+views over one or more sources. Only sources cost API requests — feeds are
+unlimited and free.
 
 ```yaml
+sources:
+  - id: my-work               # unique across sources
+    kind: search              # "search" | "notifications"
+    query: "is:open involves:@me archived:false"   # search only
+    limit: 50                 # optional; search: default 50 max 100,
+                              # notifications: default 50 max 50 (API cap)
+  - id: inbox
+    kind: notifications
 profiles:
-  - id: triage            # stable slug; renaming makes it a new profile
+  - id: triage                # stable slug; renaming makes it a new profile
     name: Triage
     feeds:
       - id: my-open-prs
         name: My open PRs
-        kind: search      # "search" | "notifications"
-        query: "is:open is:pr author:@me archived:false"
+        sources: [my-work]    # at least one; ids must exist under sources
+        filters:              # optional; groups AND, values OR, excludes win
+          types: [pr]                     # pr | issue
+          repos: ["colonyops/*"]          # owner/repo doublestar globs
+          exclude_repos: ["colonyops/x"]
+          authors: ["hay-kot"]            # case-insensitive; [ ] literal
+          exclude_authors: ["*[bot]"]
+          labels: ["bug", "area/*"]       # any item label matches any glob
+          exclude_labels: ["wontfix"]
+          reasons: [mention, review_requested]  # notification reasons
       - id: notifications-inbox
         name: Notifications inbox
-        kind: notifications
-        repos: ["colonyops/*"]        # optional owner/repo globs (doublestar)
-        exclude_repos: ["colonyops/x"]
+        sources: [inbox]
 ```
 
-Parsing is strict (unknown keys are errors) and validated: unique ids,
-kind-specific query rules, glob syntax, and a 30-feed cap — each feed is one
-GitHub API request per poll cycle, and more would exceed the authenticated
-search rate limit (30 requests/min). `repos`/`exclude_repos` filter fetched
-items client-side, so filters never add API requests.
+Parsing is strict (unknown keys are errors; configs in the old
+feed-level-kind/query schema fail with a hint) and validated: unique ids,
+kind-specific query and limit rules, glob syntax, and the types/reasons
+vocabularies. A `reasons` filter matches the notification reason, so items
+known only from a search source never match it — reasons belong on feeds
+that read a notifications source.
+
+Rate-limit model: at most **25 search sources** — each distinct search
+source is one request per poll (about once a minute) against GitHub's
+search bucket of 30 requests/min, and 25 leaves headroom for manual
+refreshes. Identical sources (same kind, query, and limit) deduplicate to
+one request no matter how many feeds or profiles read them. Notifications
+sources are uncapped: they poll the core bucket (5000/hr) with conditional
+`If-Modified-Since` requests — an unchanged inbox answers 304 at no
+rate-limit cost — and honor the server's `X-Poll-Interval` (min 60s) even
+on manual refresh. There is no cap on feeds.
 
 A `ConfigWatcher` (fsnotify on the config's parent directory, debounced)
 hot-reloads the file on external edits: the store re-parses (keeping the
-last-good profiles when the new content is broken), the provider cache is
-invalidated, and `config:updated` wakes the frontend. Creating a profile in
-the app appends to the YAML via node-tree surgery so hand-written comments
-survive. The "Feeds as code" sheet (sidebar FEEDS `+`, or ⌘K → "Edit feeds
+last-good sources and profiles when the new content is broken), the provider
+cache is invalidated, and `config:updated` wakes the frontend. App-side
+writes — creating a profile, source, or feed, and editing a feed — go
+through YAML node-tree surgery so hand-written comments survive (comments
+attached to a replaced feed node itself are lost), and the resulting
+document is validated before it is written: a config that fails validation
+never reaches disk. The "Feeds as code" sheet (sidebar FEEDS `+`, or ⌘K → "Edit feeds
 as code…") shows the file, its validity, and a **Copy prompt** button that
 puts a schema-complete prompt on the clipboard for a coding agent to edit
 the config on the user's behalf.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -91,13 +91,15 @@ wails3 generate bindings -clean=true -ts -i
 ```
 
 The frontend Vite plugin requires generated typed-event bindings. The shell
-registers the `feed:updated` and `auth:updated` events using package-variable
-initialization rather than an `init()` function because this repository
-enables `gochecknoinits` (main.go carries a comment saying the same). Both
-events are wake-up signals: `auth:updated` makes the frontend re-read auth
-Status (device-flow grants land in a Go goroutine), and `feed:updated`
-carries the profile ID whose data changed so the frontend re-reads counts
-and, when it is the active profile, items.
+registers the `feed:updated`, `auth:updated`, and `config:updated` events
+using package-variable initialization rather than an `init()` function
+because this repository enables `gochecknoinits` (main.go carries a comment
+saying the same). All are wake-up signals: `auth:updated` makes the frontend
+re-read auth Status (device-flow grants land in a Go goroutine),
+`feed:updated` carries the profile ID whose data changed so the frontend
+re-reads counts and, when it is the active profile, items, and
+`config:updated` carries `"ok"` or the config error text after a
+profiles-config reload.
 
 The feed service delegates to a `feed.Provider`: mock fixtures in
 `HIVE_DESKTOP_MOCK` modes, or the GitHub-backed `LiveProvider` (search-query
@@ -106,6 +108,46 @@ cache, app-local read state under the hive data dir's `desktop/`
 subdirectory). In live mode a poller refreshes every profile each 60s and
 emits `feed:updated` on change; the titlebar's polling indicator reflects
 the active profile's unread count.
+
+## Profiles and feeds as code
+
+Profiles ("workspaces") and their feeds are defined in a user-editable YAML
+file at `$XDG_CONFIG_HOME/hive/desktop/profiles.yaml` (`~/.config` fallback;
+`HIVE_DESKTOP_CONFIG` overrides the path) — deliberately in the config dir,
+not the data dir, so it can live in a dotfiles repo. App-local state
+(read-state) stays in the data dir.
+
+```yaml
+profiles:
+  - id: triage            # stable slug; renaming makes it a new profile
+    name: Triage
+    feeds:
+      - id: my-open-prs
+        name: My open PRs
+        kind: search      # "search" | "notifications"
+        query: "is:open is:pr author:@me archived:false"
+      - id: notifications-inbox
+        name: Notifications inbox
+        kind: notifications
+        repos: ["colonyops/*"]        # optional owner/repo globs (doublestar)
+        exclude_repos: ["colonyops/x"]
+```
+
+Parsing is strict (unknown keys are errors) and validated: unique ids,
+kind-specific query rules, glob syntax, and a 30-feed cap — each feed is one
+GitHub API request per poll cycle, and more would exceed the authenticated
+search rate limit (30 requests/min). `repos`/`exclude_repos` filter fetched
+items client-side, so filters never add API requests.
+
+A `ConfigWatcher` (fsnotify on the config's parent directory, debounced)
+hot-reloads the file on external edits: the store re-parses (keeping the
+last-good profiles when the new content is broken), the provider cache is
+invalidated, and `config:updated` wakes the frontend. Creating a profile in
+the app appends to the YAML via node-tree surgery so hand-written comments
+survive. The "Feeds as code" sheet (sidebar FEEDS `+`, or ⌘K → "Edit feeds
+as code…") shows the file, its validity, and a **Copy prompt** button that
+puts a schema-complete prompt on the clipboard for a coding agent to edit
+the config on the user's behalf.
 
 Desktop-only Go code lives under `internal/desktop/**`; the `desktop/`
 package is thin Wails wiring. `internal/desktop/auth` implements GitHub

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -184,6 +184,13 @@ as code…") shows the file, its validity, and a **Copy prompt** button that
 puts a schema-complete prompt on the clipboard for a coding agent to edit
 the config on the user's behalf.
 
+A feed editor sheet complements the raw file: ⌘K → "New feed…" creates a
+feed, and each sidebar feed row's hover pencil (or ⌘K → "Edit feed: …")
+opens it prefilled. The editor picks from the shared sources (with inline
+source creation), edits the filter groups, live-previews the YAML entry it
+will write, and saves through the same comment-preserving config writes —
+with the config path and **Copy prompt** one click away.
+
 Desktop-only Go code lives under `internal/desktop/**`; the `desktop/`
 package is thin Wails wiring. `internal/desktop/auth` implements GitHub
 authentication behind the auth service: an OAuth device flow plus a

--- a/desktop/e2e/tests/config.spec.ts
+++ b/desktop/e2e/tests/config.spec.ts
@@ -23,7 +23,7 @@ test('opens the feeds-as-code sheet from the command palette', async ({ page }) 
   await page.keyboard.press('Meta+k')
   const input = page.getByTestId('command-palette-input')
   await input.fill('as code')
-  await expect(page.getByTestId('command-palette-command')).toHaveText('Edit feeds as code…')
+  await expect(page.getByTestId('command-palette-command-title')).toHaveText('Edit feeds as code…')
   await input.press('Enter')
 
   await expect(page.getByTestId('config-sheet')).toBeVisible()

--- a/desktop/e2e/tests/config.spec.ts
+++ b/desktop/e2e/tests/config.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByTestId('feed-item')).toHaveCount(6)
+})
+
+test('opens the feeds-as-code sheet from the sidebar and closes it', async ({ page }) => {
+  await page.getByTestId('sidebar-edit-feeds').click()
+
+  const sheet = page.getByTestId('config-sheet')
+  await expect(sheet).toBeVisible()
+  await expect(page.getByTestId('config-sheet-path')).toHaveText('~/.config/hive/desktop/profiles.yaml')
+  await expect(page.getByTestId('config-sheet-yaml')).toContainText('id: my-open-prs')
+  await expect(page.getByTestId('config-sheet-valid')).toContainText('changes apply live')
+  await expect(page.getByTestId('config-sheet-copy-prompt')).toBeVisible()
+
+  await page.keyboard.press('Escape')
+  await expect(sheet).toBeHidden()
+})
+
+test('opens the feeds-as-code sheet from the command palette', async ({ page }) => {
+  await page.keyboard.press('Meta+k')
+  const input = page.getByTestId('command-palette-input')
+  await input.fill('as code')
+  await expect(page.getByTestId('command-palette-command')).toHaveText('Edit feeds as code…')
+  await input.press('Enter')
+
+  await expect(page.getByTestId('config-sheet')).toBeVisible()
+})
+
+// Profile creation is a one-way state change on the shared feed-mode
+// server, so it lives in onboarding.spec.ts, which owns per-browser
+// mutable servers. This suite only opens read-only surfaces.
+test('opens and cancels the new-profile modal without changing the rail', async ({ page }) => {
+  await page.getByTestId('profile-add').click()
+
+  const modal = page.getByTestId('new-profile-modal')
+  await expect(modal).toBeVisible()
+  await expect(page.getByTestId('new-profile-submit')).toBeDisabled()
+
+  await page.keyboard.press('Escape')
+  await expect(modal).toBeHidden()
+  await expect(page.getByTestId('profile-tile')).toHaveCount(1)
+})

--- a/desktop/e2e/tests/feed-editor.spec.ts
+++ b/desktop/e2e/tests/feed-editor.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+// Read-only feed-editor coverage against the shared feed-mode server (8931):
+// the editor is opened, inspected, and dismissed — never saved. Mutation
+// coverage (create source → create feed → edit feed) lives in
+// onboarding.spec.ts, which owns the per-browser mutable servers.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByTestId('feed-item')).toHaveCount(6)
+})
+
+test('opens the editor prefilled from the sidebar pencil and closes without mutating', async ({ page }) => {
+  const row = page.locator('[data-testid="sidebar-feed"][data-id="my-open-prs"]')
+  await row.hover()
+  await page.getByTestId('sidebar-feed-edit-my-open-prs').click()
+
+  const editor = page.getByTestId('feed-editor')
+  await expect(editor).toBeVisible()
+  await expect(page.getByTestId('feed-editor-title')).toHaveText('Edit feed')
+  await expect(page.getByTestId('feed-editor-name')).toHaveValue('My open PRs')
+
+  // The canned sources are listed; only the feed's own source is checked.
+  await expect(page.getByTestId('feed-editor-source-my-prs')).toBeChecked()
+  await expect(page.getByTestId('feed-editor-source-assigned')).not.toBeChecked()
+  await expect(page.getByTestId('feed-editor-source-inbox')).not.toBeChecked()
+
+  await expect(page.getByTestId('feed-editor-yaml')).toContainText('id: my-open-prs')
+  await expect(page.getByTestId('feed-editor-path')).toHaveText('~/.config/hive/desktop/profiles.yaml')
+  await expect(page.getByTestId('feed-editor-copy-prompt')).toBeVisible()
+
+  await page.keyboard.press('Escape')
+  await expect(editor).toBeHidden()
+  await expect(page.getByTestId('sidebar-feed')).toHaveCount(3)
+})
+
+test('opens a create-mode editor from the palette and previews the typed name', async ({ page }) => {
+  await page.keyboard.press('Meta+k')
+  await page.getByTestId('command-palette-input').fill('new feed')
+  await page.getByTestId('command-palette-command').filter({ hasText: 'New feed…' }).click()
+
+  const editor = page.getByTestId('feed-editor')
+  await expect(editor).toBeVisible()
+  await expect(page.getByTestId('feed-editor-title')).toHaveText('New feed')
+  await expect(page.getByTestId('feed-editor-source-my-prs')).toBeVisible()
+  await expect(page.getByTestId('feed-editor-source-inbox')).toBeVisible()
+
+  await page.getByTestId('feed-editor-name').fill('Scratch feed')
+  await expect(page.getByTestId('feed-editor-yaml')).toContainText('name: Scratch feed')
+  // No source checked yet, so the save gate holds.
+  await expect(page.getByTestId('feed-editor-save')).toBeDisabled()
+
+  await page.keyboard.press('Escape')
+  await expect(editor).toBeHidden()
+  await expect(page.getByTestId('sidebar-feed')).toHaveCount(3)
+})

--- a/desktop/e2e/tests/feed.spec.ts
+++ b/desktop/e2e/tests/feed.spec.ts
@@ -78,9 +78,10 @@ test('opens, filters, runs, and dismisses the command palette', async ({ page })
   await expect(palette).toBeVisible()
   const input = page.getByTestId('command-palette-input')
   await input.fill('notifications')
-  await expect(page.getByTestId('command-palette-command')).toHaveCount(1)
-  await expect(page.getByTestId('command-palette-command-title')).toHaveText('Select feed: Notifications inbox')
-  await input.press('Enter')
+  // The feed matches twice now: its Select entry and its feed-editor Edit entry.
+  const commands = page.getByTestId('command-palette-command')
+  await expect(commands).toHaveCount(2)
+  await commands.filter({ hasText: 'Select feed: Notifications inbox' }).click()
   await expect(palette).toBeHidden()
   await expect(page.getByTestId('feed-title')).toHaveText('Notifications inbox')
 

--- a/desktop/e2e/tests/onboarding.spec.ts
+++ b/desktop/e2e/tests/onboarding.spec.ts
@@ -58,4 +58,16 @@ test('first-run onboarding: token fallback card, then device flow to the feed', 
   await expect(page.getByTestId('feed-item')).toHaveCount(6, { timeout: 15_000 })
   await expect(page.getByTestId('breadcrumb-profile-name')).toHaveText('Frontend Triage')
   await expect(page.getByTestId('sidebar-profile-name')).toHaveText('Frontend Triage')
+
+  // A second profile through the rail modal — this server is ours to
+  // mutate, unlike the shared feed-mode instance.
+  await page.getByTestId('profile-add').click()
+  const modal = page.getByTestId('new-profile-modal')
+  await expect(modal).toBeVisible()
+  await page.getByTestId('new-profile-input').fill('Backend Triage')
+  await page.getByTestId('new-profile-submit').click()
+
+  await expect(modal).toBeHidden()
+  await expect(page.getByTestId('profile-tile')).toHaveCount(2)
+  await expect(page.getByTestId('sidebar-profile-name')).toHaveText('Backend Triage')
 })

--- a/desktop/e2e/tests/onboarding.spec.ts
+++ b/desktop/e2e/tests/onboarding.spec.ts
@@ -70,4 +70,52 @@ test('first-run onboarding: token fallback card, then device flow to the feed', 
   await expect(modal).toBeHidden()
   await expect(page.getByTestId('profile-tile')).toHaveCount(2)
   await expect(page.getByTestId('sidebar-profile-name')).toHaveText('Backend Triage')
+
+  // ── Feed editor: inline-create a source, create a feed, then edit it ──────
+  // Also a mutation, so it stays on this per-browser server.
+  await page.keyboard.press('Meta+k')
+  await page.getByTestId('command-palette-input').fill('new feed')
+  await page.getByTestId('command-palette-command').filter({ hasText: 'New feed…' }).click()
+
+  const editor = page.getByTestId('feed-editor')
+  await expect(editor).toBeVisible()
+  await expect(page.getByTestId('feed-editor-title')).toHaveText('New feed')
+
+  // The workspace seeded the default sources for picking.
+  await expect(page.getByTestId('feed-editor-source-my-prs')).toBeVisible()
+
+  // Inline-create a search source; it lands in the list auto-checked.
+  await page.getByTestId('feed-editor-new-source-toggle').click()
+  await page.getByTestId('feed-editor-source-id').fill('team-prs')
+  await page.getByTestId('feed-editor-source-query').fill('org:acme is:pr is:open')
+  await page.getByTestId('feed-editor-source-add').click()
+  await expect(page.getByTestId('feed-editor-source-team-prs')).toBeChecked()
+
+  await page.getByTestId('feed-editor-name').fill('Team PRs')
+  await page.getByTestId('feed-editor-filters-toggle').click()
+  await page.getByTestId('feed-editor-repos').fill('acme/*')
+  await expect(page.getByTestId('feed-editor-yaml')).toContainText('name: Team PRs')
+  await page.getByTestId('feed-editor-save').click()
+
+  await expect(editor).toBeHidden()
+  await expect(page.getByTestId('toast')).toHaveText('Feed created')
+  const teamRow = page.locator('[data-testid="sidebar-feed"][data-id="team-prs"]')
+  await expect(teamRow).toContainText('Team PRs')
+
+  // Reopen through the row's hover pencil: the definition round-trips.
+  await teamRow.hover()
+  await page.getByTestId('sidebar-feed-edit-team-prs').click()
+  await expect(page.getByTestId('feed-editor-title')).toHaveText('Edit feed')
+  await expect(page.getByTestId('feed-editor-name')).toHaveValue('Team PRs')
+  // Filters auto-expand when populated; the saved glob is intact.
+  await expect(page.getByTestId('feed-editor-repos')).toHaveValue('acme/*')
+  await expect(page.getByTestId('feed-editor-yaml')).toContainText('id: team-prs')
+
+  await page.getByTestId('feed-editor-name').fill('Team PRs (all)')
+  await page.getByTestId('feed-editor-exclude-repos').fill('acme/sandbox')
+  await page.getByTestId('feed-editor-save').click()
+
+  await expect(editor).toBeHidden()
+  await expect(page.getByTestId('toast')).toHaveText('Feed updated')
+  await expect(teamRow).toContainText('Team PRs (all)')
 })

--- a/desktop/e2e/tests/onboarding.spec.ts
+++ b/desktop/e2e/tests/onboarding.spec.ts
@@ -92,13 +92,14 @@ test('first-run onboarding: token fallback card, then device flow to the feed', 
   await expect(page.getByTestId('feed-editor-source-team-prs')).toBeChecked()
 
   await page.getByTestId('feed-editor-name').fill('Team PRs')
-  await page.getByTestId('feed-editor-filters-toggle').click()
   await page.getByTestId('feed-editor-repos').fill('acme/*')
   await expect(page.getByTestId('feed-editor-yaml')).toContainText('name: Team PRs')
   await page.getByTestId('feed-editor-save').click()
 
   await expect(editor).toBeHidden()
-  await expect(page.getByTestId('toast')).toHaveText('Feed created')
+  // .last(): toasts stack and outlive a single 4s auto-dismiss window, so an
+  // earlier toast from this same test run can still be visible here.
+  await expect(page.getByTestId('toast').last()).toHaveText('Feed created')
   const teamRow = page.locator('[data-testid="sidebar-feed"][data-id="team-prs"]')
   await expect(teamRow).toContainText('Team PRs')
 
@@ -116,6 +117,34 @@ test('first-run onboarding: token fallback card, then device flow to the feed', 
   await page.getByTestId('feed-editor-save').click()
 
   await expect(editor).toBeHidden()
-  await expect(page.getByTestId('toast')).toHaveText('Feed updated')
+  await expect(page.getByTestId('toast').last()).toHaveText('Feed updated')
   await expect(teamRow).toContainText('Team PRs (all)')
+
+  // ── Delete feed: two-step confirm inside the editor ───────────────────────
+  await teamRow.hover()
+  await page.getByTestId('sidebar-feed-edit-team-prs').click()
+  await expect(editor).toBeVisible()
+  await page.getByTestId('feed-editor-delete').click()
+  await expect(page.getByTestId('feed-editor-delete-confirm')).toBeVisible()
+  await page.getByTestId('feed-editor-delete-confirm').click()
+
+  await expect(editor).toBeHidden()
+  await expect(page.getByTestId('toast').last()).toHaveText('Feed deleted')
+  await expect(page.locator('[data-testid="sidebar-feed"][data-id="team-prs"]')).toHaveCount(0)
+
+  // ── Delete profile: hover reveals the header trash icon, modal confirms ───
+  await expect(page.getByTestId('profile-tile')).toHaveCount(2)
+  await expect(page.getByTestId('sidebar-profile-name')).toHaveText('Backend Triage')
+  await page.getByTestId('sidebar-profile-header').hover()
+  await page.getByTestId('sidebar-delete-profile').click()
+
+  const deleteProfileModal = page.getByTestId('delete-profile-modal')
+  await expect(deleteProfileModal).toBeVisible()
+  await expect(deleteProfileModal).toContainText('Backend Triage')
+  await page.getByTestId('delete-profile-confirm').click()
+
+  await expect(deleteProfileModal).toBeHidden()
+  await expect(page.getByTestId('toast').last()).toHaveText('Profile deleted')
+  await expect(page.getByTestId('profile-tile')).toHaveCount(1)
+  await expect(page.getByTestId('sidebar-profile-name')).toHaveText('Frontend Triage')
 })

--- a/desktop/feedservice.go
+++ b/desktop/feedservice.go
@@ -47,3 +47,18 @@ func (s *FeedService) CreateProfile(name string) (feed.Profile, error) {
 func (s *FeedService) Refresh(profileID string) (bool, error) {
 	return s.provider.Refresh(context.Background(), profileID)
 }
+
+// Config describes the profiles config file: path, content, validity.
+func (s *FeedService) Config() (feed.ConfigInfo, error) {
+	return s.provider.Config(context.Background())
+}
+
+// ConfigPrompt returns a paste-ready prompt for a coding agent to edit the
+// profiles config on the user's behalf.
+func (s *FeedService) ConfigPrompt() (string, error) {
+	info, err := s.provider.Config(context.Background())
+	if err != nil {
+		return "", err
+	}
+	return feed.BuildConfigPrompt(info), nil
+}

--- a/desktop/feedservice.go
+++ b/desktop/feedservice.go
@@ -42,10 +42,39 @@ func (s *FeedService) CreateProfile(name string) (feed.Profile, error) {
 	return s.provider.CreateProfile(context.Background(), name)
 }
 
-// Refresh refetches the profile's feeds, bypassing the cache TTL, and
-// reports whether anything changed. Backs the manual "Refresh now" action.
+// Refresh refetches the sources the profile's feeds reference, bypassing the
+// search cache TTL, and reports whether anything changed. Backs the manual
+// "Refresh now" action.
 func (s *FeedService) Refresh(profileID string) (bool, error) {
 	return s.provider.Refresh(context.Background(), profileID)
+}
+
+// Sources returns the top-level source definitions, for the feed editor's
+// source picker.
+func (s *FeedService) Sources() ([]feed.SourceDef, error) {
+	return s.provider.Sources(context.Background())
+}
+
+// FeedDefFor returns one feed's definition, for edit prefill.
+func (s *FeedService) FeedDefFor(profileID, feedID string) (feed.FeedDef, error) {
+	return s.provider.FeedDefFor(context.Background(), profileID, feedID)
+}
+
+// CreateSource persists a new top-level source and returns it with its
+// assigned ID.
+func (s *FeedService) CreateSource(def feed.SourceDef) (feed.SourceDef, error) {
+	return s.provider.CreateSource(context.Background(), def)
+}
+
+// CreateFeed persists a new feed in the profile (ID derived from the name)
+// and returns the feed's materialized summary.
+func (s *FeedService) CreateFeed(profileID string, def feed.FeedDef) (feed.Source, error) {
+	return s.provider.CreateFeed(context.Background(), profileID, def)
+}
+
+// UpdateFeed replaces the feed's definition; the feed keeps its ID.
+func (s *FeedService) UpdateFeed(profileID, feedID string, def feed.FeedDef) error {
+	return s.provider.UpdateFeed(context.Background(), profileID, feedID, def)
 }
 
 // Config describes the profiles config file: path, content, validity.

--- a/desktop/feedservice.go
+++ b/desktop/feedservice.go
@@ -77,6 +77,19 @@ func (s *FeedService) UpdateFeed(profileID, feedID string, def feed.FeedDef) err
 	return s.provider.UpdateFeed(context.Background(), profileID, feedID, def)
 }
 
+// DeleteFeed removes the feed from the profile; the profile and its other
+// feeds are untouched.
+func (s *FeedService) DeleteFeed(profileID, feedID string) error {
+	return s.provider.DeleteFeed(context.Background(), profileID, feedID)
+}
+
+// DeleteProfile removes the profile and its feeds. Sources are left
+// untouched: they are shared, decoupled definitions other profiles may
+// still reference.
+func (s *FeedService) DeleteProfile(profileID string) error {
+	return s.provider.DeleteProfile(context.Background(), profileID)
+}
+
 // Config describes the profiles config file: path, content, validity.
 func (s *FeedService) Config() (feed.ConfigInfo, error) {
 	return s.provider.Config(context.Background())

--- a/desktop/frontend/bindings/github.com/colonyops/hive/desktop/feedservice.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/desktop/feedservice.ts
@@ -23,6 +23,21 @@ export function ActionsFor(kind: string): $CancellablePromise<feed$0.Action[] | 
 }
 
 /**
+ * Config describes the profiles config file: path, content, validity.
+ */
+export function Config(): $CancellablePromise<feed$0.ConfigInfo> {
+    return $Call.ByID(3084968143);
+}
+
+/**
+ * ConfigPrompt returns a paste-ready prompt for a coding agent to edit the
+ * profiles config on the user's behalf.
+ */
+export function ConfigPrompt(): $CancellablePromise<string> {
+    return $Call.ByID(3108030981);
+}
+
+/**
  * CreateProfile creates a workspace seeded with the default feeds.
  */
 export function CreateProfile(name: string): $CancellablePromise<feed$0.Profile> {

--- a/desktop/frontend/bindings/github.com/colonyops/hive/desktop/feedservice.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/desktop/feedservice.ts
@@ -61,6 +61,23 @@ export function CreateSource(def: feed$0.SourceDef): $CancellablePromise<feed$0.
 }
 
 /**
+ * DeleteFeed removes the feed from the profile; the profile and its other
+ * feeds are untouched.
+ */
+export function DeleteFeed(profileID: string, feedID: string): $CancellablePromise<void> {
+    return $Call.ByID(3635964346, profileID, feedID);
+}
+
+/**
+ * DeleteProfile removes the profile and its feeds. Sources are left
+ * untouched: they are shared, decoupled definitions other profiles may
+ * still reference.
+ */
+export function DeleteProfile(profileID: string): $CancellablePromise<void> {
+    return $Call.ByID(388918543, profileID);
+}
+
+/**
  * FeedDefFor returns one feed's definition, for edit prefill.
  */
 export function FeedDefFor(profileID: string, feedID: string): $CancellablePromise<feed$0.FeedDef> {

--- a/desktop/frontend/bindings/github.com/colonyops/hive/desktop/feedservice.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/desktop/feedservice.ts
@@ -38,10 +38,33 @@ export function ConfigPrompt(): $CancellablePromise<string> {
 }
 
 /**
+ * CreateFeed persists a new feed in the profile (ID derived from the name)
+ * and returns the feed's materialized summary.
+ */
+export function CreateFeed(profileID: string, def: feed$0.FeedDef): $CancellablePromise<feed$0.Source> {
+    return $Call.ByID(2859570357, profileID, def);
+}
+
+/**
  * CreateProfile creates a workspace seeded with the default feeds.
  */
 export function CreateProfile(name: string): $CancellablePromise<feed$0.Profile> {
     return $Call.ByID(2100022366, name);
+}
+
+/**
+ * CreateSource persists a new top-level source and returns it with its
+ * assigned ID.
+ */
+export function CreateSource(def: feed$0.SourceDef): $CancellablePromise<feed$0.SourceDef> {
+    return $Call.ByID(3542744264, def);
+}
+
+/**
+ * FeedDefFor returns one feed's definition, for edit prefill.
+ */
+export function FeedDefFor(profileID: string, feedID: string): $CancellablePromise<feed$0.FeedDef> {
+    return $Call.ByID(3622655147, profileID, feedID);
 }
 
 /**
@@ -67,9 +90,25 @@ export function Profiles(): $CancellablePromise<feed$0.Profile[] | null> {
 }
 
 /**
- * Refresh refetches the profile's feeds, bypassing the cache TTL, and
- * reports whether anything changed. Backs the manual "Refresh now" action.
+ * Refresh refetches the sources the profile's feeds reference, bypassing the
+ * search cache TTL, and reports whether anything changed. Backs the manual
+ * "Refresh now" action.
  */
 export function Refresh(profileID: string): $CancellablePromise<boolean> {
     return $Call.ByID(2193367500, profileID);
+}
+
+/**
+ * Sources returns the top-level source definitions, for the feed editor's
+ * source picker.
+ */
+export function Sources(): $CancellablePromise<feed$0.SourceDef[] | null> {
+    return $Call.ByID(1179368585);
+}
+
+/**
+ * UpdateFeed replaces the feed's definition; the feed keeps its ID.
+ */
+export function UpdateFeed(profileID: string, feedID: string, def: feed$0.FeedDef): $CancellablePromise<void> {
+    return $Call.ByID(3440431000, profileID, feedID, def);
 }

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/index.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/index.ts
@@ -3,6 +3,7 @@
 
 export type {
     Action,
+    ConfigInfo,
     Item,
     Profile,
     Source

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/index.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/index.ts
@@ -4,7 +4,10 @@
 export type {
     Action,
     ConfigInfo,
+    FeedDef,
+    FilterDef,
     Item,
     Profile,
-    Source
+    Source,
+    SourceDef
 } from "./models.js";

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/models.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/models.ts
@@ -14,6 +14,24 @@ export interface Action {
 }
 
 /**
+ * ConfigInfo describes the profiles config file for the frontend: where it
+ * lives, what it contains, and whether it currently parses.
+ */
+export interface ConfigInfo {
+    "path": string;
+    "exists": boolean;
+
+    /**
+     * YAML is the raw file content, or the example template when the file
+     * does not exist yet, so the UI and the copy-prompt always have a
+     * concrete config to show.
+     */
+    "yaml": string;
+    "valid": boolean;
+    "error": string;
+}
+
+/**
  * Item is an item from a profile feed.
  */
 export interface Item {

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/models.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/models.ts
@@ -32,6 +32,60 @@ export interface ConfigInfo {
 }
 
 /**
+ * FeedDef is a feed inside a profile: a client-side filtered view over one or
+ * more top-level sources. Feeds never cost API requests of their own.
+ */
+export interface FeedDef {
+    "id": string;
+    "name": string;
+    "sources": string[] | null;
+    "filters": FilterDef;
+}
+
+/**
+ * FilterDef is a feed's client-side filter block. Filters run after the
+ * feed's source items are merged, so they change what is shown, not what is
+ * requested — filtering is free of API cost. Groups AND together; values
+ * within a group OR; exclude groups win over includes.
+ */
+export interface FilterDef {
+    /**
+     * Repos/ExcludeRepos are doublestar globs matched against "owner/repo"
+     * (e.g. "colonyops/*").
+     */
+    "repos"?: string[] | null;
+    "exclude_repos"?: string[] | null;
+
+    /**
+     * Authors/ExcludeAuthors are globs matched against the item author
+     * case-insensitively, with "[" and "]" taken literally (bot logins end
+     * in a literal "[bot]"; a character class over login characters has no
+     * realistic use).
+     */
+    "authors"?: string[] | null;
+    "exclude_authors"?: string[] | null;
+
+    /**
+     * Labels keeps items where ANY item label matches ANY glob;
+     * ExcludeLabels drops items where any label matches.
+     */
+    "labels"?: string[] | null;
+    "exclude_labels"?: string[] | null;
+
+    /**
+     * Types matches the item kind: "pr" or "issue" (case-insensitive).
+     */
+    "types"?: string[] | null;
+
+    /**
+     * Reasons matches the notification reason. Items without a reason —
+     * search results that are not also in the notifications inbox — never
+     * match, so a reasons filter excludes them.
+     */
+    "reasons"?: string[] | null;
+}
+
+/**
  * Item is an item from a profile feed.
  */
 export interface Item {
@@ -47,6 +101,12 @@ export interface Item {
     "author": string;
     "age": string;
     "unread": boolean;
+
+    /**
+     * Reason is the GitHub notification reason (e.g. "review_requested"),
+     * empty for items known only from search.
+     */
+    "reason"?: string;
     "labels": string[] | null;
     "branch": string;
     "body": string;
@@ -76,4 +136,25 @@ export interface Source {
     "name": string;
     "count": number;
     "newCount": number;
+}
+
+/**
+ * SourceDef is a top-level data source: one GitHub API acquisition, shared by
+ * any number of feeds. Sources are the only part of the config that costs API
+ * requests; feeds are free client-side views over them.
+ */
+export interface SourceDef {
+    "id": string;
+
+    /**
+     * "search" | "notifications"
+     */
+    "kind": string;
+    "query"?: string;
+
+    /**
+     * Limit bounds items per fetch. Search: default 50, max 100 (API page
+     * cap). Notifications: default 50, max 50 (API page cap).
+     */
+    "limit"?: number;
 }

--- a/desktop/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts
+++ b/desktop/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts
@@ -9,6 +9,7 @@ declare module "@wailsio/runtime" {
     namespace Events {
         interface CustomEvents {
             "auth:updated": string;
+            "config:updated": string;
             "feed:updated": string;
         }
     }

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -13,14 +13,18 @@ import SideBar from './components/SideBar.vue'
 import FeedList from './components/FeedList.vue'
 import DetailPane from './components/DetailPane.vue'
 import CommandPalette from './components/CommandPalette.vue'
+import ConfigErrorOverlay from './components/ConfigErrorOverlay.vue'
 import ConfigSheet from './components/ConfigSheet.vue'
 import FeedEditorSheet from './components/FeedEditorSheet.vue'
+import DeleteProfileModal from './components/DeleteProfileModal.vue'
 import NewProfileModal from './components/NewProfileModal.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
+import ToastStack from './components/ToastStack.vue'
 import { useAuth } from './composables/useAuth'
 import { useFeedState } from './composables/useFeedState'
 import { useCommands, useCommandPalette, type Command } from './composables/useCommands'
 import { setTheme, themeLabels, themes } from './composables/useTheme'
+import { parseConfigErrors } from './lib/configErrors'
 import type { FeedDef, SourceDef } from './types/feed'
 
 const {
@@ -30,14 +34,20 @@ const {
 
 const {
   profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, loadError,
-  selectedId, selectedItem, actions, unreadOnly, title, countLabel, toast,
-  creatingProfile, createProfileError, loadProfiles, createProfile,
-  config, loadConfig, copyConfigPrompt, copyConfigPath,
+  selectedId, selectedItem, actions, unreadOnly, title, countLabel, toasts, dismissToast, clearToasts,
+  creatingProfile, createProfileError, deletingProfile, loadProfiles, createProfile, deleteProfile,
+  config, configErrorOverlayOpen, dismissConfigError, loadConfig, copyConfigPrompt, copyConfigPath, copyConfigErrors,
   sources, creatingSource, createSourceError, savingFeed, saveFeedError,
-  loadSources, createSource, loadFeedDef, createFeed, updateFeed,
+  loadSources, createSource, loadFeedDef, createFeed, updateFeed, deleteFeed,
   selectProfile, selectSidebar, selectUnreadView, selectItem,
   toggleUnread, refresh, notWired, hideWindow,
 } = useFeedState()
+
+// The overlay only ever gets the shape the backend actually provides today
+// (see internal/desktop/feed/config.go ConfigInfo.Error — a single string);
+// parseConfigErrors is the seam where richer per-problem data would plug in
+// without touching the template.
+const configErrors = computed(() => parseConfigErrors(config.value?.error ?? ''))
 
 // ── Config sheet & profile creation overlays ─────────────────────────────────
 
@@ -88,8 +98,28 @@ async function submitFeedSave(def: FeedDef) {
   if (saved) feedEditorOpen.value = false
 }
 
+async function submitFeedDelete(feedId: string) {
+  if (!activeProfileId.value) return
+  const deleted = await deleteFeed(activeProfileId.value, feedId)
+  if (deleted) feedEditorOpen.value = false
+}
+
 function submitNewSource(def: SourceDef) {
   void createSource(def)
+}
+
+// ── Delete profile confirm modal ─────────────────────────────────────────────
+
+const deleteProfileOpen = ref(false)
+
+function openDeleteProfile() {
+  deleteProfileOpen.value = true
+}
+
+async function confirmDeleteProfile() {
+  if (!activeProfileId.value) return
+  await deleteProfile(activeProfileId.value)
+  deleteProfileOpen.value = false
 }
 
 // Booting while signed out leaves profiles unloaded (or the live backend
@@ -253,7 +283,10 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
 </script>
 
 <template>
-  <main class="h-screen w-screen overflow-hidden bg-app text-text">
+  <main
+    class="h-screen w-screen overflow-hidden bg-app text-text"
+    :class="{ 'pointer-events-none blur-[3px] opacity-40 transition-[filter,opacity] duration-200': configErrorOverlayOpen }"
+  >
     <div class="flex h-full min-h-0 flex-col overflow-hidden">
       <TitleBar
         :profile-name="authenticated && !needsWorkspace ? activeProfile?.name ?? 'Loading' : undefined"
@@ -285,6 +318,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
           @select-unread="selectUnreadView"
           @edit-feeds="openConfigSheet"
           @edit-feed="openFeedEditor"
+          @delete-profile="openDeleteProfile"
         />
         <section v-if="activeProfile" class="flex min-w-0 flex-1">
           <FeedList
@@ -309,9 +343,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
         </div>
       </div>
     </div>
-    <Transition name="toast">
-      <div v-if="toast" class="fixed bottom-5 right-5 rounded-lg border border-strong bg-chip px-4 py-2.5 font-mono text-xs text-text shadow-2xl" data-testid="toast">{{ toast }}</div>
-    </Transition>
+    <ToastStack :toasts="toasts" @dismiss="dismissToast" @clear-all="clearToasts" />
     <CommandPalette />
     <ConfigSheet
       v-if="configSheetOpen"
@@ -332,6 +364,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
       :source-error="createSourceError"
       @close="feedEditorOpen = false"
       @save="submitFeedSave"
+      @delete="submitFeedDelete"
       @create-source="submitNewSource"
       @copy-prompt="copyConfigPrompt"
       @copy-path="copyConfigPath"
@@ -343,10 +376,21 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
       @close="newProfileOpen = false"
       @create="submitNewProfile"
     />
+    <DeleteProfileModal
+      v-if="deleteProfileOpen && activeProfile"
+      :profile-name="activeProfile.name"
+      :busy="deletingProfile"
+      @close="deleteProfileOpen = false"
+      @confirm="confirmDeleteProfile"
+    />
   </main>
+  <ConfigErrorOverlay
+    v-if="configErrorOverlayOpen"
+    :path="config?.path ?? ''"
+    :errors="configErrors"
+    @retry="loadConfig"
+    @dismiss="dismissConfigError"
+    @copy-path="copyConfigPath"
+    @copy-errors="copyConfigErrors"
+  />
 </template>
-
-<style scoped>
-.toast-enter-active, .toast-leave-active { transition: opacity .16s ease, transform .16s ease; }
-.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateY(5px); }
-</style>

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import IconEye from '~icons/lucide/eye'
 import IconLayoutGrid from '~icons/lucide/layout-grid'
 import IconList from '~icons/lucide/list'
@@ -13,6 +13,8 @@ import SideBar from './components/SideBar.vue'
 import FeedList from './components/FeedList.vue'
 import DetailPane from './components/DetailPane.vue'
 import CommandPalette from './components/CommandPalette.vue'
+import ConfigSheet from './components/ConfigSheet.vue'
+import NewProfileModal from './components/NewProfileModal.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
 import { useAuth } from './composables/useAuth'
 import { useFeedState } from './composables/useFeedState'
@@ -28,9 +30,30 @@ const {
   profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, loadError,
   selectedId, selectedItem, actions, unreadOnly, title, countLabel, toast,
   creatingProfile, createProfileError, loadProfiles, createProfile,
+  config, loadConfig, copyConfigPrompt, copyConfigPath,
   selectProfile, selectSidebar, selectUnreadView, selectItem,
   toggleUnread, refresh, notWired, hideWindow,
 } = useFeedState()
+
+// ── Config sheet & profile creation overlays ─────────────────────────────────
+
+const configSheetOpen = ref(false)
+const newProfileOpen = ref(false)
+
+function openConfigSheet() {
+  configSheetOpen.value = true
+  void loadConfig()
+}
+
+function openNewProfile() {
+  createProfileError.value = null // a stale failure must not greet the reopen
+  newProfileOpen.value = true
+}
+
+async function submitNewProfile(name: string) {
+  await createProfile(name)
+  if (!createProfileError.value) newProfileOpen.value = false
+}
 
 // Booting while signed out leaves profiles unloaded (or the live backend
 // erroring); re-load the moment auth lands — and when the login changes, so
@@ -99,6 +122,30 @@ useCommands(computed(() => {
     keywords: ['reload', 'sync'],
     icon: IconRefreshCw,
     run: refresh,
+  })
+
+  cmds.push({
+    id: 'profile:new',
+    title: 'New profile…',
+    group: 'Profiles',
+    keywords: ['workspace', 'create'],
+    run: openNewProfile,
+  })
+
+  cmds.push({
+    id: 'feed:edit-config',
+    title: 'Edit feeds as code…',
+    group: 'Feeds',
+    keywords: ['config', 'yaml', 'profiles'],
+    run: openConfigSheet,
+  })
+
+  cmds.push({
+    id: 'feed:copy-config-prompt',
+    title: 'Copy feeds config prompt',
+    group: 'Feeds',
+    keywords: ['config', 'yaml', 'agent', 'prompt'],
+    run: copyConfigPrompt,
   })
 
   // Themes
@@ -176,7 +223,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
         @create-workspace="createProfile"
       />
       <div v-else class="flex min-h-0 flex-1">
-        <ProfileRail :profiles="profiles" :active-profile-id="activeProfileId" @select="selectProfile" />
+        <ProfileRail :profiles="profiles" :active-profile-id="activeProfileId" @select="selectProfile" @add="openNewProfile" />
         <SideBar
           v-if="activeProfile"
           :profile="activeProfile"
@@ -184,6 +231,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
           :unread-only="unreadOnly"
           @select="selectSidebar"
           @select-unread="selectUnreadView"
+          @edit-feeds="openConfigSheet"
         />
         <section v-if="activeProfile" class="flex min-w-0 flex-1">
           <FeedList
@@ -212,6 +260,20 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
       <div v-if="toast" class="fixed bottom-5 right-5 rounded-lg border border-strong bg-chip px-4 py-2.5 font-mono text-xs text-text shadow-2xl" data-testid="toast">{{ toast }}</div>
     </Transition>
     <CommandPalette />
+    <ConfigSheet
+      v-if="configSheetOpen"
+      :config="config"
+      @close="configSheetOpen = false"
+      @copy-prompt="copyConfigPrompt"
+      @copy-path="copyConfigPath"
+    />
+    <NewProfileModal
+      v-if="newProfileOpen"
+      :busy="creatingProfile"
+      :error="createProfileError"
+      @close="newProfileOpen = false"
+      @create="submitNewProfile"
+    />
   </main>
 </template>
 

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -14,12 +14,14 @@ import FeedList from './components/FeedList.vue'
 import DetailPane from './components/DetailPane.vue'
 import CommandPalette from './components/CommandPalette.vue'
 import ConfigSheet from './components/ConfigSheet.vue'
+import FeedEditorSheet from './components/FeedEditorSheet.vue'
 import NewProfileModal from './components/NewProfileModal.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
 import { useAuth } from './composables/useAuth'
 import { useFeedState } from './composables/useFeedState'
 import { useCommands, useCommandPalette, type Command } from './composables/useCommands'
 import { setTheme, themeLabels, themes } from './composables/useTheme'
+import type { FeedDef, SourceDef } from './types/feed'
 
 const {
   status: authStatus, authenticated, deviceFlow, card: authCard, error: authError, busy: authBusy,
@@ -31,6 +33,8 @@ const {
   selectedId, selectedItem, actions, unreadOnly, title, countLabel, toast,
   creatingProfile, createProfileError, loadProfiles, createProfile,
   config, loadConfig, copyConfigPrompt, copyConfigPath,
+  sources, creatingSource, createSourceError, savingFeed, saveFeedError,
+  loadSources, createSource, loadFeedDef, createFeed, updateFeed,
   selectProfile, selectSidebar, selectUnreadView, selectItem,
   toggleUnread, refresh, notWired, hideWindow,
 } = useFeedState()
@@ -53,6 +57,39 @@ function openNewProfile() {
 async function submitNewProfile(name: string) {
   await createProfile(name)
   if (!createProfileError.value) newProfileOpen.value = false
+}
+
+// ── Feed editor sheet ────────────────────────────────────────────────────────
+
+const feedEditorOpen = ref(false)
+// Non-null while editing an existing feed; null in create mode.
+const editingFeedId = ref<string | null>(null)
+// The edit-mode prefill, loaded async after the sheet opens.
+const editingFeedDef = ref<FeedDef | null>(null)
+
+function openFeedEditor(feedId?: string) {
+  editingFeedId.value = feedId ?? null
+  editingFeedDef.value = null
+  createSourceError.value = null // stale failures must not greet the reopen
+  saveFeedError.value = null
+  feedEditorOpen.value = true
+  void loadSources()
+  void loadConfig() // the sheet shows the config path row
+  if (feedId && activeProfileId.value) {
+    void loadFeedDef(activeProfileId.value, feedId).then((def) => { editingFeedDef.value = def })
+  }
+}
+
+async function submitFeedSave(def: FeedDef) {
+  if (!activeProfileId.value) return
+  const saved = editingFeedId.value
+    ? await updateFeed(activeProfileId.value, editingFeedId.value, def)
+    : await createFeed(activeProfileId.value, def)
+  if (saved) feedEditorOpen.value = false
+}
+
+function submitNewSource(def: SourceDef) {
+  void createSource(def)
 }
 
 // Booting while signed out leaves profiles unloaded (or the live backend
@@ -105,7 +142,22 @@ useCommands(computed(() => {
       hint: profileName,
       run: () => selectSidebar({ type: 'feed', feedId: f.id }),
     })
+    cmds.push({
+      id: `feed:edit:${f.id}`,
+      title: `Edit feed: ${f.name}`,
+      group: 'Feeds',
+      keywords: ['editor', 'filters'],
+      run: () => openFeedEditor(f.id),
+    })
   }
+
+  cmds.push({
+    id: 'feed:new',
+    title: 'New feed…',
+    group: 'Feeds',
+    keywords: ['create', 'editor', 'source'],
+    run: () => openFeedEditor(),
+  })
 
   cmds.push({
     id: 'feed:toggle-unread',
@@ -232,6 +284,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
           @select="selectSidebar"
           @select-unread="selectUnreadView"
           @edit-feeds="openConfigSheet"
+          @edit-feed="openFeedEditor"
         />
         <section v-if="activeProfile" class="flex min-w-0 flex-1">
           <FeedList
@@ -264,6 +317,22 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
       v-if="configSheetOpen"
       :config="config"
       @close="configSheetOpen = false"
+      @copy-prompt="copyConfigPrompt"
+      @copy-path="copyConfigPath"
+    />
+    <FeedEditorSheet
+      v-if="feedEditorOpen"
+      :feed-id="editingFeedId"
+      :initial-def="editingFeedDef"
+      :sources="sources"
+      :config="config"
+      :busy="savingFeed"
+      :error="saveFeedError"
+      :source-busy="creatingSource"
+      :source-error="createSourceError"
+      @close="feedEditorOpen = false"
+      @save="submitFeedSave"
+      @create-source="submitNewSource"
       @copy-prompt="copyConfigPrompt"
       @copy-path="copyConfigPath"
     />

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import App from '../App.vue'
+import { useCommandPalette } from '../composables/useCommands'
+import type { Profile } from '../types/feed'
+
+const mocks = vi.hoisted(() => ({
+  // feedservice
+  ActionsFor: vi.fn(),
+  Config: vi.fn(),
+  ConfigPrompt: vi.fn(),
+  CreateFeed: vi.fn(),
+  CreateProfile: vi.fn(),
+  CreateSource: vi.fn(),
+  FeedDefFor: vi.fn(),
+  Items: vi.fn(),
+  MarkRead: vi.fn(),
+  Profiles: vi.fn(),
+  Refresh: vi.fn(),
+  Sources: vi.fn(),
+  UpdateFeed: vi.fn(),
+  // auth service
+  Status: vi.fn(),
+  StartDeviceFlow: vi.fn(),
+  CancelDeviceFlow: vi.fn(),
+  SetToken: vi.fn(),
+  SignOut: vi.fn(),
+  // runtime
+  On: vi.fn(),
+  Hide: vi.fn(),
+}))
+
+vi.mock('../../bindings/github.com/colonyops/hive/desktop/feedservice', () => ({
+  ActionsFor: mocks.ActionsFor,
+  Config: mocks.Config,
+  ConfigPrompt: mocks.ConfigPrompt,
+  CreateFeed: mocks.CreateFeed,
+  CreateProfile: mocks.CreateProfile,
+  CreateSource: mocks.CreateSource,
+  FeedDefFor: mocks.FeedDefFor,
+  Items: mocks.Items,
+  MarkRead: mocks.MarkRead,
+  Profiles: mocks.Profiles,
+  Refresh: mocks.Refresh,
+  Sources: mocks.Sources,
+  UpdateFeed: mocks.UpdateFeed,
+}))
+
+vi.mock('../../bindings/github.com/colonyops/hive/internal/desktop/auth/service', () => ({
+  Status: mocks.Status,
+  StartDeviceFlow: mocks.StartDeviceFlow,
+  CancelDeviceFlow: mocks.CancelDeviceFlow,
+  SetToken: mocks.SetToken,
+  SignOut: mocks.SignOut,
+}))
+
+vi.mock('@wailsio/runtime', () => ({
+  Events: { On: mocks.On },
+  Window: { Hide: mocks.Hide },
+}))
+
+const profiles: Profile[] = [
+  {
+    id: 'personal',
+    letter: 'P',
+    name: 'Personal',
+    sourceSummary: '2 sources',
+    totalCount: 1,
+    unreadCount: 0,
+    feeds: [{ id: 'desktop', name: 'Desktop UI', count: 1, newCount: 0 }],
+  },
+]
+
+async function mountApp() {
+  const wrapper = mount(App)
+  await flushPromises()
+  return wrapper
+}
+
+describe('App feed editor wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.Status.mockResolvedValue({ state: 'authenticated', login: 'hay', name: 'Hay', avatarUrl: '', message: '' })
+    mocks.Profiles.mockResolvedValue(profiles)
+    mocks.Items.mockResolvedValue([])
+    mocks.ActionsFor.mockResolvedValue([])
+    mocks.Config.mockResolvedValue({ path: '/cfg/profiles.yaml', exists: true, yaml: 'profiles:\n', valid: true, error: '' })
+    mocks.Sources.mockResolvedValue([
+      { id: 'my-prs', kind: 'search', query: 'is:open is:pr author:@me' },
+      { id: 'inbox', kind: 'notifications' },
+    ])
+    mocks.FeedDefFor.mockResolvedValue({ id: 'desktop', name: 'Desktop UI', sources: ['my-prs'], filters: {} })
+    mocks.On.mockReturnValue(() => {})
+  })
+
+  it('registers New feed and per-feed Edit feed palette commands', async () => {
+    const wrapper = await mountApp()
+    const { results, query } = useCommandPalette()
+    query.value = ''
+
+    const ids = results.value.map((cmd) => cmd.id)
+    expect(ids).toContain('feed:new')
+    expect(ids).toContain('feed:edit:desktop')
+    expect(results.value.find((cmd) => cmd.id === 'feed:new')?.title).toBe('New feed…')
+    expect(results.value.find((cmd) => cmd.id === 'feed:edit:desktop')?.title).toBe('Edit feed: Desktop UI')
+
+    wrapper.unmount()
+  })
+
+  it('opens the editor in create mode from the New feed command', async () => {
+    const wrapper = await mountApp()
+    const { results } = useCommandPalette()
+
+    await results.value.find((cmd) => cmd.id === 'feed:new')?.run()
+    await flushPromises()
+
+    expect(document.querySelector('[data-testid="feed-editor-title"]')?.textContent).toBe('New feed')
+    // Canned sources are listed for picking.
+    expect(document.querySelector('[data-testid="feed-editor-source-my-prs"]')).not.toBeNull()
+    expect(mocks.FeedDefFor).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('opens the editor prefilled from the Edit feed command', async () => {
+    const wrapper = await mountApp()
+    const { results } = useCommandPalette()
+
+    await results.value.find((cmd) => cmd.id === 'feed:edit:desktop')?.run()
+    await flushPromises()
+
+    expect(document.querySelector('[data-testid="feed-editor-title"]')?.textContent).toBe('Edit feed')
+    expect(mocks.FeedDefFor).toHaveBeenCalledWith('personal', 'desktop')
+    expect(document.querySelector<HTMLInputElement>('[data-testid="feed-editor-name"]')?.value).toBe('Desktop UI')
+
+    wrapper.unmount()
+  })
+
+  it('opens the editor from the sidebar pencil and saves through UpdateFeed', async () => {
+    mocks.UpdateFeed.mockResolvedValue(undefined)
+    const wrapper = await mountApp()
+
+    await wrapper.find('[data-testid="sidebar-feed-edit-desktop"]').trigger('click')
+    await flushPromises()
+
+    expect(document.querySelector('[data-testid="feed-editor"]')).not.toBeNull()
+
+    document.querySelector<HTMLButtonElement>('[data-testid="feed-editor-save"]')?.click()
+    await flushPromises()
+
+    expect(mocks.UpdateFeed).toHaveBeenCalledWith('personal', 'desktop', {
+      id: 'desktop',
+      name: 'Desktop UI',
+      sources: ['my-prs'],
+      filters: {},
+    })
+    expect(document.querySelector('[data-testid="feed-editor"]')).toBeNull() // closed on success
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   CreateFeed: vi.fn(),
   CreateProfile: vi.fn(),
   CreateSource: vi.fn(),
+  DeleteFeed: vi.fn(),
+  DeleteProfile: vi.fn(),
   FeedDefFor: vi.fn(),
   Items: vi.fn(),
   MarkRead: vi.fn(),
@@ -37,6 +39,8 @@ vi.mock('../../bindings/github.com/colonyops/hive/desktop/feedservice', () => ({
   CreateFeed: mocks.CreateFeed,
   CreateProfile: mocks.CreateProfile,
   CreateSource: mocks.CreateSource,
+  DeleteFeed: mocks.DeleteFeed,
+  DeleteProfile: mocks.DeleteProfile,
   FeedDefFor: mocks.FeedDefFor,
   Items: mocks.Items,
   MarkRead: mocks.MarkRead,
@@ -90,6 +94,8 @@ describe('App feed editor wiring', () => {
       { id: 'inbox', kind: 'notifications' },
     ])
     mocks.FeedDefFor.mockResolvedValue({ id: 'desktop', name: 'Desktop UI', sources: ['my-prs'], filters: {} })
+    mocks.DeleteFeed.mockResolvedValue(undefined)
+    mocks.DeleteProfile.mockResolvedValue(undefined)
     mocks.On.mockReturnValue(() => {})
   })
 
@@ -155,6 +161,48 @@ describe('App feed editor wiring', () => {
       filters: {},
     })
     expect(document.querySelector('[data-testid="feed-editor"]')).toBeNull() // closed on success
+
+    wrapper.unmount()
+  })
+
+  it('deletes a feed from the sidebar editor and closes the drawer', async () => {
+    const wrapper = await mountApp()
+
+    await wrapper.find('[data-testid="sidebar-feed-edit-desktop"]').trigger('click')
+    await flushPromises()
+
+    document.querySelector<HTMLButtonElement>('[data-testid="feed-editor-delete"]')?.click()
+    await flushPromises()
+    document.querySelector<HTMLButtonElement>('[data-testid="feed-editor-delete-confirm"]')?.click()
+    await flushPromises()
+
+    expect(mocks.DeleteFeed).toHaveBeenCalledWith('personal', 'desktop')
+    expect(document.querySelector('[data-testid="feed-editor"]')).toBeNull()
+    // ToastStack isn't teleported, unlike the drawer/modals above — assert
+    // through the wrapper, not document.querySelector.
+    expect(wrapper.find('[data-testid="toast-title"]').text()).toBe('Feed deleted')
+
+    wrapper.unmount()
+  })
+
+  it('deletes the active profile through the sidebar trash icon and confirm modal, then falls back to onboarding when none remain', async () => {
+    const wrapper = await mountApp()
+
+    await wrapper.find('[data-testid="sidebar-delete-profile"]').trigger('click')
+    await flushPromises()
+
+    expect(document.querySelector('[data-testid="delete-profile-modal"]')).not.toBeNull()
+
+    mocks.Profiles.mockResolvedValue([])
+    document.querySelector<HTMLButtonElement>('[data-testid="delete-profile-confirm"]')?.click()
+    await flushPromises()
+
+    expect(mocks.DeleteProfile).toHaveBeenCalledWith('personal')
+    expect(document.querySelector('[data-testid="delete-profile-modal"]')).toBeNull()
+    // No profiles left: the same "create your first workspace" step a fresh
+    // install starts from, not a bespoke empty state. OnboardingScreen isn't
+    // teleported, so assert through the wrapper.
+    expect(wrapper.find('[data-testid="onboarding"]').exists()).toBe(true)
 
     wrapper.unmount()
   })

--- a/desktop/frontend/src/components/ConfigErrorOverlay.vue
+++ b/desktop/frontend/src/components/ConfigErrorOverlay.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+import IconTriangleAlert from '~icons/lucide/triangle-alert'
+import type { ConfigValidationError } from '../lib/configErrors'
+
+const props = defineProps<{
+  path: string
+  errors: ConfigValidationError[]
+}>()
+const emit = defineEmits<{ retry: []; dismiss: []; 'copy-path': []; 'copy-errors': [] }>()
+
+// This overlay can appear (config:updated firing with an invalid config)
+// on top of another sheet that also has an unconditional window Escape
+// listener (FeedEditorSheet, ConfigSheet, DeleteProfileModal, NewProfileModal
+// all register one directly on window, uncoordinated). A plain bubble-phase
+// listener here would fire alongside theirs on the same Escape press,
+// closing the sheet underneath too and losing its unsaved form state.
+// Registering with { capture: true } makes this listener run first, in the
+// capture phase, before the event ever reaches the target or bubbles back up
+// to those other window listeners; stopPropagation() there halts the walk
+// before it gets that far, so only the topmost (this overlay) reacts.
+function onKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Escape') return
+  e.stopPropagation()
+  emit('dismiss')
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown, { capture: true }))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown, { capture: true }))
+</script>
+
+<template>
+  <Teleport to="body">
+    <!-- Full-app block (design spec "6b"): no click-outside-to-dismiss — the
+         "Dismiss" button is the explicit, intentional way out. Config keeps
+         serving the last-good data behind this, so dismissing is safe. -->
+    <div class="fixed inset-0 z-[60] flex items-center justify-center bg-scrim-strong p-10" data-testid="config-error-overlay">
+      <div
+        class="flex w-[600px] flex-col overflow-hidden rounded-[14px] border border-card bg-pane text-text shadow-[0_40px_90px_-20px_rgba(0,0,0,.8)]"
+        role="alertdialog"
+        aria-label="Feeds config error"
+        aria-modal="true"
+      >
+        <header class="flex gap-4 border-b border-row px-7 pb-[22px] pt-[26px]">
+          <span class="flex size-[42px] shrink-0 items-center justify-center rounded-[11px] bg-severity-error-tint text-severity-error">
+            <IconTriangleAlert class="size-[22px]" />
+          </span>
+          <div class="min-w-0 flex-1">
+            <div class="text-[18px] font-semibold tracking-[-.01em]" data-testid="config-error-title">Couldn't load your feeds config</div>
+            <p class="mt-1 text-[13px] leading-relaxed text-text-2" data-testid="config-error-subtitle">
+              {{ errors.length }} problem{{ errors.length === 1 ? '' : 's' }} found — the last valid version stays active until this is fixed.
+            </p>
+            <p class="mt-2 truncate font-mono text-[11.5px] text-text-3" data-testid="config-error-path">{{ path || '…' }}</p>
+          </div>
+        </header>
+
+        <div class="px-7 pt-4">
+          <div class="mb-1.5 flex items-baseline justify-between gap-3">
+            <span class="font-mono text-[11px] tracking-[.12em] text-text-3" data-testid="config-error-eyebrow">
+              VALIDATION DETAIL · {{ errors.length }} PROBLEM{{ errors.length === 1 ? '' : 'S' }}
+            </span>
+            <button class="cursor-pointer text-[11.5px] text-text-2 hover:text-text" data-testid="config-error-copy" @click="emit('copy-errors')">Copy</button>
+          </div>
+          <div class="hive-scroll max-h-[150px] overflow-y-auto rounded-[9px] border border-row bg-app px-3.5 py-[13px] font-mono text-xs leading-[1.7]" data-testid="config-error-list">
+            <div v-for="(error, i) in errors" :key="i" :class="{ 'mt-1.5': i > 0 }" data-testid="config-error-entry">
+              <span v-if="error.line !== null" class="text-text-3">line {{ error.line }}&nbsp;&nbsp;</span><span class="text-severity-error">{{ error.message }}</span>
+            </div>
+            <div v-if="errors.length === 0" class="text-text-3">No further detail was provided.</div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2.5 px-7 pb-6 pt-5">
+          <button class="cursor-pointer rounded-lg bg-accent px-[18px] py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110" data-testid="config-error-reload" @click="emit('retry')">Reload</button>
+          <button class="cursor-pointer rounded-lg border border-card bg-sidebar px-4 py-2.5 text-[13.5px] text-text hover:border-strong" data-testid="config-error-copy-path" @click="emit('copy-path')">Copy config path</button>
+          <div class="flex-1" />
+          <button class="cursor-pointer text-[13px] text-text-2 hover:text-text" data-testid="config-error-dismiss" @click="emit('dismiss')">Dismiss</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/desktop/frontend/src/components/ConfigSheet.vue
+++ b/desktop/frontend/src/components/ConfigSheet.vue
@@ -4,35 +4,13 @@ import IconAlertTriangle from '~icons/lucide/alert-triangle'
 import IconClipboardCopy from '~icons/lucide/clipboard-copy'
 import IconFileCode from '~icons/lucide/file-code'
 import IconX from '~icons/lucide/x'
+import { tokenizeYaml } from '../lib/yamlHighlight'
 import type { ConfigInfo } from '../types/feed'
 
 const props = defineProps<{ config: ConfigInfo | null }>()
 const emit = defineEmits<{ close: []; 'copy-prompt': []; 'copy-path': [] }>()
 
-// Display-only YAML tokenizer: enough to make keys, strings, and comments
-// scan like the settings mock, nothing more. The file is never edited here.
-interface Token { text: string; kind: 'key' | 'string' | 'comment' | 'plain' }
-
-function tokenizeLine(line: string): Token[] {
-  const commentAt = line.indexOf('#')
-  const beforeComment = commentAt >= 0 ? line.slice(0, commentAt) : line
-  const comment = commentAt >= 0 ? line.slice(commentAt) : ''
-
-  const tokens: Token[] = []
-  const keyMatch = /^(\s*-?\s*)([\w-]+)(:)(.*)$/.exec(beforeComment)
-  if (keyMatch) {
-    const [, indent, key, colon, rest] = keyMatch
-    if (indent) tokens.push({ text: indent, kind: 'plain' })
-    tokens.push({ text: key + colon, kind: 'key' })
-    if (rest) tokens.push({ text: rest, kind: /["'[]/.test(rest.trimStart()[0] ?? '') ? 'string' : 'plain' })
-  } else if (beforeComment) {
-    tokens.push({ text: beforeComment, kind: 'plain' })
-  }
-  if (comment) tokens.push({ text: comment, kind: 'comment' })
-  return tokens
-}
-
-const lines = computed(() => (props.config?.yaml ?? '').replace(/\n$/, '').split('\n').map(tokenizeLine))
+const lines = computed(() => tokenizeYaml(props.config?.yaml ?? ''))
 
 function onKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') emit('close')

--- a/desktop/frontend/src/components/ConfigSheet.vue
+++ b/desktop/frontend/src/components/ConfigSheet.vue
@@ -36,13 +36,13 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
           <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" data-testid="config-sheet-close" @click="emit('close')"><IconX class="size-4.5" /></button>
         </header>
 
-        <div class="hive-scroll flex min-h-0 flex-1 flex-col gap-4.5 overflow-y-auto px-6 py-5">
-          <p class="text-[13px] leading-relaxed text-text-3">
+        <div class="flex min-h-0 flex-1 flex-col gap-4.5 px-6 py-5">
+          <p class="shrink-0 text-[13px] leading-relaxed text-text-3">
             Profiles and feeds live in a YAML file you own — edit it by hand, keep it in dotfiles, or let a coding
             agent write it. The app reloads it the moment it changes on disk.
           </p>
 
-          <div>
+          <div class="shrink-0">
             <div class="mb-1.5 text-[12.5px] text-text-2">Config file</div>
             <div class="flex gap-2">
               <div class="flex min-w-0 flex-1 items-center rounded-lg border border-card bg-app px-3 py-2 font-mono text-[12.5px] text-text-2">
@@ -59,20 +59,20 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
             </div>
           </div>
 
-          <div v-if="config && !config.valid" class="flex items-start gap-2.5 rounded-lg border border-accent/40 bg-selection px-3 py-2.5" data-testid="config-sheet-error">
+          <div v-if="config && !config.valid" class="shrink-0 flex items-start gap-2.5 rounded-lg border border-accent/40 bg-selection px-3 py-2.5" data-testid="config-sheet-error">
             <IconAlertTriangle class="mt-0.5 size-4 shrink-0 text-accent" />
             <div class="text-xs leading-relaxed text-text-2">
               <span class="font-semibold text-accent">Config error — last good version still active.</span>
               <span class="mt-0.5 block font-mono">{{ config.error }}</span>
             </div>
           </div>
-          <div v-else-if="config?.exists" class="flex items-center gap-1.5 text-[11.5px] text-kind-pr" data-testid="config-sheet-valid">
+          <div v-else-if="config?.exists" class="shrink-0 flex items-center gap-1.5 text-[11.5px] text-kind-pr" data-testid="config-sheet-valid">
             <span class="size-1.5 rounded-full bg-kind-pr" />Valid · changes apply live
           </div>
 
-          <div class="min-h-0">
-            <div class="mb-1.5 text-[12.5px] text-text-2">{{ config?.exists ? 'Current config' : 'Starting template' }}</div>
-            <pre class="hive-scroll max-h-full overflow-auto rounded-lg border border-row bg-app px-3.5 py-3 font-mono text-xs leading-[1.65]" data-testid="config-sheet-yaml"><code><template v-for="(line, i) in lines" :key="i"><span v-for="(token, j) in line" :key="j" :class="{
+          <div class="flex min-h-0 flex-1 flex-col">
+            <div class="mb-1.5 shrink-0 text-[12.5px] text-text-2">{{ config?.exists ? 'Current config' : 'Starting template' }}</div>
+            <pre class="hive-scroll min-h-0 flex-1 overflow-auto rounded-lg border border-row bg-app px-3.5 py-3 font-mono text-xs leading-[1.65]" data-testid="config-sheet-yaml"><code><template v-for="(line, i) in lines" :key="i"><span v-for="(token, j) in line" :key="j" :class="{
               'text-code-key': token.kind === 'key',
               'text-code-string': token.kind === 'string',
               'text-code-comment': token.kind === 'comment',
@@ -80,7 +80,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
             }">{{ token.text }}</span>{{ '\n' }}</template></code></pre>
           </div>
 
-          <p class="text-xs leading-relaxed text-text-4">
+          <p class="shrink-0 text-xs leading-relaxed text-text-4">
             Each feed is one GitHub API request per poll. <span class="text-text-3">repos</span> /
             <span class="text-text-3">exclude_repos</span> globs filter client-side, so prefer one broad query plus
             filters over many narrow feeds.

--- a/desktop/frontend/src/components/ConfigSheet.vue
+++ b/desktop/frontend/src/components/ConfigSheet.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
+import IconAlertTriangle from '~icons/lucide/alert-triangle'
+import IconClipboardCopy from '~icons/lucide/clipboard-copy'
+import IconFileCode from '~icons/lucide/file-code'
+import IconX from '~icons/lucide/x'
+import type { ConfigInfo } from '../types/feed'
+
+const props = defineProps<{ config: ConfigInfo | null }>()
+const emit = defineEmits<{ close: []; 'copy-prompt': []; 'copy-path': [] }>()
+
+// Display-only YAML tokenizer: enough to make keys, strings, and comments
+// scan like the settings mock, nothing more. The file is never edited here.
+interface Token { text: string; kind: 'key' | 'string' | 'comment' | 'plain' }
+
+function tokenizeLine(line: string): Token[] {
+  const commentAt = line.indexOf('#')
+  const beforeComment = commentAt >= 0 ? line.slice(0, commentAt) : line
+  const comment = commentAt >= 0 ? line.slice(commentAt) : ''
+
+  const tokens: Token[] = []
+  const keyMatch = /^(\s*-?\s*)([\w-]+)(:)(.*)$/.exec(beforeComment)
+  if (keyMatch) {
+    const [, indent, key, colon, rest] = keyMatch
+    if (indent) tokens.push({ text: indent, kind: 'plain' })
+    tokens.push({ text: key + colon, kind: 'key' })
+    if (rest) tokens.push({ text: rest, kind: /["'[]/.test(rest.trimStart()[0] ?? '') ? 'string' : 'plain' })
+  } else if (beforeComment) {
+    tokens.push({ text: beforeComment, kind: 'plain' })
+  }
+  if (comment) tokens.push({ text: comment, kind: 'comment' })
+  return tokens
+}
+
+const lines = computed(() => (props.config?.yaml ?? '').replace(/\n$/, '').split('\n').map(tokenizeLine))
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-40 bg-backdrop" data-testid="config-sheet-backdrop" @click.self="emit('close')">
+      <aside
+        class="absolute bottom-0 right-0 top-0 flex w-[620px] flex-col border-l border-strong bg-pane text-text shadow-[-30px_0_80px_-20px_rgba(0,0,0,.7)]"
+        role="dialog"
+        aria-label="Feeds as code"
+        aria-modal="true"
+        data-testid="config-sheet"
+      >
+        <header class="flex shrink-0 items-center gap-3 border-b border-row bg-pane px-6 py-5">
+          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconFileCode class="size-4" /></span>
+          <div class="flex-1 text-lg font-semibold tracking-[-.01em]">Feeds as code</div>
+          <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" data-testid="config-sheet-close" @click="emit('close')"><IconX class="size-4.5" /></button>
+        </header>
+
+        <div class="hive-scroll flex min-h-0 flex-1 flex-col gap-4.5 overflow-y-auto px-6 py-5">
+          <p class="text-[13px] leading-relaxed text-text-3">
+            Profiles and feeds live in a YAML file you own — edit it by hand, keep it in dotfiles, or let a coding
+            agent write it. The app reloads it the moment it changes on disk.
+          </p>
+
+          <div>
+            <div class="mb-1.5 text-[12.5px] text-text-2">Config file</div>
+            <div class="flex gap-2">
+              <div class="flex min-w-0 flex-1 items-center rounded-lg border border-card bg-app px-3 py-2 font-mono text-[12.5px] text-text-2">
+                <span class="truncate" data-testid="config-sheet-path">{{ config?.path ?? '…' }}</span>
+              </div>
+              <button
+                class="cursor-pointer whitespace-nowrap rounded-lg border border-card bg-sidebar px-3.5 py-2 text-[12.5px] text-text hover:border-strong"
+                data-testid="config-sheet-copy-path"
+                @click="emit('copy-path')"
+              >Copy path</button>
+            </div>
+            <div v-if="config && !config.exists" class="mt-1.5 font-mono text-[11.5px] text-text-4">
+              Not created yet — the preview below is the starting template.
+            </div>
+          </div>
+
+          <div v-if="config && !config.valid" class="flex items-start gap-2.5 rounded-lg border border-accent/40 bg-selection px-3 py-2.5" data-testid="config-sheet-error">
+            <IconAlertTriangle class="mt-0.5 size-4 shrink-0 text-accent" />
+            <div class="text-xs leading-relaxed text-text-2">
+              <span class="font-semibold text-accent">Config error — last good version still active.</span>
+              <span class="mt-0.5 block font-mono">{{ config.error }}</span>
+            </div>
+          </div>
+          <div v-else-if="config?.exists" class="flex items-center gap-1.5 text-[11.5px] text-kind-pr" data-testid="config-sheet-valid">
+            <span class="size-1.5 rounded-full bg-kind-pr" />Valid · changes apply live
+          </div>
+
+          <div class="min-h-0">
+            <div class="mb-1.5 text-[12.5px] text-text-2">{{ config?.exists ? 'Current config' : 'Starting template' }}</div>
+            <pre class="hive-scroll max-h-full overflow-auto rounded-lg border border-row bg-app px-3.5 py-3 font-mono text-xs leading-[1.65]" data-testid="config-sheet-yaml"><code><template v-for="(line, i) in lines" :key="i"><span v-for="(token, j) in line" :key="j" :class="{
+              'text-code-key': token.kind === 'key',
+              'text-code-string': token.kind === 'string',
+              'text-code-comment': token.kind === 'comment',
+              'text-text-2': token.kind === 'plain',
+            }">{{ token.text }}</span>{{ '\n' }}</template></code></pre>
+          </div>
+
+          <p class="text-xs leading-relaxed text-text-4">
+            Each feed is one GitHub API request per poll. <span class="text-text-3">repos</span> /
+            <span class="text-text-3">exclude_repos</span> globs filter client-side, so prefer one broad query plus
+            filters over many narrow feeds.
+          </p>
+        </div>
+
+        <footer class="flex shrink-0 gap-2.5 border-t border-row bg-raised px-6 py-3.5">
+          <button
+            class="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110"
+            data-testid="config-sheet-copy-prompt"
+            @click="emit('copy-prompt')"
+          ><IconClipboardCopy class="size-4" />Copy prompt for coding agent</button>
+          <button
+            class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text"
+            @click="emit('close')"
+          >Done</button>
+        </footer>
+      </aside>
+    </div>
+  </Teleport>
+</template>

--- a/desktop/frontend/src/components/DeleteProfileModal.vue
+++ b/desktop/frontend/src/components/DeleteProfileModal.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import IconTrash2 from '~icons/lucide/trash-2'
+import IconX from '~icons/lucide/x'
+
+const props = defineProps<{ profileName: string; busy: boolean }>()
+const emit = defineEmits<{ close: []; confirm: [] }>()
+
+const confirmRef = ref<HTMLButtonElement | null>(null)
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(async () => {
+  window.addEventListener('keydown', onKeydown)
+  await nextTick()
+  confirmRef.value?.focus()
+})
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-40 flex items-start justify-center bg-backdrop pt-[24vh]" @click.self="emit('close')">
+      <div
+        class="w-[420px] overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl"
+        role="alertdialog"
+        aria-label="Delete profile"
+        aria-modal="true"
+        data-testid="delete-profile-modal"
+      >
+        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
+          <span class="flex size-7 items-center justify-center rounded-[7px] bg-severity-error-tint text-severity-error"><IconTrash2 class="size-4" /></span>
+          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">Delete profile</div>
+          <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" @click="emit('close')"><IconX class="size-4" /></button>
+        </header>
+        <div class="flex flex-col gap-3 px-5 py-4">
+          <p class="text-[13px] leading-relaxed text-text-2">
+            Delete <span class="font-semibold text-text">{{ props.profileName }}</span>? Its feeds are removed from
+            <span class="font-mono text-text-3">profiles.yaml</span> — sources stay, since other profiles may still
+            reference them.
+          </p>
+        </div>
+        <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
+          <button
+            ref="confirmRef"
+            class="flex-1 cursor-pointer rounded-lg bg-severity-error px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
+            :disabled="busy"
+            data-testid="delete-profile-confirm"
+            @click="emit('confirm')"
+          >Delete profile</button>
+          <button
+            class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text"
+            data-testid="delete-profile-cancel"
+            @click="emit('close')"
+          >Cancel</button>
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/desktop/frontend/src/components/FeedEditorSheet.vue
+++ b/desktop/frontend/src/components/FeedEditorSheet.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import IconAlertTriangle from '~icons/lucide/alert-triangle'
+import IconCheck from '~icons/lucide/check'
 import IconChevronDown from '~icons/lucide/chevron-down'
 import IconChevronRight from '~icons/lucide/chevron-right'
 import IconClipboardCopy from '~icons/lucide/clipboard-copy'
+import IconMenu from '~icons/lucide/menu'
 import IconPlus from '~icons/lucide/plus'
 import IconRss from '~icons/lucide/rss'
 import IconX from '~icons/lucide/x'
@@ -27,6 +29,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   close: []
   save: [def: FeedDef]
+  delete: [feedId: string]
   'create-source': [def: SourceDef]
   'copy-prompt': []
   'copy-path': []
@@ -49,8 +52,15 @@ const excludeLabelsText = ref('')
 const types = ref<string[]>([])
 const reasons = ref<string[]>([])
 
-const filtersOpen = ref(false)
 const reasonsOpen = ref(false)
+
+function sourceSelected(id: string): boolean {
+  return checkedSources.value.includes(id)
+}
+
+function typeChecked(value: string): boolean {
+  return types.value.includes(value)
+}
 
 // The six glob groups render identically; keep the descriptors in one place.
 // `model` holds the Ref itself (arrays don't unwrap), bound via .value.
@@ -94,8 +104,6 @@ const filters = computed<FilterDef>(() => {
   return out
 })
 
-const hasFilters = computed(() => Object.keys(filters.value).length > 0)
-
 watch(() => props.initialDef, (def) => {
   if (!def) return
   name.value = def.name
@@ -109,7 +117,6 @@ watch(() => props.initialDef, (def) => {
   excludeLabelsText.value = (f.exclude_labels ?? []).join('\n')
   types.value = [...(f.types ?? [])]
   reasons.value = [...(f.reasons ?? [])]
-  if (hasFilters.value) filtersOpen.value = true
   if (reasons.value.length > 0) reasonsOpen.value = true
 }, { immediate: true })
 
@@ -131,6 +138,17 @@ const canSave = computed(() =>
 function submit() {
   if (props.busy || !canSave.value) return
   emit('save', buildDef())
+}
+
+// ── Delete (edit mode only) — two-step inline confirm, no modal. The parent
+// owns the actual delete call; this component only reports intent. ─────────
+
+const deleteConfirming = ref(false)
+
+function confirmDelete() {
+  if (!props.feedId) return
+  emit('delete', props.feedId)
+  deleteConfirming.value = false
 }
 
 // ── YAML preview ─────────────────────────────────────────────────────────────
@@ -214,13 +232,13 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
         aria-modal="true"
         data-testid="feed-editor"
       >
-        <header class="flex shrink-0 items-center gap-3 border-b border-row bg-pane px-6 py-5">
-          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconRss class="size-4" /></span>
-          <div class="flex-1 text-lg font-semibold tracking-[-.01em]" data-testid="feed-editor-title">{{ isEdit ? 'Edit feed' : 'New feed' }}</div>
+        <header class="flex shrink-0 items-center gap-3 border-b border-row bg-pane px-[22px] py-[18px]">
+          <span class="flex size-[30px] shrink-0 items-center justify-center rounded-lg bg-accent-tint text-accent"><IconRss class="size-4" /></span>
+          <div class="flex-1 text-[16px] font-semibold tracking-[-.01em]" data-testid="feed-editor-title">{{ isEdit ? 'Edit feed' : 'New feed' }}</div>
           <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" data-testid="feed-editor-close" @click="emit('close')"><IconX class="size-4.5" /></button>
         </header>
 
-        <div class="hive-scroll flex min-h-0 flex-1 flex-col gap-4.5 overflow-y-auto px-6 py-5">
+        <div class="hive-scroll flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-[22px] py-[22px]">
           <!-- Name -->
           <div>
             <div class="mb-1.5 text-[12.5px] text-text-2">Name</div>
@@ -229,148 +247,172 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
               v-model="name"
               type="text"
               placeholder="Team PRs"
-              class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+              class="w-full rounded-lg border border-strong bg-app px-3 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
               data-testid="feed-editor-name"
               @keydown.enter="submit"
             >
             <p v-if="!isEdit" class="mt-1.5 text-xs leading-relaxed text-text-4">The feed's id is derived from the name on save.</p>
           </div>
 
+          <div class="h-px shrink-0 bg-row" />
+
           <!-- Sources -->
           <div>
-            <div class="mb-1.5 text-[12.5px] text-text-2">Sources</div>
-            <p class="mb-2 text-xs leading-relaxed text-text-4">
-              Sources are the GitHub API cost, shared across feeds. This feed shows their merged items; pick at least one.
+            <div class="mb-[3px] flex items-baseline justify-between gap-2">
+              <div class="text-[14.5px] font-semibold tracking-[-.01em] text-text">Sources</div>
+              <div class="font-mono text-[11.5px] text-text-4">{{ checkedSources.length }} selected</div>
+            </div>
+            <p class="mb-3.5 text-[12.5px] leading-relaxed text-text-4">
+              Sources are the GitHub API cost, shared across feeds. This feed merges their items — pick at least one.
             </p>
-            <div class="flex flex-col gap-1 rounded-lg border border-card bg-app p-1.5" data-testid="feed-editor-sources">
+            <div class="flex flex-col gap-2" data-testid="feed-editor-sources">
               <div v-if="sources.length === 0" class="px-2 py-1.5 font-mono text-[11.5px] text-text-4" data-testid="feed-editor-no-sources">
                 No sources yet — create one below.
               </div>
               <label
                 v-for="source in sources"
                 :key="source.id"
-                class="flex cursor-pointer items-start gap-2.5 rounded-md px-2 py-1.5 hover:bg-hover"
+                class="flex cursor-pointer gap-3 rounded-[10px] border px-[13px] py-3 transition-colors"
+                :class="sourceSelected(source.id) ? 'border-strong bg-raised' : 'border-row bg-app hover:border-card'"
               >
-                <input
-                  v-model="checkedSources"
-                  type="checkbox"
-                  :value="source.id"
-                  class="mt-0.5 accent-accent"
-                  :data-testid="`feed-editor-source-${source.id}`"
+                <span
+                  class="relative mt-px flex size-[18px] shrink-0 items-center justify-center rounded-[5px] border-[1.5px]"
+                  :class="sourceSelected(source.id) ? 'border-accent bg-accent' : 'border-strong bg-transparent'"
                 >
+                  <input
+                    v-model="checkedSources"
+                    type="checkbox"
+                    :value="source.id"
+                    class="absolute inset-0 size-full cursor-pointer opacity-0"
+                    :data-testid="`feed-editor-source-${source.id}`"
+                  >
+                  <IconCheck v-if="sourceSelected(source.id)" class="size-3 text-accent-contrast" :stroke-width="3" />
+                </span>
                 <span class="min-w-0 flex-1">
                   <span class="flex items-center gap-2">
-                    <span class="font-mono text-[12.5px] text-text">{{ source.id }}</span>
-                    <span class="rounded border border-strong bg-chip px-1.5 font-mono text-[10px] text-text-3">{{ source.kind }}</span>
+                    <span class="font-mono text-[13.5px] font-semibold text-text">{{ source.id }}</span>
+                    <span class="rounded bg-chip px-1.5 py-px font-mono text-[10.5px] text-text-3">{{ source.kind }}</span>
                   </span>
-                  <span v-if="source.query" class="mt-0.5 block truncate font-mono text-[11px] text-text-4">{{ source.query }}</span>
+                  <span v-if="source.query" class="mt-[5px] block truncate font-mono text-xs leading-relaxed text-text-4">{{ source.query }}</span>
                 </span>
               </label>
             </div>
 
             <!-- Inline source creation -->
-            <button
-              class="mt-2 flex cursor-pointer items-center gap-1.5 text-[12.5px] text-text-3 hover:text-text"
-              data-testid="feed-editor-new-source-toggle"
-              @click="newSourceOpen = !newSourceOpen"
-            >
-              <component :is="newSourceOpen ? IconChevronDown : IconChevronRight" class="size-3.5" />
-              <IconPlus class="size-3" />New source…
-            </button>
-            <div v-if="newSourceOpen" class="mt-2 flex flex-col gap-2.5 rounded-lg border border-card bg-raised p-3" data-testid="feed-editor-new-source">
-              <div class="flex gap-2">
-                <div class="flex-1">
-                  <div class="mb-1.5 text-[12.5px] text-text-2">Id</div>
+            <div class="mt-3 overflow-hidden rounded-[10px] border border-row">
+              <button
+                class="flex w-full cursor-pointer items-center gap-2 bg-raised px-[13px] py-[11px] text-left"
+                :class="{ 'border-b border-row': newSourceOpen }"
+                data-testid="feed-editor-new-source-toggle"
+                @click="newSourceOpen = !newSourceOpen"
+              >
+                <IconPlus class="size-3.5 text-accent" />
+                <span class="text-[12.5px] font-semibold text-text">New source</span>
+                <span class="flex-1" />
+                <component :is="newSourceOpen ? IconChevronDown : IconChevronRight" class="size-3 text-text-3" />
+              </button>
+              <div v-if="newSourceOpen" class="flex flex-col gap-3.5 bg-app p-[13px]" data-testid="feed-editor-new-source">
+                <div class="grid grid-cols-[1fr_150px] gap-2.5">
+                  <div>
+                    <div class="mb-1.5 text-[11.5px] text-text-2">Id</div>
+                    <input
+                      v-model="sourceId"
+                      type="text"
+                      placeholder="team-prs"
+                      class="w-full rounded-lg border border-card bg-app px-[11px] py-[9px] font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+                      data-testid="feed-editor-source-id"
+                    >
+                  </div>
+                  <div>
+                    <div class="mb-1.5 text-[11.5px] text-text-2">Kind</div>
+                    <select
+                      v-model="sourceKind"
+                      class="w-full cursor-pointer rounded-lg border border-card bg-app px-[11px] py-[9px] text-[13.5px] text-text outline-none focus:border-accent"
+                      data-testid="feed-editor-source-kind"
+                    >
+                      <option value="search">search</option>
+                      <option value="notifications">notifications</option>
+                    </select>
+                  </div>
+                </div>
+                <div v-if="sourceKind === 'search'">
+                  <div class="mb-1.5 text-[11.5px] text-text-2">Query</div>
                   <input
-                    v-model="sourceId"
+                    v-model="sourceQuery"
                     type="text"
-                    placeholder="team-prs"
-                    class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
-                    data-testid="feed-editor-source-id"
+                    placeholder="is:open involves:@me archived:false"
+                    class="w-full rounded-lg border border-card bg-app px-[11px] py-[9px] font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+                    data-testid="feed-editor-source-query"
                   >
                 </div>
-                <div class="w-[170px]">
-                  <div class="mb-1.5 text-[12.5px] text-text-2">Kind</div>
-                  <select
-                    v-model="sourceKind"
-                    class="w-full cursor-pointer rounded-lg border border-strong bg-app px-3 py-2.5 text-[13.5px] text-text outline-none focus:border-accent"
-                    data-testid="feed-editor-source-kind"
-                  >
-                    <option value="search">search</option>
-                    <option value="notifications">notifications</option>
-                  </select>
+                <div class="flex items-end gap-2.5">
+                  <div class="w-[120px]">
+                    <div class="mb-1.5 text-[11.5px] text-text-2">Limit</div>
+                    <input
+                      v-model="sourceLimit"
+                      type="number"
+                      placeholder="50"
+                      min="1"
+                      class="w-full rounded-lg border border-card bg-app px-[11px] py-[9px] font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+                      data-testid="feed-editor-source-limit"
+                    >
+                  </div>
+                  <button
+                    class="cursor-pointer rounded-lg border border-card bg-sidebar px-4 py-[9px] text-[13.5px] text-text hover:border-strong disabled:cursor-default disabled:opacity-50"
+                    :disabled="sourceBusy || !canAddSource"
+                    data-testid="feed-editor-source-add"
+                    @click="addSource"
+                  >Add source</button>
                 </div>
+                <p v-if="sourceError" class="text-xs leading-relaxed text-kind-issue" data-testid="feed-editor-source-error">{{ sourceError }}</p>
               </div>
-              <div v-if="sourceKind === 'search'">
-                <div class="mb-1.5 text-[12.5px] text-text-2">Query</div>
-                <input
-                  v-model="sourceQuery"
-                  type="text"
-                  placeholder="is:open involves:@me archived:false"
-                  class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
-                  data-testid="feed-editor-source-query"
-                >
-              </div>
-              <div class="flex items-end gap-2.5">
-                <div class="w-[120px]">
-                  <div class="mb-1.5 text-[12.5px] text-text-2">Limit</div>
-                  <input
-                    v-model="sourceLimit"
-                    type="number"
-                    placeholder="50"
-                    min="1"
-                    class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
-                    data-testid="feed-editor-source-limit"
-                  >
-                </div>
-                <button
-                  class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text disabled:cursor-default disabled:opacity-50"
-                  :disabled="sourceBusy || !canAddSource"
-                  data-testid="feed-editor-source-add"
-                  @click="addSource"
-                >Add source</button>
-              </div>
-              <p v-if="sourceError" class="text-xs text-kind-issue" data-testid="feed-editor-source-error">{{ sourceError }}</p>
             </div>
           </div>
 
+          <div class="h-px shrink-0 bg-row" />
+
           <!-- Filters -->
           <div>
-            <button
-              class="flex cursor-pointer items-center gap-1.5 text-[12.5px] text-text-2 hover:text-text"
-              data-testid="feed-editor-filters-toggle"
-              @click="filtersOpen = !filtersOpen"
-            >
-              <component :is="filtersOpen ? IconChevronDown : IconChevronRight" class="size-3.5" />
-              Filters<span v-if="!filtersOpen && hasFilters" class="font-mono text-[11px] text-accent">·&nbsp;active</span>
-            </button>
-            <p class="mt-1 text-xs leading-relaxed text-text-4">
-              Client-side, no API cost. Groups AND together, values within a group OR, excludes win. Patterns are doublestar globs, one per line.
+            <div class="mb-[3px] text-[14.5px] font-semibold tracking-[-.01em] text-text">Filters</div>
+            <p class="mb-3.5 text-[12.5px] leading-relaxed text-text-4">
+              Client-side, no API cost. Groups AND together; values within a group OR; excludes win. One doublestar glob per line.
             </p>
-            <div v-if="filtersOpen" class="mt-2.5 flex flex-col gap-3" data-testid="feed-editor-filters">
-              <div class="grid grid-cols-2 gap-2.5">
+            <div class="flex flex-col gap-3.5" data-testid="feed-editor-filters">
+              <div class="grid grid-cols-2 gap-x-3.5 gap-y-3">
                 <div v-for="group in globGroups" :key="group.key">
-                  <div class="mb-1.5 text-[12.5px] text-text-2">{{ group.label }}</div>
+                  <div class="mb-1.5 text-[11.5px] text-text-2">{{ group.label }}</div>
                   <textarea
                     v-model="group.model.value"
                     rows="2"
                     :placeholder="group.placeholder"
-                    class="w-full resize-y rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[12.5px] leading-relaxed text-text outline-none placeholder:text-text-4 focus:border-accent"
+                    class="w-full resize-y rounded-lg border border-strong bg-app px-3 py-2.5 font-mono text-[12.5px] leading-relaxed text-text outline-none placeholder:text-text-4 focus:border-accent"
                     :data-testid="group.testid"
                   />
                 </div>
               </div>
 
-              <div>
-                <div class="mb-1.5 text-[12.5px] text-text-2">Types</div>
-                <div class="flex gap-4">
-                  <label class="flex cursor-pointer items-center gap-2 text-[13px] text-text-2">
-                    <input v-model="types" type="checkbox" value="pr" class="accent-accent" data-testid="feed-editor-type-pr">Pull requests
-                  </label>
-                  <label class="flex cursor-pointer items-center gap-2 text-[13px] text-text-2">
-                    <input v-model="types" type="checkbox" value="issue" class="accent-accent" data-testid="feed-editor-type-issue">Issues
-                  </label>
-                </div>
+              <div class="mt-1 flex items-center gap-6 border-t border-row pt-4">
+                <div class="text-[12.5px] text-text-2">Types</div>
+                <label class="flex cursor-pointer items-center gap-2 text-[13px]" :class="typeChecked('pr') ? 'text-text' : 'text-text-2'">
+                  <span
+                    class="relative flex size-4 shrink-0 items-center justify-center rounded-[5px] border-[1.5px]"
+                    :class="typeChecked('pr') ? 'border-accent bg-accent' : 'border-strong bg-transparent'"
+                  >
+                    <input v-model="types" type="checkbox" value="pr" class="absolute inset-0 size-full cursor-pointer opacity-0" data-testid="feed-editor-type-pr">
+                    <IconCheck v-if="typeChecked('pr')" class="size-2.5 text-accent-contrast" :stroke-width="3.2" />
+                  </span>
+                  Pull requests
+                </label>
+                <label class="flex cursor-pointer items-center gap-2 text-[13px]" :class="typeChecked('issue') ? 'text-text' : 'text-text-2'">
+                  <span
+                    class="relative flex size-4 shrink-0 items-center justify-center rounded-[5px] border-[1.5px]"
+                    :class="typeChecked('issue') ? 'border-accent bg-accent' : 'border-strong bg-transparent'"
+                  >
+                    <input v-model="types" type="checkbox" value="issue" class="absolute inset-0 size-full cursor-pointer opacity-0" data-testid="feed-editor-type-issue">
+                    <IconCheck v-if="typeChecked('issue')" class="size-2.5 text-accent-contrast" :stroke-width="3.2" />
+                  </span>
+                  Issues
+                </label>
               </div>
 
               <div>
@@ -398,10 +440,12 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
             </div>
           </div>
 
+          <div class="h-px shrink-0 bg-row" />
+
           <!-- YAML preview -->
-          <div class="min-h-0">
-            <div class="mb-1.5 text-[12.5px] text-text-2">YAML preview</div>
-            <pre class="hive-scroll max-h-full overflow-auto rounded-lg border border-row bg-app px-3.5 py-3 font-mono text-xs leading-[1.65]" data-testid="feed-editor-yaml"><code><template v-for="(line, i) in previewLines" :key="i"><span v-for="(token, j) in line" :key="j" :class="{
+          <div>
+            <div class="mb-2 font-mono text-[11px] uppercase tracking-[.12em] text-text-4">Yaml preview</div>
+            <pre class="hive-scroll max-h-[320px] overflow-y-auto rounded-[9px] border border-row bg-app px-3.5 py-3 font-mono text-xs leading-[1.65]" data-testid="feed-editor-yaml"><code><template v-for="(line, i) in previewLines" :key="i"><span v-for="(token, j) in line" :key="j" :class="{
               'text-code-key': token.kind === 'key',
               'text-code-string': token.kind === 'string',
               'text-code-comment': token.kind === 'comment',
@@ -412,11 +456,14 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
             </p>
           </div>
 
+          <div class="h-px shrink-0 bg-row" />
+
           <!-- Config file: same as-code affordances as the config sheet -->
           <div>
             <div class="mb-1.5 text-[12.5px] text-text-2">Config file</div>
             <div class="flex gap-2">
-              <div class="flex min-w-0 flex-1 items-center rounded-lg border border-card bg-app px-3 py-2 font-mono text-[12.5px] text-text-2">
+              <div class="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-card bg-app px-3 py-2 font-mono text-[12.5px] text-text-2">
+                <IconMenu class="size-3 shrink-0 text-text-3" />
                 <span class="truncate" data-testid="feed-editor-path">{{ config?.path ?? '…' }}</span>
               </div>
               <button
@@ -441,7 +488,28 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
           </div>
         </div>
 
-        <footer class="flex shrink-0 gap-2.5 border-t border-row bg-raised px-6 py-3.5">
+        <footer class="flex shrink-0 items-center gap-2.5 border-t border-row bg-raised px-[22px] py-4">
+          <div v-if="isEdit" class="flex items-center gap-2.5">
+            <button
+              v-if="!deleteConfirming"
+              class="cursor-pointer whitespace-nowrap text-[13.5px] text-kind-issue hover:brightness-110"
+              data-testid="feed-editor-delete"
+              @click="deleteConfirming = true"
+            >Delete feed</button>
+            <template v-else>
+              <span class="whitespace-nowrap text-[13px] text-text-3">Confirm delete?</span>
+              <button
+                class="cursor-pointer whitespace-nowrap text-[13.5px] font-semibold text-kind-issue hover:brightness-110"
+                data-testid="feed-editor-delete-confirm"
+                @click="confirmDelete"
+              >Delete</button>
+              <button
+                class="cursor-pointer whitespace-nowrap text-[13.5px] text-text-3 hover:text-text"
+                data-testid="feed-editor-delete-cancel"
+                @click="deleteConfirming = false"
+              >Cancel</button>
+            </template>
+          </div>
           <button
             class="flex-1 cursor-pointer rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
             :disabled="busy || !canSave"
@@ -449,7 +517,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
             @click="submit"
           >{{ isEdit ? 'Save changes' : 'Create feed' }}</button>
           <button
-            class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text"
+            class="cursor-pointer whitespace-nowrap rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text"
             data-testid="feed-editor-cancel"
             @click="emit('close')"
           >Cancel</button>

--- a/desktop/frontend/src/components/FeedEditorSheet.vue
+++ b/desktop/frontend/src/components/FeedEditorSheet.vue
@@ -1,0 +1,460 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import IconAlertTriangle from '~icons/lucide/alert-triangle'
+import IconChevronDown from '~icons/lucide/chevron-down'
+import IconChevronRight from '~icons/lucide/chevron-right'
+import IconClipboardCopy from '~icons/lucide/clipboard-copy'
+import IconPlus from '~icons/lucide/plus'
+import IconRss from '~icons/lucide/rss'
+import IconX from '~icons/lucide/x'
+import { feedEntryYaml } from '../lib/feedYaml'
+import { tokenizeYaml } from '../lib/yamlHighlight'
+import type { ConfigInfo, FeedDef, FilterDef, SourceDef } from '../types/feed'
+
+const props = defineProps<{
+  /** Non-null selects edit mode; the definition arrives via initialDef. */
+  feedId: string | null
+  /** Edit-mode prefill (FeedDefFor result); null while loading or in create mode. */
+  initialDef: FeedDef | null
+  sources: SourceDef[]
+  config: ConfigInfo | null
+  busy: boolean
+  error: string | null
+  sourceBusy: boolean
+  sourceError: string | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+  save: [def: FeedDef]
+  'create-source': [def: SourceDef]
+  'copy-prompt': []
+  'copy-path': []
+}>()
+
+const isEdit = computed(() => props.feedId !== null)
+
+// ── Form state ───────────────────────────────────────────────────────────────
+
+const name = ref('')
+const checkedSources = ref<string[]>([])
+// Glob groups are textareas, one pattern per line. Globs may contain commas
+// via brace expansion ("acme/{a,b}"), so lines are never comma-split.
+const reposText = ref('')
+const excludeReposText = ref('')
+const authorsText = ref('')
+const excludeAuthorsText = ref('')
+const labelsText = ref('')
+const excludeLabelsText = ref('')
+const types = ref<string[]>([])
+const reasons = ref<string[]>([])
+
+const filtersOpen = ref(false)
+const reasonsOpen = ref(false)
+
+// The six glob groups render identically; keep the descriptors in one place.
+// `model` holds the Ref itself (arrays don't unwrap), bound via .value.
+const globGroups = [
+  { key: 'repos', label: 'Repos', model: reposText, testid: 'feed-editor-repos', placeholder: 'colonyops/*' },
+  { key: 'exclude_repos', label: 'Exclude repos', model: excludeReposText, testid: 'feed-editor-exclude-repos', placeholder: 'colonyops/sandbox' },
+  { key: 'authors', label: 'Authors', model: authorsText, testid: 'feed-editor-authors', placeholder: 'hay-kot' },
+  { key: 'exclude_authors', label: 'Exclude authors', model: excludeAuthorsText, testid: 'feed-editor-exclude-authors', placeholder: '*[bot]' },
+  { key: 'labels', label: 'Labels', model: labelsText, testid: 'feed-editor-labels', placeholder: 'area/*' },
+  { key: 'exclude_labels', label: 'Exclude labels', model: excludeLabelsText, testid: 'feed-editor-exclude-labels', placeholder: 'wontfix' },
+]
+
+const nameRef = ref<HTMLInputElement | null>(null)
+
+// The full reasons vocabulary GitHub delivers (see internal/desktop/feed/filters.go).
+const allReasons = [
+  'approval_requested', 'assign', 'author', 'ci_activity', 'comment', 'invitation', 'manual',
+  'member_feature_requested', 'mention', 'review_requested', 'security_advisory_credit',
+  'security_alert', 'state_change', 'subscribed', 'team_mention',
+]
+
+function parseLines(text: string): string[] {
+  return text.split('\n').map((line) => line.trim()).filter((line) => line.length > 0)
+}
+
+const filters = computed<FilterDef>(() => {
+  const out: FilterDef = {}
+  const groups: Array<[keyof FilterDef, string[]]> = [
+    ['repos', parseLines(reposText.value)],
+    ['exclude_repos', parseLines(excludeReposText.value)],
+    ['authors', parseLines(authorsText.value)],
+    ['exclude_authors', parseLines(excludeAuthorsText.value)],
+    ['labels', parseLines(labelsText.value)],
+    ['exclude_labels', parseLines(excludeLabelsText.value)],
+    ['types', types.value],
+    ['reasons', reasons.value],
+  ]
+  for (const [key, values] of groups) {
+    if (values.length > 0) out[key] = [...values]
+  }
+  return out
+})
+
+const hasFilters = computed(() => Object.keys(filters.value).length > 0)
+
+watch(() => props.initialDef, (def) => {
+  if (!def) return
+  name.value = def.name
+  checkedSources.value = [...(def.sources ?? [])]
+  const f = def.filters ?? {}
+  reposText.value = (f.repos ?? []).join('\n')
+  excludeReposText.value = (f.exclude_repos ?? []).join('\n')
+  authorsText.value = (f.authors ?? []).join('\n')
+  excludeAuthorsText.value = (f.exclude_authors ?? []).join('\n')
+  labelsText.value = (f.labels ?? []).join('\n')
+  excludeLabelsText.value = (f.exclude_labels ?? []).join('\n')
+  types.value = [...(f.types ?? [])]
+  reasons.value = [...(f.reasons ?? [])]
+  if (hasFilters.value) filtersOpen.value = true
+  if (reasons.value.length > 0) reasonsOpen.value = true
+}, { immediate: true })
+
+function buildDef(): FeedDef {
+  return {
+    id: props.feedId ?? '',
+    name: name.value.trim(),
+    sources: [...checkedSources.value],
+    // Empty filters stay {}: FeedDef.filters is non-optional on the wire.
+    filters: filters.value,
+  }
+}
+
+const canSave = computed(() =>
+  name.value.trim().length > 0 &&
+  checkedSources.value.length > 0 &&
+  !(isEdit.value && !props.initialDef))
+
+function submit() {
+  if (props.busy || !canSave.value) return
+  emit('save', buildDef())
+}
+
+// ── YAML preview ─────────────────────────────────────────────────────────────
+
+const previewLines = computed(() => tokenizeYaml(feedEntryYaml(buildPreviewDef())))
+
+function buildPreviewDef(): FeedDef {
+  const def = buildDef()
+  return { ...def, name: name.value.trim() || 'New feed' }
+}
+
+// ── Inline source creation ───────────────────────────────────────────────────
+
+const newSourceOpen = ref(false)
+const sourceId = ref('')
+const sourceKind = ref<'search' | 'notifications'>('search')
+const sourceQuery = ref('')
+const sourceLimit = ref('')
+
+const canAddSource = computed(() =>
+  sourceId.value.trim().length > 0 &&
+  (sourceKind.value === 'notifications' || sourceQuery.value.trim().length > 0))
+
+// Set while an inline CreateSource is in flight so the sources watcher below
+// knows the next new id is ours to auto-check.
+const awaitingSource = ref(false)
+
+function addSource() {
+  if (props.sourceBusy || !canAddSource.value) return
+  const def: SourceDef = { id: sourceId.value.trim(), kind: sourceKind.value }
+  if (sourceKind.value === 'search') def.query = sourceQuery.value.trim()
+  const limit = Number.parseInt(sourceLimit.value, 10)
+  if (Number.isFinite(limit) && limit > 0) def.limit = limit
+  awaitingSource.value = true
+  emit('create-source', def)
+}
+
+// The parent appends the created source (with its backend-assigned id) to
+// the sources prop; auto-check it and fold the expander away.
+watch(() => props.sources, (next, prev) => {
+  if (!awaitingSource.value) return
+  const prevIds = new Set((prev ?? []).map((source) => source.id))
+  const added = next.filter((source) => !prevIds.has(source.id))
+  if (added.length === 0) return
+  for (const source of added) {
+    if (!checkedSources.value.includes(source.id)) checkedSources.value.push(source.id)
+  }
+  awaitingSource.value = false
+  newSourceOpen.value = false
+  sourceId.value = ''
+  sourceQuery.value = ''
+  sourceLimit.value = ''
+  sourceKind.value = 'search'
+})
+
+watch(() => props.sourceError, (err) => {
+  if (err) awaitingSource.value = false
+})
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(async () => {
+  window.addEventListener('keydown', onKeydown)
+  await nextTick()
+  nameRef.value?.focus()
+})
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-40 bg-backdrop" data-testid="feed-editor-backdrop" @click.self="emit('close')">
+      <aside
+        class="absolute bottom-0 right-0 top-0 flex w-[620px] flex-col border-l border-strong bg-pane text-text shadow-[-30px_0_80px_-20px_rgba(0,0,0,.7)]"
+        role="dialog"
+        :aria-label="isEdit ? 'Edit feed' : 'New feed'"
+        aria-modal="true"
+        data-testid="feed-editor"
+      >
+        <header class="flex shrink-0 items-center gap-3 border-b border-row bg-pane px-6 py-5">
+          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconRss class="size-4" /></span>
+          <div class="flex-1 text-lg font-semibold tracking-[-.01em]" data-testid="feed-editor-title">{{ isEdit ? 'Edit feed' : 'New feed' }}</div>
+          <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" data-testid="feed-editor-close" @click="emit('close')"><IconX class="size-4.5" /></button>
+        </header>
+
+        <div class="hive-scroll flex min-h-0 flex-1 flex-col gap-4.5 overflow-y-auto px-6 py-5">
+          <!-- Name -->
+          <div>
+            <div class="mb-1.5 text-[12.5px] text-text-2">Name</div>
+            <input
+              ref="nameRef"
+              v-model="name"
+              type="text"
+              placeholder="Team PRs"
+              class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+              data-testid="feed-editor-name"
+              @keydown.enter="submit"
+            >
+            <p v-if="!isEdit" class="mt-1.5 text-xs leading-relaxed text-text-4">The feed's id is derived from the name on save.</p>
+          </div>
+
+          <!-- Sources -->
+          <div>
+            <div class="mb-1.5 text-[12.5px] text-text-2">Sources</div>
+            <p class="mb-2 text-xs leading-relaxed text-text-4">
+              Sources are the GitHub API cost, shared across feeds. This feed shows their merged items; pick at least one.
+            </p>
+            <div class="flex flex-col gap-1 rounded-lg border border-card bg-app p-1.5" data-testid="feed-editor-sources">
+              <div v-if="sources.length === 0" class="px-2 py-1.5 font-mono text-[11.5px] text-text-4" data-testid="feed-editor-no-sources">
+                No sources yet — create one below.
+              </div>
+              <label
+                v-for="source in sources"
+                :key="source.id"
+                class="flex cursor-pointer items-start gap-2.5 rounded-md px-2 py-1.5 hover:bg-hover"
+              >
+                <input
+                  v-model="checkedSources"
+                  type="checkbox"
+                  :value="source.id"
+                  class="mt-0.5 accent-accent"
+                  :data-testid="`feed-editor-source-${source.id}`"
+                >
+                <span class="min-w-0 flex-1">
+                  <span class="flex items-center gap-2">
+                    <span class="font-mono text-[12.5px] text-text">{{ source.id }}</span>
+                    <span class="rounded border border-strong bg-chip px-1.5 font-mono text-[10px] text-text-3">{{ source.kind }}</span>
+                  </span>
+                  <span v-if="source.query" class="mt-0.5 block truncate font-mono text-[11px] text-text-4">{{ source.query }}</span>
+                </span>
+              </label>
+            </div>
+
+            <!-- Inline source creation -->
+            <button
+              class="mt-2 flex cursor-pointer items-center gap-1.5 text-[12.5px] text-text-3 hover:text-text"
+              data-testid="feed-editor-new-source-toggle"
+              @click="newSourceOpen = !newSourceOpen"
+            >
+              <component :is="newSourceOpen ? IconChevronDown : IconChevronRight" class="size-3.5" />
+              <IconPlus class="size-3" />New source…
+            </button>
+            <div v-if="newSourceOpen" class="mt-2 flex flex-col gap-2.5 rounded-lg border border-card bg-raised p-3" data-testid="feed-editor-new-source">
+              <div class="flex gap-2">
+                <div class="flex-1">
+                  <div class="mb-1.5 text-[12.5px] text-text-2">Id</div>
+                  <input
+                    v-model="sourceId"
+                    type="text"
+                    placeholder="team-prs"
+                    class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+                    data-testid="feed-editor-source-id"
+                  >
+                </div>
+                <div class="w-[170px]">
+                  <div class="mb-1.5 text-[12.5px] text-text-2">Kind</div>
+                  <select
+                    v-model="sourceKind"
+                    class="w-full cursor-pointer rounded-lg border border-strong bg-app px-3 py-2.5 text-[13.5px] text-text outline-none focus:border-accent"
+                    data-testid="feed-editor-source-kind"
+                  >
+                    <option value="search">search</option>
+                    <option value="notifications">notifications</option>
+                  </select>
+                </div>
+              </div>
+              <div v-if="sourceKind === 'search'">
+                <div class="mb-1.5 text-[12.5px] text-text-2">Query</div>
+                <input
+                  v-model="sourceQuery"
+                  type="text"
+                  placeholder="is:open involves:@me archived:false"
+                  class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+                  data-testid="feed-editor-source-query"
+                >
+              </div>
+              <div class="flex items-end gap-2.5">
+                <div class="w-[120px]">
+                  <div class="mb-1.5 text-[12.5px] text-text-2">Limit</div>
+                  <input
+                    v-model="sourceLimit"
+                    type="number"
+                    placeholder="50"
+                    min="1"
+                    class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+                    data-testid="feed-editor-source-limit"
+                  >
+                </div>
+                <button
+                  class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text disabled:cursor-default disabled:opacity-50"
+                  :disabled="sourceBusy || !canAddSource"
+                  data-testid="feed-editor-source-add"
+                  @click="addSource"
+                >Add source</button>
+              </div>
+              <p v-if="sourceError" class="text-xs text-kind-issue" data-testid="feed-editor-source-error">{{ sourceError }}</p>
+            </div>
+          </div>
+
+          <!-- Filters -->
+          <div>
+            <button
+              class="flex cursor-pointer items-center gap-1.5 text-[12.5px] text-text-2 hover:text-text"
+              data-testid="feed-editor-filters-toggle"
+              @click="filtersOpen = !filtersOpen"
+            >
+              <component :is="filtersOpen ? IconChevronDown : IconChevronRight" class="size-3.5" />
+              Filters<span v-if="!filtersOpen && hasFilters" class="font-mono text-[11px] text-accent">·&nbsp;active</span>
+            </button>
+            <p class="mt-1 text-xs leading-relaxed text-text-4">
+              Client-side, no API cost. Groups AND together, values within a group OR, excludes win. Patterns are doublestar globs, one per line.
+            </p>
+            <div v-if="filtersOpen" class="mt-2.5 flex flex-col gap-3" data-testid="feed-editor-filters">
+              <div class="grid grid-cols-2 gap-2.5">
+                <div v-for="group in globGroups" :key="group.key">
+                  <div class="mb-1.5 text-[12.5px] text-text-2">{{ group.label }}</div>
+                  <textarea
+                    v-model="group.model.value"
+                    rows="2"
+                    :placeholder="group.placeholder"
+                    class="w-full resize-y rounded-lg border border-strong bg-app px-3.5 py-2.5 font-mono text-[12.5px] leading-relaxed text-text outline-none placeholder:text-text-4 focus:border-accent"
+                    :data-testid="group.testid"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <div class="mb-1.5 text-[12.5px] text-text-2">Types</div>
+                <div class="flex gap-4">
+                  <label class="flex cursor-pointer items-center gap-2 text-[13px] text-text-2">
+                    <input v-model="types" type="checkbox" value="pr" class="accent-accent" data-testid="feed-editor-type-pr">Pull requests
+                  </label>
+                  <label class="flex cursor-pointer items-center gap-2 text-[13px] text-text-2">
+                    <input v-model="types" type="checkbox" value="issue" class="accent-accent" data-testid="feed-editor-type-issue">Issues
+                  </label>
+                </div>
+              </div>
+
+              <div>
+                <button
+                  class="flex cursor-pointer items-center gap-1.5 text-[12.5px] text-text-2 hover:text-text"
+                  data-testid="feed-editor-reasons-toggle"
+                  @click="reasonsOpen = !reasonsOpen"
+                >
+                  <component :is="reasonsOpen ? IconChevronDown : IconChevronRight" class="size-3.5" />
+                  Notification reasons<span v-if="!reasonsOpen && reasons.length" class="font-mono text-[11px] text-accent">·&nbsp;{{ reasons.length }}</span>
+                </button>
+                <div v-if="reasonsOpen" class="mt-2 grid grid-cols-3 gap-x-3 gap-y-1.5" data-testid="feed-editor-reasons">
+                  <label
+                    v-for="reason in allReasons"
+                    :key="reason"
+                    class="flex cursor-pointer items-center gap-2 font-mono text-[11.5px] text-text-2"
+                  >
+                    <input v-model="reasons" type="checkbox" :value="reason" class="accent-accent" :data-testid="`feed-editor-reason-${reason}`">{{ reason }}
+                  </label>
+                </div>
+                <p v-if="reasons.length > 0" class="mt-2 text-xs leading-relaxed text-text-4" data-testid="feed-editor-reasons-hint">
+                  Reasons exist only on notification items — with a reasons filter, items known only from search sources are excluded.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- YAML preview -->
+          <div class="min-h-0">
+            <div class="mb-1.5 text-[12.5px] text-text-2">YAML preview</div>
+            <pre class="hive-scroll max-h-full overflow-auto rounded-lg border border-row bg-app px-3.5 py-3 font-mono text-xs leading-[1.65]" data-testid="feed-editor-yaml"><code><template v-for="(line, i) in previewLines" :key="i"><span v-for="(token, j) in line" :key="j" :class="{
+              'text-code-key': token.kind === 'key',
+              'text-code-string': token.kind === 'string',
+              'text-code-comment': token.kind === 'comment',
+              'text-text-2': token.kind === 'plain',
+            }">{{ token.text }}</span>{{ '\n' }}</template></code></pre>
+            <p class="mt-1.5 text-xs leading-relaxed text-text-4">
+              Written into this profile's <span class="text-text-3">feeds</span> in the config below — hand edits and app edits share one file.
+            </p>
+          </div>
+
+          <!-- Config file: same as-code affordances as the config sheet -->
+          <div>
+            <div class="mb-1.5 text-[12.5px] text-text-2">Config file</div>
+            <div class="flex gap-2">
+              <div class="flex min-w-0 flex-1 items-center rounded-lg border border-card bg-app px-3 py-2 font-mono text-[12.5px] text-text-2">
+                <span class="truncate" data-testid="feed-editor-path">{{ config?.path ?? '…' }}</span>
+              </div>
+              <button
+                class="cursor-pointer whitespace-nowrap rounded-lg border border-card bg-sidebar px-3.5 py-2 text-[12.5px] text-text hover:border-strong"
+                data-testid="feed-editor-copy-path"
+                @click="emit('copy-path')"
+              >Copy path</button>
+              <button
+                class="flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-lg border border-card bg-sidebar px-3.5 py-2 text-[12.5px] text-text hover:border-strong"
+                data-testid="feed-editor-copy-prompt"
+                @click="emit('copy-prompt')"
+              ><IconClipboardCopy class="size-3.5" />Copy prompt</button>
+            </div>
+          </div>
+
+          <div v-if="error" class="flex items-start gap-2.5 rounded-lg border border-accent/40 bg-selection px-3 py-2.5" data-testid="feed-editor-error">
+            <IconAlertTriangle class="mt-0.5 size-4 shrink-0 text-accent" />
+            <div class="text-xs leading-relaxed text-text-2">
+              <span class="font-semibold text-accent">Could not save the feed.</span>
+              <span class="mt-0.5 block font-mono">{{ error }}</span>
+            </div>
+          </div>
+        </div>
+
+        <footer class="flex shrink-0 gap-2.5 border-t border-row bg-raised px-6 py-3.5">
+          <button
+            class="flex-1 cursor-pointer rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
+            :disabled="busy || !canSave"
+            data-testid="feed-editor-save"
+            @click="submit"
+          >{{ isEdit ? 'Save changes' : 'Create feed' }}</button>
+          <button
+            class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text"
+            data-testid="feed-editor-cancel"
+            @click="emit('close')"
+          >Cancel</button>
+        </footer>
+      </aside>
+    </div>
+  </Teleport>
+</template>

--- a/desktop/frontend/src/components/FeedList.vue
+++ b/desktop/frontend/src/components/FeedList.vue
@@ -31,7 +31,7 @@ const visibleItems = computed(() => props.unreadOnly ? props.items.filter((item)
         <button class="refresh-chip" aria-label="Refresh" @click="emit('refresh')"><IconRefreshCw class="size-3" /></button>
       </div>
     </header>
-    <div class="hive-scroll flex-1 overflow-y-auto">
+    <div class="hive-scroll min-h-0 flex-1 overflow-y-auto">
       <!-- Load failure: the "GitHub unreachable" design state. -->
       <div v-if="loadError" class="state-frame" data-testid="feed-error">
         <div class="state-icon text-accent"><IconTriangleAlert class="size-5" /></div>

--- a/desktop/frontend/src/components/FeedListItem.vue
+++ b/desktop/frontend/src/components/FeedListItem.vue
@@ -30,6 +30,7 @@ const emit = defineEmits<{ select: [] }>()
           <span v-if="item.unread" data-testid="unread-dot" class="size-[7px] shrink-0 rounded-full bg-accent" />
         </div>
         <div class="flex max-w-[150px] flex-wrap items-center justify-end gap-[5px]">
+          <span v-if="item.reason" data-testid="reason-chip" class="rounded border border-card bg-chip px-1.5 py-px font-mono text-[10px] text-text-2">{{ item.reason.replaceAll('_', ' ') }}</span>
           <span v-for="label in item.labels ?? []" :key="label" class="rounded border border-card bg-chip px-1.5 py-px font-mono text-[10px] text-text-2">{{ label }}</span>
         </div>
       </div>

--- a/desktop/frontend/src/components/NewProfileModal.vue
+++ b/desktop/frontend/src/components/NewProfileModal.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import IconLayoutGrid from '~icons/lucide/layout-grid'
+import IconX from '~icons/lucide/x'
+
+const props = defineProps<{ busy: boolean; error: string | null }>()
+const emit = defineEmits<{ close: []; create: [name: string] }>()
+
+const name = ref('')
+const inputRef = ref<HTMLInputElement | null>(null)
+
+function submit() {
+  if (props.busy) return
+  const trimmed = name.value.trim()
+  if (trimmed) emit('create', trimmed)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(async () => {
+  window.addEventListener('keydown', onKeydown)
+  await nextTick()
+  inputRef.value?.focus()
+})
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-40 flex items-start justify-center bg-backdrop pt-[24vh]" @click.self="emit('close')">
+      <div
+        class="w-[420px] overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl"
+        role="dialog"
+        aria-label="New profile"
+        aria-modal="true"
+        data-testid="new-profile-modal"
+      >
+        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
+          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconLayoutGrid class="size-4" /></span>
+          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">New profile</div>
+          <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" @click="emit('close')"><IconX class="size-4" /></button>
+        </header>
+        <div class="flex flex-col gap-3 px-5 py-4">
+          <input
+            ref="inputRef"
+            v-model="name"
+            type="text"
+            placeholder="Frontend Triage"
+            class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+            data-testid="new-profile-input"
+            @keydown.enter="submit"
+          >
+          <p class="text-xs leading-relaxed text-text-4">
+            Saved to <span class="font-mono text-text-3">profiles.yaml</span> with the default feeds — your open PRs,
+            the notifications inbox, and cross-repo assignments.
+          </p>
+          <p v-if="error" class="text-xs text-kind-issue" data-testid="new-profile-error">{{ error }}</p>
+        </div>
+        <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
+          <button
+            class="flex-1 cursor-pointer rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
+            :disabled="busy || !name.trim()"
+            data-testid="new-profile-submit"
+            @click="submit"
+          >Create profile ↵</button>
+          <button class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text" @click="emit('close')">Cancel</button>
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/desktop/frontend/src/components/ProfileRail.vue
+++ b/desktop/frontend/src/components/ProfileRail.vue
@@ -4,7 +4,7 @@ import IconPlus from '~icons/lucide/plus'
 import type { Profile } from '../types/feed'
 
 defineProps<{ profiles: Profile[]; activeProfileId: string }>()
-const emit = defineEmits<{ select: [profileId: string] }>()
+const emit = defineEmits<{ select: [profileId: string]; add: [] }>()
 </script>
 
 <template>
@@ -22,7 +22,7 @@ const emit = defineEmits<{ select: [profileId: string] }>()
       <span v-if="profile.id === activeProfileId" class="absolute bottom-2 left-[-13px] top-2 w-[3px] rounded-sm bg-accent" />
       {{ profile.letter }}
     </button>
-    <button class="flex size-[38px] cursor-default items-center justify-center rounded-[10px] border border-dashed border-card text-text-4 hover:border-strong hover:text-text-2" aria-label="Add profile"><IconPlus class="size-4" /></button>
+    <button class="flex size-[38px] cursor-pointer items-center justify-center rounded-[10px] border border-dashed border-card text-text-4 hover:border-strong hover:text-text-2" aria-label="Add profile" data-testid="profile-add" @click="emit('add')"><IconPlus class="size-4" /></button>
     <div class="flex-1" />
     <span class="flex size-[38px] items-center justify-center text-text-4"><IconClock class="size-4" /></span>
     <span class="flex size-[30px] items-center justify-center rounded-full bg-accent-tint font-mono text-xs font-semibold text-accent">hy</span>

--- a/desktop/frontend/src/components/SideBar.vue
+++ b/desktop/frontend/src/components/SideBar.vue
@@ -7,7 +7,7 @@ import IconRss from '~icons/lucide/rss'
 import type { Profile, SidebarSelection } from '../types/feed'
 
 const props = defineProps<{ profile: Profile; selection: SidebarSelection; unreadOnly: boolean }>()
-const emit = defineEmits<{ select: [sel: SidebarSelection]; 'select-unread': [] }>()
+const emit = defineEmits<{ select: [sel: SidebarSelection]; 'select-unread': []; 'edit-feeds': [] }>()
 
 // "All items" and "Unread" are both all-scope; the unread filter picks
 // which entry lights up. A feed entry highlights regardless of the filter.
@@ -44,7 +44,10 @@ function feedSelected(feedId: string): boolean {
     </div>
 
     <section class="px-2.5 pb-1.5 pt-2">
-      <div class="section-label"><IconRss class="size-3 text-feeds" />FEEDS <IconPlus class="ml-auto size-3.5 text-strong" /></div>
+      <div class="section-label">
+        <IconRss class="size-3 text-feeds" />FEEDS
+        <button class="ml-auto cursor-pointer text-strong hover:text-text-2" aria-label="Edit feeds" data-testid="sidebar-edit-feeds" @click="emit('edit-feeds')"><IconPlus class="size-3.5" /></button>
+      </div>
       <button
         v-for="feed in profile.feeds ?? []"
         :key="feed.id"

--- a/desktop/frontend/src/components/SideBar.vue
+++ b/desktop/frontend/src/components/SideBar.vue
@@ -5,10 +5,11 @@ import IconList from '~icons/lucide/list'
 import IconPencil from '~icons/lucide/pencil'
 import IconPlus from '~icons/lucide/plus'
 import IconRss from '~icons/lucide/rss'
+import IconTrash2 from '~icons/lucide/trash-2'
 import type { Profile, SidebarSelection } from '../types/feed'
 
 const props = defineProps<{ profile: Profile; selection: SidebarSelection; unreadOnly: boolean }>()
-const emit = defineEmits<{ select: [sel: SidebarSelection]; 'select-unread': []; 'edit-feeds': []; 'edit-feed': [feedId: string] }>()
+const emit = defineEmits<{ select: [sel: SidebarSelection]; 'select-unread': []; 'edit-feeds': []; 'edit-feed': [feedId: string]; 'delete-profile': [] }>()
 
 // "All items" and "Unread" are both all-scope; the unread filter picks
 // which entry lights up. A feed entry highlights regardless of the filter.
@@ -27,8 +28,16 @@ function feedSelected(feedId: string): boolean {
 
 <template>
   <aside class="hive-scroll flex w-[250px] shrink-0 flex-col overflow-y-auto border-r border-border bg-sidebar">
-    <div class="border-b border-border px-4 pb-3 pt-4">
-      <div class="text-[15px] font-semibold tracking-[-.01em]" data-testid="sidebar-profile-name">{{ profile.name }}</div>
+    <div class="profile-header border-b border-border px-4 pb-3 pt-4" data-testid="sidebar-profile-header">
+      <div class="flex items-center gap-2">
+        <div class="min-w-0 flex-1 truncate text-[15px] font-semibold tracking-[-.01em]" data-testid="sidebar-profile-name">{{ profile.name }}</div>
+        <button
+          class="profile-delete shrink-0 cursor-pointer text-text-3 hover:text-severity-error"
+          aria-label="Delete profile"
+          data-testid="sidebar-delete-profile"
+          @click="emit('delete-profile')"
+        ><IconTrash2 class="size-3.5" /></button>
+      </div>
       <div class="mt-1 flex items-center gap-1.5">
         <span class="flex size-[15px] items-center justify-center rounded border border-strong bg-chip text-text-2"><IconGitBranch class="size-2.5" /></span>
         <span class="text-xs text-text-3">{{ profile.sourceSummary }}</span>
@@ -83,6 +92,9 @@ function feedSelected(feedId: string): boolean {
 /* The pencil holds its space (opacity, not display) so hovering never shifts the count badge. */
 .feed-edit { display: inline-flex; opacity: 0; }
 .sidebar-entry:hover .feed-edit, .feed-edit:focus-visible { opacity: 1; }
+/* Same pattern as .feed-edit: holds its space, only reveals on header hover. */
+.profile-delete { display: inline-flex; opacity: 0; }
+.profile-header:hover .profile-delete, .profile-delete:focus-visible { opacity: 1; }
 .sidebar-entry-selected .nav-icon { border-color: var(--color-accent-tint); color: var(--color-accent); }
 .nav-icon { display: inline-flex; flex: none; align-items: center; justify-content: center; width: 18px; height: 18px; border: 1px solid var(--color-strong); border-radius: 5px; background: var(--color-app); color: var(--color-text-2); }
 .section-label { display: flex; align-items: center; gap: 7px; padding: 0 6px 8px; color: var(--color-text-4); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .12em; }

--- a/desktop/frontend/src/components/SideBar.vue
+++ b/desktop/frontend/src/components/SideBar.vue
@@ -2,12 +2,13 @@
 import IconCircle from '~icons/lucide/circle'
 import IconGitBranch from '~icons/lucide/git-branch'
 import IconList from '~icons/lucide/list'
+import IconPencil from '~icons/lucide/pencil'
 import IconPlus from '~icons/lucide/plus'
 import IconRss from '~icons/lucide/rss'
 import type { Profile, SidebarSelection } from '../types/feed'
 
 const props = defineProps<{ profile: Profile; selection: SidebarSelection; unreadOnly: boolean }>()
-const emit = defineEmits<{ select: [sel: SidebarSelection]; 'select-unread': []; 'edit-feeds': [] }>()
+const emit = defineEmits<{ select: [sel: SidebarSelection]; 'select-unread': []; 'edit-feeds': []; 'edit-feed': [feedId: string] }>()
 
 // "All items" and "Unread" are both all-scope; the unread filter picks
 // which entry lights up. A feed entry highlights regardless of the filter.
@@ -48,15 +49,29 @@ function feedSelected(feedId: string): boolean {
         <IconRss class="size-3 text-feeds" />FEEDS
         <button class="ml-auto cursor-pointer text-strong hover:text-text-2" aria-label="Edit feeds" data-testid="sidebar-edit-feeds" @click="emit('edit-feeds')"><IconPlus class="size-3.5" /></button>
       </div>
-      <button
+      <!-- A div, not a button: the hover pencil is itself a button and
+           interactive elements must not nest. -->
+      <div
         v-for="feed in profile.feeds ?? []"
         :key="feed.id"
         class="sidebar-entry"
+        role="button"
+        tabindex="0"
         :class="{ 'sidebar-entry-selected': feedSelected(feed.id) }"
+        data-testid="sidebar-feed"
+        :data-id="feed.id"
         @click="emit('select', { type: 'feed', feedId: feed.id })"
+        @keydown.enter="emit('select', { type: 'feed', feedId: feed.id })"
       >
-        <span class="nav-icon"><IconGitBranch class="size-3" /></span><span class="flex-1 text-left">{{ feed.name }}</span><span class="font-mono text-[11px]" :class="feed.newCount ? 'text-accent' : 'text-text-3'">{{ feed.newCount || feed.count }}</span>
-      </button>
+        <span class="nav-icon"><IconGitBranch class="size-3" /></span><span class="min-w-0 flex-1 truncate text-left">{{ feed.name }}</span>
+        <button
+          class="feed-edit cursor-pointer text-text-3 hover:text-text"
+          :aria-label="`Edit feed ${feed.name}`"
+          :data-testid="`sidebar-feed-edit-${feed.id}`"
+          @click.stop="emit('edit-feed', feed.id)"
+        ><IconPencil class="size-3" /></button>
+        <span class="font-mono text-[11px]" :class="feed.newCount ? 'text-accent' : 'text-text-3'">{{ feed.newCount || feed.count }}</span>
+      </div>
     </section>
   </aside>
 </template>
@@ -65,6 +80,9 @@ function feedSelected(feedId: string): boolean {
 .sidebar-entry { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
 .sidebar-entry:hover { background: var(--color-chip); color: var(--color-text); }
 .sidebar-entry-selected { background: var(--color-hover); color: var(--color-accent); font-weight: 500; }
+/* The pencil holds its space (opacity, not display) so hovering never shifts the count badge. */
+.feed-edit { display: inline-flex; opacity: 0; }
+.sidebar-entry:hover .feed-edit, .feed-edit:focus-visible { opacity: 1; }
 .sidebar-entry-selected .nav-icon { border-color: var(--color-accent-tint); color: var(--color-accent); }
 .nav-icon { display: inline-flex; flex: none; align-items: center; justify-content: center; width: 18px; height: 18px; border: 1px solid var(--color-strong); border-radius: 5px; background: var(--color-app); color: var(--color-text-2); }
 .section-label { display: flex; align-items: center; gap: 7px; padding: 0 6px 8px; color: var(--color-text-4); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .12em; }

--- a/desktop/frontend/src/components/ToastCard.vue
+++ b/desktop/frontend/src/components/ToastCard.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import IconCircleAlert from '~icons/lucide/circle-alert'
+import IconCircleCheck from '~icons/lucide/circle-check'
+import IconInfo from '~icons/lucide/info'
+import IconX from '~icons/lucide/x'
+import IconZap from '~icons/lucide/zap'
+import type { ToastActionDef, ToastInstance, ToastSeverity } from '../types/toast'
+
+const props = defineProps<{ toast: ToastInstance }>()
+const emit = defineEmits<{ dismiss: [] }>()
+
+const icons: Record<ToastSeverity, unknown> = {
+  info: IconInfo,
+  success: IconCircleCheck,
+  error: IconCircleAlert,
+  'auto-action': IconZap,
+}
+
+// design spec "6a Toasts": one border/icon/accent/progress-bar color per
+// severity, plus the primary inline action (first entry) inheriting it.
+const severityStyles: Record<ToastSeverity, { border: string; iconBg: string; iconColor: string; accent: string; bar: string }> = {
+  info: { border: 'border-border', iconBg: 'bg-severity-info-tint', iconColor: 'text-severity-info', accent: 'text-severity-info', bar: 'bg-severity-info' },
+  success: { border: 'border-severity-success-border', iconBg: 'bg-severity-success-tint', iconColor: 'text-severity-success', accent: 'text-severity-success', bar: 'bg-severity-success' },
+  error: { border: 'border-severity-error-border', iconBg: 'bg-severity-error-tint', iconColor: 'text-severity-error', accent: 'text-severity-error', bar: 'bg-severity-error' },
+  'auto-action': { border: 'border-severity-auto-border', iconBg: 'bg-severity-auto-tint', iconColor: 'text-accent', accent: 'text-accent', bar: 'bg-accent' },
+}
+
+const icon = computed(() => icons[props.toast.severity])
+const style = computed(() => severityStyles[props.toast.severity])
+
+// The auto-dismiss progress bar shrinks from 100% to 0% over the toast's
+// duration. Starting the CSS transition a frame after mount (rather than at
+// width:100% from the first paint) gives the browser a frame to render the
+// full-width state before animating away from it.
+const progressStarted = ref(false)
+onMounted(() => {
+  requestAnimationFrame(() => { progressStarted.value = true })
+})
+
+function runAction(action: ToastActionDef) {
+  action.onClick()
+  emit('dismiss')
+}
+</script>
+
+<template>
+  <div
+    class="overflow-hidden rounded-[11px] bg-raised shadow-[0_18px_40px_-14px_rgba(0,0,0,.7)]"
+    :class="['border', style.border]"
+    data-testid="toast"
+    :data-toast-severity="toast.severity"
+  >
+    <div class="flex gap-3 px-3.5 pb-[13px] pt-3.5">
+      <span class="flex size-[26px] shrink-0 items-center justify-center rounded-[7px]" :class="style.iconBg">
+        <component :is="icon" class="size-[15px]" :class="style.iconColor" />
+      </span>
+      <div class="min-w-0 flex-1">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-[13.5px] font-semibold text-text" data-testid="toast-title">{{ toast.message }}</span>
+          <span
+            v-if="toast.severity === 'auto-action'"
+            class="rounded-[4px] border border-accent/30 bg-accent/13 px-[5px] py-px font-mono text-[9.5px] tracking-[.06em] text-accent"
+            data-testid="toast-auto-badge"
+          >AUTO</span>
+        </div>
+        <p v-if="toast.body" class="mt-0.5 text-[12.5px] leading-[1.45] text-text-2" data-testid="toast-body">{{ toast.body }}</p>
+        <div v-if="toast.actions.length" class="mt-[9px] flex gap-3.5">
+          <button
+            v-for="(action, i) in toast.actions"
+            :key="action.label"
+            class="cursor-pointer text-[12.5px]"
+            :class="i === 0 ? [style.accent, 'font-semibold hover:brightness-125'] : 'text-text-3 hover:text-text'"
+            data-testid="toast-action"
+            @click="runAction(action)"
+          >{{ action.label }}</button>
+        </div>
+      </div>
+      <button class="shrink-0 cursor-pointer self-start leading-none text-text-3 hover:text-text" aria-label="Dismiss" data-testid="toast-dismiss" @click="emit('dismiss')">
+        <IconX class="size-[15px]" />
+      </button>
+    </div>
+    <div
+      v-if="toast.duration !== null"
+      class="h-0.5 transition-[width] ease-linear"
+      :class="style.bar"
+      :style="{ width: progressStarted ? '0%' : '100%', transitionDuration: `${toast.duration}ms` }"
+      data-testid="toast-progress"
+    />
+  </div>
+</template>

--- a/desktop/frontend/src/components/ToastStack.vue
+++ b/desktop/frontend/src/components/ToastStack.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import ToastCard from './ToastCard.vue'
+import type { ToastInstance } from '../types/toast'
+
+const props = defineProps<{ toasts: ToastInstance[] }>()
+const emit = defineEmits<{ dismiss: [id: number]; 'clear-all': [] }>()
+
+// design spec "6a Toasts": overflow beyond ~4 visible toasts collapses into
+// an "N more · Clear all" footer instead of growing the stack unbounded.
+// Newest toasts (end of the array — showToast appends) stay visible; older
+// ones roll into the overflow count.
+const MAX_VISIBLE = 4
+
+const visible = computed(() => props.toasts.slice(-MAX_VISIBLE))
+const overflowCount = computed(() => Math.max(0, props.toasts.length - MAX_VISIBLE))
+</script>
+
+<template>
+  <div v-if="toasts.length" class="fixed bottom-[22px] right-[22px] z-40 flex w-[376px] flex-col gap-3" data-testid="toast-stack">
+    <TransitionGroup name="toast">
+      <ToastCard
+        v-for="toast in visible"
+        :key="toast.id"
+        :toast="toast"
+        @dismiss="emit('dismiss', toast.id)"
+      />
+    </TransitionGroup>
+    <div v-if="overflowCount > 0" class="text-center font-mono text-[11.5px] text-text-3" data-testid="toast-overflow">
+      {{ overflowCount }} more · <button class="cursor-pointer hover:text-text" data-testid="toast-clear-all" @click="emit('clear-all')">Clear all</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.toast-enter-active, .toast-leave-active { transition: opacity .16s ease, transform .16s ease; }
+.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateY(5px); }
+.toast-leave-active { position: absolute; }
+</style>

--- a/desktop/frontend/src/components/__tests__/ConfigErrorOverlay.spec.ts
+++ b/desktop/frontend/src/components/__tests__/ConfigErrorOverlay.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ConfigErrorOverlay from '../ConfigErrorOverlay.vue'
+import type { ConfigValidationError } from '../../lib/configErrors'
+
+function mountOverlay(errors: ConfigValidationError[], path = '/home/u/.config/hive/desktop/profiles.yaml') {
+  return mount(ConfigErrorOverlay, { props: { path, errors } })
+}
+
+describe('ConfigErrorOverlay', () => {
+  it('renders the config path and a single unstructured error entry', () => {
+    const wrapper = mountOverlay([{ line: null, message: 'source "x": kind "search" requires a query' }])
+
+    expect(document.querySelector('[data-testid="config-error-overlay"]')).not.toBeNull()
+    expect(document.querySelector('[data-testid="config-error-path"]')?.textContent).toContain('profiles.yaml')
+    expect(document.querySelector('[data-testid="config-error-eyebrow"]')?.textContent).toContain('1 PROBLEM')
+    expect(document.querySelector('[data-testid="config-error-subtitle"]')?.textContent).toContain('1 problem')
+
+    const entries = document.querySelectorAll('[data-testid="config-error-entry"]')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].textContent).toContain('kind "search" requires a query')
+    // No line number was parsed, so no "line N" prefix renders.
+    expect(entries[0].textContent).not.toContain('line')
+
+    wrapper.unmount()
+  })
+
+  it('renders multiple line-numbered errors and pluralizes the counts', () => {
+    const errors: ConfigValidationError[] = [
+      { line: 4, message: 'field foo not found in type feed.configFile' },
+      { line: 9, message: 'field bar not found in type feed.configFile' },
+    ]
+    const wrapper = mountOverlay(errors)
+
+    expect(document.querySelector('[data-testid="config-error-eyebrow"]')?.textContent).toContain('2 PROBLEMS')
+    expect(document.querySelector('[data-testid="config-error-subtitle"]')?.textContent).toContain('2 problems')
+
+    const entries = document.querySelectorAll('[data-testid="config-error-entry"]')
+    expect(entries).toHaveLength(2)
+    expect(entries[0].textContent).toContain('line 4')
+    expect(entries[0].textContent).toContain('field foo not found')
+    expect(entries[1].textContent).toContain('line 9')
+
+    wrapper.unmount()
+  })
+
+  it('emits retry, dismiss, copy-path, and copy-errors', async () => {
+    const wrapper = mountOverlay([{ line: null, message: 'boom' }])
+
+    await document.querySelector<HTMLButtonElement>('[data-testid="config-error-reload"]')?.click()
+    await document.querySelector<HTMLButtonElement>('[data-testid="config-error-copy-path"]')?.click()
+    await document.querySelector<HTMLButtonElement>('[data-testid="config-error-copy"]')?.click()
+    await document.querySelector<HTMLButtonElement>('[data-testid="config-error-dismiss"]')?.click()
+
+    expect(wrapper.emitted('retry')).toHaveLength(1)
+    expect(wrapper.emitted('copy-path')).toHaveLength(1)
+    expect(wrapper.emitted('copy-errors')).toHaveLength(1)
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('dismisses on Escape but not on a scrim click (hard block, no click-outside)', () => {
+    const wrapper = mountOverlay([{ line: null, message: 'boom' }])
+
+    document.querySelector<HTMLElement>('[data-testid="config-error-overlay"]')?.click()
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  // Regression: this overlay can appear over another sheet (e.g. the feed
+  // editor) that also has its own unconditional, uncoordinated window Escape
+  // listener holding unsaved form state. Escape must dismiss only the
+  // topmost overlay, not also fire the sheet's own listener underneath.
+  it('handles Escape in the capture phase, stopping it from reaching bubble-phase window listeners underneath', () => {
+    const wrapper = mountOverlay([{ line: null, message: 'boom' }])
+
+    // Stand-in for another sheet's own `window.addEventListener('keydown', ...)`
+    // (no capture option — bubble phase, same as FeedEditorSheet/ConfigSheet/etc).
+    const bubbleListener = vi.fn()
+    window.addEventListener('keydown', bubbleListener)
+
+    // Dispatched on document (not window) with bubbles:true so the event
+    // actually travels capture-phase-down-then-bubble-phase-up through
+    // window, like a real keydown originating on a focused element does —
+    // dispatching directly on window collapses capture/bubble into a single
+    // "at target" step where stopPropagation() has no effect to test.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+    expect(bubbleListener).not.toHaveBeenCalled()
+
+    window.removeEventListener('keydown', bubbleListener)
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/components/__tests__/ConfigSheet.spec.ts
+++ b/desktop/frontend/src/components/__tests__/ConfigSheet.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ConfigSheet from '../ConfigSheet.vue'
+import type { ConfigInfo } from '../../types/feed'
+
+function makeConfig(overrides: Partial<ConfigInfo> = {}): ConfigInfo {
+  return {
+    path: '/home/u/.config/hive/desktop/profiles.yaml',
+    exists: true,
+    yaml: '# feeds\nprofiles:\n  - id: work\n    name: Work\n',
+    valid: true,
+    error: '',
+    ...overrides,
+  }
+}
+
+function mountSheet(config: ConfigInfo | null) {
+  return mount(ConfigSheet, { props: { config } })
+}
+
+describe('ConfigSheet', () => {
+  it('renders the config path and highlighted YAML', () => {
+    const wrapper = mountSheet(makeConfig())
+
+    expect(document.querySelector('[data-testid="config-sheet-path"]')?.textContent).toContain('profiles.yaml')
+    const yaml = document.querySelector('[data-testid="config-sheet-yaml"]')
+    expect(yaml?.textContent).toContain('- id: work')
+    expect(yaml?.querySelector('.text-code-comment')?.textContent).toBe('# feeds')
+    expect(yaml?.querySelector('.text-code-key')?.textContent).toBe('profiles:')
+    expect(document.querySelector('[data-testid="config-sheet-valid"]')).not.toBeNull()
+    expect(document.querySelector('[data-testid="config-sheet-error"]')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('shows the error callout when the config is invalid', () => {
+    const wrapper = mountSheet(makeConfig({ valid: false, error: 'profiles.yaml: line 3: oops' }))
+
+    expect(document.querySelector('[data-testid="config-sheet-error"]')?.textContent).toContain('line 3: oops')
+    expect(document.querySelector('[data-testid="config-sheet-valid"]')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('labels a missing file as the starting template', () => {
+    const wrapper = mountSheet(makeConfig({ exists: false }))
+
+    expect(document.body.textContent).toContain('Not created yet')
+    expect(document.body.textContent).toContain('Starting template')
+
+    wrapper.unmount()
+  })
+
+  it('emits copy-prompt, copy-path, and close', async () => {
+    const wrapper = mountSheet(makeConfig())
+
+    document.querySelector<HTMLButtonElement>('[data-testid="config-sheet-copy-prompt"]')?.click()
+    document.querySelector<HTMLButtonElement>('[data-testid="config-sheet-copy-path"]')?.click()
+    document.querySelector<HTMLButtonElement>('[data-testid="config-sheet-close"]')?.click()
+
+    expect(wrapper.emitted('copy-prompt')).toHaveLength(1)
+    expect(wrapper.emitted('copy-path')).toHaveLength(1)
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('closes on Escape', () => {
+    const wrapper = mountSheet(makeConfig())
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/components/__tests__/DeleteProfileModal.spec.ts
+++ b/desktop/frontend/src/components/__tests__/DeleteProfileModal.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DeleteProfileModal from '../DeleteProfileModal.vue'
+
+function mountModal(props: { profileName?: string; busy?: boolean } = {}) {
+  return mount(DeleteProfileModal, {
+    props: { profileName: props.profileName ?? 'Backend Triage', busy: props.busy ?? false },
+  })
+}
+
+describe('DeleteProfileModal', () => {
+  it('names the profile in the body copy', () => {
+    const wrapper = mountModal({ profileName: 'Backend Triage' })
+
+    expect(document.body.textContent).toContain('Backend Triage')
+    expect(document.body.textContent).toContain('profiles.yaml')
+
+    wrapper.unmount()
+  })
+
+  it('emits confirm and close', () => {
+    const wrapper = mountModal()
+
+    document.querySelector<HTMLButtonElement>('[data-testid="delete-profile-confirm"]')?.click()
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+
+    document.querySelector<HTMLButtonElement>('[data-testid="delete-profile-cancel"]')?.click()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('disables the confirm button while busy', () => {
+    const wrapper = mountModal({ busy: true })
+
+    expect(document.querySelector<HTMLButtonElement>('[data-testid="delete-profile-confirm"]')?.disabled).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('closes on Escape', () => {
+    const wrapper = mountModal()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/components/__tests__/FeedEditorSheet.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedEditorSheet.spec.ts
@@ -73,7 +73,22 @@ describe('FeedEditorSheet', () => {
     wrapper.unmount()
   })
 
-  it('prefills from the initial definition in edit mode and expands filters', async () => {
+  it('renders source rows as selectable cards with a distinct selected state', async () => {
+    const wrapper = mountEditor()
+
+    const checkbox = el<HTMLInputElement>('feed-editor-source-my-prs')!
+    const card = checkbox.closest('label')!
+    expect(card.className).toContain('bg-app')
+    expect(card.className).not.toContain('bg-raised')
+
+    await check(checkbox)
+    expect(card.className).toContain('bg-raised')
+    expect(card.className).not.toContain('bg-app')
+
+    wrapper.unmount()
+  })
+
+  it('prefills from the initial definition in edit mode and auto-expands populated reasons', async () => {
     const def: FeedDef = {
       id: 'team-prs',
       name: 'Team PRs',
@@ -87,7 +102,7 @@ describe('FeedEditorSheet', () => {
     expect(el<HTMLInputElement>('feed-editor-name')?.value).toBe('Team PRs')
     expect(el<HTMLInputElement>('feed-editor-source-my-prs')?.checked).toBe(true)
     expect(el<HTMLInputElement>('feed-editor-source-inbox')?.checked).toBe(false)
-    // Filters and reasons auto-expand when populated; one glob per line.
+    // Filters are always visible now; reasons still auto-expand when populated.
     expect(el<HTMLTextAreaElement>('feed-editor-repos')?.value).toBe('acme/*\nacme/{a,b}/**')
     expect(el<HTMLTextAreaElement>('feed-editor-exclude-authors')?.value).toBe('*[bot]')
     expect(el<HTMLInputElement>('feed-editor-type-pr')?.checked).toBe(true)
@@ -114,8 +129,6 @@ describe('FeedEditorSheet', () => {
     await check(el<HTMLInputElement>('feed-editor-source-my-prs')!)
     await check(el<HTMLInputElement>('feed-editor-source-inbox')!)
 
-    el<HTMLButtonElement>('feed-editor-filters-toggle')!.click()
-    await nextTick()
     // Brace globs contain commas; a line is one pattern, never comma-split.
     await setValue(el<HTMLTextAreaElement>('feed-editor-repos')!, 'acme/{api,web}/**\n acme/cli \n\n')
     await check(el<HTMLInputElement>('feed-editor-type-pr')!)
@@ -150,8 +163,6 @@ describe('FeedEditorSheet', () => {
   it('shows the search-items-excluded hint only while a reason is checked', async () => {
     const wrapper = mountEditor()
 
-    el<HTMLButtonElement>('feed-editor-filters-toggle')!.click()
-    await nextTick()
     el<HTMLButtonElement>('feed-editor-reasons-toggle')!.click()
     await nextTick()
     expect(el('feed-editor-reasons-hint')).toBeNull()
@@ -170,8 +181,6 @@ describe('FeedEditorSheet', () => {
 
     await setValue(el<HTMLInputElement>('feed-editor-name')!, 'Team PRs')
     await check(el<HTMLInputElement>('feed-editor-source-my-prs')!)
-    el<HTMLButtonElement>('feed-editor-filters-toggle')!.click()
-    await nextTick()
     await setValue(el<HTMLTextAreaElement>('feed-editor-repos')!, 'acme/{api,web}/**')
 
     const yaml = el('feed-editor-yaml')!.textContent ?? ''
@@ -257,6 +266,58 @@ describe('FeedEditorSheet', () => {
 
     expect(wrapper.emitted('copy-prompt')).toHaveLength(1)
     expect(wrapper.emitted('copy-path')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('hides the delete button entirely in create mode', () => {
+    const wrapper = mountEditor()
+
+    expect(el('feed-editor-delete')).toBeNull()
+    expect(el('feed-editor-delete-confirm')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('requires a two-step inline confirm before emitting delete', async () => {
+    const def: FeedDef = { id: 'team-prs', name: 'Team PRs', sources: ['my-prs'], filters: {} }
+    const wrapper = mountEditor({ feedId: 'team-prs', initialDef: def })
+    await nextTick()
+
+    expect(el('feed-editor-delete-confirm')).toBeNull()
+
+    el<HTMLButtonElement>('feed-editor-delete')!.click()
+    await nextTick()
+
+    // The initial button swaps for the inline confirm row — no modal.
+    expect(el('feed-editor-delete')).toBeNull()
+    expect(el('feed-editor-delete-confirm')).not.toBeNull()
+    expect(wrapper.emitted('delete')).toBeUndefined()
+
+    el<HTMLButtonElement>('feed-editor-delete-confirm')!.click()
+    await nextTick()
+
+    expect(wrapper.emitted('delete')).toEqual([['team-prs']])
+    // Confirm collapses back to the plain delete button afterward.
+    expect(el('feed-editor-delete')).not.toBeNull()
+    expect(el('feed-editor-delete-confirm')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('cancels the delete confirm without emitting', async () => {
+    const def: FeedDef = { id: 'team-prs', name: 'Team PRs', sources: ['my-prs'], filters: {} }
+    const wrapper = mountEditor({ feedId: 'team-prs', initialDef: def })
+    await nextTick()
+
+    el<HTMLButtonElement>('feed-editor-delete')!.click()
+    await nextTick()
+    el<HTMLButtonElement>('feed-editor-delete-cancel')!.click()
+    await nextTick()
+
+    expect(el('feed-editor-delete')).not.toBeNull()
+    expect(el('feed-editor-delete-confirm')).toBeNull()
+    expect(wrapper.emitted('delete')).toBeUndefined()
 
     wrapper.unmount()
   })

--- a/desktop/frontend/src/components/__tests__/FeedEditorSheet.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedEditorSheet.spec.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import FeedEditorSheet from '../FeedEditorSheet.vue'
+import type { FeedDef, SourceDef } from '../../types/feed'
+
+const cannedSources: SourceDef[] = [
+  { id: 'my-prs', kind: 'search', query: 'is:open is:pr author:@me' },
+  { id: 'inbox', kind: 'notifications' },
+]
+
+function mountEditor(overrides: Record<string, unknown> = {}) {
+  return mount(FeedEditorSheet, {
+    props: {
+      feedId: null,
+      initialDef: null,
+      sources: cannedSources,
+      config: { path: '/cfg/profiles.yaml', exists: true, yaml: '', valid: true, error: '' },
+      busy: false,
+      error: null,
+      sourceBusy: false,
+      sourceError: null,
+      ...overrides,
+    },
+  })
+}
+
+function el<T extends HTMLElement>(testid: string): T | null {
+  return document.querySelector<T>(`[data-testid="${testid}"]`)
+}
+
+async function setValue(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  await nextTick()
+}
+
+async function check(box: HTMLInputElement) {
+  box.click()
+  await nextTick()
+}
+
+describe('FeedEditorSheet', () => {
+  it('disables save until a name is set and at least one source is checked', async () => {
+    const wrapper = mountEditor()
+
+    expect(el('feed-editor-title')?.textContent).toBe('New feed')
+    const save = el<HTMLButtonElement>('feed-editor-save')!
+    expect(save.disabled).toBe(true)
+
+    await setValue(el<HTMLInputElement>('feed-editor-name')!, 'Team PRs')
+    expect(save.disabled).toBe(true) // sources requirement still unmet
+
+    await check(el<HTMLInputElement>('feed-editor-source-my-prs')!)
+    expect(save.disabled).toBe(false)
+
+    await check(el<HTMLInputElement>('feed-editor-source-my-prs')!)
+    expect(save.disabled).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('lists sources with kind badge and query caption', () => {
+    const wrapper = mountEditor()
+
+    const list = el('feed-editor-sources')!
+    expect(list.textContent).toContain('my-prs')
+    expect(list.textContent).toContain('search')
+    expect(list.textContent).toContain('is:open is:pr author:@me')
+    expect(list.textContent).toContain('inbox')
+    expect(list.textContent).toContain('notifications')
+
+    wrapper.unmount()
+  })
+
+  it('prefills from the initial definition in edit mode and expands filters', async () => {
+    const def: FeedDef = {
+      id: 'team-prs',
+      name: 'Team PRs',
+      sources: ['my-prs'],
+      filters: { repos: ['acme/*', 'acme/{a,b}/**'], exclude_authors: ['*[bot]'], types: ['pr'], reasons: ['mention'] },
+    }
+    const wrapper = mountEditor({ feedId: 'team-prs', initialDef: def })
+    await nextTick()
+
+    expect(el('feed-editor-title')?.textContent).toBe('Edit feed')
+    expect(el<HTMLInputElement>('feed-editor-name')?.value).toBe('Team PRs')
+    expect(el<HTMLInputElement>('feed-editor-source-my-prs')?.checked).toBe(true)
+    expect(el<HTMLInputElement>('feed-editor-source-inbox')?.checked).toBe(false)
+    // Filters and reasons auto-expand when populated; one glob per line.
+    expect(el<HTMLTextAreaElement>('feed-editor-repos')?.value).toBe('acme/*\nacme/{a,b}/**')
+    expect(el<HTMLTextAreaElement>('feed-editor-exclude-authors')?.value).toBe('*[bot]')
+    expect(el<HTMLInputElement>('feed-editor-type-pr')?.checked).toBe(true)
+    expect(el<HTMLInputElement>('feed-editor-reason-mention')?.checked).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('disables save in edit mode until the definition arrives', async () => {
+    const wrapper = mountEditor({ feedId: 'team-prs', initialDef: null })
+
+    expect(el<HTMLButtonElement>('feed-editor-save')?.disabled).toBe(true)
+
+    await wrapper.setProps({ initialDef: { id: 'team-prs', name: 'Team PRs', sources: ['my-prs'], filters: {} } })
+    expect(el<HTMLButtonElement>('feed-editor-save')?.disabled).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('emits a save payload with per-line globs kept intact and empty groups omitted', async () => {
+    const wrapper = mountEditor()
+
+    await setValue(el<HTMLInputElement>('feed-editor-name')!, '  Team PRs  ')
+    await check(el<HTMLInputElement>('feed-editor-source-my-prs')!)
+    await check(el<HTMLInputElement>('feed-editor-source-inbox')!)
+
+    el<HTMLButtonElement>('feed-editor-filters-toggle')!.click()
+    await nextTick()
+    // Brace globs contain commas; a line is one pattern, never comma-split.
+    await setValue(el<HTMLTextAreaElement>('feed-editor-repos')!, 'acme/{api,web}/**\n acme/cli \n\n')
+    await check(el<HTMLInputElement>('feed-editor-type-pr')!)
+
+    el<HTMLButtonElement>('feed-editor-save')!.click()
+    await nextTick()
+
+    expect(wrapper.emitted('save')).toEqual([[{
+      id: '',
+      name: 'Team PRs',
+      sources: ['my-prs', 'inbox'],
+      filters: { repos: ['acme/{api,web}/**', 'acme/cli'], types: ['pr'] },
+    }]])
+
+    wrapper.unmount()
+  })
+
+  it('sends filters as an empty object when nothing is filtered', async () => {
+    const wrapper = mountEditor()
+
+    await setValue(el<HTMLInputElement>('feed-editor-name')!, 'Everything')
+    await check(el<HTMLInputElement>('feed-editor-source-inbox')!)
+
+    el<HTMLButtonElement>('feed-editor-save')!.click()
+    await nextTick()
+
+    expect(wrapper.emitted('save')).toEqual([[{ id: '', name: 'Everything', sources: ['inbox'], filters: {} }]])
+
+    wrapper.unmount()
+  })
+
+  it('shows the search-items-excluded hint only while a reason is checked', async () => {
+    const wrapper = mountEditor()
+
+    el<HTMLButtonElement>('feed-editor-filters-toggle')!.click()
+    await nextTick()
+    el<HTMLButtonElement>('feed-editor-reasons-toggle')!.click()
+    await nextTick()
+    expect(el('feed-editor-reasons-hint')).toBeNull()
+
+    await check(el<HTMLInputElement>('feed-editor-reason-review_requested')!)
+    expect(el('feed-editor-reasons-hint')?.textContent).toContain('search sources are excluded')
+
+    await check(el<HTMLInputElement>('feed-editor-reason-review_requested')!)
+    expect(el('feed-editor-reasons-hint')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('renders a live YAML preview of the entry as it will be written', async () => {
+    const wrapper = mountEditor()
+
+    await setValue(el<HTMLInputElement>('feed-editor-name')!, 'Team PRs')
+    await check(el<HTMLInputElement>('feed-editor-source-my-prs')!)
+    el<HTMLButtonElement>('feed-editor-filters-toggle')!.click()
+    await nextTick()
+    await setValue(el<HTMLTextAreaElement>('feed-editor-repos')!, 'acme/{api,web}/**')
+
+    const yaml = el('feed-editor-yaml')!.textContent ?? ''
+    expect(yaml).toContain('- name: Team PRs')
+    expect(yaml).not.toContain('id:') // backend derives the id on create
+    expect(yaml).toContain('sources:')
+    expect(yaml).toContain('- my-prs')
+    expect(yaml).toContain('repos:')
+    expect(yaml).toContain('- "acme/{api,web}/**"')
+
+    wrapper.unmount()
+  })
+
+  it('creates a source inline and auto-checks it when the list refreshes', async () => {
+    const wrapper = mountEditor()
+
+    el<HTMLButtonElement>('feed-editor-new-source-toggle')!.click()
+    await nextTick()
+
+    const add = el<HTMLButtonElement>('feed-editor-source-add')!
+    expect(add.disabled).toBe(true)
+
+    await setValue(el<HTMLInputElement>('feed-editor-source-id')!, 'team-prs')
+    expect(add.disabled).toBe(true) // search kind needs a query
+
+    await setValue(el<HTMLInputElement>('feed-editor-source-query')!, 'org:acme is:pr is:open')
+    await setValue(el<HTMLInputElement>('feed-editor-source-limit')!, '25')
+    expect(add.disabled).toBe(false)
+
+    add.click()
+    await nextTick()
+
+    expect(wrapper.emitted('create-source')).toEqual([[
+      { id: 'team-prs', kind: 'search', query: 'org:acme is:pr is:open', limit: 25 },
+    ]])
+
+    // Parent appends the created source (backend may have uniquified the id).
+    await wrapper.setProps({ sources: [...cannedSources, { id: 'team-prs-2', kind: 'search', query: 'org:acme is:pr is:open' }] })
+    await nextTick()
+
+    expect(el<HTMLInputElement>('feed-editor-source-team-prs-2')?.checked).toBe(true)
+    expect(el('feed-editor-new-source')).toBeNull() // expander folded away
+
+    wrapper.unmount()
+  })
+
+  it('hides the query field for notifications sources and shows backend errors inline', async () => {
+    const wrapper = mountEditor({ sourceError: 'source "inbox": kind "notifications" takes no query' })
+
+    el<HTMLButtonElement>('feed-editor-new-source-toggle')!.click()
+    await nextTick()
+
+    const kind = el<HTMLSelectElement>('feed-editor-source-kind')!
+    kind.value = 'notifications'
+    kind.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(el('feed-editor-source-query')).toBeNull()
+    await setValue(el<HTMLInputElement>('feed-editor-source-id')!, 'inbox-2')
+    expect(el<HTMLButtonElement>('feed-editor-source-add')?.disabled).toBe(false)
+    expect(el('feed-editor-source-error')?.textContent).toContain('takes no query')
+
+    wrapper.unmount()
+  })
+
+  it('shows the save error callout and emits close on Escape', async () => {
+    const wrapper = mountEditor({ error: 'profile "x": feed "y": unknown source "gone"' })
+
+    expect(el('feed-editor-error')?.textContent).toContain('unknown source')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('emits copy-prompt and copy-path from the config row', () => {
+    const wrapper = mountEditor()
+
+    expect(el('feed-editor-path')?.textContent).toBe('/cfg/profiles.yaml')
+    el<HTMLButtonElement>('feed-editor-copy-prompt')!.click()
+    el<HTMLButtonElement>('feed-editor-copy-path')!.click()
+
+    expect(wrapper.emitted('copy-prompt')).toHaveLength(1)
+    expect(wrapper.emitted('copy-path')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/components/__tests__/FeedListItem.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedListItem.spec.ts
@@ -47,6 +47,18 @@ describe('FeedListItem', () => {
     expect(read.find('[data-testid="unread-dot"]').exists()).toBe(false)
   })
 
+  it('renders the notification reason as a chip before the labels, humanized', () => {
+    const wrapper = mountItem({ reason: 'review_requested', labels: ['bug'] })
+    expect(wrapper.find('[data-testid="reason-chip"]').text()).toBe('review requested')
+    expect(wrapper.findAll('span.bg-chip').map((chip) => chip.text())).toEqual(['review requested', 'bug'])
+  })
+
+  it('omits the reason chip when the item has no reason', () => {
+    const wrapper = mountItem()
+    expect(wrapper.find('[data-testid="reason-chip"]').exists()).toBe(false)
+    expect(wrapper.findAll('span.bg-chip').map((chip) => chip.text())).toEqual(['frontend'])
+  })
+
   it('applies selected styling', () => {
     const wrapper = mountItem({}, true)
     expect(wrapper.find('button.feed-item').classes()).toContain('selected')

--- a/desktop/frontend/src/components/__tests__/NewProfileModal.spec.ts
+++ b/desktop/frontend/src/components/__tests__/NewProfileModal.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NewProfileModal from '../NewProfileModal.vue'
+
+function mountModal(props: { busy?: boolean; error?: string | null } = {}) {
+  return mount(NewProfileModal, { props: { busy: props.busy ?? false, error: props.error ?? null } })
+}
+
+function input(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>('[data-testid="new-profile-input"]')
+  if (!el) throw new Error('input not rendered')
+  return el
+}
+
+function submitButton(): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>('[data-testid="new-profile-submit"]')
+  if (!el) throw new Error('submit not rendered')
+  return el
+}
+
+describe('NewProfileModal', () => {
+  it('emits create with the trimmed name', async () => {
+    const wrapper = mountModal()
+
+    input().value = '  Frontend Triage  '
+    input().dispatchEvent(new Event('input'))
+    await wrapper.vm.$nextTick()
+    submitButton().click()
+
+    expect(wrapper.emitted('create')).toEqual([['Frontend Triage']])
+
+    wrapper.unmount()
+  })
+
+  it('disables submit while empty or busy', async () => {
+    const wrapper = mountModal()
+    expect(submitButton().disabled).toBe(true)
+
+    input().value = 'Work'
+    input().dispatchEvent(new Event('input'))
+    await wrapper.vm.$nextTick()
+    expect(submitButton().disabled).toBe(false)
+
+    await wrapper.setProps({ busy: true })
+    expect(submitButton().disabled).toBe(true)
+    submitButton().click()
+    expect(wrapper.emitted('create')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('shows the error and closes on Escape', () => {
+    const wrapper = mountModal({ error: 'boom' })
+
+    expect(document.querySelector('[data-testid="new-profile-error"]')?.textContent).toBe('boom')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/components/__tests__/SideBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SideBar.spec.ts
@@ -55,4 +55,12 @@ describe('SideBar', () => {
 
     expect(wrapper.emitted('edit-feeds')).toHaveLength(1)
   })
+
+  it('emits delete-profile from the header trash icon', async () => {
+    const wrapper = mountSideBar()
+
+    await wrapper.find('[data-testid="sidebar-delete-profile"]').trigger('click')
+
+    expect(wrapper.emitted('delete-profile')).toHaveLength(1)
+  })
 })

--- a/desktop/frontend/src/components/__tests__/SideBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SideBar.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SideBar from '../SideBar.vue'
+import type { Profile } from '../../types/feed'
+
+const profile: Profile = {
+  id: 'personal',
+  letter: 'P',
+  name: 'Personal',
+  sourceSummary: '2 sources',
+  totalCount: 3,
+  unreadCount: 1,
+  feeds: [
+    { id: 'desktop', name: 'Desktop UI', count: 2, newCount: 1 },
+    { id: 'backend', name: 'Backend', count: 1, newCount: 0 },
+  ],
+}
+
+function mountSideBar() {
+  return mount(SideBar, {
+    props: { profile, selection: { type: 'all' }, unreadOnly: false },
+  })
+}
+
+describe('SideBar', () => {
+  it('emits edit-feed with the feed id from the row pencil, without selecting the row', async () => {
+    const wrapper = mountSideBar()
+
+    await wrapper.find('[data-testid="sidebar-feed-edit-desktop"]').trigger('click')
+
+    expect(wrapper.emitted('edit-feed')).toEqual([['desktop']])
+    expect(wrapper.emitted('select')).toBeUndefined()
+  })
+
+  it('renders one pencil per feed row', () => {
+    const wrapper = mountSideBar()
+
+    expect(wrapper.find('[data-testid="sidebar-feed-edit-desktop"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="sidebar-feed-edit-backend"]').exists()).toBe(true)
+  })
+
+  it('still selects a feed when the row itself is clicked', async () => {
+    const wrapper = mountSideBar()
+
+    await wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').trigger('click')
+
+    expect(wrapper.emitted('select')).toEqual([[{ type: 'feed', feedId: 'backend' }]])
+    expect(wrapper.emitted('edit-feed')).toBeUndefined()
+  })
+
+  it('keeps the FEEDS header button emitting edit-feeds', async () => {
+    const wrapper = mountSideBar()
+
+    await wrapper.find('[data-testid="sidebar-edit-feeds"]').trigger('click')
+
+    expect(wrapper.emitted('edit-feeds')).toHaveLength(1)
+  })
+})

--- a/desktop/frontend/src/components/__tests__/ToastStack.spec.ts
+++ b/desktop/frontend/src/components/__tests__/ToastStack.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import ToastStack from '../ToastStack.vue'
+import type { ToastInstance } from '../../types/toast'
+
+let nextId = 1
+function toast(overrides: Partial<ToastInstance> = {}): ToastInstance {
+  return {
+    id: nextId++,
+    message: 'Feed refreshed',
+    severity: 'info',
+    actions: [],
+    duration: 4000,
+    ...overrides,
+  }
+}
+
+function toastEls(wrapper: VueWrapper) {
+  return wrapper.findAll('[data-testid="toast"]')
+}
+
+describe('ToastStack', () => {
+  it('renders nothing when there are no toasts', () => {
+    const wrapper = mount(ToastStack, { props: { toasts: [] } })
+
+    expect(wrapper.find('[data-testid="toast-stack"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('stacks multiple toasts bottom-to-top in insertion order', () => {
+    const toasts = [toast({ message: 'First' }), toast({ message: 'Second' }), toast({ message: 'Third' })]
+    const wrapper = mount(ToastStack, { props: { toasts } })
+
+    const titles = toastEls(wrapper).map((el) => el.find('[data-testid="toast-title"]').text())
+    expect(titles).toEqual(['First', 'Second', 'Third'])
+
+    wrapper.unmount()
+  })
+
+  it('renders severity-specific styling, the AUTO badge, and inline actions', () => {
+    const undo = { label: 'Undo', onClick: () => {} }
+    const view = { label: 'View in activity', onClick: () => {} }
+    const toasts = [
+      toast({ severity: 'info', message: 'Feed refreshed' }),
+      toast({ severity: 'auto-action', message: 'Automatic action taken', actions: [undo, view] }),
+      toast({ severity: 'error', message: "Couldn't reach GitHub", duration: null }),
+      toast({ severity: 'success', message: 'Session created' }),
+    ]
+    const wrapper = mount(ToastStack, { props: { toasts } })
+
+    const els = toastEls(wrapper)
+    expect(els.map((el) => el.attributes('data-toast-severity'))).toEqual(['info', 'auto-action', 'error', 'success'])
+
+    const autoToast = els[1]
+    expect(autoToast.find('[data-testid="toast-auto-badge"]').text()).toBe('AUTO')
+    const actionLabels = autoToast.findAll('[data-testid="toast-action"]').map((el) => el.text())
+    expect(actionLabels).toEqual(['Undo', 'View in activity'])
+
+    // Other severities show no AUTO badge.
+    expect(els[0].find('[data-testid="toast-auto-badge"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('gives error toasts no auto-dismiss progress bar, and other severities one', () => {
+    const toasts = [toast({ severity: 'error', duration: null }), toast({ severity: 'success', duration: 4000 })]
+    const wrapper = mount(ToastStack, { props: { toasts } })
+
+    const els = toastEls(wrapper)
+    expect(els[0].find('[data-testid="toast-progress"]').exists()).toBe(false)
+    expect(els[1].find('[data-testid="toast-progress"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('emits dismiss with the toast id when its close button is clicked', async () => {
+    const t = toast({ message: 'Dismiss me' })
+    const wrapper = mount(ToastStack, { props: { toasts: [t] } })
+
+    await toastEls(wrapper)[0].find('[data-testid="toast-dismiss"]').trigger('click')
+
+    expect(wrapper.emitted('dismiss')).toEqual([[t.id]])
+
+    wrapper.unmount()
+  })
+
+  it('runs a toast action and dismisses the toast', async () => {
+    let ran = false
+    const t = toast({ actions: [{ label: 'Retry now', onClick: () => { ran = true } }] })
+    const wrapper = mount(ToastStack, { props: { toasts: [t] } })
+
+    await toastEls(wrapper)[0].find('[data-testid="toast-action"]').trigger('click')
+
+    expect(ran).toBe(true)
+    expect(wrapper.emitted('dismiss')).toEqual([[t.id]])
+
+    wrapper.unmount()
+  })
+
+  it('collapses overflow beyond 4 visible toasts into an "N more · Clear all" footer', async () => {
+    const toasts = Array.from({ length: 6 }, (_, i) => toast({ message: `Toast ${i + 1}` }))
+    const wrapper = mount(ToastStack, { props: { toasts } })
+
+    // Newest 4 stay visible; the oldest 2 roll into the overflow count.
+    const titles = toastEls(wrapper).map((el) => el.find('[data-testid="toast-title"]').text())
+    expect(titles).toEqual(['Toast 3', 'Toast 4', 'Toast 5', 'Toast 6'])
+    expect(wrapper.find('[data-testid="toast-overflow"]').text()).toContain('2 more')
+
+    await wrapper.find('[data-testid="toast-clear-all"]').trigger('click')
+    expect(wrapper.emitted('clear-all')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('omits the overflow footer at exactly 4 toasts', () => {
+    const toasts = Array.from({ length: 4 }, (_, i) => toast({ message: `Toast ${i + 1}` }))
+    const wrapper = mount(ToastStack, { props: { toasts } })
+
+    expect(toastEls(wrapper)).toHaveLength(4)
+    expect(wrapper.find('[data-testid="toast-overflow"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   CreateFeed: vi.fn(),
   CreateProfile: vi.fn(),
   CreateSource: vi.fn(),
+  DeleteFeed: vi.fn(),
+  DeleteProfile: vi.fn(),
   FeedDefFor: vi.fn(),
   Hide: vi.fn(),
   Items: vi.fn(),
@@ -28,6 +30,8 @@ vi.mock('../../../bindings/github.com/colonyops/hive/desktop/feedservice', () =>
   CreateFeed: mocks.CreateFeed,
   CreateProfile: mocks.CreateProfile,
   CreateSource: mocks.CreateSource,
+  DeleteFeed: mocks.DeleteFeed,
+  DeleteProfile: mocks.DeleteProfile,
   FeedDefFor: mocks.FeedDefFor,
   Items: mocks.Items,
   MarkRead: mocks.MarkRead,
@@ -136,6 +140,8 @@ describe('useFeedState', () => {
     mocks.CreateFeed.mockResolvedValue({ id: 'team-prs', name: 'Team PRs', count: 0, newCount: 0 })
     mocks.UpdateFeed.mockResolvedValue(undefined)
     mocks.FeedDefFor.mockResolvedValue({ id: 'desktop', name: 'Desktop UI', sources: ['my-prs'], filters: {} })
+    mocks.DeleteFeed.mockResolvedValue(undefined)
+    mocks.DeleteProfile.mockResolvedValue(undefined)
   })
 
   it('loads profiles on mount and switches profiles by resetting selection and reloading items', async () => {
@@ -506,10 +512,11 @@ describe('useFeedState', () => {
 
     await state.copyConfigPrompt()
     expect(writeText).toHaveBeenCalledWith('the prompt')
-    expect(state.toast.value).toContain('Prompt copied')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: expect.stringContaining('Prompt copied'), severity: 'success' })
 
     await state.copyConfigPath()
     expect(writeText).toHaveBeenCalledWith('/cfg/profiles.yaml')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: 'Path copied', severity: 'success' })
 
     vi.unstubAllGlobals()
     wrapper.unmount()
@@ -536,7 +543,7 @@ describe('useFeedState', () => {
 
     expect(state.selection.value).toEqual({ type: 'all' })
     expect(mocks.Items).toHaveBeenCalledWith('personal', '')
-    expect(state.toast.value).toContain('reloaded')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: expect.stringContaining('reloaded'), severity: 'success' })
     expect(mocks.Config).toHaveBeenCalled()
 
     wrapper.unmount()
@@ -561,7 +568,7 @@ describe('useFeedState', () => {
     wrapper.unmount()
   })
 
-  it('keeps data and surfaces a toast when config:updated reports an error', async () => {
+  it('keeps data and opens the config-error overlay (not a toast) when config:updated reports an error', async () => {
     let handler: ((event: { data: unknown }) => void) | undefined
     mocks.On.mockImplementation((event: string, cb: (event: { data: unknown }) => void) => {
       if (event === 'config:updated') handler = cb
@@ -569,15 +576,146 @@ describe('useFeedState', () => {
     })
     const { state, wrapper } = await mountLoadedState()
     mocks.Profiles.mockClear()
+    mocks.Config.mockResolvedValueOnce({ path: '/cfg/profiles.yaml', exists: true, yaml: 'profiles:\n', valid: false, error: 'profiles.yaml: parse error' })
 
     handler?.({ data: 'profiles.yaml: parse error' })
     await flushPromises()
 
-    expect(state.toast.value).toContain('error')
+    expect(state.configErrorOverlayOpen.value).toBe(true)
+    expect(state.config.value?.error).toBe('profiles.yaml: parse error')
+    expect(state.toasts.value).toHaveLength(0)
     expect(mocks.Profiles).not.toHaveBeenCalled()
     expect(state.items.value).not.toHaveLength(0)
 
     wrapper.unmount()
+  })
+
+  it('closes the config-error overlay on dismiss and re-opens it once for a fresh error', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    mocks.Config.mockResolvedValueOnce({ path: '/cfg/profiles.yaml', exists: true, yaml: '', valid: false, error: 'boom 1' })
+    await state.loadConfig()
+    expect(state.configErrorOverlayOpen.value).toBe(true)
+
+    state.dismissConfigError()
+    expect(state.configErrorOverlayOpen.value).toBe(false)
+
+    // Reloading with the *same* unresolved error respects the dismissal.
+    mocks.Config.mockResolvedValueOnce({ path: '/cfg/profiles.yaml', exists: true, yaml: '', valid: false, error: 'boom 1' })
+    await state.loadConfig()
+    expect(state.configErrorOverlayOpen.value).toBe(false)
+
+    // A *new* error re-opens it even though the old one was dismissed.
+    mocks.Config.mockResolvedValueOnce({ path: '/cfg/profiles.yaml', exists: true, yaml: '', valid: false, error: 'boom 2' })
+    await state.loadConfig()
+    expect(state.configErrorOverlayOpen.value).toBe(true)
+
+    // Fixing the file (valid again) closes it too.
+    mocks.Config.mockResolvedValueOnce({ path: '/cfg/profiles.yaml', exists: true, yaml: 'profiles:\n', valid: true, error: '' })
+    await state.loadConfig()
+    expect(state.configErrorOverlayOpen.value).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('copies the config error text to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    const { state, wrapper } = await mountLoadedState()
+    mocks.Config.mockResolvedValueOnce({ path: '/cfg/profiles.yaml', exists: true, yaml: '', valid: false, error: 'boom' })
+    await state.loadConfig()
+
+    await state.copyConfigErrors()
+
+    expect(writeText).toHaveBeenCalledWith('boom')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: 'Errors copied', severity: 'success' })
+
+    vi.unstubAllGlobals()
+    wrapper.unmount()
+  })
+
+  describe('showToast', () => {
+    it('stacks multiple toasts and lets each be dismissed independently', async () => {
+      const { state, wrapper } = await mountLoadedState()
+
+      const firstId = state.showToast('First')
+      const secondId = state.showToast('Second', { severity: 'success' })
+
+      expect(state.toasts.value.map((t) => t.message)).toEqual(['First', 'Second'])
+
+      state.dismissToast(firstId)
+
+      expect(state.toasts.value.map((t) => t.id)).toEqual([secondId])
+
+      wrapper.unmount()
+    })
+
+    // Fake timers are only enabled after the initial mount settles: mounting
+    // calls @vue/test-utils' flushPromises(), which itself schedules through
+    // setImmediate/setTimeout — faking timers first would make that hang.
+    it('auto-dismisses a default-severity toast after its duration elapses', async () => {
+      const { state, wrapper } = await mountLoadedState()
+      vi.useFakeTimers()
+      try {
+        state.showToast('Feed refreshed')
+        expect(state.toasts.value).toHaveLength(1)
+
+        vi.advanceTimersByTime(3999)
+        expect(state.toasts.value).toHaveLength(1)
+
+        vi.advanceTimersByTime(1)
+        expect(state.toasts.value).toHaveLength(0)
+      } finally {
+        vi.useRealTimers()
+        wrapper.unmount()
+      }
+    })
+
+    it('never auto-dismisses an error toast', async () => {
+      const { state, wrapper } = await mountLoadedState()
+      vi.useFakeTimers()
+      try {
+        const id = state.showToast("Couldn't reach GitHub", { severity: 'error' })
+        expect(state.toasts.value[0].duration).toBeNull()
+
+        vi.advanceTimersByTime(60_000)
+        expect(state.toasts.value.map((t) => t.id)).toEqual([id])
+      } finally {
+        vi.useRealTimers()
+        wrapper.unmount()
+      }
+    })
+
+    it('clearToasts removes every toast and cancels their timers', async () => {
+      const { state, wrapper } = await mountLoadedState()
+      vi.useFakeTimers()
+      try {
+        state.showToast('One')
+        state.showToast('Two', { severity: 'error' })
+        expect(state.toasts.value).toHaveLength(2)
+
+        state.clearToasts()
+        expect(state.toasts.value).toHaveLength(0)
+
+        // No stray timer fires later and resurrects/crashes on a removed toast.
+        vi.advanceTimersByTime(60_000)
+        expect(state.toasts.value).toHaveLength(0)
+      } finally {
+        vi.useRealTimers()
+        wrapper.unmount()
+      }
+    })
+
+    it('passes actions through to the toast instance', async () => {
+      const { state, wrapper } = await mountLoadedState()
+      const onClick = vi.fn()
+
+      state.showToast('Automatic action taken', { severity: 'auto-action', actions: [{ label: 'Undo', onClick }] })
+
+      expect(state.toasts.value[0].actions).toEqual([{ label: 'Undo', onClick }])
+
+      wrapper.unmount()
+    })
   })
 
   it('loads sources for the feed editor', async () => {
@@ -654,7 +792,7 @@ describe('useFeedState', () => {
 
     expect(saved).toBe(true)
     expect(mocks.CreateFeed).toHaveBeenCalledWith('personal', def)
-    expect(state.toast.value).toBe('Feed created')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: 'Feed created', severity: 'success' })
     expect(mocks.Profiles).toHaveBeenCalled()
     expect(state.saveFeedError.value).toBeNull()
 
@@ -669,7 +807,7 @@ describe('useFeedState', () => {
 
     expect(saved).toBe(true)
     expect(mocks.UpdateFeed).toHaveBeenCalledWith('personal', 'desktop', def)
-    expect(state.toast.value).toBe('Feed updated')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: 'Feed updated', severity: 'success' })
 
     mocks.UpdateFeed.mockRejectedValueOnce(new Error('feed: unknown source "gone"'))
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -679,6 +817,101 @@ describe('useFeedState', () => {
     expect(failed).toBe(false)
     expect(state.saveFeedError.value).toContain('unknown source')
     expect(state.savingFeed.value).toBe(false)
+
+    warn.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('deletes a feed, toasts, and falls back to All when it was selected', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    await state.selectSidebar({ type: 'feed', feedId: 'desktop' })
+    mocks.Items.mockClear()
+
+    const deleted = await state.deleteFeed('personal', 'desktop')
+
+    expect(deleted).toBe(true)
+    expect(mocks.DeleteFeed).toHaveBeenCalledWith('personal', 'desktop')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: 'Feed deleted', severity: 'success' })
+    expect(state.selection.value).toEqual({ type: 'all' })
+    expect(mocks.Items).toHaveBeenCalledWith('personal', '')
+
+    wrapper.unmount()
+  })
+
+  it('deletes a feed without touching selection when a different feed was selected', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    await state.selectSidebar({ type: 'all' })
+    mocks.Items.mockClear()
+
+    await state.deleteFeed('personal', 'backend')
+
+    expect(state.selection.value).toEqual({ type: 'all' })
+    // No feed selection to fall back from, so selectSidebar never re-fires.
+    expect(mocks.Items).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('surfaces feed deletion failures as an error toast', async () => {
+    mocks.DeleteFeed.mockRejectedValue(new Error('feed: unknown feed "gone"'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { state, wrapper } = await mountLoadedState()
+
+    const deleted = await state.deleteFeed('personal', 'gone')
+
+    expect(deleted).toBe(false)
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: expect.stringContaining('unknown feed'), severity: 'error' })
+
+    warn.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('deletes a profile, toasts, and switches to the first remaining profile', async () => {
+    const { state, wrapper } = await mountLoadedState()
+    expect(state.activeProfileId.value).toBe('personal')
+
+    mocks.Profiles.mockResolvedValue([profiles[1]])
+
+    const deleted = await state.deleteProfile('personal')
+
+    expect(deleted).toBe(true)
+    expect(mocks.DeleteProfile).toHaveBeenCalledWith('personal')
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: 'Profile deleted', severity: 'success' })
+    expect(state.activeProfileId.value).toBe('work')
+
+    wrapper.unmount()
+  })
+
+  it('clears active profile and items when the last profile is deleted', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    mocks.Profiles.mockResolvedValue([])
+
+    await state.deleteProfile('personal')
+
+    expect(state.activeProfileId.value).toBe('')
+    expect(state.items.value).toEqual([])
+    expect(state.selectedId.value).toBeNull()
+    // profilesLoaded stays true: this is the "no workspaces yet" shape,
+    // which App's needsWorkspace computed routes into onboarding for.
+    expect(state.profilesLoaded.value).toBe(true)
+    expect(state.profiles.value).toEqual([])
+
+    wrapper.unmount()
+  })
+
+  it('surfaces profile deletion failures as an error toast and keeps the active profile', async () => {
+    mocks.DeleteProfile.mockRejectedValue(new Error('feed: unknown profile "gone"'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { state, wrapper } = await mountLoadedState()
+
+    const deleted = await state.deleteProfile('personal')
+
+    expect(deleted).toBe(false)
+    expect(state.toasts.value.at(-1)).toMatchObject({ message: expect.stringContaining('unknown profile'), severity: 'error' })
+    expect(state.activeProfileId.value).toBe('personal')
 
     warn.mockRestore()
     wrapper.unmount()

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -7,24 +7,34 @@ const mocks = vi.hoisted(() => ({
   ActionsFor: vi.fn(),
   Config: vi.fn(),
   ConfigPrompt: vi.fn(),
+  CreateFeed: vi.fn(),
   CreateProfile: vi.fn(),
+  CreateSource: vi.fn(),
+  FeedDefFor: vi.fn(),
   Hide: vi.fn(),
   Items: vi.fn(),
   MarkRead: vi.fn(),
   On: vi.fn(),
   Profiles: vi.fn(),
   Refresh: vi.fn(),
+  Sources: vi.fn(),
+  UpdateFeed: vi.fn(),
 }))
 
 vi.mock('../../../bindings/github.com/colonyops/hive/desktop/feedservice', () => ({
   ActionsFor: mocks.ActionsFor,
   Config: mocks.Config,
   ConfigPrompt: mocks.ConfigPrompt,
+  CreateFeed: mocks.CreateFeed,
   CreateProfile: mocks.CreateProfile,
+  CreateSource: mocks.CreateSource,
+  FeedDefFor: mocks.FeedDefFor,
   Items: mocks.Items,
   MarkRead: mocks.MarkRead,
   Profiles: mocks.Profiles,
   Refresh: mocks.Refresh,
+  Sources: mocks.Sources,
+  UpdateFeed: mocks.UpdateFeed,
 }))
 
 vi.mock('@wailsio/runtime', () => ({
@@ -118,6 +128,14 @@ describe('useFeedState', () => {
     mocks.On.mockReturnValue(() => {})
     mocks.MarkRead.mockResolvedValue(undefined)
     mocks.Refresh.mockResolvedValue(false)
+    mocks.Sources.mockResolvedValue([
+      { id: 'my-prs', kind: 'search', query: 'is:open is:pr author:@me' },
+      { id: 'inbox', kind: 'notifications' },
+    ])
+    mocks.CreateSource.mockImplementation((def: object) => Promise.resolve({ ...def }))
+    mocks.CreateFeed.mockResolvedValue({ id: 'team-prs', name: 'Team PRs', count: 0, newCount: 0 })
+    mocks.UpdateFeed.mockResolvedValue(undefined)
+    mocks.FeedDefFor.mockResolvedValue({ id: 'desktop', name: 'Desktop UI', sources: ['my-prs'], filters: {} })
   })
 
   it('loads profiles on mount and switches profiles by resetting selection and reloading items', async () => {
@@ -559,6 +577,110 @@ describe('useFeedState', () => {
     expect(mocks.Profiles).not.toHaveBeenCalled()
     expect(state.items.value).not.toHaveLength(0)
 
+    wrapper.unmount()
+  })
+
+  it('loads sources for the feed editor', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    await state.loadSources()
+
+    expect(state.sources.value.map((source) => source.id)).toEqual(['my-prs', 'inbox'])
+
+    wrapper.unmount()
+  })
+
+  it('keeps the previous sources when loading fails', async () => {
+    const { state, wrapper } = await mountLoadedState()
+    await state.loadSources()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mocks.Sources.mockRejectedValueOnce(new Error('boom'))
+
+    await state.loadSources()
+
+    expect(state.sources.value.map((source) => source.id)).toEqual(['my-prs', 'inbox'])
+
+    warn.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('creates a source and appends the backend-assigned definition', async () => {
+    mocks.CreateSource.mockResolvedValue({ id: 'team-prs-2', kind: 'search', query: 'org:acme' })
+    const { state, wrapper } = await mountLoadedState()
+    await state.loadSources()
+
+    const created = await state.createSource({ id: 'team-prs', kind: 'search', query: 'org:acme' })
+
+    expect(mocks.CreateSource).toHaveBeenCalledWith({ id: 'team-prs', kind: 'search', query: 'org:acme' })
+    expect(created?.id).toBe('team-prs-2')
+    expect(state.sources.value.map((source) => source.id)).toEqual(['my-prs', 'inbox', 'team-prs-2'])
+    expect(state.createSourceError.value).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('surfaces source creation failures', async () => {
+    mocks.CreateSource.mockRejectedValue(new Error('source "x": kind "search" requires a query'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { state, wrapper } = await mountLoadedState()
+
+    const created = await state.createSource({ id: 'x', kind: 'search' })
+
+    expect(created).toBeNull()
+    expect(state.createSourceError.value).toContain('requires a query')
+    expect(state.creatingSource.value).toBe(false)
+
+    warn.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('loads a feed definition for edit prefill', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    const def = await state.loadFeedDef('personal', 'desktop')
+
+    expect(mocks.FeedDefFor).toHaveBeenCalledWith('personal', 'desktop')
+    expect(def?.name).toBe('Desktop UI')
+
+    wrapper.unmount()
+  })
+
+  it('creates a feed, toasts, and optimistically reloads profiles', async () => {
+    const { state, wrapper } = await mountLoadedState()
+    mocks.Profiles.mockClear()
+
+    const def = { id: '', name: 'Team PRs', sources: ['my-prs'], filters: {} }
+    const saved = await state.createFeed('personal', def)
+
+    expect(saved).toBe(true)
+    expect(mocks.CreateFeed).toHaveBeenCalledWith('personal', def)
+    expect(state.toast.value).toBe('Feed created')
+    expect(mocks.Profiles).toHaveBeenCalled()
+    expect(state.saveFeedError.value).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('updates a feed and reports failures without a toast', async () => {
+    const { state, wrapper } = await mountLoadedState()
+
+    const def = { id: 'desktop', name: 'Desktop UI', sources: ['my-prs'], filters: { types: ['pr'] } }
+    const saved = await state.updateFeed('personal', 'desktop', def)
+
+    expect(saved).toBe(true)
+    expect(mocks.UpdateFeed).toHaveBeenCalledWith('personal', 'desktop', def)
+    expect(state.toast.value).toBe('Feed updated')
+
+    mocks.UpdateFeed.mockRejectedValueOnce(new Error('feed: unknown source "gone"'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const failed = await state.updateFeed('personal', 'desktop', def)
+
+    expect(failed).toBe(false)
+    expect(state.saveFeedError.value).toContain('unknown source')
+    expect(state.savingFeed.value).toBe(false)
+
+    warn.mockRestore()
     wrapper.unmount()
   })
 

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -5,6 +5,8 @@ import type { FeedItem, Profile } from '../../types/feed'
 
 const mocks = vi.hoisted(() => ({
   ActionsFor: vi.fn(),
+  Config: vi.fn(),
+  ConfigPrompt: vi.fn(),
   CreateProfile: vi.fn(),
   Hide: vi.fn(),
   Items: vi.fn(),
@@ -16,6 +18,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../../bindings/github.com/colonyops/hive/desktop/feedservice', () => ({
   ActionsFor: mocks.ActionsFor,
+  Config: mocks.Config,
+  ConfigPrompt: mocks.ConfigPrompt,
   CreateProfile: mocks.CreateProfile,
   Items: mocks.Items,
   MarkRead: mocks.MarkRead,
@@ -103,6 +107,8 @@ describe('useFeedState', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.Profiles.mockResolvedValue(profiles)
+    mocks.Config.mockResolvedValue({ path: '/cfg/profiles.yaml', exists: true, yaml: 'profiles:\n', valid: true, error: '' })
+    mocks.ConfigPrompt.mockResolvedValue('the prompt')
     // Clone so markItemRead's in-place `item.unread = false` on one test never
     // leaks into the shared fixture arrays seen by later tests.
     mocks.Items.mockImplementation((profileID: string, feedID: string) =>
@@ -469,6 +475,90 @@ describe('useFeedState', () => {
     expect(mocks.Items).not.toHaveBeenCalled()
 
     warn.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('loads the config and copies the agent prompt to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    const { state, wrapper } = await mountLoadedState()
+
+    await state.loadConfig()
+    expect(state.config.value?.path).toBe('/cfg/profiles.yaml')
+
+    await state.copyConfigPrompt()
+    expect(writeText).toHaveBeenCalledWith('the prompt')
+    expect(state.toast.value).toContain('Prompt copied')
+
+    await state.copyConfigPath()
+    expect(writeText).toHaveBeenCalledWith('/cfg/profiles.yaml')
+
+    vi.unstubAllGlobals()
+    wrapper.unmount()
+  })
+
+  it('reloads profiles and re-anchors the selection when config:updated fires', async () => {
+    let handler: ((event: { data: unknown }) => void) | undefined
+    mocks.On.mockImplementation((event: string, cb: (event: { data: unknown }) => void) => {
+      if (event === 'config:updated') handler = cb
+      return () => {}
+    })
+    const { state, wrapper } = await mountLoadedState()
+
+    await state.selectSidebar({ type: 'feed', feedId: 'desktop' })
+
+    // The reloaded profile no longer has the selected feed: scope resets.
+    mocks.Profiles.mockResolvedValue([
+      { ...profiles[0], feeds: [{ id: 'backend', name: 'Backend', count: 1, newCount: 0 }] },
+    ])
+    mocks.Items.mockClear()
+
+    handler?.({ data: 'ok' })
+    await flushPromises()
+
+    expect(state.selection.value).toEqual({ type: 'all' })
+    expect(mocks.Items).toHaveBeenCalledWith('personal', '')
+    expect(state.toast.value).toContain('reloaded')
+    expect(mocks.Config).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('switches to the first profile when config:updated removed the active one', async () => {
+    let handler: ((event: { data: unknown }) => void) | undefined
+    mocks.On.mockImplementation((event: string, cb: (event: { data: unknown }) => void) => {
+      if (event === 'config:updated') handler = cb
+      return () => {}
+    })
+    const { state, wrapper } = await mountLoadedState()
+    expect(state.activeProfileId.value).toBe('personal')
+
+    mocks.Profiles.mockResolvedValue([profiles[1]])
+
+    handler?.({ data: 'ok' })
+    await flushPromises()
+
+    expect(state.activeProfileId.value).toBe('work')
+
+    wrapper.unmount()
+  })
+
+  it('keeps data and surfaces a toast when config:updated reports an error', async () => {
+    let handler: ((event: { data: unknown }) => void) | undefined
+    mocks.On.mockImplementation((event: string, cb: (event: { data: unknown }) => void) => {
+      if (event === 'config:updated') handler = cb
+      return () => {}
+    })
+    const { state, wrapper } = await mountLoadedState()
+    mocks.Profiles.mockClear()
+
+    handler?.({ data: 'profiles.yaml: parse error' })
+    await flushPromises()
+
+    expect(state.toast.value).toContain('error')
+    expect(mocks.Profiles).not.toHaveBeenCalled()
+    expect(state.items.value).not.toHaveLength(0)
+
     wrapper.unmount()
   })
 

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { Events, Window } from '@wailsio/runtime'
-import { ActionsFor, CreateProfile, Items, MarkRead, Profiles, Refresh } from '../../bindings/github.com/colonyops/hive/desktop/feedservice'
-import type { Action, FeedItem, Profile, SidebarSelection } from '../types/feed'
+import { ActionsFor, Config, ConfigPrompt, CreateProfile, Items, MarkRead, Profiles, Refresh } from '../../bindings/github.com/colonyops/hive/desktop/feedservice'
+import type { Action, ConfigInfo, FeedItem, Profile, SidebarSelection } from '../types/feed'
 
 export function useFeedState() {
   const profiles = ref<Profile[]>([])
@@ -23,6 +23,9 @@ export function useFeedState() {
   const toast = ref<string | null>(null)
   const creatingProfile = ref(false)
   const createProfileError = ref<string | null>(null)
+  // The profiles config file (path, content, validity) for the
+  // feeds-as-code sheet; null until first loaded.
+  const config = ref<ConfigInfo | null>(null)
   let toastTimeout: ReturnType<typeof setTimeout> | undefined
   // Monotonic token: loadItems responses arriving out of order (slow feed
   // switch, live backend latency) must not clobber the newest request.
@@ -210,6 +213,74 @@ export function useFeedState() {
     showToast('Not wired up yet')
   }
 
+  async function loadConfig() {
+    try {
+      config.value = await Config()
+    } catch (error) {
+      console.warn('Unable to load feeds config', error)
+      config.value = null
+    }
+  }
+
+  // The feeds-as-code handoff: put a schema-complete prompt on the
+  // clipboard for the user to paste into a coding agent, which edits the
+  // YAML the app then hot-reloads.
+  async function copyConfigPrompt() {
+    try {
+      const prompt = await ConfigPrompt()
+      await navigator.clipboard.writeText(prompt)
+      showToast('Prompt copied — paste it into a coding agent')
+    } catch (error) {
+      console.warn('Unable to copy config prompt', error)
+      showToast('Could not copy the prompt')
+    }
+  }
+
+  async function copyConfigPath() {
+    const path = config.value?.path
+    if (!path) return
+    try {
+      await navigator.clipboard.writeText(path)
+      showToast('Path copied')
+    } catch (error) {
+      console.warn('Unable to copy config path', error)
+      showToast('Could not copy the path')
+    }
+  }
+
+  // A config hot-reload can rename or remove the active profile or the
+  // selected feed; re-anchor rather than showing items of a definition that
+  // no longer exists. Errors keep the last-good data on the backend, so the
+  // toast is the only change the user sees.
+  async function onConfigUpdated(status: string) {
+    await loadConfig()
+    if (status !== 'ok') {
+      showToast('Feeds config has an error — open Feeds as code')
+      return
+    }
+    showToast('Feeds config reloaded')
+    await reloadProfilesQuietly()
+    profilesLoaded.value = true
+    const active = profiles.value.find((profile) => profile.id === activeProfileId.value) ?? profiles.value[0]
+    if (!active) {
+      activeProfileId.value = ''
+      items.value = []
+      selectedId.value = null
+      actions.value = []
+      return
+    }
+    if (active.id !== activeProfileId.value) {
+      await selectProfile(active.id)
+      return
+    }
+    const currentSelection = selection.value
+    if (currentSelection.type === 'feed' && !active.feeds?.some((feed) => feed.id === currentSelection.feedId)) {
+      await selectSidebar({ type: 'all' })
+      return
+    }
+    await loadItems(currentFeedId())
+  }
+
   async function hideWindow() {
     try {
       if (typeof Window !== 'undefined' && typeof Window.Hide === 'function') await Window.Hide()
@@ -230,17 +301,23 @@ export function useFeedState() {
   }
 
   let unsubscribeFeed: (() => void) | undefined
+  let unsubscribeConfig: (() => void) | undefined
 
   onMounted(() => {
     unsubscribeFeed = Events.On('feed:updated', (event) => {
       const profileID = Array.isArray(event.data) ? event.data[0] : event.data
       void onFeedUpdated(typeof profileID === 'string' ? profileID : '')
     })
+    unsubscribeConfig = Events.On('config:updated', (event) => {
+      const status = Array.isArray(event.data) ? event.data[0] : event.data
+      void onConfigUpdated(typeof status === 'string' ? status : 'ok')
+    })
     void loadProfiles()
   })
 
   onUnmounted(() => {
     unsubscribeFeed?.()
+    unsubscribeConfig?.()
   })
 
   return {
@@ -261,6 +338,10 @@ export function useFeedState() {
     toast,
     creatingProfile,
     createProfileError,
+    config,
+    loadConfig,
+    copyConfigPrompt,
+    copyConfigPath,
     loadProfiles,
     createProfile,
     selectProfile,

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,7 +1,8 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { Events, Window } from '@wailsio/runtime'
-import { ActionsFor, Config, ConfigPrompt, CreateFeed, CreateProfile, CreateSource, FeedDefFor, Items, MarkRead, Profiles, Refresh, Sources, UpdateFeed } from '../../bindings/github.com/colonyops/hive/desktop/feedservice'
+import { ActionsFor, Config, ConfigPrompt, CreateFeed, CreateProfile, CreateSource, DeleteFeed, DeleteProfile, FeedDefFor, Items, MarkRead, Profiles, Refresh, Sources, UpdateFeed } from '../../bindings/github.com/colonyops/hive/desktop/feedservice'
 import type { Action, ConfigInfo, FeedDef, FeedItem, Profile, SidebarSelection, SourceDef } from '../types/feed'
+import type { ToastInstance, ToastOptions } from '../types/toast'
 
 export function useFeedState() {
   const profiles = ref<Profile[]>([])
@@ -20,9 +21,14 @@ export function useFeedState() {
   const loadError = ref<string | null>(null)
   const selectedId = ref<string | null>(null)
   const actions = ref<Action[]>([])
-  const toast = ref<string | null>(null)
+  // Stacked toasts (design spec "6a Toasts"): bottom-right, up to ~4 visible,
+  // each with its own auto-dismiss timer. Error-severity toasts never
+  // auto-dismiss — they sit until the user clears them or resolves the
+  // underlying failure.
+  const toasts = ref<ToastInstance[]>([])
   const creatingProfile = ref(false)
   const createProfileError = ref<string | null>(null)
+  const deletingProfile = ref(false)
   // Top-level source definitions for the feed editor's picker; loaded when
   // the editor opens.
   const sources = ref<SourceDef[]>([])
@@ -35,10 +41,21 @@ export function useFeedState() {
   // The profiles config file (path, content, validity) for the
   // feeds-as-code sheet; null until first loaded.
   const config = ref<ConfigInfo | null>(null)
-  let toastTimeout: ReturnType<typeof setTimeout> | undefined
+  // The config-error overlay (design spec "6b") is dismissible: the user can
+  // keep working on the last-good config. Dismissal is cleared whenever a
+  // *new* invalid state arrives (fresh error text, or a valid→invalid
+  // transition) so an unresolved edit that fails again still interrupts.
+  const configErrorDismissed = ref(false)
+  let nextToastId = 1
+  const toastTimers = new Map<number, ReturnType<typeof setTimeout>>()
+  const defaultToastDuration = 4000
   // Monotonic token: loadItems responses arriving out of order (slow feed
   // switch, live backend latency) must not clobber the newest request.
   let loadSeq = 0
+  // Re-entry guard for deleteFeed: the sheet's confirm button collapses back
+  // to the plain "Delete feed" button synchronously on emit, so a fast
+  // second click could otherwise fire a second delete mid-flight.
+  let deletingFeed = false
 
   const activeProfile = computed(() => profiles.value.find((profile) => profile.id === activeProfileId.value) ?? null)
   const selectedItem = computed(() => items.value.find((item) => item.id === selectedId.value) ?? null)
@@ -48,11 +65,40 @@ export function useFeedState() {
     return unreadOnly.value ? 'Unread' : 'All items'
   })
   const countLabel = computed(() => activeProfile.value ? `${activeProfile.value.totalCount} · ${activeProfile.value.unreadCount} unread` : '')
+  // Full-app blocking overlay (design spec "6b"): shown whenever the loaded
+  // config is invalid and the user hasn't dismissed *this* error.
+  const configErrorOverlayOpen = computed(() => !!config.value && !config.value.valid && !configErrorDismissed.value)
 
-  function showToast(message: string) {
-    toast.value = message
-    if (toastTimeout) clearTimeout(toastTimeout)
-    toastTimeout = setTimeout(() => { toast.value = null }, 2000)
+  function showToast(message: string, options: ToastOptions = {}): number {
+    const severity = options.severity ?? 'info'
+    const id = nextToastId++
+    // Error toasts persist until manually cleared or resolved — auto-dismiss
+    // would hide a failure the user hasn't necessarily seen yet.
+    const duration = severity === 'error' ? null : options.duration ?? defaultToastDuration
+    toasts.value = [...toasts.value, { id, message, body: options.body, severity, actions: options.actions ?? [], duration }]
+    if (duration !== null) {
+      toastTimers.set(id, setTimeout(() => dismissToast(id), duration))
+    }
+    return id
+  }
+
+  function dismissToast(id: number) {
+    const timer = toastTimers.get(id)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      toastTimers.delete(id)
+    }
+    toasts.value = toasts.value.filter((t) => t.id !== id)
+  }
+
+  function clearToasts() {
+    for (const timer of toastTimers.values()) clearTimeout(timer)
+    toastTimers.clear()
+    toasts.value = []
+  }
+
+  function dismissConfigError() {
+    configErrorDismissed.value = true
   }
 
   async function loadActions(item: FeedItem | null) {
@@ -130,6 +176,40 @@ export function useFeedState() {
     }
   }
 
+  // Deletes the active profile (the sidebar only exposes this for the
+  // active one). On success the modal always closes (see App.vue); errors
+  // surface as a toast rather than blocking the confirm flow.
+  async function deleteProfile(profileID: string): Promise<boolean> {
+    if (deletingProfile.value) return false
+    deletingProfile.value = true
+    try {
+      await DeleteProfile(profileID)
+    } catch (error) {
+      console.warn('Unable to delete profile', error)
+      showToast(error instanceof Error && error.message ? error.message : 'Could not delete the profile.', { severity: 'error' })
+      return false
+    } finally {
+      deletingProfile.value = false
+    }
+    showToast('Profile deleted', { severity: 'success' })
+    await reloadProfilesQuietly()
+    if (activeProfileId.value === profileID) {
+      const next = profiles.value[0]
+      if (next) {
+        await selectProfile(next.id)
+      } else {
+        // No profiles left: same shape as a fresh install — profilesLoaded
+        // stays true, so App's needsWorkspace computed routes to the
+        // existing "create your first workspace" onboarding step.
+        activeProfileId.value = ''
+        items.value = []
+        selectedId.value = null
+        actions.value = []
+      }
+    }
+    return true
+  }
+
   async function loadSources() {
     try {
       sources.value = (await Sources()) ?? []
@@ -191,7 +271,31 @@ export function useFeedState() {
     } finally {
       savingFeed.value = false
     }
-    showToast(toastMessage)
+    showToast(toastMessage, { severity: 'success' })
+    await reloadProfilesQuietly()
+    return true
+  }
+
+  // The sheet stays open on failure (error surfaces as a toast, not the
+  // inline saveFeedError callout — delete has no form to point the error
+  // at); the caller closes it on success.
+  async function deleteFeed(profileID: string, feedID: string): Promise<boolean> {
+    if (deletingFeed) return false
+    deletingFeed = true
+    try {
+      await DeleteFeed(profileID, feedID)
+    } catch (error) {
+      console.warn('Unable to delete feed', error)
+      showToast(error instanceof Error && error.message ? error.message : 'Could not delete the feed.', { severity: 'error' })
+      return false
+    } finally {
+      deletingFeed = false
+    }
+    showToast('Feed deleted', { severity: 'success' })
+    // The deleted feed can no longer anchor the sidebar selection.
+    if (selection.value.type === 'feed' && selection.value.feedId === feedID) {
+      await selectSidebar({ type: 'all' })
+    }
     await reloadProfilesQuietly()
     return true
   }
@@ -290,7 +394,16 @@ export function useFeedState() {
 
   async function loadConfig() {
     try {
-      config.value = await Config()
+      const info = await Config()
+      // A fresh invalid state (first sight of this error, or a valid→invalid
+      // transition) always re-opens the overlay even if an earlier, now-
+      // resolved error was dismissed; an unchanged still-broken error
+      // respects an existing dismissal so re-opening the sheet doesn't
+      // re-interrupt the user.
+      if (!info.valid && (!config.value || config.value.valid || config.value.error !== info.error)) {
+        configErrorDismissed.value = false
+      }
+      config.value = info
     } catch (error) {
       console.warn('Unable to load feeds config', error)
       config.value = null
@@ -304,10 +417,10 @@ export function useFeedState() {
     try {
       const prompt = await ConfigPrompt()
       await navigator.clipboard.writeText(prompt)
-      showToast('Prompt copied — paste it into a coding agent')
+      showToast('Prompt copied — paste it into a coding agent', { severity: 'success' })
     } catch (error) {
       console.warn('Unable to copy config prompt', error)
-      showToast('Could not copy the prompt')
+      showToast('Could not copy the prompt', { severity: 'error' })
     }
   }
 
@@ -316,24 +429,36 @@ export function useFeedState() {
     if (!path) return
     try {
       await navigator.clipboard.writeText(path)
-      showToast('Path copied')
+      showToast('Path copied', { severity: 'success' })
     } catch (error) {
       console.warn('Unable to copy config path', error)
-      showToast('Could not copy the path')
+      showToast('Could not copy the path', { severity: 'error' })
+    }
+  }
+
+  // Copies the raw validation error text shown in the config-error overlay —
+  // the "Copy" affordance next to its VALIDATION DETAIL list.
+  async function copyConfigErrors() {
+    const text = config.value?.error
+    if (!text) return
+    try {
+      await navigator.clipboard.writeText(text)
+      showToast('Errors copied', { severity: 'success' })
+    } catch (error) {
+      console.warn('Unable to copy config errors', error)
+      showToast('Could not copy the errors', { severity: 'error' })
     }
   }
 
   // A config hot-reload can rename or remove the active profile or the
   // selected feed; re-anchor rather than showing items of a definition that
-  // no longer exists. Errors keep the last-good data on the backend, so the
-  // toast is the only change the user sees.
+  // no longer exists. Errors keep the last-good data on the backend; the
+  // config-error overlay (driven by config.valid, refreshed above) is the
+  // signal now, not a toast — it needs the user's attention, not a 4s blip.
   async function onConfigUpdated(status: string) {
     await loadConfig()
-    if (status !== 'ok') {
-      showToast('Feeds config has an error — open Feeds as code')
-      return
-    }
-    showToast('Feeds config reloaded')
+    if (status !== 'ok') return
+    showToast('Feeds config reloaded', { severity: 'success' })
     await reloadProfilesQuietly()
     profilesLoaded.value = true
     const active = profiles.value.find((profile) => profile.id === activeProfileId.value) ?? profiles.value[0]
@@ -388,11 +513,15 @@ export function useFeedState() {
       void onConfigUpdated(typeof status === 'string' ? status : 'ok')
     })
     void loadProfiles()
+    // Loaded eagerly (not just when the config sheet/feed editor opens) so a
+    // broken config surfaces the blocking overlay right at startup.
+    void loadConfig()
   })
 
   onUnmounted(() => {
     unsubscribeFeed?.()
     unsubscribeConfig?.()
+    clearToasts()
   })
 
   return {
@@ -410,9 +539,13 @@ export function useFeedState() {
     unreadOnly,
     title,
     countLabel,
-    toast,
+    toasts,
+    showToast,
+    dismissToast,
+    clearToasts,
     creatingProfile,
     createProfileError,
+    deletingProfile,
     sources,
     creatingSource,
     createSourceError,
@@ -423,12 +556,17 @@ export function useFeedState() {
     loadFeedDef,
     createFeed,
     updateFeed,
+    deleteFeed,
     config,
+    configErrorOverlayOpen,
+    dismissConfigError,
     loadConfig,
     copyConfigPrompt,
     copyConfigPath,
+    copyConfigErrors,
     loadProfiles,
     createProfile,
+    deleteProfile,
     selectProfile,
     selectSidebar,
     selectUnreadView,

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { Events, Window } from '@wailsio/runtime'
-import { ActionsFor, Config, ConfigPrompt, CreateProfile, Items, MarkRead, Profiles, Refresh } from '../../bindings/github.com/colonyops/hive/desktop/feedservice'
-import type { Action, ConfigInfo, FeedItem, Profile, SidebarSelection } from '../types/feed'
+import { ActionsFor, Config, ConfigPrompt, CreateFeed, CreateProfile, CreateSource, FeedDefFor, Items, MarkRead, Profiles, Refresh, Sources, UpdateFeed } from '../../bindings/github.com/colonyops/hive/desktop/feedservice'
+import type { Action, ConfigInfo, FeedDef, FeedItem, Profile, SidebarSelection, SourceDef } from '../types/feed'
 
 export function useFeedState() {
   const profiles = ref<Profile[]>([])
@@ -23,6 +23,15 @@ export function useFeedState() {
   const toast = ref<string | null>(null)
   const creatingProfile = ref(false)
   const createProfileError = ref<string | null>(null)
+  // Top-level source definitions for the feed editor's picker; loaded when
+  // the editor opens.
+  const sources = ref<SourceDef[]>([])
+  const creatingSource = ref(false)
+  const createSourceError = ref<string | null>(null)
+  // One busy/error pair covers create and update: the editor sheet only ever
+  // runs one save at a time.
+  const savingFeed = ref(false)
+  const saveFeedError = ref<string | null>(null)
   // The profiles config file (path, content, validity) for the
   // feeds-as-code sheet; null until first loaded.
   const config = ref<ConfigInfo | null>(null)
@@ -119,6 +128,72 @@ export function useFeedState() {
     } finally {
       creatingProfile.value = false
     }
+  }
+
+  async function loadSources() {
+    try {
+      sources.value = (await Sources()) ?? []
+    } catch (error) {
+      // Keep whatever list we had; the editor's ≥1-source rule still guards
+      // saves, and a retry happens on the next open.
+      console.warn('Unable to load sources', error)
+    }
+  }
+
+  async function createSource(def: SourceDef): Promise<SourceDef | null> {
+    if (creatingSource.value) return null
+    creatingSource.value = true
+    createSourceError.value = null
+    try {
+      const created = await CreateSource(def)
+      sources.value = [...sources.value, created]
+      return created
+    } catch (error) {
+      console.warn('Unable to create source', error)
+      createSourceError.value = error instanceof Error && error.message ? error.message : 'Could not create the source.'
+      return null
+    } finally {
+      creatingSource.value = false
+    }
+  }
+
+  async function loadFeedDef(profileID: string, feedID: string): Promise<FeedDef | null> {
+    try {
+      return await FeedDefFor(profileID, feedID)
+    } catch (error) {
+      console.warn('Unable to load feed definition', error)
+      saveFeedError.value = error instanceof Error && error.message ? error.message : 'Could not load the feed.'
+      return null
+    }
+  }
+
+  async function createFeed(profileID: string, def: FeedDef): Promise<boolean> {
+    return saveFeed(async () => { await CreateFeed(profileID, def) }, 'Feed created')
+  }
+
+  async function updateFeed(profileID: string, feedID: string, def: FeedDef): Promise<boolean> {
+    return saveFeed(async () => { await UpdateFeed(profileID, feedID, def) }, 'Feed updated')
+  }
+
+  // The config:updated event that follows a successful write also refreshes
+  // state, but it rides fsnotify; reload optimistically so the sidebar shows
+  // the new feed the moment the sheet closes.
+  async function saveFeed(write: () => Promise<void>, toastMessage: string): Promise<boolean> {
+    if (savingFeed.value) return false // re-entry guard: Enter-key can double-submit
+    savingFeed.value = true
+    saveFeedError.value = null
+    try {
+      await write()
+    } catch (error) {
+      console.warn('Unable to save feed', error)
+      saveFeedError.value = error instanceof Error && error.message ? error.message : 'Could not save the feed.'
+      return false
+    } finally {
+      savingFeed.value = false
+    }
+    showToast(toastMessage)
+    await reloadProfilesQuietly()
+    return true
   }
 
   async function selectProfile(profileID: string) {
@@ -338,6 +413,16 @@ export function useFeedState() {
     toast,
     creatingProfile,
     createProfileError,
+    sources,
+    creatingSource,
+    createSourceError,
+    savingFeed,
+    saveFeedError,
+    loadSources,
+    createSource,
+    loadFeedDef,
+    createFeed,
+    updateFeed,
     config,
     loadConfig,
     copyConfigPrompt,

--- a/desktop/frontend/src/lib/__tests__/configErrors.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/configErrors.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { parseConfigErrors } from '../configErrors'
+
+describe('parseConfigErrors', () => {
+  it('returns no entries for an empty or blank string', () => {
+    expect(parseConfigErrors('')).toEqual([])
+    expect(parseConfigErrors('   \n  ')).toEqual([])
+  })
+
+  it('treats a plain fmt.Errorf-style message as one unnumbered entry', () => {
+    expect(parseConfigErrors('source "x": kind "search" requires a query')).toEqual([
+      { line: null, message: 'source "x": kind "search" requires a query' },
+    ])
+  })
+
+  it('splits multi-line yaml.v3 "line N:" errors into separate numbered entries', () => {
+    const raw = 'yaml: unmarshal errors:\n  line 4: field foo not found in type feed.configFile\n  line 9: field bar not found in type feed.configFile'
+    expect(parseConfigErrors(raw)).toEqual([
+      { line: 4, message: 'field foo not found in type feed.configFile' },
+      { line: 9, message: 'field bar not found in type feed.configFile' },
+    ])
+  })
+
+  it('parses a single "line N:" prefixed message', () => {
+    expect(parseConfigErrors('yaml: line 3: mapping values are not allowed in this context')).toEqual([
+      { line: 3, message: 'mapping values are not allowed in this context' },
+    ])
+  })
+})

--- a/desktop/frontend/src/lib/__tests__/feedYaml.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/feedYaml.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { feedEntryYaml } from '../feedYaml'
+
+describe('feedEntryYaml', () => {
+  it('renders a minimal entry without an id or filters block', () => {
+    expect(feedEntryYaml({ id: '', name: 'Team PRs', sources: ['my-prs'], filters: {} })).toBe(
+      ['- name: Team PRs', '  sources:', '    - my-prs'].join('\n'),
+    )
+  })
+
+  it('renders the id first in edit mode and keeps filter group order', () => {
+    const yaml = feedEntryYaml({
+      id: 'team-prs',
+      name: 'Team PRs',
+      sources: ['my-prs', 'inbox'],
+      filters: { reasons: ['mention'], types: ['pr'], repos: ['acme/*'] },
+    })
+    expect(yaml).toBe([
+      '- id: team-prs',
+      '  name: Team PRs',
+      '  sources:',
+      '    - my-prs',
+      '    - inbox',
+      '  filters:',
+      '    repos:',
+      '      - "acme/*"',
+      '    types:',
+      '      - pr',
+      '    reasons:',
+      '      - mention',
+    ].join('\n'))
+  })
+
+  it('quotes glob patterns, including brace globs with commas, without splitting them', () => {
+    const yaml = feedEntryYaml({
+      id: '',
+      name: 'X',
+      sources: ['s'],
+      filters: { repos: ['acme/{api,web}/**'], exclude_authors: ['*[bot]'] },
+    })
+    expect(yaml).toContain('- "acme/{api,web}/**"')
+    expect(yaml).toContain('- "*[bot]"')
+  })
+
+  it('quotes scalars YAML would reparse as another type and shows empty sources explicitly', () => {
+    const yaml = feedEntryYaml({ id: '', name: 'true', sources: [], filters: {} })
+    expect(yaml).toContain('- name: "true"')
+    expect(yaml).toContain('  sources: []')
+  })
+})

--- a/desktop/frontend/src/lib/configErrors.ts
+++ b/desktop/frontend/src/lib/configErrors.ts
@@ -1,0 +1,41 @@
+// Splits the backend's config error text into displayable entries for the
+// config-error overlay's "VALIDATION DETAIL" list.
+//
+// The backend (internal/desktop/feed/config.go ConfigInfo.Error) currently
+// reports a single string — either a hand-written fmt.Errorf validation
+// message, or a yaml.v3 decode failure. Multi-problem yaml.v3 failures are
+// formatted as one "line N: message" per line under a "yaml: unmarshal
+// errors:" header; hand-written validation errors are a single line with no
+// line number. This parses the former into multiple line-numbered entries
+// and falls back to treating the whole string as one entry otherwise, so the
+// overlay already renders a real per-problem list where the data supports
+// it, without the Go side needing to change. If the backend later returns
+// structured errors, this function (and its ConfigValidationError return
+// type) is the only thing that needs to change — callers just consume the
+// array.
+export interface ConfigValidationError {
+  line: number | null
+  message: string
+}
+
+// Matches "line N:" at the start of a line (the multi-error yaml.v3 format,
+// each already split onto its own line) or after a "yaml: " prefix (the
+// single-error format, e.g. "yaml: line 3: mapping values are not allowed
+// in this context") — anything preceded by whitespace or the string start.
+const LINE_PREFIX = /(?:^|\s)line (\d+):\s*(.*)$/i
+
+export function parseConfigErrors(raw: string): ConfigValidationError[] {
+  const trimmed = raw.trim()
+  if (!trimmed) return []
+
+  const entries: ConfigValidationError[] = []
+  for (const rawLine of trimmed.split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+    const match = LINE_PREFIX.exec(line)
+    if (match) entries.push({ line: Number(match[1]), message: match[2] })
+  }
+  if (entries.length > 0) return entries
+
+  return [{ line: null, message: trimmed }]
+}

--- a/desktop/frontend/src/lib/feedYaml.ts
+++ b/desktop/frontend/src/lib/feedYaml.ts
@@ -1,0 +1,50 @@
+// Hand-rolled serializer for the feed editor's YAML preview: renders one
+// feed entry the way the backend writes it into profiles.yaml (block style,
+// 2-space indent, filter groups omitted when empty). Preview-only — the
+// backend owns the real YAML surgery, so no yaml dependency is warranted
+// for a shape this small.
+
+import type { FeedDef, FilterDef } from '../types/feed'
+
+// Plain-safe scalars: start and end on a word-ish character, no YAML
+// indicator characters anywhere (interior spaces are fine — "Team PRs" stays
+// unquoted like the backend writes it). Anything else — globs with
+// *, ?, [, {, }, commas, leading/trailing spaces — is double-quoted;
+// JSON string escaping is valid YAML double-quote escaping.
+const PLAIN_SCALAR = /^[A-Za-z0-9_](?:[A-Za-z0-9 _.@/-]*[A-Za-z0-9_.@/-])?$/
+// Strings YAML would reparse as another type must be quoted to stay strings.
+const AMBIGUOUS = /^(?:true|false|null|yes|no|on|off|[+-]?\d+(?:\.\d+)?)$/i
+
+function scalar(value: string): string {
+  return PLAIN_SCALAR.test(value) && !AMBIGUOUS.test(value) ? value : JSON.stringify(value)
+}
+
+function listLines(key: string, values: string[] | null | undefined): string[] {
+  if (!values || values.length === 0) return []
+  return [`${key}:`, ...values.map((value) => `  - ${scalar(value)}`)]
+}
+
+// filterGroups fixes the render order to match the backend struct order.
+const filterGroups: Array<keyof FilterDef> = [
+  'repos', 'exclude_repos', 'authors', 'exclude_authors', 'labels', 'exclude_labels', 'types', 'reasons',
+]
+
+/**
+ * Render a feed as a `profiles[].feeds` sequence entry. An empty id is
+ * omitted entirely: on create the backend derives it from the name.
+ */
+export function feedEntryYaml(def: FeedDef): string {
+  const lines: string[] = []
+  if (def.id) lines.push(`id: ${scalar(def.id)}`)
+  lines.push(`name: ${scalar(def.name)}`)
+  const sources = def.sources ?? []
+  if (sources.length === 0) {
+    lines.push('sources: []')
+  } else {
+    lines.push('sources:', ...sources.map((id) => `  - ${scalar(id)}`))
+  }
+  const filters = def.filters ?? {}
+  const filterLines = filterGroups.flatMap((key) => listLines(key, filters[key]).map((line) => `  ${line}`))
+  if (filterLines.length > 0) lines.push('filters:', ...filterLines)
+  return lines.map((line, i) => (i === 0 ? `- ${line}` : `  ${line}`)).join('\n')
+}

--- a/desktop/frontend/src/lib/yamlHighlight.ts
+++ b/desktop/frontend/src/lib/yamlHighlight.ts
@@ -1,0 +1,32 @@
+// Display-only YAML tokenizer: enough to make keys, strings, and comments
+// scan like the settings mock, nothing more. Shared by the feeds-as-code
+// sheet and the feed editor's live preview; nothing here edits YAML.
+
+export interface Token {
+  text: string
+  kind: 'key' | 'string' | 'comment' | 'plain'
+}
+
+export function tokenizeLine(line: string): Token[] {
+  const commentAt = line.indexOf('#')
+  const beforeComment = commentAt >= 0 ? line.slice(0, commentAt) : line
+  const comment = commentAt >= 0 ? line.slice(commentAt) : ''
+
+  const tokens: Token[] = []
+  const keyMatch = /^(\s*-?\s*)([\w-]+)(:)(.*)$/.exec(beforeComment)
+  if (keyMatch) {
+    const [, indent, key, colon, rest] = keyMatch
+    if (indent) tokens.push({ text: indent, kind: 'plain' })
+    tokens.push({ text: key + colon, kind: 'key' })
+    if (rest) tokens.push({ text: rest, kind: /["'[]/.test(rest.trimStart()[0] ?? '') ? 'string' : 'plain' })
+  } else if (beforeComment) {
+    tokens.push({ text: beforeComment, kind: 'plain' })
+  }
+  if (comment) tokens.push({ text: comment, kind: 'comment' })
+  return tokens
+}
+
+/** Tokenize a whole YAML document into per-line token lists. */
+export function tokenizeYaml(text: string): Token[][] {
+  return text.replace(/\n$/, '').split('\n').map(tokenizeLine)
+}

--- a/desktop/frontend/src/styles/main.css
+++ b/desktop/frontend/src/styles/main.css
@@ -30,9 +30,20 @@
   --color-feeds: var(--hv-feeds);
   --color-selection: var(--hv-selection);
   --color-backdrop: var(--hv-backdrop);
+  --color-scrim-strong: var(--hv-scrim-strong);
   --color-code-key: var(--hv-code-key);
   --color-code-string: var(--hv-code-string);
   --color-code-comment: var(--hv-code-comment);
+  --color-severity-info: var(--hv-severity-info);
+  --color-severity-info-tint: var(--hv-severity-info-tint);
+  --color-severity-success: var(--hv-severity-success);
+  --color-severity-success-tint: var(--hv-severity-success-tint);
+  --color-severity-success-border: var(--hv-severity-success-border);
+  --color-severity-error: var(--hv-severity-error);
+  --color-severity-error-tint: var(--hv-severity-error-tint);
+  --color-severity-error-border: var(--hv-severity-error-border);
+  --color-severity-auto-tint: var(--hv-severity-auto-tint);
+  --color-severity-auto-border: var(--hv-severity-auto-border);
 }
 
 @theme {
@@ -71,9 +82,24 @@
   --hv-feeds: #34d399;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(0, 0, 0, 0.5);
+  --hv-scrim-strong: rgba(10, 11, 14, 0.72);
   --hv-code-key: #7dcfff;
   --hv-code-string: #9ece6a;
   --hv-code-comment: #565f89;
+  /* Toast/overlay severity accents (design spec "shared design tokens" §0 —
+     dark-theme reference hexes). Kept theme-invariant, same as the
+     kind-pr/kind-issue item-type colors above: severity meaning (info,
+     success, error, automatic) shouldn't shift with the app's chrome theme. */
+  --hv-severity-info: #7aa2f7;
+  --hv-severity-info-tint: rgba(122, 162, 247, 0.15);
+  --hv-severity-success: #4ade80;
+  --hv-severity-success-tint: rgba(74, 222, 128, 0.15);
+  --hv-severity-success-border: #2c4a38;
+  --hv-severity-error: #f7768e;
+  --hv-severity-error-tint: rgba(247, 118, 142, 0.15);
+  --hv-severity-error-border: #4a2b32;
+  --hv-severity-auto-tint: rgba(245, 158, 11, 0.15);
+  --hv-severity-auto-border: #4a3f22;
 }
 
 [data-theme="light"] {
@@ -101,6 +127,7 @@
   --hv-accent-tint: #f5e6c8;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(24, 24, 27, 0.25);
+  --hv-scrim-strong: rgba(27, 27, 25, 0.45);
   --hv-code-key: #0f6bb8;
   --hv-code-string: #4d7c0f;
   --hv-code-comment: #a8a59d;
@@ -131,6 +158,7 @@
   --hv-accent-tint: #3a2f18;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(0, 0, 0, 0.55);
+  --hv-scrim-strong: rgba(0, 0, 0, 0.7);
   --hv-code-key: #7dcfff;
   --hv-code-string: #9ece6a;
   --hv-code-comment: #4a5480;
@@ -161,6 +189,7 @@
   --hv-accent-tint: #3a2f18;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(0, 0, 0, 0.55);
+  --hv-scrim-strong: rgba(0, 0, 0, 0.7);
   --hv-code-key: #83a598;
   --hv-code-string: #b8bb26;
   --hv-code-comment: #928374;

--- a/desktop/frontend/src/styles/main.css
+++ b/desktop/frontend/src/styles/main.css
@@ -30,6 +30,9 @@
   --color-feeds: var(--hv-feeds);
   --color-selection: var(--hv-selection);
   --color-backdrop: var(--hv-backdrop);
+  --color-code-key: var(--hv-code-key);
+  --color-code-string: var(--hv-code-string);
+  --color-code-comment: var(--hv-code-comment);
 }
 
 @theme {
@@ -68,6 +71,9 @@
   --hv-feeds: #34d399;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(0, 0, 0, 0.5);
+  --hv-code-key: #7dcfff;
+  --hv-code-string: #9ece6a;
+  --hv-code-comment: #565f89;
 }
 
 [data-theme="light"] {
@@ -95,6 +101,9 @@
   --hv-accent-tint: #f5e6c8;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(24, 24, 27, 0.25);
+  --hv-code-key: #0f6bb8;
+  --hv-code-string: #4d7c0f;
+  --hv-code-comment: #a8a59d;
 }
 
 [data-theme="midnight"] {
@@ -122,6 +131,9 @@
   --hv-accent-tint: #3a2f18;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(0, 0, 0, 0.55);
+  --hv-code-key: #7dcfff;
+  --hv-code-string: #9ece6a;
+  --hv-code-comment: #4a5480;
 }
 
 [data-theme="gruvbox"] {
@@ -149,6 +161,9 @@
   --hv-accent-tint: #3a2f18;
   --hv-selection: rgba(245, 158, 11, 0.1);
   --hv-backdrop: rgba(0, 0, 0, 0.55);
+  --hv-code-key: #83a598;
+  --hv-code-string: #b8bb26;
+  --hv-code-comment: #928374;
 }
 
 @keyframes hivePulse {

--- a/desktop/frontend/src/types/feed.ts
+++ b/desktop/frontend/src/types/feed.ts
@@ -3,7 +3,7 @@
 // keeping binding churn contained to this module and useFeedState. The Go
 // types live in internal/desktop/feed; the aliases keep component-facing
 // names stable across that move.
-export type { Action, Item as FeedItem, Source as FeedSource, Profile } from '../../bindings/github.com/colonyops/hive/internal/desktop/feed/models'
+export type { Action, ConfigInfo, Item as FeedItem, Source as FeedSource, Profile } from '../../bindings/github.com/colonyops/hive/internal/desktop/feed/models'
 
 // Scope only: the unread filter is an independent axis (unreadOnly in
 // useFeedState). The sidebar "Unread" view is all-scope + filter on.

--- a/desktop/frontend/src/types/feed.ts
+++ b/desktop/frontend/src/types/feed.ts
@@ -3,7 +3,7 @@
 // keeping binding churn contained to this module and useFeedState. The Go
 // types live in internal/desktop/feed; the aliases keep component-facing
 // names stable across that move.
-export type { Action, ConfigInfo, Item as FeedItem, Source as FeedSource, Profile } from '../../bindings/github.com/colonyops/hive/internal/desktop/feed/models'
+export type { Action, ConfigInfo, FeedDef, FilterDef, Item as FeedItem, Source as FeedSource, Profile, SourceDef } from '../../bindings/github.com/colonyops/hive/internal/desktop/feed/models'
 
 // Scope only: the unread filter is an independent axis (unreadOnly in
 // useFeedState). The sidebar "Unread" view is all-scope + filter on.

--- a/desktop/frontend/src/types/toast.ts
+++ b/desktop/frontend/src/types/toast.ts
@@ -1,0 +1,32 @@
+// Toast stack types shared by useFeedState (owns the queue) and the
+// ToastStack/ToastCard components (render it). See the design spec's "6a
+// Toasts" section: four severities, stacked bottom-right, optional inline
+// actions, auto-dismiss timer that error toasts opt out of.
+
+export type ToastSeverity = 'info' | 'success' | 'error' | 'auto-action'
+
+export interface ToastActionDef {
+  label: string
+  onClick: () => void
+}
+
+export interface ToastOptions {
+  /** Defaults to 'info'. */
+  severity?: ToastSeverity
+  /** Secondary detail line under the title. */
+  body?: string
+  /** Up to two inline actions; the first renders as primary (bold, severity-colored), the rest as muted secondary links. */
+  actions?: ToastActionDef[]
+  /** Auto-dismiss delay in ms. Ignored for severity 'error', which never auto-dismisses. */
+  duration?: number
+}
+
+export interface ToastInstance {
+  id: number
+  message: string
+  body?: string
+  severity: ToastSeverity
+  actions: ToastActionDef[]
+  /** null means "does not auto-dismiss" (always true for severity 'error'). */
+  duration: number | null
+}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -32,30 +32,55 @@ var _ = registerEvents()
 
 func registerEvents() struct{} {
 	// feed:updated carries the profile ID whose data changed; auth:updated
-	// carries the new auth state string. Both are wake-up signals: the
-	// frontend re-reads the relevant service on receipt.
+	// carries the new auth state string; config:updated carries "ok" or the
+	// config error text after a profiles-config reload. All are wake-up
+	// signals: the frontend re-reads the relevant service on receipt.
 	application.RegisterEvent[string]("feed:updated")
 	application.RegisterEvent[string]("auth:updated")
+	application.RegisterEvent[string]("config:updated")
 	return struct{}{}
 }
 
 // buildFeedProvider returns the provider plus, in live mode, a poller that
-// pushes feed:updated when a background refresh finds changes. Mock modes
-// serve static fixtures and need no poller.
-func buildFeedProvider() (feed.Provider, *feed.Poller) {
+// pushes feed:updated when a background refresh finds changes and a watcher
+// that hot-reloads the profiles config on external edits. Mock modes serve
+// static fixtures and need neither.
+func buildFeedProvider() (feed.Provider, *feed.Poller, *feed.ConfigWatcher) {
 	switch desktop.MockMode() {
 	case "feed":
-		return feed.NewMockProvider(), nil
+		return feed.NewMockProvider(), nil, nil
 	case "onboarding":
 		// Empty start so e2e walks the whole first run: auth, then
 		// workspace creation, then the fixture feed.
-		return feed.NewEmptyMockProvider(), nil
+		return feed.NewEmptyMockProvider(), nil, nil
 	default:
 		logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
-		store := feed.NewStore(desktop.StateDir())
+		store := feed.NewStore(desktop.ConfigPath(), desktop.StateDir())
 		provider := feed.NewLiveProvider(github.NewClient(), github.NewKeychainStore(), store, logger)
 		poller := feed.NewPoller(provider, feed.DefaultPollInterval, emitFeedUpdated, logger)
-		return provider, poller
+		watcher, err := feed.NewConfigWatcher(desktop.ConfigPath(), func() {
+			reloadConfig(store, provider)
+		}, logger)
+		if err != nil {
+			// The app works without hot reload; edits then need a restart.
+			logger.Warn().Err(err).Msg("profiles config hot-reload unavailable")
+		}
+		return provider, poller, watcher
+	}
+}
+
+// reloadConfig re-reads the profiles config after an on-disk change, drops
+// the fetch cache (feed definitions may have changed), and wakes the
+// frontend with the outcome. A broken config keeps the last-good profiles;
+// the error text rides the event so the UI can say what is wrong.
+func reloadConfig(store *feed.Store, provider *feed.LiveProvider) {
+	status := "ok"
+	if err := store.Reload(); err != nil {
+		status = err.Error()
+	}
+	provider.Invalidate()
+	if app := application.Get(); app != nil {
+		app.Event.Emit("config:updated", status)
 	}
 }
 
@@ -87,11 +112,15 @@ func emitAuthUpdated() {
 }
 
 func main() {
-	// The poller lives for the whole process; it dies with it, so there is
-	// no Stop call here (and log.Fatal below would skip a defer anyway).
-	provider, poller := buildFeedProvider()
+	// The poller and watcher live for the whole process; they die with it,
+	// so there are no Stop/Close calls here (and log.Fatal below would skip
+	// a defer anyway).
+	provider, poller, watcher := buildFeedProvider()
 	if poller != nil {
 		poller.Start()
+	}
+	if watcher != nil {
+		watcher.Start()
 	}
 
 	// Every auth transition drops the feed cache before the frontend is

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/wailsapp/wails/v3 v3.0.0-alpha2.116
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/mod v0.38.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -68,7 +69,6 @@ require (
 	github.com/yuin/goldmark v1.7.16 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/desktop/desktop.go
+++ b/internal/desktop/desktop.go
@@ -15,13 +15,17 @@ import (
 // "onboarding" starts signed out with a self-granting fake device flow.
 const EnvMockMode = "HIVE_DESKTOP_MOCK"
 
+// EnvConfigPath overrides the profiles config file location, mirroring how
+// HIVE_CONFIG overrides the CLI config file.
+const EnvConfigPath = "HIVE_DESKTOP_CONFIG"
+
 // MockMode returns the requested mock mode, or "" for live backends.
 func MockMode() string {
 	return os.Getenv(EnvMockMode)
 }
 
-// StateDir is where the desktop app persists its state (profiles,
-// read-state). It follows the CLI's data-dir convention: HIVE_DATA_DIR,
+// StateDir is where the desktop app persists its app-local state
+// (read-state). It follows the CLI's data-dir convention: HIVE_DATA_DIR,
 // then XDG_DATA_HOME, then ~/.local/share — with a desktop/ subdirectory
 // keeping app state apart from CLI state.
 func StateDir() string {
@@ -34,4 +38,20 @@ func StateDir() string {
 		dataHome = filepath.Join(home, ".local", "share")
 	}
 	return filepath.Join(dataHome, "hive", "desktop")
+}
+
+// ConfigPath is the profiles config file — user-editable, dotfiles-managed
+// YAML, deliberately separate from StateDir so config can live in a dotfiles
+// repo while state stays local. It follows the CLI's config convention:
+// XDG_CONFIG_HOME, then ~/.config, with a desktop/ subdirectory.
+func ConfigPath() string {
+	if path := os.Getenv(EnvConfigPath); path != "" {
+		return path
+	}
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, _ := os.UserHomeDir()
+		configHome = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configHome, "hive", "desktop", "profiles.yaml")
 }

--- a/internal/desktop/feed/config.go
+++ b/internal/desktop/feed/config.go
@@ -5,24 +5,44 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bmatcuk/doublestar/v4"
 	"gopkg.in/yaml.v3"
 )
 
-// FeedDef is a feed definition inside a profile. The vocabulary (kind +
-// query) deliberately mirrors the saved-view schema proposed for TUI sources
-// (issue #370) so the two can converge on one definition later.
-type FeedDef struct {
+// SourceDef is a top-level data source: one GitHub API acquisition, shared by
+// any number of feeds. Sources are the only part of the config that costs API
+// requests; feeds are free client-side views over them.
+type SourceDef struct {
 	ID    string `json:"id"              yaml:"id"`
-	Name  string `json:"name"            yaml:"name"`
 	Kind  string `json:"kind"            yaml:"kind"` // "search" | "notifications"
 	Query string `json:"query,omitempty" yaml:"query,omitempty"`
-	// Repos/ExcludeRepos are doublestar globs matched against "owner/repo"
-	// (e.g. "colonyops/*"). They filter fetched results client-side, so
-	// they never add API requests — one request per feed per poll holds
-	// regardless of how the filters are written.
-	Repos        []string `json:"repos,omitempty"         yaml:"repos,omitempty"`
-	ExcludeRepos []string `json:"exclude_repos,omitempty" yaml:"exclude_repos,omitempty"`
+	// Limit bounds items per fetch. Search: default 50, max 100 (API page
+	// cap). Notifications: default 50, max 50 (API page cap).
+	Limit int `json:"limit,omitempty" yaml:"limit,omitempty"`
+}
+
+const (
+	defaultSourceLimit    = 50
+	maxSearchLimit        = 100
+	maxNotificationsLimit = 50
+)
+
+// effectiveLimit resolves the configured limit against per-kind defaults and
+// API caps; validation rejects out-of-range values, so this only fills the
+// default.
+func (s SourceDef) effectiveLimit() int {
+	if s.Limit > 0 {
+		return s.Limit
+	}
+	return defaultSourceLimit
+}
+
+// FeedDef is a feed inside a profile: a client-side filtered view over one or
+// more top-level sources. Feeds never cost API requests of their own.
+type FeedDef struct {
+	ID      string    `json:"id"      yaml:"id"`
+	Name    string    `json:"name"    yaml:"name"`
+	Sources []string  `json:"sources" yaml:"sources"`
+	Filters FilterDef `json:"filters" yaml:"filters,omitempty"`
 }
 
 // ProfileDef is a profile ("workspace") definition.
@@ -34,14 +54,17 @@ type ProfileDef struct {
 
 // configFile is the on-disk shape of the profiles config.
 type configFile struct {
+	Sources  []SourceDef  `yaml:"sources"`
 	Profiles []ProfileDef `yaml:"profiles"`
 }
 
-// maxFeeds caps the total feed count across all profiles. Every feed costs
-// one GitHub API request per poll cycle (once a minute), and authenticated
-// search allows 30 requests/min — a config past that ceiling would sit in
-// permanent rate-limit backoff, so reject it outright with an explanation.
-const maxFeeds = 30
+// maxSearchSources caps sources of kind "search". Each distinct search source
+// is one request per poll cycle (about once a minute) against GitHub's search
+// bucket of 30 requests/min; 25 leaves headroom for manual refreshes.
+// Notifications sources are uncapped: they poll the core bucket (5000/hr) with
+// conditional requests whose 304 responses are free, and identical sources
+// deduplicate to one request anyway.
+const maxSearchSources = 25
 
 // ConfigInfo describes the profiles config file for the frontend: where it
 // lives, what it contains, and whether it currently parses.
@@ -56,29 +79,61 @@ type ConfigInfo struct {
 	Error string `json:"error"`
 }
 
-// parseConfig strictly decodes and validates profiles YAML. Unknown fields
-// are errors: a typo like "filter:" for "repos:" must fail loudly, not
+// legacyFeedFieldMarkers identify KnownFields errors caused by the pre-source
+// schema, where kind/query/repos/exclude_repos lived on feeds. None of these
+// fields exist on FeedDef anymore, so the substrings only fire on old configs.
+var legacyFeedFieldMarkers = []string{
+	"field kind not found",
+	"field query not found",
+	"field repos not found",
+	"field exclude_repos not found",
+}
+
+// parseConfig strictly decodes and validates the profiles YAML. Unknown fields
+// are errors: a typo like "filter:" for "filters:" must fail loudly, not
 // silently configure nothing.
-func parseConfig(data []byte) ([]ProfileDef, error) {
+func parseConfig(data []byte) (configFile, error) {
 	var file configFile
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(&file); err != nil {
-		if err.Error() == "EOF" { // empty file: valid, no profiles
-			return nil, nil
+		if err.Error() == "EOF" { // empty file: valid, no sources or profiles
+			return configFile{}, nil
 		}
-		return nil, fmt.Errorf("parse profiles config: %w", err)
+		for _, marker := range legacyFeedFieldMarkers {
+			if strings.Contains(err.Error(), marker) {
+				return configFile{}, fmt.Errorf("parse profiles config: %w (hint: feeds now reference top-level sources: entries — kind/query moved to sources, and repos/exclude_repos moved under the feed's filters: block)", err)
+			}
+		}
+		return configFile{}, fmt.Errorf("parse profiles config: %w", err)
 	}
-	if err := validateProfiles(file.Profiles); err != nil {
-		return nil, err
+	if err := validateConfig(file); err != nil {
+		return configFile{}, err
 	}
-	return file.Profiles, nil
+	return file, nil
 }
 
-func validateProfiles(defs []ProfileDef) error {
+func validateConfig(file configFile) error {
+	sourceIDs := make(map[string]bool, len(file.Sources))
+	searchSources := 0
+	for _, def := range file.Sources {
+		if err := validateSource(def); err != nil {
+			return err
+		}
+		if sourceIDs[def.ID] {
+			return fmt.Errorf("source id %q is defined twice", def.ID)
+		}
+		sourceIDs[def.ID] = true
+		if def.Kind == "search" {
+			searchSources++
+		}
+	}
+	if searchSources > maxSearchSources {
+		return fmt.Errorf("%d search sources defined; the limit is %d — each search source is one request per poll against GitHub's search rate limit (30 requests/min), and %d leaves headroom for manual refreshes (notifications sources are not capped)", searchSources, maxSearchSources, maxSearchSources)
+	}
+
 	profileIDs := make(map[string]bool)
-	feeds := 0
-	for _, def := range defs {
+	for _, def := range file.Profiles {
 		if def.ID == "" {
 			return fmt.Errorf("profile %q: id is required", def.Name)
 		}
@@ -92,8 +147,7 @@ func validateProfiles(defs []ProfileDef) error {
 
 		feedIDs := make(map[string]bool)
 		for _, feedDef := range def.Feeds {
-			feeds++
-			if err := validateFeed(def.ID, feedDef); err != nil {
+			if err := validateFeed(def.ID, feedDef, sourceIDs); err != nil {
 				return err
 			}
 			if feedIDs[feedDef.ID] {
@@ -102,113 +156,227 @@ func validateProfiles(defs []ProfileDef) error {
 			feedIDs[feedDef.ID] = true
 		}
 	}
-	if feeds > maxFeeds {
-		return fmt.Errorf("%d feeds defined; the limit is %d — each feed is one GitHub API request per poll, and more than %d would exceed the search rate limit (30 requests/min)", feeds, maxFeeds, maxFeeds)
+	return nil
+}
+
+func validateSource(def SourceDef) error {
+	if def.ID == "" {
+		return fmt.Errorf("source: id is required")
+	}
+	switch def.Kind {
+	case "search":
+		if strings.TrimSpace(def.Query) == "" {
+			return fmt.Errorf("source %q: kind \"search\" requires a query", def.ID)
+		}
+		if def.Limit > maxSearchLimit {
+			return fmt.Errorf("source %q: limit %d exceeds the search API page cap of %d", def.ID, def.Limit, maxSearchLimit)
+		}
+	case "notifications":
+		if def.Query != "" {
+			return fmt.Errorf("source %q: kind \"notifications\" takes no query", def.ID)
+		}
+		if def.Limit > maxNotificationsLimit {
+			return fmt.Errorf("source %q: limit %d exceeds the notifications API page cap of %d", def.ID, def.Limit, maxNotificationsLimit)
+		}
+	default:
+		return fmt.Errorf("source %q: unknown kind %q (want \"search\" or \"notifications\")", def.ID, def.Kind)
+	}
+	if def.Limit < 0 {
+		return fmt.Errorf("source %q: limit must not be negative", def.ID)
 	}
 	return nil
 }
 
-func validateFeed(profileID string, def FeedDef) error {
+func validateFeed(profileID string, def FeedDef, sourceIDs map[string]bool) error {
 	if def.ID == "" {
 		return fmt.Errorf("profile %q: feed %q: id is required", profileID, def.Name)
 	}
 	if def.Name == "" {
 		return fmt.Errorf("profile %q: feed %q: name is required", profileID, def.ID)
 	}
-	switch def.Kind {
-	case "search":
-		if strings.TrimSpace(def.Query) == "" {
-			return fmt.Errorf("profile %q: feed %q: kind \"search\" requires a query", profileID, def.ID)
-		}
-	case "notifications":
-		if def.Query != "" {
-			return fmt.Errorf("profile %q: feed %q: kind \"notifications\" takes no query", profileID, def.ID)
-		}
-	default:
-		return fmt.Errorf("profile %q: feed %q: unknown kind %q (want \"search\" or \"notifications\")", profileID, def.ID, def.Kind)
+	if len(def.Sources) == 0 {
+		return fmt.Errorf("profile %q: feed %q: at least one source is required", profileID, def.ID)
 	}
-	for _, pattern := range append(append([]string{}, def.Repos...), def.ExcludeRepos...) {
-		if !doublestar.ValidatePattern(pattern) {
-			return fmt.Errorf("profile %q: feed %q: invalid repo glob %q", profileID, def.ID, pattern)
+	for _, sourceID := range def.Sources {
+		if !sourceIDs[sourceID] {
+			return fmt.Errorf("profile %q: feed %q: unknown source %q (not defined under top-level sources:)", profileID, def.ID, sourceID)
+		}
+	}
+	if err := validateFilters(def.Filters); err != nil {
+		return fmt.Errorf("profile %q: feed %q: %w", profileID, def.ID, err)
+	}
+	return nil
+}
+
+const configHeader = `# Hive Desktop feeds — sources, workspaces, and feeds, as code.
+# Edited by hand or by the app; changes apply live, no restart needed.
+# Sources are the GitHub API cost (deduplicated, polled about once a
+# minute); feeds are free client-side filtered views over them.
+`
+
+// appendProfileToConfig returns the config document with the profile appended
+// to the top-level profiles sequence, preserving comments and formatting.
+func appendProfileToConfig(data []byte, def ProfileDef) ([]byte, error) {
+	return appendTopLevelEntry(data, "profiles", def)
+}
+
+// appendSourceToConfig returns the config document with the source appended
+// to the top-level sources sequence, preserving comments and formatting.
+func appendSourceToConfig(data []byte, def SourceDef) ([]byte, error) {
+	return appendTopLevelEntry(data, "sources", def)
+}
+
+// appendTopLevelEntry appends value to the top-level sequence under key,
+// creating the key when missing. It edits the YAML node tree instead of
+// re-marshalling the whole document so comments and formatting in a
+// hand-managed file survive an app-side edit.
+func appendTopLevelEntry(data []byte, key string, value any) ([]byte, error) {
+	var valueNode yaml.Node
+	if err := valueNode.Encode(value); err != nil {
+		return nil, fmt.Errorf("encode %s entry: %w", key, err)
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: key},
+				{Kind: yaml.SequenceNode, Content: []*yaml.Node{&valueNode}},
+			},
+		}}}
+		out, err := encodeConfigNode(doc)
+		if err != nil {
+			return nil, err
+		}
+		return append([]byte(configHeader), out...), nil
+	}
+
+	doc, root, err := parseConfigNode(data)
+	if err != nil {
+		return nil, err
+	}
+	if seq := mappingValue(root, key); seq != nil {
+		if seq.Kind == yaml.SequenceNode {
+			seq.Content = append(seq.Content, &valueNode)
+		} else { // key present with a null value
+			*seq = yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&valueNode}}
+		}
+		return encodeConfigNode(doc)
+	}
+
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		&yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&valueNode}},
+	)
+	return encodeConfigNode(doc)
+}
+
+// appendFeedToConfig appends the feed to the profile's feeds sequence,
+// preserving comments and formatting elsewhere in the document.
+func appendFeedToConfig(data []byte, profileID string, def FeedDef) ([]byte, error) {
+	doc, profileNode, err := findProfileNode(data, profileID)
+	if err != nil {
+		return nil, err
+	}
+
+	var feedNode yaml.Node
+	if err := feedNode.Encode(def); err != nil {
+		return nil, fmt.Errorf("encode feed: %w", err)
+	}
+
+	if seq := mappingValue(profileNode, "feeds"); seq != nil {
+		if seq.Kind == yaml.SequenceNode {
+			seq.Content = append(seq.Content, &feedNode)
+		} else { // "feeds:" with a null value
+			*seq = yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&feedNode}}
+		}
+		return encodeConfigNode(doc)
+	}
+
+	profileNode.Content = append(profileNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "feeds"},
+		&yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&feedNode}},
+	)
+	return encodeConfigNode(doc)
+}
+
+// updateFeedInConfig replaces the feed's mapping node in place. Comments
+// elsewhere in the document survive; comments attached to the replaced feed
+// node itself are lost — the node is re-encoded wholesale.
+func updateFeedInConfig(data []byte, profileID, feedID string, def FeedDef) ([]byte, error) {
+	doc, profileNode, err := findProfileNode(data, profileID)
+	if err != nil {
+		return nil, err
+	}
+	feeds := mappingValue(profileNode, "feeds")
+	if feeds == nil || feeds.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("profile %q has no feeds", profileID)
+	}
+	feedNode := sequenceEntryByID(feeds, feedID)
+	if feedNode == nil {
+		return nil, fmt.Errorf("feed %q not found in profile %q", feedID, profileID)
+	}
+
+	var replacement yaml.Node
+	if err := replacement.Encode(def); err != nil {
+		return nil, fmt.Errorf("encode feed: %w", err)
+	}
+	*feedNode = replacement
+	return encodeConfigNode(doc)
+}
+
+// findProfileNode parses the document and locates the profile's mapping node.
+func findProfileNode(data []byte, profileID string) (doc, profile *yaml.Node, err error) {
+	doc, root, err := parseConfigNode(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	profiles := mappingValue(root, "profiles")
+	if profiles == nil || profiles.Kind != yaml.SequenceNode {
+		return nil, nil, fmt.Errorf("profile %q not found: config has no profiles", profileID)
+	}
+	profileNode := sequenceEntryByID(profiles, profileID)
+	if profileNode == nil {
+		return nil, nil, fmt.Errorf("profile %q not found", profileID)
+	}
+	return doc, profileNode, nil
+}
+
+// parseConfigNode parses the raw document into its node tree and returns the
+// document node plus the root mapping.
+func parseConfigNode(data []byte) (doc, root *yaml.Node, err error) {
+	doc = &yaml.Node{}
+	if err := yaml.Unmarshal(data, doc); err != nil {
+		return nil, nil, fmt.Errorf("parse profiles config: %w", err)
+	}
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, nil, fmt.Errorf("profiles config is not a mapping")
+	}
+	return doc, doc.Content[0], nil
+}
+
+// mappingValue returns the value node for key in a mapping node, or nil.
+func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
 		}
 	}
 	return nil
 }
 
-// matchesRepo reports whether an item's repo ("owner/name") passes the
-// feed's include/exclude globs. Excludes win; an empty include list means
-// include everything.
-func (d FeedDef) matchesRepo(repo string) bool {
-	if matchAnyGlob(d.ExcludeRepos, repo) {
-		return false
-	}
-	if len(d.Repos) == 0 {
-		return true
-	}
-	return matchAnyGlob(d.Repos, repo)
-}
-
-func matchAnyGlob(patterns []string, repo string) bool {
-	for _, pattern := range patterns {
-		// Match errors only on malformed patterns, which validation
-		// rejected at load; a malformed pattern here just doesn't match.
-		if ok, err := doublestar.Match(pattern, repo); err == nil && ok {
-			return true
-		}
-	}
-	return false
-}
-
-const configHeader = `# Hive Desktop profiles — workspaces and their feeds, as code.
-# Edited by hand or by the app; changes apply live, no restart needed.
-# Each feed is one GitHub API request per poll (about once a minute).
-`
-
-// appendProfileToConfig returns the config document with the profile
-// appended. It edits the YAML node tree instead of re-marshalling the whole
-// document so comments and formatting in a hand-managed file survive an
-// app-side profile creation.
-func appendProfileToConfig(data []byte, def ProfileDef) ([]byte, error) {
-	if len(bytes.TrimSpace(data)) == 0 {
-		out, err := yaml.Marshal(configFile{Profiles: []ProfileDef{def}})
-		if err != nil {
-			return nil, fmt.Errorf("encode profiles config: %w", err)
-		}
-		return append([]byte(configHeader), out...), nil
-	}
-
-	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, fmt.Errorf("parse profiles config: %w", err)
-	}
-	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("profiles config is not a mapping")
-	}
-
-	var profileNode yaml.Node
-	if err := profileNode.Encode(def); err != nil {
-		return nil, fmt.Errorf("encode profile: %w", err)
-	}
-
-	root := doc.Content[0]
-	for i := 0; i+1 < len(root.Content); i += 2 {
-		if root.Content[i].Value != "profiles" {
+// sequenceEntryByID returns the sequence's mapping entry whose "id" scalar
+// equals id, or nil.
+func sequenceEntryByID(seq *yaml.Node, id string) *yaml.Node {
+	for _, entry := range seq.Content {
+		if entry.Kind != yaml.MappingNode {
 			continue
 		}
-		seq := root.Content[i+1]
-		if seq.Kind == yaml.SequenceNode {
-			seq.Content = append(seq.Content, &profileNode)
-		} else { // "profiles:" with a null value
-			*seq = yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&profileNode}}
+		if idNode := mappingValue(entry, "id"); idNode != nil && idNode.Value == id {
+			return entry
 		}
-		return encodeConfigNode(&doc)
 	}
-
-	root.Content = append(root.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: "profiles"},
-		&yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&profileNode}},
-	)
-	return encodeConfigNode(&doc)
+	return nil
 }
 
 func encodeConfigNode(doc *yaml.Node) ([]byte, error) {
@@ -227,19 +395,33 @@ func encodeConfigNode(doc *yaml.Node) ([]byte, error) {
 // ExampleConfig is what the UI and copy-prompt show before the file exists:
 // a concrete, commented starting point rather than an empty pane.
 func ExampleConfig() string {
-	return configHeader + `profiles:
+	return configHeader + `sources:
+  - id: my-prs
+    kind: search
+    query: "is:open is:pr author:@me archived:false"
+  - id: assigned
+    kind: search
+    query: "is:open assignee:@me archived:false"
+  - id: inbox
+    kind: notifications
+profiles:
   - id: triage
     name: Triage
     feeds:
       - id: my-open-prs
         name: My open PRs
-        kind: search
-        query: "is:open is:pr author:@me archived:false"
+        sources: [my-prs]
       - id: notifications-inbox
         name: Notifications inbox
-        kind: notifications
-        # Optional owner/repo globs, matched client-side (no extra API cost):
-        # repos: ["colonyops/*"]
-        # exclude_repos: ["colonyops/noisy-repo"]
+        sources: [inbox]
+        # Optional client-side filters (no API cost). Groups AND together,
+        # values within a group OR, excludes win over includes:
+        filters:
+          exclude_authors: ["dependabot[bot]"]
+          # repos: ["colonyops/*"]
+          # reasons: [mention, review_requested]
+      - id: assigned-across-org
+        name: Assigned across org
+        sources: [assigned]
 `
 }

--- a/internal/desktop/feed/config.go
+++ b/internal/desktop/feed/config.go
@@ -325,6 +325,42 @@ func updateFeedInConfig(data []byte, profileID, feedID string, def FeedDef) ([]b
 	return encodeConfigNode(doc)
 }
 
+// deleteFeedFromConfig removes the feed from the profile's feeds sequence,
+// preserving comments and formatting elsewhere in the document.
+func deleteFeedFromConfig(data []byte, profileID, feedID string) ([]byte, error) {
+	doc, profileNode, err := findProfileNode(data, profileID)
+	if err != nil {
+		return nil, err
+	}
+	feeds := mappingValue(profileNode, "feeds")
+	if feeds == nil || feeds.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("profile %q has no feeds", profileID)
+	}
+	if !removeSequenceEntryByID(feeds, feedID) {
+		return nil, fmt.Errorf("feed %q not found in profile %q", feedID, profileID)
+	}
+	return encodeConfigNode(doc)
+}
+
+// deleteProfileFromConfig removes the profile — and its feeds — from the
+// top-level profiles sequence, preserving comments and formatting elsewhere
+// in the document. Sources are untouched: they are shared, decoupled
+// definitions other profiles may still reference.
+func deleteProfileFromConfig(data []byte, profileID string) ([]byte, error) {
+	doc, root, err := parseConfigNode(data)
+	if err != nil {
+		return nil, err
+	}
+	profiles := mappingValue(root, "profiles")
+	if profiles == nil || profiles.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("profile %q not found: config has no profiles", profileID)
+	}
+	if !removeSequenceEntryByID(profiles, profileID) {
+		return nil, fmt.Errorf("profile %q not found", profileID)
+	}
+	return encodeConfigNode(doc)
+}
+
 // findProfileNode parses the document and locates the profile's mapping node.
 func findProfileNode(data []byte, profileID string) (doc, profile *yaml.Node, err error) {
 	doc, root, err := parseConfigNode(data)
@@ -377,6 +413,21 @@ func sequenceEntryByID(seq *yaml.Node, id string) *yaml.Node {
 		}
 	}
 	return nil
+}
+
+// removeSequenceEntryByID removes the sequence's mapping entry whose "id"
+// scalar equals id, reporting whether an entry was found and removed.
+func removeSequenceEntryByID(seq *yaml.Node, id string) bool {
+	for i, entry := range seq.Content {
+		if entry.Kind != yaml.MappingNode {
+			continue
+		}
+		if idNode := mappingValue(entry, "id"); idNode != nil && idNode.Value == id {
+			seq.Content = append(seq.Content[:i], seq.Content[i+1:]...)
+			return true
+		}
+	}
+	return false
 }
 
 func encodeConfigNode(doc *yaml.Node) ([]byte, error) {

--- a/internal/desktop/feed/config.go
+++ b/internal/desktop/feed/config.go
@@ -1,0 +1,245 @@
+package feed
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"gopkg.in/yaml.v3"
+)
+
+// FeedDef is a feed definition inside a profile. The vocabulary (kind +
+// query) deliberately mirrors the saved-view schema proposed for TUI sources
+// (issue #370) so the two can converge on one definition later.
+type FeedDef struct {
+	ID    string `json:"id"              yaml:"id"`
+	Name  string `json:"name"            yaml:"name"`
+	Kind  string `json:"kind"            yaml:"kind"` // "search" | "notifications"
+	Query string `json:"query,omitempty" yaml:"query,omitempty"`
+	// Repos/ExcludeRepos are doublestar globs matched against "owner/repo"
+	// (e.g. "colonyops/*"). They filter fetched results client-side, so
+	// they never add API requests — one request per feed per poll holds
+	// regardless of how the filters are written.
+	Repos        []string `json:"repos,omitempty"         yaml:"repos,omitempty"`
+	ExcludeRepos []string `json:"exclude_repos,omitempty" yaml:"exclude_repos,omitempty"`
+}
+
+// ProfileDef is a profile ("workspace") definition.
+type ProfileDef struct {
+	ID    string    `json:"id"    yaml:"id"`
+	Name  string    `json:"name"  yaml:"name"`
+	Feeds []FeedDef `json:"feeds" yaml:"feeds"`
+}
+
+// configFile is the on-disk shape of the profiles config.
+type configFile struct {
+	Profiles []ProfileDef `yaml:"profiles"`
+}
+
+// maxFeeds caps the total feed count across all profiles. Every feed costs
+// one GitHub API request per poll cycle (once a minute), and authenticated
+// search allows 30 requests/min — a config past that ceiling would sit in
+// permanent rate-limit backoff, so reject it outright with an explanation.
+const maxFeeds = 30
+
+// ConfigInfo describes the profiles config file for the frontend: where it
+// lives, what it contains, and whether it currently parses.
+type ConfigInfo struct {
+	Path   string `json:"path"`
+	Exists bool   `json:"exists"`
+	// YAML is the raw file content, or the example template when the file
+	// does not exist yet, so the UI and the copy-prompt always have a
+	// concrete config to show.
+	YAML  string `json:"yaml"`
+	Valid bool   `json:"valid"`
+	Error string `json:"error"`
+}
+
+// parseConfig strictly decodes and validates profiles YAML. Unknown fields
+// are errors: a typo like "filter:" for "repos:" must fail loudly, not
+// silently configure nothing.
+func parseConfig(data []byte) ([]ProfileDef, error) {
+	var file configFile
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&file); err != nil {
+		if err.Error() == "EOF" { // empty file: valid, no profiles
+			return nil, nil
+		}
+		return nil, fmt.Errorf("parse profiles config: %w", err)
+	}
+	if err := validateProfiles(file.Profiles); err != nil {
+		return nil, err
+	}
+	return file.Profiles, nil
+}
+
+func validateProfiles(defs []ProfileDef) error {
+	profileIDs := make(map[string]bool)
+	feeds := 0
+	for _, def := range defs {
+		if def.ID == "" {
+			return fmt.Errorf("profile %q: id is required", def.Name)
+		}
+		if def.Name == "" {
+			return fmt.Errorf("profile %q: name is required", def.ID)
+		}
+		if profileIDs[def.ID] {
+			return fmt.Errorf("profile id %q is defined twice", def.ID)
+		}
+		profileIDs[def.ID] = true
+
+		feedIDs := make(map[string]bool)
+		for _, feedDef := range def.Feeds {
+			feeds++
+			if err := validateFeed(def.ID, feedDef); err != nil {
+				return err
+			}
+			if feedIDs[feedDef.ID] {
+				return fmt.Errorf("profile %q: feed id %q is defined twice", def.ID, feedDef.ID)
+			}
+			feedIDs[feedDef.ID] = true
+		}
+	}
+	if feeds > maxFeeds {
+		return fmt.Errorf("%d feeds defined; the limit is %d — each feed is one GitHub API request per poll, and more than %d would exceed the search rate limit (30 requests/min)", feeds, maxFeeds, maxFeeds)
+	}
+	return nil
+}
+
+func validateFeed(profileID string, def FeedDef) error {
+	if def.ID == "" {
+		return fmt.Errorf("profile %q: feed %q: id is required", profileID, def.Name)
+	}
+	if def.Name == "" {
+		return fmt.Errorf("profile %q: feed %q: name is required", profileID, def.ID)
+	}
+	switch def.Kind {
+	case "search":
+		if strings.TrimSpace(def.Query) == "" {
+			return fmt.Errorf("profile %q: feed %q: kind \"search\" requires a query", profileID, def.ID)
+		}
+	case "notifications":
+		if def.Query != "" {
+			return fmt.Errorf("profile %q: feed %q: kind \"notifications\" takes no query", profileID, def.ID)
+		}
+	default:
+		return fmt.Errorf("profile %q: feed %q: unknown kind %q (want \"search\" or \"notifications\")", profileID, def.ID, def.Kind)
+	}
+	for _, pattern := range append(append([]string{}, def.Repos...), def.ExcludeRepos...) {
+		if !doublestar.ValidatePattern(pattern) {
+			return fmt.Errorf("profile %q: feed %q: invalid repo glob %q", profileID, def.ID, pattern)
+		}
+	}
+	return nil
+}
+
+// matchesRepo reports whether an item's repo ("owner/name") passes the
+// feed's include/exclude globs. Excludes win; an empty include list means
+// include everything.
+func (d FeedDef) matchesRepo(repo string) bool {
+	if matchAnyGlob(d.ExcludeRepos, repo) {
+		return false
+	}
+	if len(d.Repos) == 0 {
+		return true
+	}
+	return matchAnyGlob(d.Repos, repo)
+}
+
+func matchAnyGlob(patterns []string, repo string) bool {
+	for _, pattern := range patterns {
+		// Match errors only on malformed patterns, which validation
+		// rejected at load; a malformed pattern here just doesn't match.
+		if ok, err := doublestar.Match(pattern, repo); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+const configHeader = `# Hive Desktop profiles — workspaces and their feeds, as code.
+# Edited by hand or by the app; changes apply live, no restart needed.
+# Each feed is one GitHub API request per poll (about once a minute).
+`
+
+// appendProfileToConfig returns the config document with the profile
+// appended. It edits the YAML node tree instead of re-marshalling the whole
+// document so comments and formatting in a hand-managed file survive an
+// app-side profile creation.
+func appendProfileToConfig(data []byte, def ProfileDef) ([]byte, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		out, err := yaml.Marshal(configFile{Profiles: []ProfileDef{def}})
+		if err != nil {
+			return nil, fmt.Errorf("encode profiles config: %w", err)
+		}
+		return append([]byte(configHeader), out...), nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse profiles config: %w", err)
+	}
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("profiles config is not a mapping")
+	}
+
+	var profileNode yaml.Node
+	if err := profileNode.Encode(def); err != nil {
+		return nil, fmt.Errorf("encode profile: %w", err)
+	}
+
+	root := doc.Content[0]
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "profiles" {
+			continue
+		}
+		seq := root.Content[i+1]
+		if seq.Kind == yaml.SequenceNode {
+			seq.Content = append(seq.Content, &profileNode)
+		} else { // "profiles:" with a null value
+			*seq = yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&profileNode}}
+		}
+		return encodeConfigNode(&doc)
+	}
+
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "profiles"},
+		&yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{&profileNode}},
+	)
+	return encodeConfigNode(&doc)
+}
+
+func encodeConfigNode(doc *yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("encode profiles config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("encode profiles config: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ExampleConfig is what the UI and copy-prompt show before the file exists:
+// a concrete, commented starting point rather than an empty pane.
+func ExampleConfig() string {
+	return configHeader + `profiles:
+  - id: triage
+    name: Triage
+    feeds:
+      - id: my-open-prs
+        name: My open PRs
+        kind: search
+        query: "is:open is:pr author:@me archived:false"
+      - id: notifications-inbox
+        name: Notifications inbox
+        kind: notifications
+        # Optional owner/repo globs, matched client-side (no extra API cost):
+        # repos: ["colonyops/*"]
+        # exclude_repos: ["colonyops/noisy-repo"]
+`
+}

--- a/internal/desktop/feed/config_test.go
+++ b/internal/desktop/feed/config_test.go
@@ -1,0 +1,151 @@
+package feed
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfigStrict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{name: "empty file", yaml: ""},
+		{name: "valid", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: prs
+        name: PRs
+        kind: search
+        query: "is:open is:pr author:@me"
+      - id: inbox
+        name: Inbox
+        kind: notifications
+        repos: ["acme/*"]
+        exclude_repos: ["acme/noisy"]
+`},
+		{name: "unknown field", wantErr: "not found", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: prs
+        name: PRs
+        kind: search
+        query: "is:pr"
+        filter: "acme/*"
+`},
+		{name: "missing profile id", wantErr: "id is required", yaml: `profiles:
+  - name: Work
+    feeds: []
+`},
+		{name: "duplicate profile id", wantErr: "defined twice", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds: []
+  - id: work
+    name: Other
+    feeds: []
+`},
+		{name: "duplicate feed id", wantErr: "defined twice", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - {id: a, name: A, kind: notifications}
+      - {id: a, name: B, kind: notifications}
+`},
+		{name: "search without query", wantErr: "requires a query", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - {id: a, name: A, kind: search}
+`},
+		{name: "notifications with query", wantErr: "takes no query", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - {id: a, name: A, kind: notifications, query: "is:pr"}
+`},
+		{name: "unknown kind", wantErr: "unknown kind", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - {id: a, name: A, kind: rss}
+`},
+		{name: "bad glob", wantErr: "invalid repo glob", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - {id: a, name: A, kind: notifications, repos: ["acme/["]}
+`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseConfig([]byte(tc.yaml))
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestParseConfigFeedCap(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString("profiles:\n  - id: big\n    name: Big\n    feeds:\n")
+	for i := 0; i <= maxFeeds; i++ {
+		b.WriteString("      - {id: f")
+		b.WriteByte(byte('a' + i/10))
+		b.WriteByte(byte('0' + i%10))
+		b.WriteString(", name: F, kind: notifications}\n")
+	}
+	_, err := parseConfig([]byte(b.String()))
+	require.ErrorContains(t, err, "rate limit")
+}
+
+func TestFeedDefMatchesRepo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		def  FeedDef
+		repo string
+		want bool
+	}{
+		{name: "no filters includes all", def: FeedDef{}, repo: "acme/app", want: true},
+		{name: "include glob match", def: FeedDef{Repos: []string{"acme/*"}}, repo: "acme/app", want: true},
+		{name: "include glob miss", def: FeedDef{Repos: []string{"acme/*"}}, repo: "other/app", want: false},
+		{name: "glob does not cross slash", def: FeedDef{Repos: []string{"*"}}, repo: "acme/app", want: false},
+		{name: "doublestar crosses slash", def: FeedDef{Repos: []string{"**"}}, repo: "acme/app", want: true},
+		{name: "exclude wins over include", def: FeedDef{Repos: []string{"acme/*"}, ExcludeRepos: []string{"acme/noisy"}}, repo: "acme/noisy", want: false},
+		{name: "exclude only", def: FeedDef{ExcludeRepos: []string{"acme/noisy"}}, repo: "acme/app", want: true},
+		{name: "alternation", def: FeedDef{Repos: []string{"acme/{app,web}"}}, repo: "acme/web", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.def.matchesRepo(tc.repo))
+		})
+	}
+}
+
+func TestExampleConfigParses(t *testing.T) {
+	t.Parallel()
+
+	profiles, err := parseConfig([]byte(ExampleConfig()))
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.Equal(t, "triage", profiles[0].ID)
+}

--- a/internal/desktop/feed/config_test.go
+++ b/internal/desktop/feed/config_test.go
@@ -1,6 +1,7 @@
 package feed
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -17,21 +18,39 @@ func TestParseConfigStrict(t *testing.T) {
 		wantErr string
 	}{
 		{name: "empty file", yaml: ""},
-		{name: "valid", yaml: `profiles:
+		{name: "valid", yaml: `sources:
+  - id: my-prs
+    kind: search
+    query: "is:open is:pr author:@me"
+    limit: 100
+  - id: inbox
+    kind: notifications
+profiles:
   - id: work
     name: Work
     feeds:
       - id: prs
         name: PRs
-        kind: search
-        query: "is:open is:pr author:@me"
-      - id: inbox
-        name: Inbox
-        kind: notifications
-        repos: ["acme/*"]
-        exclude_repos: ["acme/noisy"]
+        sources: [my-prs]
+      - id: triage
+        name: Triage
+        sources: [my-prs, inbox]
+        filters:
+          repos: ["acme/*"]
+          exclude_repos: ["acme/noisy"]
+          authors: ["hayden"]
+          exclude_authors: ["*[bot]"]
+          labels: ["bug", "area/*"]
+          exclude_labels: ["wontfix"]
+          types: [pr, issue]
+          reasons: [mention, review_requested]
 `},
-		{name: "unknown field", wantErr: "not found", yaml: `profiles:
+		{name: "unknown field", wantErr: "not found", yaml: `sources:
+  - id: s
+    kind: notifications
+    color: red
+`},
+		{name: "legacy feed kind gets hint", wantErr: "top-level sources", yaml: `profiles:
   - id: work
     name: Work
     feeds:
@@ -39,7 +58,39 @@ func TestParseConfigStrict(t *testing.T) {
         name: PRs
         kind: search
         query: "is:pr"
-        filter: "acme/*"
+`},
+		{name: "legacy feed repos gets hint", wantErr: "filters", yaml: `profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: prs
+        name: PRs
+        repos: ["acme/*"]
+`},
+		{name: "missing source id", wantErr: "id is required", yaml: `sources:
+  - kind: notifications
+`},
+		{name: "duplicate source id", wantErr: "defined twice", yaml: `sources:
+  - {id: s, kind: notifications}
+  - {id: s, kind: search, query: "is:pr"}
+`},
+		{name: "search source without query", wantErr: "requires a query", yaml: `sources:
+  - {id: s, kind: search}
+`},
+		{name: "notifications source with query", wantErr: "takes no query", yaml: `sources:
+  - {id: s, kind: notifications, query: "is:pr"}
+`},
+		{name: "unknown source kind", wantErr: "unknown kind", yaml: `sources:
+  - {id: s, kind: rss}
+`},
+		{name: "negative limit", wantErr: "negative", yaml: `sources:
+  - {id: s, kind: notifications, limit: -1}
+`},
+		{name: "search limit above cap", wantErr: "page cap of 100", yaml: `sources:
+  - {id: s, kind: search, query: "is:pr", limit: 101}
+`},
+		{name: "notifications limit above cap", wantErr: "page cap of 50", yaml: `sources:
+  - {id: s, kind: notifications, limit: 51}
 `},
 		{name: "missing profile id", wantErr: "id is required", yaml: `profiles:
   - name: Work
@@ -53,36 +104,74 @@ func TestParseConfigStrict(t *testing.T) {
     name: Other
     feeds: []
 `},
-		{name: "duplicate feed id", wantErr: "defined twice", yaml: `profiles:
+		{name: "duplicate feed id", wantErr: "defined twice", yaml: `sources:
+  - {id: s, kind: notifications}
+profiles:
   - id: work
     name: Work
     feeds:
-      - {id: a, name: A, kind: notifications}
-      - {id: a, name: B, kind: notifications}
+      - {id: a, name: A, sources: [s]}
+      - {id: a, name: B, sources: [s]}
 `},
-		{name: "search without query", wantErr: "requires a query", yaml: `profiles:
+		{name: "feed without sources", wantErr: "at least one source", yaml: `profiles:
   - id: work
     name: Work
     feeds:
-      - {id: a, name: A, kind: search}
+      - {id: a, name: A}
 `},
-		{name: "notifications with query", wantErr: "takes no query", yaml: `profiles:
+		{name: "feed with unknown source", wantErr: "unknown source", yaml: `profiles:
   - id: work
     name: Work
     feeds:
-      - {id: a, name: A, kind: notifications, query: "is:pr"}
+      - {id: a, name: A, sources: [ghost]}
 `},
-		{name: "unknown kind", wantErr: "unknown kind", yaml: `profiles:
+		{name: "bad repo glob", wantErr: "invalid repos glob", yaml: `sources:
+  - {id: s, kind: notifications}
+profiles:
   - id: work
     name: Work
     feeds:
-      - {id: a, name: A, kind: rss}
+      - id: a
+        name: A
+        sources: [s]
+        filters:
+          repos: ["acme/["]
 `},
-		{name: "bad glob", wantErr: "invalid repo glob", yaml: `profiles:
+		{name: "bad exclude author glob", wantErr: "invalid exclude_authors glob", yaml: `sources:
+  - {id: s, kind: notifications}
+profiles:
   - id: work
     name: Work
     feeds:
-      - {id: a, name: A, kind: notifications, repos: ["acme/["]}
+      - id: a
+        name: A
+        sources: [s]
+        filters:
+          exclude_authors: ["{a"]
+`},
+		{name: "unknown type", wantErr: "unknown type", yaml: `sources:
+  - {id: s, kind: notifications}
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [s]
+        filters:
+          types: [discussion]
+`},
+		{name: "unknown reason", wantErr: "unknown notification reason", yaml: `sources:
+  - {id: s, kind: notifications}
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [s]
+        filters:
+          reasons: [poked]
 `},
 	}
 
@@ -99,53 +188,150 @@ func TestParseConfigStrict(t *testing.T) {
 	}
 }
 
-func TestParseConfigFeedCap(t *testing.T) {
+func TestParseConfigSearchSourceCap(t *testing.T) {
 	t.Parallel()
 
 	var b strings.Builder
-	b.WriteString("profiles:\n  - id: big\n    name: Big\n    feeds:\n")
-	for i := 0; i <= maxFeeds; i++ {
-		b.WriteString("      - {id: f")
-		b.WriteByte(byte('a' + i/10))
-		b.WriteByte(byte('0' + i%10))
-		b.WriteString(", name: F, kind: notifications}\n")
+	b.WriteString("sources:\n")
+	for i := 0; i <= maxSearchSources; i++ {
+		fmt.Fprintf(&b, "  - {id: s%d, kind: search, query: \"is:pr\"}\n", i)
 	}
 	_, err := parseConfig([]byte(b.String()))
 	require.ErrorContains(t, err, "rate limit")
+	require.ErrorContains(t, err, "search")
+
+	// Notifications sources are not capped: the same count of them passes.
+	b.Reset()
+	b.WriteString("sources:\n")
+	for i := 0; i <= maxSearchSources; i++ {
+		fmt.Fprintf(&b, "  - {id: n%d, kind: notifications}\n", i)
+	}
+	_, err = parseConfig([]byte(b.String()))
+	require.NoError(t, err)
 }
 
-func TestFeedDefMatchesRepo(t *testing.T) {
+func TestSourceDefEffectiveLimit(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		def  FeedDef
-		repo string
-		want bool
-	}{
-		{name: "no filters includes all", def: FeedDef{}, repo: "acme/app", want: true},
-		{name: "include glob match", def: FeedDef{Repos: []string{"acme/*"}}, repo: "acme/app", want: true},
-		{name: "include glob miss", def: FeedDef{Repos: []string{"acme/*"}}, repo: "other/app", want: false},
-		{name: "glob does not cross slash", def: FeedDef{Repos: []string{"*"}}, repo: "acme/app", want: false},
-		{name: "doublestar crosses slash", def: FeedDef{Repos: []string{"**"}}, repo: "acme/app", want: true},
-		{name: "exclude wins over include", def: FeedDef{Repos: []string{"acme/*"}, ExcludeRepos: []string{"acme/noisy"}}, repo: "acme/noisy", want: false},
-		{name: "exclude only", def: FeedDef{ExcludeRepos: []string{"acme/noisy"}}, repo: "acme/app", want: true},
-		{name: "alternation", def: FeedDef{Repos: []string{"acme/{app,web}"}}, repo: "acme/web", want: true},
-	}
+	assert.Equal(t, 50, SourceDef{Kind: "search"}.effectiveLimit())
+	assert.Equal(t, 100, SourceDef{Kind: "search", Limit: 100}.effectiveLimit())
+	assert.Equal(t, 50, SourceDef{Kind: "notifications"}.effectiveLimit())
+	assert.Equal(t, 10, SourceDef{Kind: "notifications", Limit: 10}.effectiveLimit())
+}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, tc.def.matchesRepo(tc.repo))
-		})
-	}
+func TestAppendFeedToConfigPreservesComments(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`# my dotfiles-managed feeds
+sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  # the day job
+  - id: work
+    name: Work
+    feeds:
+      - id: prs
+        name: My PRs
+        sources: [inbox]
+`)
+	updated, err := appendFeedToConfig(data, "work", FeedDef{ID: "inbox-feed", Name: "Inbox", Sources: []string{"inbox"}})
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# my dotfiles-managed feeds")
+	assert.Contains(t, string(updated), "# the day job")
+	assert.Contains(t, string(updated), "inbox-feed")
+
+	file, err := parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Profiles[0].Feeds, 2)
+	assert.Equal(t, "inbox-feed", file.Profiles[0].Feeds[1].ID)
+}
+
+func TestAppendFeedToConfigNullFeeds(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  - id: work
+    name: Work
+    feeds:
+`)
+	updated, err := appendFeedToConfig(data, "work", FeedDef{ID: "a", Name: "A", Sources: []string{"inbox"}})
+	require.NoError(t, err)
+	file, err := parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Profiles[0].Feeds, 1)
+
+	_, err = appendFeedToConfig(data, "ghost", FeedDef{ID: "a", Name: "A", Sources: []string{"inbox"}})
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestUpdateFeedInConfig(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`# header comment
+sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [inbox]
+      - id: b
+        name: B
+        sources: [inbox]
+`)
+	def := FeedDef{ID: "a", Name: "Renamed", Sources: []string{"inbox"}, Filters: FilterDef{Reasons: []string{"mention"}}}
+	updated, err := updateFeedInConfig(data, "work", "a", def)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# header comment")
+
+	file, err := parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Profiles[0].Feeds, 2)
+	assert.Equal(t, "Renamed", file.Profiles[0].Feeds[0].Name)
+	assert.Equal(t, []string{"mention"}, file.Profiles[0].Feeds[0].Filters.Reasons)
+	assert.Equal(t, "B", file.Profiles[0].Feeds[1].Name, "sibling feed untouched")
+
+	_, err = updateFeedInConfig(data, "work", "ghost", def)
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestAppendSourceToConfigCreatesKey(t *testing.T) {
+	t.Parallel()
+
+	// A profiles-only document gains a sources key.
+	data := []byte("profiles: []\n")
+	updated, err := appendSourceToConfig(data, SourceDef{ID: "inbox", Kind: "notifications"})
+	require.NoError(t, err)
+	file, err := parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Sources, 1)
+	assert.Equal(t, "inbox", file.Sources[0].ID)
+
+	// An empty document gets the header and the key.
+	updated, err = appendSourceToConfig(nil, SourceDef{ID: "inbox", Kind: "notifications"})
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# Hive Desktop feeds")
+	file, err = parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Sources, 1)
 }
 
 func TestExampleConfigParses(t *testing.T) {
 	t.Parallel()
 
-	profiles, err := parseConfig([]byte(ExampleConfig()))
+	file, err := parseConfig([]byte(ExampleConfig()))
 	require.NoError(t, err)
-	require.Len(t, profiles, 1)
-	assert.Equal(t, "triage", profiles[0].ID)
+	require.Len(t, file.Sources, 3)
+	require.Len(t, file.Profiles, 1)
+	assert.Equal(t, "triage", file.Profiles[0].ID)
+	require.Len(t, file.Profiles[0].Feeds, 3)
+	assert.Equal(t, "my-open-prs", file.Profiles[0].Feeds[0].ID, "e2e asserts on this feed id")
+	assert.Equal(t, []string{"dependabot[bot]"}, file.Profiles[0].Feeds[1].Filters.ExcludeAuthors)
 }

--- a/internal/desktop/feed/config_test.go
+++ b/internal/desktop/feed/config_test.go
@@ -302,6 +302,113 @@ profiles:
 	require.ErrorContains(t, err, "not found")
 }
 
+func TestDeleteFeedFromConfig(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`# header comment
+sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  # the day job
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [inbox]
+      # keep this one, it matters
+      - id: b
+        name: B
+        sources: [inbox]
+      - id: c
+        name: C
+        sources: [inbox]
+`)
+	// Delete a feed from the middle of the list; comments elsewhere survive.
+	updated, err := deleteFeedFromConfig(data, "work", "b")
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# header comment")
+	assert.Contains(t, string(updated), "# the day job")
+
+	file, err := parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Profiles[0].Feeds, 2)
+	assert.Equal(t, "a", file.Profiles[0].Feeds[0].ID)
+	assert.Equal(t, "c", file.Profiles[0].Feeds[1].ID)
+
+	// Deleting the only remaining feed leaves an empty feeds sequence.
+	onlyOne := []byte(`sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: solo
+        name: Solo
+        sources: [inbox]
+`)
+	updated, err = deleteFeedFromConfig(onlyOne, "work", "solo")
+	require.NoError(t, err)
+	file, err = parseConfig(updated)
+	require.NoError(t, err)
+	assert.Empty(t, file.Profiles[0].Feeds)
+
+	_, err = deleteFeedFromConfig(data, "work", "ghost")
+	require.ErrorContains(t, err, "not found")
+	_, err = deleteFeedFromConfig(data, "ghost", "a")
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestDeleteProfileFromConfig(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`# my dotfiles-managed feeds
+sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  # the day job
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [inbox]
+  - id: side
+    name: Side Projects
+    feeds:
+      - id: b
+        name: B
+        sources: [inbox]
+`)
+	updated, err := deleteProfileFromConfig(data, "work")
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# my dotfiles-managed feeds")
+	assert.NotContains(t, string(updated), "# the day job", "comment attached to the removed profile is gone with it")
+
+	file, err := parseConfig(updated)
+	require.NoError(t, err)
+	require.Len(t, file.Profiles, 1)
+	assert.Equal(t, "side", file.Profiles[0].ID)
+	// Sources are untouched by a profile deletion.
+	require.Len(t, file.Sources, 1)
+	assert.Equal(t, "inbox", file.Sources[0].ID)
+
+	// Deleting the last remaining profile leaves an empty (but valid) profiles
+	// list; sources stay behind since they are decoupled and shared.
+	updated, err = deleteProfileFromConfig(updated, "side")
+	require.NoError(t, err)
+	file, err = parseConfig(updated)
+	require.NoError(t, err)
+	assert.Empty(t, file.Profiles)
+	require.Len(t, file.Sources, 1)
+
+	_, err = deleteProfileFromConfig(data, "ghost")
+	require.ErrorContains(t, err, "not found")
+}
+
 func TestAppendSourceToConfigCreatesKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/desktop/feed/feed.go
+++ b/internal/desktop/feed/feed.go
@@ -69,6 +69,9 @@ type Provider interface {
 	// "Refresh now" is a real fetch. It reports whether anything changed and
 	// fails only when every feed fails.
 	Refresh(ctx context.Context, profileID string) (bool, error)
+	// Config describes the profiles config file backing the provider —
+	// path, content, and validity — for the feeds-as-code UI.
+	Config(ctx context.Context) (ConfigInfo, error)
 }
 
 // ActionsFor returns the actions available for a PR or issue. Shared by

--- a/internal/desktop/feed/feed.go
+++ b/internal/desktop/feed/feed.go
@@ -89,6 +89,13 @@ type Provider interface {
 	CreateFeed(ctx context.Context, profileID string, def FeedDef) (Source, error)
 	// UpdateFeed replaces the feed's definition; the feed keeps its ID.
 	UpdateFeed(ctx context.Context, profileID, feedID string, def FeedDef) error
+	// DeleteFeed removes the feed from the profile; the profile and its
+	// other feeds are untouched.
+	DeleteFeed(ctx context.Context, profileID, feedID string) error
+	// DeleteProfile removes the profile and its feeds. Sources are left
+	// untouched: they are shared, decoupled definitions other profiles may
+	// still reference. Deleting the last profile is allowed.
+	DeleteProfile(ctx context.Context, profileID string) error
 }
 
 // ActionsFor returns the actions available for a PR or issue. Shared by

--- a/internal/desktop/feed/feed.go
+++ b/internal/desktop/feed/feed.go
@@ -7,14 +7,17 @@ import "context"
 
 // Item is an item from a profile feed.
 type Item struct {
-	ID     string   `json:"id"`
-	Kind   string   `json:"kind"` // "PR" | "Issue"
-	Repo   string   `json:"repo"`
-	Num    int      `json:"num"`
-	Title  string   `json:"title"`
-	Author string   `json:"author"`
-	Age    string   `json:"age"`
-	Unread bool     `json:"unread"`
+	ID     string `json:"id"`
+	Kind   string `json:"kind"` // "PR" | "Issue"
+	Repo   string `json:"repo"`
+	Num    int    `json:"num"`
+	Title  string `json:"title"`
+	Author string `json:"author"`
+	Age    string `json:"age"`
+	Unread bool   `json:"unread"`
+	// Reason is the GitHub notification reason (e.g. "review_requested"),
+	// empty for items known only from search.
+	Reason string   `json:"reason,omitempty"`
 	Labels []string `json:"labels"`
 	Branch string   `json:"branch"`
 	Body   string   `json:"body"`
@@ -65,13 +68,27 @@ type Provider interface {
 	// CreateProfile persists a new profile ("workspace") seeded with the
 	// default feeds — onboarding step 2.
 	CreateProfile(ctx context.Context, name string) (Profile, error)
-	// Refresh refetches the profile's feeds bypassing any cache, so a manual
-	// "Refresh now" is a real fetch. It reports whether anything changed and
-	// fails only when every feed fails.
+	// Refresh refetches the distinct sources the profile's feeds reference,
+	// bypassing the search cache TTL, so a manual "Refresh now" is a real
+	// fetch. It reports whether anything changed and fails only when every
+	// source fails.
 	Refresh(ctx context.Context, profileID string) (bool, error)
 	// Config describes the profiles config file backing the provider —
 	// path, content, and validity — for the feeds-as-code UI.
 	Config(ctx context.Context) (ConfigInfo, error)
+	// Sources returns the top-level source definitions, for the feed
+	// editor's source picker.
+	Sources(ctx context.Context) ([]SourceDef, error)
+	// FeedDefFor returns one feed's definition, for edit prefill.
+	FeedDefFor(ctx context.Context, profileID, feedID string) (FeedDef, error)
+	// CreateSource persists a new top-level source and returns it with its
+	// assigned ID.
+	CreateSource(ctx context.Context, def SourceDef) (SourceDef, error)
+	// CreateFeed persists a new feed in the profile — its ID is derived
+	// from the name — and returns the feed's materialized summary.
+	CreateFeed(ctx context.Context, profileID string, def FeedDef) (Source, error)
+	// UpdateFeed replaces the feed's definition; the feed keeps its ID.
+	UpdateFeed(ctx context.Context, profileID, feedID string, def FeedDef) error
 }
 
 // ActionsFor returns the actions available for a PR or issue. Shared by

--- a/internal/desktop/feed/filters.go
+++ b/internal/desktop/feed/filters.go
@@ -1,0 +1,190 @@
+package feed
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// FilterDef is a feed's client-side filter block. Filters run after the
+// feed's source items are merged, so they change what is shown, not what is
+// requested — filtering is free of API cost. Groups AND together; values
+// within a group OR; exclude groups win over includes.
+type FilterDef struct {
+	// Repos/ExcludeRepos are doublestar globs matched against "owner/repo"
+	// (e.g. "colonyops/*").
+	Repos        []string `json:"repos,omitempty"         yaml:"repos,omitempty"`
+	ExcludeRepos []string `json:"exclude_repos,omitempty" yaml:"exclude_repos,omitempty"`
+	// Authors/ExcludeAuthors are globs matched against the item author
+	// case-insensitively, with "[" and "]" taken literally (bot logins end
+	// in a literal "[bot]"; a character class over login characters has no
+	// realistic use).
+	Authors        []string `json:"authors,omitempty"         yaml:"authors,omitempty"`
+	ExcludeAuthors []string `json:"exclude_authors,omitempty" yaml:"exclude_authors,omitempty"`
+	// Labels keeps items where ANY item label matches ANY glob;
+	// ExcludeLabels drops items where any label matches.
+	Labels        []string `json:"labels,omitempty"         yaml:"labels,omitempty"`
+	ExcludeLabels []string `json:"exclude_labels,omitempty" yaml:"exclude_labels,omitempty"`
+	// Types matches the item kind: "pr" or "issue" (case-insensitive).
+	Types []string `json:"types,omitempty" yaml:"types,omitempty"`
+	// Reasons matches the notification reason. Items without a reason —
+	// search results that are not also in the notifications inbox — never
+	// match, so a reasons filter excludes them.
+	Reasons []string `json:"reasons,omitempty" yaml:"reasons,omitempty"`
+}
+
+// IsZero reports whether no filter group is set. yaml.v3 consults it for
+// omitempty, so feeds written by the app omit an empty filters block.
+func (f FilterDef) IsZero() bool {
+	return len(f.Repos) == 0 && len(f.ExcludeRepos) == 0 &&
+		len(f.Authors) == 0 && len(f.ExcludeAuthors) == 0 &&
+		len(f.Labels) == 0 && len(f.ExcludeLabels) == 0 &&
+		len(f.Types) == 0 && len(f.Reasons) == 0
+}
+
+// validTypes are the allowed values of the types filter, matched against
+// Item.Kind case-insensitively.
+var validTypes = map[string]bool{"pr": true, "issue": true}
+
+// validReasons are the notification reasons GitHub delivers.
+var validReasons = map[string]bool{
+	"approval_requested":       true,
+	"assign":                   true,
+	"author":                   true,
+	"ci_activity":              true,
+	"comment":                  true,
+	"invitation":               true,
+	"manual":                   true,
+	"member_feature_requested": true,
+	"mention":                  true,
+	"review_requested":         true,
+	"security_advisory_credit": true,
+	"security_alert":           true,
+	"state_change":             true,
+	"subscribed":               true,
+	"team_mention":             true,
+}
+
+func validateFilters(f FilterDef) error {
+	globGroups := []struct {
+		name     string
+		patterns []string
+	}{
+		{"repos", f.Repos},
+		{"exclude_repos", f.ExcludeRepos},
+		{"authors", f.Authors},
+		{"exclude_authors", f.ExcludeAuthors},
+		{"labels", f.Labels},
+		{"exclude_labels", f.ExcludeLabels},
+	}
+	for _, group := range globGroups {
+		for _, pattern := range group.patterns {
+			if !doublestar.ValidatePattern(pattern) {
+				return fmt.Errorf("invalid %s glob %q", group.name, pattern)
+			}
+		}
+	}
+	for _, t := range f.Types {
+		if !validTypes[strings.ToLower(t)] {
+			return fmt.Errorf("unknown type %q (want \"pr\" or \"issue\")", t)
+		}
+	}
+	for _, reason := range f.Reasons {
+		if !validReasons[reason] {
+			return fmt.Errorf("unknown notification reason %q", reason)
+		}
+	}
+	return nil
+}
+
+// applyFilters returns the items passing the feed's filter block. It runs
+// after the feed's source items are merged and deduplicated, so a merged
+// search+notification item carries both its author and its reason.
+func applyFilters(def FeedDef, items []liveItem) []liveItem {
+	f := def.Filters
+	if f.IsZero() {
+		return items
+	}
+	out := make([]liveItem, 0, len(items))
+	for _, li := range items {
+		if f.matches(li.item) {
+			out = append(out, li)
+		}
+	}
+	return out
+}
+
+func (f FilterDef) matches(item Item) bool {
+	if matchAnyGlob(f.ExcludeRepos, item.Repo) {
+		return false
+	}
+	if len(f.Repos) > 0 && !matchAnyGlob(f.Repos, item.Repo) {
+		return false
+	}
+	if matchAnyAuthorGlob(f.ExcludeAuthors, item.Author) {
+		return false
+	}
+	if len(f.Authors) > 0 && !matchAnyAuthorGlob(f.Authors, item.Author) {
+		return false
+	}
+	if matchAnyLabel(f.ExcludeLabels, item.Labels) {
+		return false
+	}
+	if len(f.Labels) > 0 && !matchAnyLabel(f.Labels, item.Labels) {
+		return false
+	}
+	if len(f.Types) > 0 && !containsFold(f.Types, item.Kind) {
+		return false
+	}
+	// A missing reason (item.Reason == "") matches no reasons filter: a
+	// reasons filter deliberately excludes search-only items.
+	if len(f.Reasons) > 0 && !containsFold(f.Reasons, item.Reason) {
+		return false
+	}
+	return true
+}
+
+func matchAnyGlob(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		// Match errors only on malformed patterns, which validation
+		// rejected at load; a malformed pattern here just doesn't match.
+		if ok, err := doublestar.Match(pattern, value); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// matchAnyAuthorGlob matches a login case-insensitively, with "[" and "]"
+// escaped to literals so "*[bot]" excludes every bot login as written.
+func matchAnyAuthorGlob(patterns []string, author string) bool {
+	author = strings.ToLower(author)
+	for _, pattern := range patterns {
+		pattern = bracketEscaper.Replace(strings.ToLower(pattern))
+		if ok, err := doublestar.Match(pattern, author); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+var bracketEscaper = strings.NewReplacer("[", `\[`, "]", `\]`)
+
+func matchAnyLabel(patterns, labels []string) bool {
+	for _, label := range labels {
+		if matchAnyGlob(patterns, label) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(values []string, value string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, value) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/desktop/feed/filters.go
+++ b/internal/desktop/feed/filters.go
@@ -100,7 +100,7 @@ func validateFilters(f FilterDef) error {
 
 // applyFilters returns the items passing the feed's filter block. It runs
 // after the feed's source items are merged and deduplicated, so a merged
-// search+notification item carries both its author and its reason.
+// search+notification item carries its author, labels, and reason.
 func applyFilters(def FeedDef, items []liveItem) []liveItem {
 	f := def.Filters
 	if f.IsZero() {

--- a/internal/desktop/feed/filters_test.go
+++ b/internal/desktop/feed/filters_test.go
@@ -1,0 +1,70 @@
+package feed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// filterItem builds a liveItem with the fields filtering inspects.
+func filterItem(id, kind, repo, author, reason string, labels ...string) liveItem {
+	return liveItem{item: Item{ID: id, Kind: kind, Repo: repo, Author: author, Reason: reason, Labels: labels}}
+}
+
+func TestApplyFilters(t *testing.T) {
+	t.Parallel()
+
+	searchPR := filterItem("acme/app#1", "PR", "acme/app", "hayden", "", "bug", "area/ui")
+	searchIssue := filterItem("acme/web#2", "Issue", "acme/web", "Mira", "", "wontfix")
+	botPR := filterItem("acme/app#3", "PR", "acme/app", "dependabot[bot]", "")
+	notifIssue := filterItem("other/repo#4", "Issue", "other/repo", "", "mention")
+	mergedPR := filterItem("acme/app#5", "PR", "acme/app", "koji", "review_requested", "bug")
+	all := []liveItem{searchPR, searchIssue, botPR, notifIssue, mergedPR}
+
+	ids := func(items []liveItem) []string {
+		out := make([]string, 0, len(items))
+		for _, li := range items {
+			out = append(out, li.item.ID)
+		}
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		filters FilterDef
+		want    []string
+	}{
+		{name: "no filters keeps all", filters: FilterDef{}, want: ids(all)},
+		{name: "repos include", filters: FilterDef{Repos: []string{"acme/*"}}, want: []string{"acme/app#1", "acme/web#2", "acme/app#3", "acme/app#5"}},
+		{name: "repos exclude", filters: FilterDef{ExcludeRepos: []string{"acme/web"}}, want: []string{"acme/app#1", "acme/app#3", "other/repo#4", "acme/app#5"}},
+		{name: "exclude wins over include", filters: FilterDef{Repos: []string{"acme/*"}, ExcludeRepos: []string{"acme/app"}}, want: []string{"acme/web#2"}},
+		{name: "authors case-insensitive", filters: FilterDef{Authors: []string{"MIRA"}}, want: []string{"acme/web#2"}},
+		{name: "authors glob", filters: FilterDef{Authors: []string{"h*"}}, want: []string{"acme/app#1"}},
+		{name: "exclude bot author literal brackets", filters: FilterDef{ExcludeAuthors: []string{"dependabot[bot]"}}, want: []string{"acme/app#1", "acme/web#2", "other/repo#4", "acme/app#5"}},
+		{name: "exclude bot author wildcard", filters: FilterDef{ExcludeAuthors: []string{"*[bot]"}}, want: []string{"acme/app#1", "acme/web#2", "other/repo#4", "acme/app#5"}},
+		{name: "labels any-match", filters: FilterDef{Labels: []string{"area/*"}}, want: []string{"acme/app#1"}},
+		{name: "labels or within group", filters: FilterDef{Labels: []string{"bug", "wontfix"}}, want: []string{"acme/app#1", "acme/web#2", "acme/app#5"}},
+		{name: "exclude labels", filters: FilterDef{ExcludeLabels: []string{"wontfix"}}, want: []string{"acme/app#1", "acme/app#3", "other/repo#4", "acme/app#5"}},
+		{name: "types pr", filters: FilterDef{Types: []string{"pr"}}, want: []string{"acme/app#1", "acme/app#3", "acme/app#5"}},
+		{name: "types issue case-insensitive", filters: FilterDef{Types: []string{"ISSUE"}}, want: []string{"acme/web#2", "other/repo#4"}},
+		{name: "reasons match", filters: FilterDef{Reasons: []string{"mention", "review_requested"}}, want: []string{"other/repo#4", "acme/app#5"}},
+		{name: "reasons exclude search-only items", filters: FilterDef{Reasons: []string{"mention"}}, want: []string{"other/repo#4"}},
+		{name: "groups AND together", filters: FilterDef{Repos: []string{"acme/*"}, Types: []string{"pr"}, Labels: []string{"bug"}}, want: []string{"acme/app#1", "acme/app#5"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := applyFilters(FeedDef{Filters: tc.filters}, all)
+			assert.Equal(t, tc.want, ids(got))
+		})
+	}
+}
+
+func TestFilterDefIsZero(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, FilterDef{}.IsZero())
+	assert.False(t, FilterDef{Types: []string{"pr"}}.IsZero())
+	assert.False(t, FilterDef{ExcludeAuthors: []string{"*[bot]"}}.IsZero())
+}

--- a/internal/desktop/feed/live.go
+++ b/internal/desktop/feed/live.go
@@ -141,6 +141,11 @@ func (p *LiveProvider) MarkRead(_ context.Context, profileID, itemID string) err
 	return p.store.MarkRead(itemID, updatedAt)
 }
 
+// Config reports the profiles config file's location and current state.
+func (p *LiveProvider) Config(context.Context) (ConfigInfo, error) {
+	return p.store.ConfigInfo(), nil
+}
+
 // Invalidate drops the fetch cache so the next call refetches.
 func (p *LiveProvider) Invalidate() {
 	p.mu.Lock()
@@ -357,16 +362,32 @@ func (p *LiveProvider) fetchFeed(ctx context.Context, def FeedDef) ([]liveItem, 
 		if err != nil {
 			return nil, err
 		}
-		return p.notificationItems(notifications), nil
+		return filterByRepo(def, p.notificationItems(notifications)), nil
 	case "search":
 		result, err := client.SearchIssues(ctx, def.Query, searchLimit)
 		if err != nil {
 			return nil, err
 		}
-		return p.searchItems(result.Items), nil
+		return filterByRepo(def, p.searchItems(result.Items)), nil
 	default:
 		return nil, fmt.Errorf("feed: unknown feed kind %q", def.Kind)
 	}
+}
+
+// filterByRepo applies the feed's include/exclude repo globs. Filtering
+// happens after the fetch, so it changes what is shown, not what is
+// requested — a filtered feed still costs exactly one API call.
+func filterByRepo(def FeedDef, items []liveItem) []liveItem {
+	if len(def.Repos) == 0 && len(def.ExcludeRepos) == 0 {
+		return items
+	}
+	out := make([]liveItem, 0, len(items))
+	for _, li := range items {
+		if def.matchesRepo(li.item.Repo) {
+			out = append(out, li)
+		}
+	}
+	return out
 }
 
 func (p *LiveProvider) searchItems(items []github.SearchItem) []liveItem {

--- a/internal/desktop/feed/live.go
+++ b/internal/desktop/feed/live.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -21,15 +22,18 @@ var ErrNotAuthenticated = errors.New("feed: not authenticated")
 
 const (
 	// liveCacheTTL keeps feed switches snappy between poller refreshes
-	// without hammering the API.
+	// without hammering the search API.
 	liveCacheTTL = 30 * time.Second
-	// searchLimit bounds items per feed; the desktop feed is a triage
-	// surface, not an archive browser.
-	searchLimit = 30
+	// notificationsMinPoll is the floor for the notifications poll interval.
+	// GitHub's X-Poll-Interval header is a contract (typically 60s); it is
+	// honored even when absent.
+	notificationsMinPoll = 60 * time.Second
 )
 
 // LiveProvider serves feed data from the GitHub API, with app-local unread
-// state. Fetches are cached per (profile, feed) for liveCacheTTL.
+// state. Fetches are cached per source — keyed by what is requested, not by
+// which feed or profile asked — so any number of feeds sharing a source cost
+// one request per poll.
 type LiveProvider struct {
 	client *github.Client
 	tokens github.TokenStore
@@ -38,18 +42,28 @@ type LiveProvider struct {
 	now    func() time.Time
 
 	mu    sync.Mutex
-	cache map[string]*cachedFeed
+	cache map[string]*cachedSource
 }
 
-type cachedFeed struct {
+type cachedSource struct {
 	items     []liveItem
 	fetchedAt time.Time
+	// lastModified and pollInterval drive the notifications conditional-GET
+	// loop; both stay zero for search sources.
+	lastModified string
+	pollInterval time.Duration
 }
 
 // liveItem pairs the wire item with the timestamp unread state derives from.
 type liveItem struct {
 	item      Item
 	updatedAt time.Time
+}
+
+// sourceKey is the canonical cache key of a source: two source definitions
+// requesting the same data share one cache entry and one API request.
+func sourceKey(src SourceDef) string {
+	return src.Kind + "\x00" + src.Query + "\x00" + strconv.Itoa(src.effectiveLimit())
 }
 
 func NewLiveProvider(client *github.Client, tokens github.TokenStore, store *Store, logger zerolog.Logger) *LiveProvider {
@@ -59,7 +73,7 @@ func NewLiveProvider(client *github.Client, tokens github.TokenStore, store *Sto
 		store:  store,
 		logger: logger,
 		now:    time.Now,
-		cache:  make(map[string]*cachedFeed),
+		cache:  make(map[string]*cachedSource),
 	}
 }
 
@@ -68,22 +82,80 @@ func (p *LiveProvider) Profiles(ctx context.Context) ([]Profile, error) {
 	if err != nil {
 		return nil, err
 	}
+	srcByID, err := p.sourcesByID()
+	if err != nil {
+		return nil, err
+	}
 
 	profiles := make([]Profile, 0, len(defs))
 	for _, def := range defs {
-		profiles = append(profiles, p.materializeProfile(ctx, def))
+		profiles = append(profiles, p.materializeProfile(ctx, srcByID, def))
 	}
 	return profiles, nil
 }
 
 // CreateProfile persists a new profile with default feeds and returns it
-// materialized (fetching its feeds).
+// materialized (fetching its sources).
 func (p *LiveProvider) CreateProfile(ctx context.Context, name string) (Profile, error) {
 	def, err := p.store.CreateProfile(name)
 	if err != nil {
 		return Profile{}, err
 	}
-	return p.materializeProfile(ctx, def), nil
+	srcByID, err := p.sourcesByID()
+	if err != nil {
+		return Profile{}, err
+	}
+	return p.materializeProfile(ctx, srcByID, def), nil
+}
+
+// Sources returns the source definitions, for the source picker in the feed
+// editor.
+func (p *LiveProvider) Sources(context.Context) ([]SourceDef, error) {
+	return p.store.Sources()
+}
+
+// FeedDefFor returns one feed's definition, for edit prefill.
+func (p *LiveProvider) FeedDefFor(_ context.Context, profileID, feedID string) (FeedDef, error) {
+	return p.store.FeedDefFor(profileID, feedID)
+}
+
+// CreateSource persists a new top-level source. No fetch happens until a feed
+// references it.
+func (p *LiveProvider) CreateSource(_ context.Context, def SourceDef) (SourceDef, error) {
+	return p.store.CreateSource(def)
+}
+
+// CreateFeed persists a new feed in the profile and returns its materialized
+// summary. Fetch failures degrade to zero counts with a log line, matching
+// materializeProfile.
+func (p *LiveProvider) CreateFeed(ctx context.Context, profileID string, def FeedDef) (Source, error) {
+	created, err := p.store.CreateFeed(profileID, def)
+	if err != nil {
+		return Source{}, err
+	}
+	summary := Source{ID: created.ID, Name: created.Name}
+	srcByID, err := p.sourcesByID()
+	if err != nil {
+		return Source{}, err
+	}
+	items, err := p.feedItems(ctx, srcByID, created)
+	if err != nil {
+		p.logger.Debug().Err(err).Str("feed", created.ID).Msg("feed fetch failed; counting as empty")
+		return summary, nil
+	}
+	summary.Count = len(items)
+	for _, li := range items {
+		if p.finalize(li).Unread {
+			summary.NewCount++
+		}
+	}
+	return summary, nil
+}
+
+// UpdateFeed replaces the feed's definition; the feed keeps its ID. The
+// source cache is unaffected — filters apply at read time.
+func (p *LiveProvider) UpdateFeed(_ context.Context, profileID, feedID string, def FeedDef) error {
+	return p.store.UpdateFeed(profileID, feedID, def)
 }
 
 func (p *LiveProvider) Items(ctx context.Context, profileID, feedID string) ([]Item, error) {
@@ -118,16 +190,13 @@ func (p *LiveProvider) ActionsFor(kind string) []Action {
 }
 
 // MarkRead records the item as read as of its currently-known update time.
-// The same item can sit in several feed caches with different timestamps
+// The same item can sit in several source caches with different timestamps
 // (search result vs notification thread); the newest wins so the item does
 // not bounce back to unread.
-func (p *LiveProvider) MarkRead(_ context.Context, profileID, itemID string) error {
+func (p *LiveProvider) MarkRead(_ context.Context, _, itemID string) error {
 	var updatedAt time.Time
 	p.mu.Lock()
-	for key, cached := range p.cache {
-		if !strings.HasPrefix(key, profileID+"\x00") {
-			continue
-		}
+	for _, cached := range p.cache {
 		for _, li := range cached.items {
 			if li.item.ID == itemID && li.updatedAt.After(updatedAt) {
 				updatedAt = li.updatedAt
@@ -146,52 +215,85 @@ func (p *LiveProvider) Config(context.Context) (ConfigInfo, error) {
 	return p.store.ConfigInfo(), nil
 }
 
-// Invalidate drops the fetch cache so the next call refetches.
+// Invalidate drops the fetch cache so the next call refetches. Config
+// reloads and auth changes call it: a notifications refetch is nearly free
+// (conditional), and a search refetch is one request per source.
 func (p *LiveProvider) Invalidate() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.cache = make(map[string]*cachedFeed)
+	p.cache = make(map[string]*cachedSource)
 }
 
-// Refresh refetches every feed of the profile, bypassing the TTL, and
-// reports whether anything changed versus the cached state. The poller uses
-// it to decide when to push feed:updated. It returns an error only when
-// every feed fails.
+// Refresh refetches the distinct sources referenced by the profile's feeds,
+// bypassing the search TTL. Notifications sources still honor X-Poll-Interval
+// — the conditional request is cheap, but the header is a contract. It
+// reports whether any referenced source's data changed and fails only when
+// every source fails.
 func (p *LiveProvider) Refresh(ctx context.Context, profileID string) (bool, error) {
 	def, err := p.profileDef(profileID)
 	if err != nil {
 		return false, err
 	}
+	srcByID, err := p.sourcesByID()
+	if err != nil {
+		return false, err
+	}
 
 	var (
-		changed bool
-		lastErr error
-		fetched int
+		changed   bool
+		lastErr   error
+		refreshed int
 	)
-	for _, feedDef := range def.Feeds {
-		items, err := p.fetchFeed(ctx, feedDef)
+	for _, src := range distinctSources(def.Feeds, srcByID) {
+		sourceChanged, err := p.refreshSource(ctx, src)
 		if err != nil {
 			lastErr = err
-			p.logger.Debug().Err(err).Str("profile", def.Name).Str("feed", feedDef.ID).Msg("poll fetch failed")
+			p.logger.Debug().Err(err).Str("profile", def.Name).Str("source", src.ID).Msg("refresh fetch failed")
 			continue
 		}
-		fetched++
-
-		key := def.ID + "\x00" + feedDef.ID
-		p.mu.Lock()
-		if prev, ok := p.cache[key]; !ok || !sameItems(prev.items, items) {
+		refreshed++
+		if sourceChanged {
 			changed = true
 		}
-		p.cache[key] = &cachedFeed{items: items, fetchedAt: p.now()}
-		p.mu.Unlock()
 	}
-	if fetched == 0 && lastErr != nil {
+	if refreshed == 0 && lastErr != nil {
 		return false, lastErr
 	}
 	return changed, nil
 }
 
-// sameItems reports whether two fetches carry the same feed state: same
+// refreshSource force-fetches one source, bypassing the search TTL, and
+// reports whether its cached items changed. Notifications sources within
+// their X-Poll-Interval window are skipped unchanged.
+func (p *LiveProvider) refreshSource(ctx context.Context, src SourceDef) (bool, error) {
+	key := sourceKey(src)
+	p.mu.Lock()
+	prev, hadPrev := p.cache[key]
+	p.mu.Unlock()
+
+	if hadPrev && src.Kind == "notifications" {
+		if p.now().Sub(prev.fetchedAt) < notificationsTTL(prev) {
+			return false, nil
+		}
+	}
+
+	items, err := p.fetchSource(ctx, src)
+	if err != nil {
+		return false, err
+	}
+	return !hadPrev || !sameItems(prev.items, items), nil
+}
+
+// notificationsTTL is the effective minimum interval between notification
+// fetches for a cache entry.
+func notificationsTTL(cached *cachedSource) time.Duration {
+	if cached.pollInterval > notificationsMinPoll {
+		return cached.pollInterval
+	}
+	return notificationsMinPoll
+}
+
+// sameItems reports whether two fetches carry the same source state: same
 // items, same order, same update times and native unread flags.
 func sameItems(a, b []liveItem) bool {
 	if len(a) != len(b) {
@@ -210,20 +312,20 @@ func sameItems(a, b []liveItem) bool {
 // ── Materialization ──────────────────────────────────────────────────────────
 
 // materializeProfile builds the wire profile, including per-feed and total
-// counts. Feed fetch failures degrade to zero counts with a log line: the
-// rail should render even when GitHub is unreachable.
-func (p *LiveProvider) materializeProfile(ctx context.Context, def ProfileDef) Profile {
+// counts. Fetch failures degrade to zero counts with a log line: the rail
+// should render even when GitHub is unreachable.
+func (p *LiveProvider) materializeProfile(ctx context.Context, srcByID map[string]SourceDef, def ProfileDef) Profile {
 	profile := Profile{
 		ID:            def.ID,
 		Letter:        ProfileLetter(def.Name),
 		Name:          def.Name,
-		SourceSummary: fmt.Sprintf("GitHub · %d sources", len(def.Feeds)),
+		SourceSummary: fmt.Sprintf("GitHub · %d sources", len(distinctSources(def.Feeds, srcByID))),
 	}
 
 	newest := make(map[string]liveItem)
 	for _, feedDef := range def.Feeds {
 		source := Source{ID: feedDef.ID, Name: feedDef.Name}
-		items, err := p.feedItems(ctx, def.ID, feedDef)
+		items, err := p.feedItems(ctx, srcByID, feedDef)
 		if err != nil {
 			p.logger.Debug().Err(err).Str("profile", def.Name).Str("feed", feedDef.ID).Msg("feed fetch failed; counting as empty")
 		} else {
@@ -252,10 +354,15 @@ func (p *LiveProvider) materializeProfile(ctx context.Context, def ProfileDef) P
 	return profile
 }
 
-// gather fetches the given feeds, deduplicates by item ID (a PR can be in a
-// search feed and the notifications inbox), and orders newest-updated first.
-// It fails only when every feed fails; partial failures degrade with a log.
+// gather materializes the given feeds, deduplicates by item ID (a PR can be
+// in two feeds), and orders newest-updated first. It fails only when every
+// feed fails; partial failures degrade with a log.
 func (p *LiveProvider) gather(ctx context.Context, def ProfileDef, feeds []FeedDef) ([]liveItem, error) {
+	srcByID, err := p.sourcesByID()
+	if err != nil {
+		return nil, err
+	}
+
 	var (
 		merged  []liveItem
 		index   = make(map[string]int)
@@ -263,7 +370,7 @@ func (p *LiveProvider) gather(ctx context.Context, def ProfileDef, feeds []FeedD
 		fetched int
 	)
 	for _, feedDef := range feeds {
-		items, err := p.feedItems(ctx, def.ID, feedDef)
+		items, err := p.feedItems(ctx, srcByID, feedDef)
 		if err != nil {
 			lastErr = err
 			p.logger.Debug().Err(err).Str("profile", def.Name).Str("feed", feedDef.ID).Msg("feed fetch failed")
@@ -283,16 +390,16 @@ func (p *LiveProvider) gather(ctx context.Context, def ProfileDef, feeds []FeedD
 		return nil, lastErr
 	}
 
-	sort.SliceStable(merged, func(i, j int) bool {
-		return merged[i].updatedAt.After(merged[j].updatedAt)
-	})
+	sortNewestFirst(merged)
 	return merged, nil
 }
 
-// mergeNewest resolves an item present in several feeds (search result vs
+// mergeNewest resolves an item present in several sources (search result vs
 // notification thread) to its newest copy, so age and read state derive from
 // the latest activity — the same newest-wins contract MarkRead records.
-// Notifications carry no author; backfill it from the older copy.
+// Notifications carry no author and search results no reason; backfill both
+// from the other copy so a merged item has author and reason regardless of
+// which side is newer.
 func mergeNewest(a, b liveItem) liveItem {
 	newer, older := a, b
 	if older.updatedAt.After(newer.updatedAt) {
@@ -300,6 +407,9 @@ func mergeNewest(a, b liveItem) liveItem {
 	}
 	if newer.item.Author == "" {
 		newer.item.Author = older.item.Author
+	}
+	if newer.item.Reason == "" {
+		newer.item.Reason = older.item.Reason
 	}
 	return newer
 }
@@ -318,35 +428,86 @@ func (p *LiveProvider) finalize(li liveItem) Item {
 
 // ── Fetching ─────────────────────────────────────────────────────────────────
 
-func (p *LiveProvider) feedItems(ctx context.Context, profileID string, def FeedDef) ([]liveItem, error) {
-	key := profileID + "\x00" + def.ID
+// feedItems materializes one feed: union the cached/fetched items of its
+// sources, dedupe and merge by item ID, apply the feed's filters, and order
+// newest first. It fails only when every source fails.
+func (p *LiveProvider) feedItems(ctx context.Context, srcByID map[string]SourceDef, def FeedDef) ([]liveItem, error) {
+	var (
+		merged  []liveItem
+		index   = make(map[string]int)
+		lastErr error
+		fetched int
+	)
+	for _, sourceID := range def.Sources {
+		src, ok := srcByID[sourceID]
+		if !ok {
+			// Possible only in the window between a config reload and this
+			// read racing on split store snapshots; the next poll heals it.
+			lastErr = fmt.Errorf("feed: unknown source %q", sourceID)
+			p.logger.Debug().Str("feed", def.ID).Str("source", sourceID).Msg("source not found; skipping")
+			continue
+		}
+		items, err := p.sourceItems(ctx, src)
+		if err != nil {
+			lastErr = err
+			p.logger.Debug().Err(err).Str("feed", def.ID).Str("source", src.ID).Msg("source fetch failed")
+			continue
+		}
+		fetched++
+		for _, li := range items {
+			if at, ok := index[li.item.ID]; ok {
+				merged[at] = mergeNewest(merged[at], li)
+				continue
+			}
+			index[li.item.ID] = len(merged)
+			merged = append(merged, li)
+		}
+	}
+	if fetched == 0 && lastErr != nil {
+		return nil, lastErr
+	}
+
+	sortNewestFirst(merged)
+	return applyFilters(def, merged), nil
+}
+
+// sourceItems returns the source's items, from cache within the TTL — 30s
+// for search, the X-Poll-Interval contract for notifications — and fetching
+// otherwise.
+func (p *LiveProvider) sourceItems(ctx context.Context, src SourceDef) ([]liveItem, error) {
+	key := sourceKey(src)
 
 	p.mu.Lock()
 	cached, ok := p.cache[key]
 	p.mu.Unlock()
-	if ok && p.now().Sub(cached.fetchedAt) < liveCacheTTL {
-		return cached.items, nil
+	if ok {
+		ttl := liveCacheTTL
+		if src.Kind == "notifications" {
+			ttl = notificationsTTL(cached)
+		}
+		if p.now().Sub(cached.fetchedAt) < ttl {
+			return cached.items, nil
+		}
 	}
 
-	items, err := p.fetchFeed(ctx, def)
+	items, err := p.fetchSource(ctx, src)
 	if err != nil {
 		// Serve stale data over an error when we have it: triage beats
 		// freshness during a blip. Auth failures pass through even so —
 		// stale data would mask the reconnect prompt.
 		if ok && !errors.Is(err, github.ErrUnauthorized) && !errors.Is(err, ErrNotAuthenticated) {
-			p.logger.Debug().Err(err).Str("feed", def.ID).Msg("feed fetch failed; serving stale cache")
+			p.logger.Debug().Err(err).Str("source", src.ID).Msg("source fetch failed; serving stale cache")
 			return cached.items, nil
 		}
 		return nil, err
 	}
-
-	p.mu.Lock()
-	p.cache[key] = &cachedFeed{items: items, fetchedAt: p.now()}
-	p.mu.Unlock()
 	return items, nil
 }
 
-func (p *LiveProvider) fetchFeed(ctx context.Context, def FeedDef) ([]liveItem, error) {
+// fetchSource performs the source's API request and updates the cache.
+// Notifications requests are conditional: a 304 keeps the cached items and
+// refreshes their fetch time at no rate-limit cost.
+func (p *LiveProvider) fetchSource(ctx context.Context, src SourceDef) ([]liveItem, error) {
 	token, err := p.tokens.Token()
 	if err != nil {
 		return nil, err
@@ -355,39 +516,62 @@ func (p *LiveProvider) fetchFeed(ctx context.Context, def FeedDef) ([]liveItem, 
 		return nil, ErrNotAuthenticated
 	}
 	client := p.client.WithTokenCopy(token)
+	key := sourceKey(src)
 
-	switch def.Kind {
+	switch src.Kind {
 	case "notifications":
-		notifications, err := client.Notifications(ctx, searchLimit)
+		p.mu.Lock()
+		prev := p.cache[key]
+		ifModifiedSince := ""
+		if prev != nil {
+			ifModifiedSince = prev.lastModified
+		}
+		p.mu.Unlock()
+
+		result, err := client.Notifications(ctx, src.effectiveLimit(), ifModifiedSince)
 		if err != nil {
 			return nil, err
 		}
-		return filterByRepo(def, p.notificationItems(notifications)), nil
+		pollInterval := time.Duration(result.PollInterval) * time.Second
+		if result.NotModified && prev != nil {
+			p.mu.Lock()
+			prev.fetchedAt = p.now()
+			if pollInterval > 0 {
+				prev.pollInterval = pollInterval
+			}
+			if result.LastModified != "" {
+				prev.lastModified = result.LastModified
+			}
+			p.cache[key] = prev // re-adopt if Invalidate raced the request
+			items := prev.items
+			p.mu.Unlock()
+			return items, nil
+		}
+		items := p.notificationItems(result.Items)
+		p.setCache(key, &cachedSource{
+			items:        items,
+			fetchedAt:    p.now(),
+			lastModified: result.LastModified,
+			pollInterval: pollInterval,
+		})
+		return items, nil
 	case "search":
-		result, err := client.SearchIssues(ctx, def.Query, searchLimit)
+		result, err := client.SearchIssues(ctx, src.Query, src.effectiveLimit())
 		if err != nil {
 			return nil, err
 		}
-		return filterByRepo(def, p.searchItems(result.Items)), nil
+		items := p.searchItems(result.Items)
+		p.setCache(key, &cachedSource{items: items, fetchedAt: p.now()})
+		return items, nil
 	default:
-		return nil, fmt.Errorf("feed: unknown feed kind %q", def.Kind)
+		return nil, fmt.Errorf("feed: unknown source kind %q", src.Kind)
 	}
 }
 
-// filterByRepo applies the feed's include/exclude repo globs. Filtering
-// happens after the fetch, so it changes what is shown, not what is
-// requested — a filtered feed still costs exactly one API call.
-func filterByRepo(def FeedDef, items []liveItem) []liveItem {
-	if len(def.Repos) == 0 && len(def.ExcludeRepos) == 0 {
-		return items
-	}
-	out := make([]liveItem, 0, len(items))
-	for _, li := range items {
-		if def.matchesRepo(li.item.Repo) {
-			out = append(out, li)
-		}
-	}
-	return out
+func (p *LiveProvider) setCache(key string, cached *cachedSource) {
+	p.mu.Lock()
+	p.cache[key] = cached
+	p.mu.Unlock()
 }
 
 func (p *LiveProvider) searchItems(items []github.SearchItem) []liveItem {
@@ -441,6 +625,7 @@ func (p *LiveProvider) notificationItems(notifications []github.Notification) []
 			Title:  n.Subject.Title,
 			Age:    shortAge(p.now().Sub(n.UpdatedAt)),
 			Unread: n.Unread, // native inbox state seeds unread
+			Reason: n.Reason,
 			Labels: []string{strings.ReplaceAll(n.Reason, "_", " ")},
 			Branch: suggestedBranch(kind, num, n.Subject.Title),
 			Body:   fmt.Sprintf("GitHub notification (%s) for %s in %s.", strings.ReplaceAll(n.Reason, "_", " "), strings.ToLower(kind), repo),
@@ -465,6 +650,47 @@ func (p *LiveProvider) profileDef(profileID string) (ProfileDef, error) {
 		}
 	}
 	return ProfileDef{}, fmt.Errorf("feed: unknown profile %q", profileID)
+}
+
+func (p *LiveProvider) sourcesByID() (map[string]SourceDef, error) {
+	sources, err := p.store.Sources()
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]SourceDef, len(sources))
+	for _, src := range sources {
+		byID[src.ID] = src
+	}
+	return byID, nil
+}
+
+// distinctSources resolves the sources referenced by the feeds, deduplicated
+// by canonical key, in first-reference order. Unresolvable references are
+// skipped; validation prevents them in a consistent config snapshot.
+func distinctSources(feeds []FeedDef, srcByID map[string]SourceDef) []SourceDef {
+	var out []SourceDef
+	seen := make(map[string]bool)
+	for _, feedDef := range feeds {
+		for _, sourceID := range feedDef.Sources {
+			src, ok := srcByID[sourceID]
+			if !ok {
+				continue
+			}
+			key := sourceKey(src)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, src)
+		}
+	}
+	return out
+}
+
+func sortNewestFirst(items []liveItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].updatedAt.After(items[j].updatedAt)
+	})
 }
 
 func findFeed(feeds []FeedDef, id string) (FeedDef, bool) {

--- a/internal/desktop/feed/live.go
+++ b/internal/desktop/feed/live.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/colonyops/hive/internal/github"
 )
@@ -43,8 +44,14 @@ type LiveProvider struct {
 
 	mu    sync.Mutex
 	cache map[string]*cachedSource
+	// flight coalesces concurrent fetches of the same source (by canonical
+	// key) into one API request.
+	flight singleflight.Group
 }
 
+// cachedSource is one source's cached fetch. Entries are immutable once
+// published into the cache: readers use their fields after releasing p.mu,
+// so an update must publish a new entry, never mutate one in place.
 type cachedSource struct {
 	items     []liveItem
 	fetchedAt time.Time
@@ -397,9 +404,9 @@ func (p *LiveProvider) gather(ctx context.Context, def ProfileDef, feeds []FeedD
 // mergeNewest resolves an item present in several sources (search result vs
 // notification thread) to its newest copy, so age and read state derive from
 // the latest activity — the same newest-wins contract MarkRead records.
-// Notifications carry no author and search results no reason; backfill both
-// from the other copy so a merged item has author and reason regardless of
-// which side is newer.
+// Notifications carry no author or labels, and search results no reason;
+// backfill each empty field from the other copy so a merged item has author,
+// labels, and reason regardless of which side is newer.
 func mergeNewest(a, b liveItem) liveItem {
 	newer, older := a, b
 	if older.updatedAt.After(newer.updatedAt) {
@@ -410,6 +417,9 @@ func mergeNewest(a, b liveItem) liveItem {
 	}
 	if newer.item.Reason == "" {
 		newer.item.Reason = older.item.Reason
+	}
+	if len(newer.item.Labels) == 0 {
+		newer.item.Labels = older.item.Labels
 	}
 	return newer
 }
@@ -504,10 +514,26 @@ func (p *LiveProvider) sourceItems(ctx context.Context, src SourceDef) ([]liveIt
 	return items, nil
 }
 
-// fetchSource performs the source's API request and updates the cache.
+// fetchSource performs the source's API request and updates the cache,
+// coalescing concurrent fetches of the same source into one request — a poll
+// tick racing a user navigation costs one API call, and both callers see the
+// same result. A TTL-bypassing refresh that joins an in-flight fetch adopts
+// its result: the data is at most one request old, fresh enough for a manual
+// refresh.
+func (p *LiveProvider) fetchSource(ctx context.Context, src SourceDef) ([]liveItem, error) {
+	result, err, _ := p.flight.Do(sourceKey(src), func() (any, error) {
+		return p.fetchSourceDirect(ctx, src)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]liveItem), nil
+}
+
+// fetchSourceDirect is the uncoalesced fetch behind fetchSource.
 // Notifications requests are conditional: a 304 keeps the cached items and
 // refreshes their fetch time at no rate-limit cost.
-func (p *LiveProvider) fetchSource(ctx context.Context, src SourceDef) ([]liveItem, error) {
+func (p *LiveProvider) fetchSourceDirect(ctx context.Context, src SourceDef) ([]liveItem, error) {
 	token, err := p.tokens.Token()
 	if err != nil {
 		return nil, err
@@ -534,18 +560,19 @@ func (p *LiveProvider) fetchSource(ctx context.Context, src SourceDef) ([]liveIt
 		}
 		pollInterval := time.Duration(result.PollInterval) * time.Second
 		if result.NotModified && prev != nil {
-			p.mu.Lock()
-			prev.fetchedAt = p.now()
+			// Published entries are immutable (readers use them outside the
+			// lock): publish a refreshed copy instead of mutating prev. This
+			// also re-adopts the entry if Invalidate raced the request.
+			next := *prev
+			next.fetchedAt = p.now()
 			if pollInterval > 0 {
-				prev.pollInterval = pollInterval
+				next.pollInterval = pollInterval
 			}
 			if result.LastModified != "" {
-				prev.lastModified = result.LastModified
+				next.lastModified = result.LastModified
 			}
-			p.cache[key] = prev // re-adopt if Invalidate raced the request
-			items := prev.items
-			p.mu.Unlock()
-			return items, nil
+			p.setCache(key, &next)
+			return next.items, nil
 		}
 		items := p.notificationItems(result.Items)
 		p.setCache(key, &cachedSource{
@@ -626,9 +653,11 @@ func (p *LiveProvider) notificationItems(notifications []github.Notification) []
 			Age:    shortAge(p.now().Sub(n.UpdatedAt)),
 			Unread: n.Unread, // native inbox state seeds unread
 			Reason: n.Reason,
-			Labels: []string{strings.ReplaceAll(n.Reason, "_", " ")},
+			// No Labels: the notifications API does not deliver them. The
+			// reason renders as its own chip from Reason, and mergeNewest
+			// backfills real labels from a search copy of the same item.
 			Branch: suggestedBranch(kind, num, n.Subject.Title),
-			Body:   fmt.Sprintf("GitHub notification (%s) for %s in %s.", strings.ReplaceAll(n.Reason, "_", " "), strings.ToLower(kind), repo),
+			Body:   fmt.Sprintf("GitHub notification for %s in %s.", strings.ToLower(kind), repo),
 			Prompt: suggestedPrompt(kind, repo, num, n.Subject.Title),
 			URL:    htmlURLForSubject(repo, kind, num),
 		}

--- a/internal/desktop/feed/live.go
+++ b/internal/desktop/feed/live.go
@@ -165,6 +165,20 @@ func (p *LiveProvider) UpdateFeed(_ context.Context, profileID, feedID string, d
 	return p.store.UpdateFeed(profileID, feedID, def)
 }
 
+// DeleteFeed removes the feed from the profile. The source cache is
+// unaffected, matching UpdateFeed: sources are shared and other feeds may
+// still reference them.
+func (p *LiveProvider) DeleteFeed(_ context.Context, profileID, feedID string) error {
+	return p.store.DeleteFeed(profileID, feedID)
+}
+
+// DeleteProfile removes the profile and its feeds. Sources are left
+// untouched — they are shared, decoupled definitions other profiles may
+// still reference.
+func (p *LiveProvider) DeleteProfile(_ context.Context, profileID string) error {
+	return p.store.DeleteProfile(profileID)
+}
+
 func (p *LiveProvider) Items(ctx context.Context, profileID, feedID string) ([]Item, error) {
 	def, err := p.profileDef(profileID)
 	if err != nil {

--- a/internal/desktop/feed/live_test.go
+++ b/internal/desktop/feed/live_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,18 +18,51 @@ import (
 	"github.com/colonyops/hive/internal/github"
 )
 
-const testNow = "2026-07-18T12:00:00Z"
+const (
+	testNow          = "2026-07-18T12:00:00Z"
+	testLastModified = "Sat, 18 Jul 2026 11:00:00 GMT"
+)
 
-// liveAPIServer fakes the search and notifications endpoints. The search
-// response includes one PR shared with the notifications inbox so dedupe is
-// observable.
-func liveAPIServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+// testClock is a settable clock for provider TTL tests.
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newTestClock(t *testing.T) *testClock {
 	t.Helper()
+	now, err := time.Parse(time.RFC3339, testNow)
+	require.NoError(t, err)
+	return &testClock{now: now}
+}
 
-	var searchCalls atomic.Int32
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// fakeAPI fakes the search and notifications endpoints. The search response
+// includes one PR shared with the notifications inbox so dedupe is
+// observable. Notifications support the conditional-GET loop: a request
+// carrying the current Last-Modified answers 304.
+type fakeAPI struct {
+	searchCalls  atomic.Int32
+	notifCalls   atomic.Int32
+	notifFull    atomic.Int32 // non-304 notification responses
+	pollInterval atomic.Int32 // X-Poll-Interval value; 0 omits the header
+}
+
+func (f *fakeAPI) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
-		searchCalls.Add(1)
+		f.searchCalls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Query().Get("q") {
 		case "is:open is:pr author:@me archived:false":
@@ -55,8 +90,18 @@ func liveAPIServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
 			]}`))
 		}
 	})
-	mux.HandleFunc("/notifications", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
+		f.notifCalls.Add(1)
+		if interval := f.pollInterval.Load(); interval > 0 {
+			w.Header().Set("X-Poll-Interval", strconv.Itoa(int(interval)))
+		}
+		if r.Header.Get("If-Modified-Since") == testLastModified {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		f.notifFull.Add(1)
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Last-Modified", testLastModified)
 		_, _ = w.Write([]byte(`[
 			{"id":"n1","unread":true,"reason":"review_requested","updated_at":"2026-07-18T11:00:00Z",
 			 "subject":{"title":"Fix spawn env","url":"https://api.github.com/repos/colonyops/hive/pulls/42","type":"PullRequest"},
@@ -69,22 +114,21 @@ func liveAPIServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
 			 "repository":{"full_name":"colonyops/hive"}}
 		]`))
 	})
-
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-	return server, &searchCalls
+	return mux
 }
 
-func newLiveProviderForTest(t *testing.T) (*LiveProvider, *Store, *atomic.Int32) {
+func newLiveProviderForTest(t *testing.T) (*LiveProvider, *Store, *fakeAPI, *testClock) {
 	t.Helper()
-	server, searchCalls := liveAPIServer(t)
+	api := &fakeAPI{}
+	server := httptest.NewServer(api.handler())
+	t.Cleanup(server.Close)
+
 	client := github.NewClient(github.WithAPIBase(server.URL))
 	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
-	now, err := time.Parse(time.RFC3339, testNow)
-	require.NoError(t, err)
-	provider.now = func() time.Time { return now }
-	return provider, store, searchCalls
+	clock := newTestClock(t)
+	provider.now = clock.Now
+	return provider, store, api, clock
 }
 
 func createTestProfile(t *testing.T, store *Store) ProfileDef {
@@ -97,7 +141,7 @@ func createTestProfile(t *testing.T, store *Store) ProfileDef {
 func TestLiveProviderItemsMergesAndDedupes(t *testing.T) {
 	t.Parallel()
 
-	provider, store, _ := newLiveProviderForTest(t)
+	provider, store, _, _ := newLiveProviderForTest(t)
 	def := createTestProfile(t, store)
 
 	items, err := provider.Items(t.Context(), def.ID, "")
@@ -111,14 +155,15 @@ func TestLiveProviderItemsMergesAndDedupes(t *testing.T) {
 	}
 	assert.Equal(t, []string{"colonyops/hive#42", "colonyops/hive#3", "colonyops/hive#9", "colonyops/docs#7"}, ids)
 
-	// PR#42 exists in both the search feed (10:00) and the notifications
+	// PR#42 exists in both the my-prs source (10:00) and the notifications
 	// inbox (11:00): the newer notification copy wins, with the author
-	// backfilled from the search copy.
+	// backfilled from the search copy and the reason carried on the item.
 	pr := items[0]
 	assert.Equal(t, "PR", pr.Kind)
 	assert.Equal(t, "colonyops/hive", pr.Repo)
 	assert.Equal(t, 42, pr.Num)
 	assert.Equal(t, "hayden", pr.Author)
+	assert.Equal(t, "review_requested", pr.Reason)
 	assert.Equal(t, "1h", pr.Age)
 	assert.Equal(t, []string{"review requested"}, pr.Labels)
 	assert.True(t, pr.Unread)
@@ -128,13 +173,15 @@ func TestLiveProviderItemsMergesAndDedupes(t *testing.T) {
 
 	// Read notification arrives read; search items start unread.
 	assert.False(t, items[1].Unread, "read notification stays read")
+	assert.Equal(t, "mention", items[1].Reason)
 	assert.True(t, items[2].Unread)
+	assert.Empty(t, items[2].Reason, "search-only item has no reason")
 }
 
 func TestLiveProviderSingleFeedAndUnknownFeed(t *testing.T) {
 	t.Parallel()
 
-	provider, store, _ := newLiveProviderForTest(t)
+	provider, store, _, _ := newLiveProviderForTest(t)
 	def := createTestProfile(t, store)
 
 	items, err := provider.Items(t.Context(), def.ID, "my-open-prs")
@@ -152,7 +199,7 @@ func TestLiveProviderSingleFeedAndUnknownFeed(t *testing.T) {
 func TestLiveProviderMarkReadClearsUnread(t *testing.T) {
 	t.Parallel()
 
-	provider, store, _ := newLiveProviderForTest(t)
+	provider, store, _, _ := newLiveProviderForTest(t)
 	def := createTestProfile(t, store)
 
 	items, err := provider.Items(t.Context(), def.ID, "")
@@ -169,7 +216,7 @@ func TestLiveProviderMarkReadClearsUnread(t *testing.T) {
 func TestLiveProviderProfilesCounts(t *testing.T) {
 	t.Parallel()
 
-	provider, store, _ := newLiveProviderForTest(t)
+	provider, store, _, _ := newLiveProviderForTest(t)
 	def := createTestProfile(t, store)
 
 	profiles, err := provider.Profiles(t.Context())
@@ -196,19 +243,121 @@ func TestLiveProviderProfilesCounts(t *testing.T) {
 func TestLiveProviderCachesWithinTTL(t *testing.T) {
 	t.Parallel()
 
-	provider, store, searchCalls := newLiveProviderForTest(t)
+	provider, store, api, _ := newLiveProviderForTest(t)
 	def := createTestProfile(t, store)
 
 	_, err := provider.Items(t.Context(), def.ID, "my-open-prs")
 	require.NoError(t, err)
 	_, err = provider.Items(t.Context(), def.ID, "my-open-prs")
 	require.NoError(t, err)
-	assert.Equal(t, int32(1), searchCalls.Load(), "second read within TTL hits the cache")
+	assert.Equal(t, int32(1), api.searchCalls.Load(), "second read within TTL hits the cache")
 
 	provider.Invalidate()
 	_, err = provider.Items(t.Context(), def.ID, "my-open-prs")
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), searchCalls.Load(), "invalidate forces a refetch")
+	assert.Equal(t, int32(2), api.searchCalls.Load(), "invalidate forces a refetch")
+}
+
+func TestLiveProviderSharedSourceSingleFetch(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{}
+	server := httptest.NewServer(api.handler())
+	t.Cleanup(server.Close)
+	client := github.NewClient(github.WithAPIBase(server.URL))
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`sources:
+  - id: my-work
+    kind: search
+    query: "is:open is:pr author:@me archived:false"
+  - id: my-work-twin # identical acquisition: same canonical key, one request
+    kind: search
+    query: "is:open is:pr author:@me archived:false"
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: all
+        name: All
+        sources: [my-work]
+      - id: hive-only
+        name: Hive only
+        sources: [my-work-twin]
+        filters:
+          repos: ["colonyops/hive"]
+`), 0o600))
+	store := newStoreAt(dir)
+	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
+	provider.now = newTestClock(t).Now
+
+	// Materializing the whole profile touches both feeds — and both source
+	// defs — but they share one canonical source key: one request.
+	items, err := provider.Items(t.Context(), "work", "")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, int32(1), api.searchCalls.Load(), "two feeds over one source cost one request")
+
+	filtered, err := provider.Items(t.Context(), "work", "hive-only")
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "colonyops/hive#42", filtered[0].ID)
+	assert.Equal(t, int32(1), api.searchCalls.Load(), "filtered view reads the same cache")
+}
+
+func TestLiveProviderNotificationsConditionalFlow(t *testing.T) {
+	t.Parallel()
+
+	provider, store, api, clock := newLiveProviderForTest(t)
+	def := createTestProfile(t, store)
+
+	items, err := provider.Items(t.Context(), def.ID, "notifications-inbox")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, int32(1), api.notifCalls.Load())
+	assert.Equal(t, int32(1), api.notifFull.Load())
+
+	// Within the 60s poll floor: served from cache, no request at all.
+	clock.Advance(30 * time.Second)
+	_, err = provider.Items(t.Context(), def.ID, "notifications-inbox")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), api.notifCalls.Load(), "poll floor gates the fetch")
+
+	// Past the floor: a conditional request goes out and answers 304; the
+	// cached items survive.
+	clock.Advance(31 * time.Second)
+	items, err = provider.Items(t.Context(), def.ID, "notifications-inbox")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, int32(2), api.notifCalls.Load(), "conditional refetch past the floor")
+	assert.Equal(t, int32(1), api.notifFull.Load(), "304 keeps the cached items")
+}
+
+func TestRefreshHonorsNotificationsPollInterval(t *testing.T) {
+	t.Parallel()
+
+	provider, store, api, clock := newLiveProviderForTest(t)
+	api.pollInterval.Store(300)
+	def := createTestProfile(t, store)
+
+	changed, err := provider.Refresh(t.Context(), def.ID)
+	require.NoError(t, err)
+	assert.True(t, changed, "first refresh populates the cache")
+	require.Equal(t, int32(1), api.notifCalls.Load())
+	searchCalls := api.searchCalls.Load()
+
+	// A manual refresh bypasses the search TTL but not X-Poll-Interval.
+	clock.Advance(2 * time.Minute)
+	_, err = provider.Refresh(t.Context(), def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), api.notifCalls.Load(), "notifications wait out X-Poll-Interval")
+	assert.Equal(t, searchCalls+2, api.searchCalls.Load(), "search sources refetch on manual refresh")
+
+	// Past the server-mandated interval the conditional request goes out.
+	clock.Advance(4 * time.Minute)
+	_, err = provider.Refresh(t.Context(), def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), api.notifCalls.Load())
+	assert.Equal(t, int32(1), api.notifFull.Load(), "unchanged inbox answers 304")
 }
 
 // flakyAPIServer serves one search item and an empty inbox, and fails every
@@ -254,18 +403,17 @@ func TestLiveProviderStaleCacheOnTransientError(t *testing.T) {
 	client := github.NewClient(github.WithAPIBase(server.URL))
 	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
-	current, err := time.Parse(time.RFC3339, testNow)
-	require.NoError(t, err)
-	provider.now = func() time.Time { return current }
+	clock := newTestClock(t)
+	provider.now = clock.Now
 	def := createTestProfile(t, store)
 
 	items, err := provider.Items(t.Context(), def.ID, "")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
-	// Transient server failure past the TTL: stale cache keeps the feed up.
+	// Transient server failure past every TTL: stale cache keeps the feed up.
 	failStatus.Store(http.StatusInternalServerError)
-	current = current.Add(liveCacheTTL + time.Second)
+	clock.Advance(notificationsMinPoll + time.Second)
 	items, err = provider.Items(t.Context(), def.ID, "")
 	require.NoError(t, err)
 	assert.Len(t, items, 1, "stale cache serves through a transient error")
@@ -273,7 +421,7 @@ func TestLiveProviderStaleCacheOnTransientError(t *testing.T) {
 	// Auth failure past the TTL: pass through so the reconnect state shows
 	// instead of an indefinitely stale feed.
 	failStatus.Store(http.StatusUnauthorized)
-	current = current.Add(liveCacheTTL + time.Second)
+	clock.Advance(notificationsMinPoll + time.Second)
 	_, err = provider.Items(t.Context(), def.ID, "")
 	require.ErrorIs(t, err, github.ErrUnauthorized)
 }
@@ -281,7 +429,9 @@ func TestLiveProviderStaleCacheOnTransientError(t *testing.T) {
 func TestLiveProviderRequiresToken(t *testing.T) {
 	t.Parallel()
 
-	server, _ := liveAPIServer(t)
+	api := &fakeAPI{}
+	server := httptest.NewServer(api.handler())
+	t.Cleanup(server.Close)
 	client := github.NewClient(github.WithAPIBase(server.URL))
 	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore(""), store, zerolog.Nop())
@@ -305,21 +455,50 @@ func TestSlugifyAndShortAge(t *testing.T) {
 	assert.Equal(t, "2w", shortAge(15*24*time.Hour))
 }
 
+func TestLiveProviderCreateFeedMaterializes(t *testing.T) {
+	t.Parallel()
+
+	provider, store, _, _ := newLiveProviderForTest(t)
+	def := createTestProfile(t, store)
+
+	summary, err := provider.CreateFeed(t.Context(), def.ID, FeedDef{
+		Name:    "Hive PRs",
+		Sources: []string{"my-prs"},
+		Filters: FilterDef{Repos: []string{"colonyops/hive"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hive-prs", summary.ID)
+	assert.Equal(t, "Hive PRs", summary.Name)
+	assert.Equal(t, 1, summary.Count, "filters apply to the materialized summary")
+	assert.Equal(t, 1, summary.NewCount)
+
+	items, err := provider.Items(t.Context(), def.ID, "hive-prs")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "colonyops/hive#42", items[0].ID)
+}
+
 func TestLiveProviderRepoFilters(t *testing.T) {
 	t.Parallel()
 
-	server, _ := liveAPIServer(t)
+	api := &fakeAPI{}
+	server := httptest.NewServer(api.handler())
+	t.Cleanup(server.Close)
 	client := github.NewClient(github.WithAPIBase(server.URL))
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`profiles:
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`sources:
+  - id: my-prs
+    kind: search
+    query: "is:open is:pr author:@me archived:false"
+profiles:
   - id: work
     name: Work
     feeds:
       - id: prs
         name: My PRs
-        kind: search
-        query: "is:open is:pr author:@me archived:false"
-        exclude_repos: ["colonyops/docs"]
+        sources: [my-prs]
+        filters:
+          exclude_repos: ["colonyops/docs"]
 `), 0o600))
 	store := newStoreAt(dir)
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())

--- a/internal/desktop/feed/live_test.go
+++ b/internal/desktop/feed/live_test.go
@@ -57,12 +57,23 @@ type fakeAPI struct {
 	notifCalls   atomic.Int32
 	notifFull    atomic.Int32 // non-304 notification responses
 	pollInterval atomic.Int32 // X-Poll-Interval value; 0 omits the header
+	// searchStarted (when non-nil) receives one signal per search request;
+	// searchRelease (when non-nil) blocks search responses until closed.
+	// Together they let concurrency tests hold a fetch in flight.
+	searchStarted chan struct{}
+	searchRelease chan struct{}
 }
 
 func (f *fakeAPI) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
 		f.searchCalls.Add(1)
+		if f.searchStarted != nil {
+			f.searchStarted <- struct{}{}
+		}
+		if f.searchRelease != nil {
+			<-f.searchRelease
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Query().Get("q") {
 		case "is:open is:pr author:@me archived:false":
@@ -120,15 +131,21 @@ func (f *fakeAPI) handler() http.Handler {
 func newLiveProviderForTest(t *testing.T) (*LiveProvider, *Store, *fakeAPI, *testClock) {
 	t.Helper()
 	api := &fakeAPI{}
+	provider, store := newLiveProviderWithAPI(t, api)
+	clock := newTestClock(t)
+	provider.now = clock.Now
+	return provider, store, api, clock
+}
+
+func newLiveProviderWithAPI(t *testing.T, api *fakeAPI) (*LiveProvider, *Store) {
+	t.Helper()
 	server := httptest.NewServer(api.handler())
 	t.Cleanup(server.Close)
 
 	client := github.NewClient(github.WithAPIBase(server.URL))
 	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
-	clock := newTestClock(t)
-	provider.now = clock.Now
-	return provider, store, api, clock
+	return provider, store
 }
 
 func createTestProfile(t *testing.T, store *Store) ProfileDef {
@@ -156,8 +173,9 @@ func TestLiveProviderItemsMergesAndDedupes(t *testing.T) {
 	assert.Equal(t, []string{"colonyops/hive#42", "colonyops/hive#3", "colonyops/hive#9", "colonyops/docs#7"}, ids)
 
 	// PR#42 exists in both the my-prs source (10:00) and the notifications
-	// inbox (11:00): the newer notification copy wins, with the author
-	// backfilled from the search copy and the reason carried on the item.
+	// inbox (11:00): the newer notification copy wins, with the author and
+	// labels backfilled from the search copy and the reason carried on the
+	// item.
 	pr := items[0]
 	assert.Equal(t, "PR", pr.Kind)
 	assert.Equal(t, "colonyops/hive", pr.Repo)
@@ -165,7 +183,7 @@ func TestLiveProviderItemsMergesAndDedupes(t *testing.T) {
 	assert.Equal(t, "hayden", pr.Author)
 	assert.Equal(t, "review_requested", pr.Reason)
 	assert.Equal(t, "1h", pr.Age)
-	assert.Equal(t, []string{"review requested"}, pr.Labels)
+	assert.Equal(t, []string{"bug"}, pr.Labels, "real labels survive the newer notification copy")
 	assert.True(t, pr.Unread)
 	assert.Equal(t, "review/42-fix-spawn-env", pr.Branch)
 	assert.Equal(t, "https://github.com/colonyops/hive/pull/42", pr.URL)
@@ -174,6 +192,7 @@ func TestLiveProviderItemsMergesAndDedupes(t *testing.T) {
 	// Read notification arrives read; search items start unread.
 	assert.False(t, items[1].Unread, "read notification stays read")
 	assert.Equal(t, "mention", items[1].Reason)
+	assert.Empty(t, items[1].Labels, "notification-only item carries no labels")
 	assert.True(t, items[2].Unread)
 	assert.Empty(t, items[2].Reason, "search-only item has no reason")
 }
@@ -476,6 +495,152 @@ func TestLiveProviderCreateFeedMaterializes(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, "colonyops/hive#42", items[0].ID)
+}
+
+// TestLiveProviderLabelsFilterSurvivesNotificationMerge guards the labels
+// merge contract: PR#42 is labeled "bug" in the search source and unlabeled
+// in its (newer) notification copy, so a labels filter must still match the
+// merged item.
+func TestLiveProviderLabelsFilterSurvivesNotificationMerge(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{}
+	server := httptest.NewServer(api.handler())
+	t.Cleanup(server.Close)
+	client := github.NewClient(github.WithAPIBase(server.URL))
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`sources:
+  - id: my-prs
+    kind: search
+    query: "is:open is:pr author:@me archived:false"
+  - id: inbox
+    kind: notifications
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: bugs
+        name: Bugs
+        sources: [my-prs, inbox]
+        filters:
+          labels: ["bug"]
+`), 0o600))
+	store := newStoreAt(dir)
+	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
+	provider.now = newTestClock(t).Now
+
+	items, err := provider.Items(t.Context(), "work", "bugs")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "colonyops/hive#42", items[0].ID)
+	assert.Equal(t, []string{"bug"}, items[0].Labels)
+	assert.Equal(t, "review_requested", items[0].Reason)
+}
+
+// TestLiveProviderConcurrentReadsAndRefreshRaceFree hammers reads
+// (sourceItems via Items) against poller-style refreshes (refreshSource)
+// while time marches past the TTLs, so conditional 304 responses republish
+// cache entries while readers use previously published ones. Run with -race:
+// it fails if cache entries are ever mutated after publication.
+func TestLiveProviderConcurrentReadsAndRefreshRaceFree(t *testing.T) {
+	t.Parallel()
+
+	provider, store, _, clock := newLiveProviderForTest(t)
+	def := createTestProfile(t, store)
+
+	// Populate the cache so refreshes take the conditional-GET path.
+	_, err := provider.Items(t.Context(), def.ID, "")
+	require.NoError(t, err)
+
+	profileDef, err := provider.profileDef(def.ID)
+	require.NoError(t, err)
+	srcByID, err := provider.sourcesByID()
+	require.NoError(t, err)
+	sources := distinctSources(profileDef.Feeds, srcByID)
+	require.NotEmpty(t, sources)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, err := provider.Items(t.Context(), def.ID, "")
+				assert.NoError(t, err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, src := range sources {
+					_, err := provider.refreshSource(t.Context(), src)
+					assert.NoError(t, err)
+				}
+			}
+		}()
+	}
+
+	// March past the search TTL (30s) and the notifications poll floor (60s)
+	// repeatedly so refreshes keep fetching — the notifications fetch answers
+	// 304 and republishes its entry each time.
+	for range 20 {
+		clock.Advance(31 * time.Second)
+		time.Sleep(2 * time.Millisecond)
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestLiveProviderConcurrentFetchesCoalesce holds a fetch in flight and lets
+// a TTL-bypassing refresh race it: singleflight must collapse both callers
+// onto one API request.
+func TestLiveProviderConcurrentFetchesCoalesce(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{searchStarted: make(chan struct{}, 8), searchRelease: make(chan struct{})}
+	provider, store := newLiveProviderWithAPI(t, api)
+	provider.now = newTestClock(t).Now
+	def := createTestProfile(t, store)
+
+	srcByID, err := provider.sourcesByID()
+	require.NoError(t, err)
+	src, ok := srcByID["my-prs"]
+	require.True(t, ok)
+
+	// A user navigation (empty cache) and a poll tick (TTL bypass) race for
+	// the same source.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		items, err := provider.Items(t.Context(), def.ID, "my-open-prs")
+		assert.NoError(t, err)
+		assert.Len(t, items, 2)
+	}()
+	<-api.searchStarted // the first request is in flight and blocked
+	go func() {
+		defer wg.Done()
+		_, err := provider.refreshSource(t.Context(), src)
+		assert.NoError(t, err)
+	}()
+	// Give the second caller time to reach the fetch and join the flight;
+	// without coalescing it would open a second request.
+	time.Sleep(100 * time.Millisecond)
+	close(api.searchRelease)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), api.searchCalls.Load(), "concurrent fetches of one source coalesce into one request")
 }
 
 func TestLiveProviderRepoFilters(t *testing.T) {

--- a/internal/desktop/feed/live_test.go
+++ b/internal/desktop/feed/live_test.go
@@ -3,6 +3,8 @@ package feed
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -77,7 +79,7 @@ func newLiveProviderForTest(t *testing.T) (*LiveProvider, *Store, *atomic.Int32)
 	t.Helper()
 	server, searchCalls := liveAPIServer(t)
 	client := github.NewClient(github.WithAPIBase(server.URL))
-	store := NewStore(t.TempDir())
+	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
 	now, err := time.Parse(time.RFC3339, testNow)
 	require.NoError(t, err)
@@ -250,7 +252,7 @@ func TestLiveProviderStaleCacheOnTransientError(t *testing.T) {
 
 	server, failStatus := flakyAPIServer(t)
 	client := github.NewClient(github.WithAPIBase(server.URL))
-	store := NewStore(t.TempDir())
+	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
 	current, err := time.Parse(time.RFC3339, testNow)
 	require.NoError(t, err)
@@ -281,7 +283,7 @@ func TestLiveProviderRequiresToken(t *testing.T) {
 
 	server, _ := liveAPIServer(t)
 	client := github.NewClient(github.WithAPIBase(server.URL))
-	store := NewStore(t.TempDir())
+	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore(""), store, zerolog.Nop())
 	def := createTestProfile(t, store)
 
@@ -301,4 +303,29 @@ func TestSlugifyAndShortAge(t *testing.T) {
 	assert.Equal(t, "2h", shortAge(2*time.Hour))
 	assert.Equal(t, "3d", shortAge(3*24*time.Hour))
 	assert.Equal(t, "2w", shortAge(15*24*time.Hour))
+}
+
+func TestLiveProviderRepoFilters(t *testing.T) {
+	t.Parallel()
+
+	server, _ := liveAPIServer(t)
+	client := github.NewClient(github.WithAPIBase(server.URL))
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: prs
+        name: My PRs
+        kind: search
+        query: "is:open is:pr author:@me archived:false"
+        exclude_repos: ["colonyops/docs"]
+`), 0o600))
+	store := newStoreAt(dir)
+	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
+
+	items, err := provider.Items(t.Context(), "work", "prs")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "colonyops/hive#42", items[0].ID)
 }

--- a/internal/desktop/feed/mock.go
+++ b/internal/desktop/feed/mock.go
@@ -124,6 +124,17 @@ func (p *MockProvider) Refresh(context.Context, string) (bool, error) {
 	return false, nil
 }
 
+// Config returns a fixture config so the feeds-as-code sheet is walkable
+// offline. The stable path keeps e2e snapshots deterministic.
+func (p *MockProvider) Config(context.Context) (ConfigInfo, error) {
+	return ConfigInfo{
+		Path:   "~/.config/hive/desktop/profiles.yaml",
+		Exists: true,
+		YAML:   ExampleConfig(),
+		Valid:  true,
+	}, nil
+}
+
 // CreateProfile appends a fixture-backed profile with the given name.
 // Deterministic ID: e2e asserts against a stable snapshot.
 func (p *MockProvider) CreateProfile(_ context.Context, name string) (Profile, error) {

--- a/internal/desktop/feed/mock.go
+++ b/internal/desktop/feed/mock.go
@@ -288,6 +288,43 @@ func (p *MockProvider) UpdateFeed(_ context.Context, profileID, feedID string, d
 	return nil
 }
 
+// DeleteFeed removes the feed definition and its summary from the profile.
+func (p *MockProvider) DeleteFeed(_ context.Context, profileID, feedID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	at := p.profileIndexLocked(profileID)
+	if at < 0 {
+		return fmt.Errorf("feed: unknown profile %q", profileID)
+	}
+	defs := p.feedDefs[profileID]
+	if _, ok := defs[feedID]; !ok {
+		return fmt.Errorf("feed: unknown feed %q in profile %q", feedID, profileID)
+	}
+	delete(defs, feedID)
+	for i, summary := range p.profiles[at].Feeds {
+		if summary.ID == feedID {
+			p.profiles[at].Feeds = append(p.profiles[at].Feeds[:i], p.profiles[at].Feeds[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// DeleteProfile removes the profile and its feed definitions. Sources are
+// left untouched: they are shared, decoupled definitions other profiles may
+// still reference.
+func (p *MockProvider) DeleteProfile(_ context.Context, profileID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	at := p.profileIndexLocked(profileID)
+	if at < 0 {
+		return fmt.Errorf("feed: unknown profile %q", profileID)
+	}
+	delete(p.feedDefs, profileID)
+	p.profiles = append(p.profiles[:at], p.profiles[at+1:]...)
+	return nil
+}
+
 func (p *MockProvider) profileIndexLocked(profileID string) int {
 	for i, profile := range p.profiles {
 		if profile.ID == profileID {

--- a/internal/desktop/feed/mock.go
+++ b/internal/desktop/feed/mock.go
@@ -9,23 +9,37 @@ import (
 
 // MockProvider serves the fixture data the e2e suite snapshots. It is the
 // provider in HIVE_DESKTOP_MOCK modes; MarkRead is a no-op and Items are
-// static so repeated e2e interactions never mutate the fixtures. Profiles
-// are the one mutable piece: the onboarding variant starts empty so e2e can
-// walk workspace creation.
+// static so repeated e2e interactions never mutate the fixtures. Sources,
+// profiles, and feed definitions are the mutable pieces: the onboarding
+// variant starts empty so e2e can walk workspace creation and the
+// create-source → create-feed → edit-feed flow.
 type MockProvider struct {
 	mu       sync.Mutex
 	profiles []Profile
+	sources  []SourceDef
+	feedDefs map[string]map[string]FeedDef // profileID → feedID → def
 }
 
 // NewMockProvider starts with the fixture profile (mock mode "feed").
 func NewMockProvider() *MockProvider {
-	return &MockProvider{profiles: []Profile{fixtureProfile("hive-core", "Frontend Triage")}}
+	p := &MockProvider{sources: DefaultSources(), feedDefs: make(map[string]map[string]FeedDef)}
+	p.profiles = []Profile{fixtureProfile("hive-core", "Frontend Triage")}
+	p.seedFeedDefs("hive-core")
+	return p
 }
 
 // NewEmptyMockProvider starts with no profiles (mock mode "onboarding"), so
 // the workspace-creation step is reachable offline.
 func NewEmptyMockProvider() *MockProvider {
-	return &MockProvider{}
+	return &MockProvider{feedDefs: make(map[string]map[string]FeedDef)}
+}
+
+func (p *MockProvider) seedFeedDefs(profileID string) {
+	defs := make(map[string]FeedDef, len(DefaultFeeds()))
+	for _, def := range DefaultFeeds() {
+		defs[def.ID] = def
+	}
+	p.feedDefs[profileID] = defs
 }
 
 func fixtureProfile(id, name string) Profile {
@@ -66,7 +80,7 @@ func (p *MockProvider) Items(_ context.Context, _, _ string) ([]Item, error) {
 		{
 			ID: "iss1190", Kind: "Issue", Repo: "hive/desktop", Num: 1190,
 			Title:  "Feed source: mirror GitHub notifications inbox",
-			Author: "hayden", Age: "5h", Unread: true, Labels: []string{"feature", "mvp"},
+			Author: "hayden", Age: "5h", Unread: true, Reason: "mention", Labels: []string{"feature", "mvp"},
 			Branch: "feat/1190-notifications-feed",
 			Body:   "Add a notifications-based feed source that mirrors the user’s GitHub inbox, with local read/dismiss state so triage does not touch GitHub until the user acts.",
 			Prompt: "Implement a notifications-based feed source mirroring the GitHub inbox, with app-local read/dismiss triage state.",
@@ -135,7 +149,8 @@ func (p *MockProvider) Config(context.Context) (ConfigInfo, error) {
 	}, nil
 }
 
-// CreateProfile appends a fixture-backed profile with the given name.
+// CreateProfile appends a fixture-backed profile with the given name, seeding
+// the default sources and feed definitions like the live store does.
 // Deterministic ID: e2e asserts against a stable snapshot.
 func (p *MockProvider) CreateProfile(_ context.Context, name string) (Profile, error) {
 	name = strings.TrimSpace(name)
@@ -146,5 +161,156 @@ func (p *MockProvider) CreateProfile(_ context.Context, name string) (Profile, e
 	defer p.mu.Unlock()
 	profile := fixtureProfile(fmt.Sprintf("workspace-%d", len(p.profiles)+1), name)
 	p.profiles = append(p.profiles, profile)
+	p.seedFeedDefs(profile.ID)
+	existing := make(map[string]bool, len(p.sources))
+	for _, src := range p.sources {
+		existing[src.ID] = true
+	}
+	for _, src := range DefaultSources() {
+		if !existing[src.ID] {
+			p.sources = append(p.sources, src)
+		}
+	}
 	return profile, nil
+}
+
+// Sources returns the in-memory source definitions.
+func (p *MockProvider) Sources(context.Context) ([]SourceDef, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]SourceDef, len(p.sources))
+	copy(out, p.sources)
+	return out, nil
+}
+
+// FeedDefFor returns the stored feed definition, for edit prefill.
+func (p *MockProvider) FeedDefFor(_ context.Context, profileID, feedID string) (FeedDef, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	defs, ok := p.feedDefs[profileID]
+	if !ok {
+		return FeedDef{}, fmt.Errorf("feed: unknown profile %q", profileID)
+	}
+	def, ok := defs[feedID]
+	if !ok {
+		return FeedDef{}, fmt.Errorf("feed: unknown feed %q in profile %q", feedID, profileID)
+	}
+	return def, nil
+}
+
+// CreateSource validates and stores a source in memory, uniquifying its ID
+// like the live store.
+func (p *MockProvider) CreateSource(_ context.Context, def SourceDef) (SourceDef, error) {
+	slug := slugify(def.ID)
+	if slug == "" {
+		return SourceDef{}, fmt.Errorf("feed: source id is empty")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	taken := make(map[string]bool, len(p.sources))
+	for _, src := range p.sources {
+		taken[src.ID] = true
+	}
+	def.ID = uniqueID(slug, taken)
+	if err := validateSource(def); err != nil {
+		return SourceDef{}, fmt.Errorf("feed: %w", err)
+	}
+	p.sources = append(p.sources, def)
+	return def, nil
+}
+
+// CreateFeed stores a feed definition and appends its summary to the
+// profile's feed list, deriving the ID from the name like the live store.
+func (p *MockProvider) CreateFeed(_ context.Context, profileID string, def FeedDef) (Source, error) {
+	def.Name = strings.TrimSpace(def.Name)
+	if def.Name == "" {
+		return Source{}, fmt.Errorf("feed: feed name is empty")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	at := p.profileIndexLocked(profileID)
+	if at < 0 {
+		return Source{}, fmt.Errorf("feed: unknown profile %q", profileID)
+	}
+	if err := p.validateFeedSourcesLocked(def); err != nil {
+		return Source{}, err
+	}
+
+	slug := slugify(def.Name)
+	if slug == "" {
+		slug = "feed"
+	}
+	defs := p.feedDefs[profileID]
+	if defs == nil {
+		defs = make(map[string]FeedDef)
+		p.feedDefs[profileID] = defs
+	}
+	taken := make(map[string]bool, len(defs))
+	for id := range defs {
+		taken[id] = true
+	}
+	def.ID = uniqueID(slug, taken)
+	defs[def.ID] = def
+
+	summary := Source{ID: def.ID, Name: def.Name}
+	p.profiles[at].Feeds = append(p.profiles[at].Feeds, summary)
+	return summary, nil
+}
+
+// UpdateFeed replaces the stored feed definition; the feed keeps its ID.
+func (p *MockProvider) UpdateFeed(_ context.Context, profileID, feedID string, def FeedDef) error {
+	def.ID = feedID
+	def.Name = strings.TrimSpace(def.Name)
+	if def.Name == "" {
+		return fmt.Errorf("feed: feed name is empty")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	at := p.profileIndexLocked(profileID)
+	if at < 0 {
+		return fmt.Errorf("feed: unknown profile %q", profileID)
+	}
+	defs := p.feedDefs[profileID]
+	if _, ok := defs[feedID]; !ok {
+		return fmt.Errorf("feed: unknown feed %q in profile %q", feedID, profileID)
+	}
+	if err := p.validateFeedSourcesLocked(def); err != nil {
+		return err
+	}
+	defs[feedID] = def
+	for i, summary := range p.profiles[at].Feeds {
+		if summary.ID == feedID {
+			p.profiles[at].Feeds[i].Name = def.Name
+		}
+	}
+	return nil
+}
+
+func (p *MockProvider) profileIndexLocked(profileID string) int {
+	for i, profile := range p.profiles {
+		if profile.ID == profileID {
+			return i
+		}
+	}
+	return -1
+}
+
+// validateFeedSourcesLocked mirrors the live config validation: a feed needs
+// at least one source and every reference must resolve.
+func (p *MockProvider) validateFeedSourcesLocked(def FeedDef) error {
+	if len(def.Sources) == 0 {
+		return fmt.Errorf("feed: at least one source is required")
+	}
+	known := make(map[string]bool, len(p.sources))
+	for _, src := range p.sources {
+		known[src.ID] = true
+	}
+	for _, sourceID := range def.Sources {
+		if !known[sourceID] {
+			return fmt.Errorf("feed: unknown source %q", sourceID)
+		}
+	}
+	return nil
 }

--- a/internal/desktop/feed/mock_test.go
+++ b/internal/desktop/feed/mock_test.go
@@ -176,6 +176,48 @@ func TestMockProviderSourceAndFeedFlow(t *testing.T) {
 	require.ErrorContains(t, provider.UpdateFeed(t.Context(), profile.ID, "ghost", FeedDef{Name: "X", Sources: []string{"team-reviews"}}), "unknown feed")
 }
 
+// TestMockProviderDeleteFlow walks the delete half of the editor flow the
+// e2e mutable server must support: delete a feed, then delete the profile,
+// leaving sources untouched throughout.
+func TestMockProviderDeleteFlow(t *testing.T) {
+	t.Parallel()
+
+	provider := NewEmptyMockProvider()
+	profile, err := provider.CreateProfile(t.Context(), "My Triage")
+	require.NoError(t, err)
+	require.NotEmpty(t, profile.Feeds)
+
+	sourcesBefore, err := provider.Sources(t.Context())
+	require.NoError(t, err)
+
+	firstFeed := profile.Feeds[0].ID
+	require.NoError(t, provider.DeleteFeed(t.Context(), profile.ID, firstFeed))
+
+	profiles, err := provider.Profiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	for _, summary := range profiles[0].Feeds {
+		assert.NotEqual(t, firstFeed, summary.ID, "deleted feed still in profile summary")
+	}
+	_, err = provider.FeedDefFor(t.Context(), profile.ID, firstFeed)
+	require.ErrorContains(t, err, "unknown feed")
+
+	require.ErrorContains(t, provider.DeleteFeed(t.Context(), profile.ID, "ghost"), "unknown feed")
+	require.ErrorContains(t, provider.DeleteFeed(t.Context(), "ghost", firstFeed), "unknown profile")
+
+	require.NoError(t, provider.DeleteProfile(t.Context(), profile.ID))
+	profiles, err = provider.Profiles(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, profiles)
+
+	// Sources are shared/decoupled: deleting the profile leaves them alone.
+	sourcesAfter, err := provider.Sources(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, sourcesBefore, sourcesAfter)
+
+	require.ErrorContains(t, provider.DeleteProfile(t.Context(), "ghost"), "unknown profile")
+}
+
 // TestMockProviderFeedDefsForFixture pins that the fixture profile's feed
 // summaries all have definitions behind them, so the edit flow works on the
 // canned data too.

--- a/internal/desktop/feed/mock_test.go
+++ b/internal/desktop/feed/mock_test.go
@@ -90,6 +90,10 @@ func TestEmptyMockProviderCreatesWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, profiles)
 
+	sources, err := provider.Sources(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, sources, "onboarding starts without sources")
+
 	_, err = provider.CreateProfile(t.Context(), "  ")
 	require.Error(t, err)
 
@@ -104,4 +108,99 @@ func TestEmptyMockProviderCreatesWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, profiles, 1)
 	assert.Equal(t, "workspace-1", profiles[0].ID)
+
+	sources, err = provider.Sources(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, sources, 3, "workspace creation seeds the default sources")
+}
+
+// TestMockProviderSourceAndFeedFlow walks the full editor flow the e2e
+// mutable server must support: create a source, create a feed over it, read
+// it back for edit prefill, and update it.
+func TestMockProviderSourceAndFeedFlow(t *testing.T) {
+	t.Parallel()
+
+	provider := NewEmptyMockProvider()
+	profile, err := provider.CreateProfile(t.Context(), "My Triage")
+	require.NoError(t, err)
+
+	src, err := provider.CreateSource(t.Context(), SourceDef{ID: "Team Reviews", Kind: "search", Query: "is:open review-requested:@me"})
+	require.NoError(t, err)
+	assert.Equal(t, "team-reviews", src.ID)
+
+	dup, err := provider.CreateSource(t.Context(), SourceDef{ID: "team-reviews", Kind: "search", Query: "other"})
+	require.NoError(t, err)
+	assert.Equal(t, "team-reviews-2", dup.ID, "taken ids uniquify")
+
+	_, err = provider.CreateSource(t.Context(), SourceDef{ID: "bad", Kind: "search"})
+	require.ErrorContains(t, err, "requires a query")
+
+	summary, err := provider.CreateFeed(t.Context(), profile.ID, FeedDef{
+		Name:    "Team Reviews",
+		Sources: []string{"team-reviews"},
+		Filters: FilterDef{Types: []string{"pr"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "team-reviews", summary.ID)
+
+	_, err = provider.CreateFeed(t.Context(), profile.ID, FeedDef{Name: "Broken", Sources: []string{"ghost"}})
+	require.ErrorContains(t, err, "unknown source")
+	_, err = provider.CreateFeed(t.Context(), "ghost", FeedDef{Name: "X", Sources: []string{"team-reviews"}})
+	require.ErrorContains(t, err, "unknown profile")
+
+	def, err := provider.FeedDefFor(t.Context(), profile.ID, "team-reviews")
+	require.NoError(t, err)
+	assert.Equal(t, "Team Reviews", def.Name)
+	assert.Equal(t, []string{"pr"}, def.Filters.Types)
+
+	err = provider.UpdateFeed(t.Context(), profile.ID, "team-reviews", FeedDef{
+		Name:    "Reviews (renamed)",
+		Sources: []string{"team-reviews", "team-reviews-2"},
+	})
+	require.NoError(t, err)
+
+	def, err = provider.FeedDefFor(t.Context(), profile.ID, "team-reviews")
+	require.NoError(t, err)
+	assert.Equal(t, "team-reviews", def.ID, "feed keeps its id")
+	assert.Equal(t, "Reviews (renamed)", def.Name)
+	assert.Equal(t, []string{"team-reviews", "team-reviews-2"}, def.Sources)
+
+	profiles, err := provider.Profiles(t.Context())
+	require.NoError(t, err)
+	var names []string
+	for _, feedSummary := range profiles[0].Feeds {
+		names = append(names, feedSummary.Name)
+	}
+	assert.Contains(t, names, "Reviews (renamed)", "profile summary reflects the rename")
+
+	require.ErrorContains(t, provider.UpdateFeed(t.Context(), profile.ID, "ghost", FeedDef{Name: "X", Sources: []string{"team-reviews"}}), "unknown feed")
+}
+
+// TestMockProviderFeedDefsForFixture pins that the fixture profile's feed
+// summaries all have definitions behind them, so the edit flow works on the
+// canned data too.
+func TestMockProviderFeedDefsForFixture(t *testing.T) {
+	t.Parallel()
+
+	provider := NewMockProvider()
+	profiles, err := provider.Profiles(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, profiles)
+
+	sources, err := provider.Sources(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, sources)
+	known := make(map[string]bool, len(sources))
+	for _, src := range sources {
+		known[src.ID] = true
+	}
+
+	for _, summary := range profiles[0].Feeds {
+		def, err := provider.FeedDefFor(t.Context(), profiles[0].ID, summary.ID)
+		require.NoError(t, err, summary.ID)
+		require.NotEmpty(t, def.Sources, summary.ID)
+		for _, sourceID := range def.Sources {
+			assert.True(t, known[sourceID], "feed %s references unknown source %s", summary.ID, sourceID)
+		}
+	}
 }

--- a/internal/desktop/feed/poller.go
+++ b/internal/desktop/feed/poller.go
@@ -12,9 +12,10 @@ import (
 // a settings surface can make it configurable later.
 const DefaultPollInterval = time.Minute
 
-// Poller periodically refreshes every profile of a LiveProvider and calls
-// onUpdate with a profile ID whenever its feed state changed. main.go wires
-// onUpdate to the feed:updated event.
+// Poller periodically refreshes the distinct sources referenced across every
+// profile of a LiveProvider and calls onUpdate with a profile ID whenever a
+// source its feeds read from changed. main.go wires onUpdate to the
+// feed:updated event.
 type Poller struct {
 	provider *LiveProvider
 	interval time.Duration
@@ -58,22 +59,56 @@ func (p *Poller) Stop() {
 	p.stopOnce.Do(func() { close(p.stop) })
 }
 
-// PollOnce refreshes every profile once, notifying per changed profile.
+// PollOnce refreshes each distinct source exactly once across all profiles —
+// profiles sharing sources do not multiply requests — then notifies every
+// profile whose feeds reference a changed source.
 func (p *Poller) PollOnce(ctx context.Context) {
 	defs, err := p.provider.store.Profiles()
 	if err != nil {
 		p.logger.Warn().Err(err).Msg("poll: reading profiles failed")
 		return
 	}
+	srcByID, err := p.provider.sourcesByID()
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("poll: reading sources failed")
+		return
+	}
+
+	allFeeds := make([]FeedDef, 0)
 	for _, def := range defs {
-		changed, err := p.provider.Refresh(ctx, def.ID)
+		allFeeds = append(allFeeds, def.Feeds...)
+	}
+
+	changedKeys := make(map[string]bool)
+	for _, src := range distinctSources(allFeeds, srcByID) {
+		changed, err := p.provider.refreshSource(ctx, src)
 		if err != nil {
 			// Expected during offline stretches; the UI keeps stale data.
-			p.logger.Debug().Err(err).Str("profile", def.Name).Msg("poll: refresh failed")
+			p.logger.Debug().Err(err).Str("source", src.ID).Msg("poll: refresh failed")
 			continue
 		}
-		if changed && p.onUpdate != nil {
+		if changed {
+			changedKeys[sourceKey(src)] = true
+		}
+	}
+	if len(changedKeys) == 0 || p.onUpdate == nil {
+		return
+	}
+
+	for _, def := range defs {
+		if profileReferencesChanged(def, srcByID, changedKeys) {
 			p.onUpdate(def.ID)
 		}
 	}
+}
+
+// profileReferencesChanged reports whether any feed of the profile reads from
+// a source whose data changed this poll.
+func profileReferencesChanged(def ProfileDef, srcByID map[string]SourceDef, changedKeys map[string]bool) bool {
+	for _, src := range distinctSources(def.Feeds, srcByID) {
+		if changedKeys[sourceKey(src)] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/desktop/feed/poller_test.go
+++ b/internal/desktop/feed/poller_test.go
@@ -65,7 +65,7 @@ func newPollerFixture(t *testing.T) (*LiveProvider, *mutableAPIServer, ProfileDe
 	t.Cleanup(server.Close)
 
 	client := github.NewClient(github.WithAPIBase(server.URL))
-	store := NewStore(t.TempDir())
+	store := newStoreAt(t.TempDir())
 	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
 	def, err := store.CreateProfile("Triage")
 	require.NoError(t, err)

--- a/internal/desktop/feed/poller_test.go
+++ b/internal/desktop/feed/poller_test.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,10 +20,12 @@ import (
 )
 
 // mutableAPIServer serves a single search item whose title can be swapped,
-// and an empty notifications inbox.
+// and an empty notifications inbox. It counts search requests so source
+// deduplication across profiles is observable.
 type mutableAPIServer struct {
-	mu    sync.Mutex
-	title string
+	mu          sync.Mutex
+	title       string
+	searchCalls atomic.Int32
 }
 
 func (m *mutableAPIServer) setTitle(title string) {
@@ -32,6 +37,7 @@ func (m *mutableAPIServer) setTitle(title string) {
 func (m *mutableAPIServer) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, _ *http.Request) {
+		m.searchCalls.Add(1)
 		m.mu.Lock()
 		title := m.title
 		m.mu.Unlock()
@@ -111,6 +117,55 @@ func TestPollOnceNotifiesChangedProfiles(t *testing.T) {
 	api.setTitle("v2-renamed")
 	poller.PollOnce(t.Context())
 	assert.Equal(t, []string{def.ID, def.ID}, notified)
+}
+
+// TestPollOnceDedupesSourcesAcrossProfiles is the point of the source split:
+// two profiles reading the same source cost one request per poll, and both
+// wake when it changes.
+func TestPollOnceDedupesSourcesAcrossProfiles(t *testing.T) {
+	t.Parallel()
+
+	api := &mutableAPIServer{title: "v1"}
+	server := httptest.NewServer(api.handler())
+	t.Cleanup(server.Close)
+
+	client := github.NewClient(github.WithAPIBase(server.URL))
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`sources:
+  - id: shared
+    kind: search
+    query: "is:open involves:@me"
+profiles:
+  - id: one
+    name: One
+    feeds:
+      - {id: f1, name: F1, sources: [shared]}
+  - id: two
+    name: Two
+    feeds:
+      - {id: f2, name: F2, sources: [shared]}
+      - id: f3
+        name: F3
+        sources: [shared]
+        filters:
+          types: [issue]
+`), 0o600))
+	store := newStoreAt(dir)
+	provider := NewLiveProvider(client, github.NewMemoryTokenStore("tok"), store, zerolog.Nop())
+
+	var notified []string
+	poller := NewPoller(provider, time.Hour, func(profileID string) {
+		notified = append(notified, profileID)
+	}, zerolog.Nop())
+
+	poller.PollOnce(t.Context())
+	assert.Equal(t, int32(1), api.searchCalls.Load(), "three feeds in two profiles, one source, one request")
+	assert.Equal(t, []string{"one", "two"}, notified, "both profiles reference the changed source")
+
+	api.setTitle("v2-renamed")
+	poller.PollOnce(t.Context())
+	assert.Equal(t, int32(2), api.searchCalls.Load())
+	assert.Equal(t, []string{"one", "two", "one", "two"}, notified)
 }
 
 func TestPollerStartStop(t *testing.T) {

--- a/internal/desktop/feed/prompt.go
+++ b/internal/desktop/feed/prompt.go
@@ -19,26 +19,51 @@ func BuildConfigPrompt(info ConfigInfo) string {
 	}
 	b.WriteString("The app watches this file and hot-reloads on save; no restart needed.\n\n")
 	b.WriteString(`Schema (strict YAML — unknown keys are rejected):
+- sources: list of GitHub data acquisitions. Sources are the only part of
+  the config that costs API requests; identical sources are deduplicated.
+  - id: unique lowercase slug across all sources.
+  - kind: "search" or "notifications".
+  - query: required for kind "search"; GitHub issue/PR search syntax
+    (e.g. "is:open is:pr author:@me archived:false"). Forbidden for
+    kind "notifications", which mirrors the GitHub notifications inbox.
+  - limit: optional items per fetch. Search: default 50, max 100.
+    Notifications: default 50, max 50 (API cap).
 - profiles: list of workspaces shown in the app rail.
   - id: unique lowercase slug. Stable — renaming it makes it a new profile.
   - name: display name.
-  - feeds: list of feeds in the workspace.
+  - feeds: list of feeds in the workspace. A feed is a client-side
+    filtered view over sources — feeds are unlimited and free of API cost.
     - id: unique slug within the profile.
     - name: display name.
-    - kind: "search" or "notifications".
-    - query: required for kind "search"; GitHub issue/PR search syntax
-      (e.g. "is:open is:pr author:@me archived:false"). Forbidden for
-      kind "notifications", which mirrors the GitHub notifications inbox.
-    - repos: optional list of "owner/repo" globs to keep (e.g. "acme/*").
-    - exclude_repos: optional list of globs to drop; excludes win.
+    - sources: list of source ids to read from (at least one; every id
+      must exist under top-level sources). A feed over several sources
+      merges and deduplicates their items.
+    - filters: optional block. Groups AND together; values within a group
+      OR; exclude groups win over includes. All groups optional:
+      - repos / exclude_repos: doublestar globs matched against
+        "owner/repo" (e.g. "acme/*", "acme/**").
+      - authors / exclude_authors: globs matched against the item author,
+        case-insensitively; "[" and "]" match literally, so
+        exclude_authors: ["*[bot]"] drops every bot account.
+      - labels / exclude_labels: globs; an item matches when ANY of its
+        labels matches ANY glob (exclude: dropped when any label matches).
+      - types: "pr" | "issue".
+      - reasons: notification reasons (mention, review_requested, assign,
+        author, comment, subscribed, team_mention, state_change, and the
+        other GitHub reasons). Items that came only from a search source
+        have no reason, so a reasons filter excludes them — reasons only
+        make sense on feeds reading a notifications source.
 
 Constraints:
-- Each feed costs one GitHub API request per poll (about once a minute).
-  Keep the feed list lean; configs with more than 30 feeds are rejected
-  because they would exceed GitHub's search rate limit (30 requests/min).
-- repos/exclude_repos filter client-side after fetching — free of API
-  cost, so prefer one broad query plus glob filters over many narrow
-  query feeds.
+- At most 25 sources of kind "search": each distinct search source is one
+  request per poll (about once a minute) against GitHub's search rate
+  limit of 30 requests/min, and 25 leaves headroom for manual refreshes.
+- Notifications sources are not capped: they poll the core rate bucket
+  (5000/hr) with conditional requests, and an unchanged inbox answers 304
+  at no rate-limit cost.
+- Feeds are unlimited and free: filtering happens client-side after the
+  fetch. Prefer a few broad sources shared by many filtered feeds over
+  many narrow search sources.
 
 Current config:
 `)

--- a/internal/desktop/feed/prompt.go
+++ b/internal/desktop/feed/prompt.go
@@ -1,0 +1,50 @@
+package feed
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildConfigPrompt renders a paste-ready prompt for a coding agent to
+// create or edit the profiles config on the user's behalf — the
+// "config-as-code via agent" path for users who would rather describe their
+// feeds than hand-write YAML. It carries the schema contract and the
+// current config so the agent needs no other context.
+func BuildConfigPrompt(info ConfigInfo) string {
+	var b strings.Builder
+	b.WriteString("Edit my Hive Desktop feed configuration.\n\n")
+	fmt.Fprintf(&b, "File: %s\n", info.Path)
+	if !info.Exists {
+		b.WriteString("The file does not exist yet — create it.\n")
+	}
+	b.WriteString("The app watches this file and hot-reloads on save; no restart needed.\n\n")
+	b.WriteString(`Schema (strict YAML — unknown keys are rejected):
+- profiles: list of workspaces shown in the app rail.
+  - id: unique lowercase slug. Stable — renaming it makes it a new profile.
+  - name: display name.
+  - feeds: list of feeds in the workspace.
+    - id: unique slug within the profile.
+    - name: display name.
+    - kind: "search" or "notifications".
+    - query: required for kind "search"; GitHub issue/PR search syntax
+      (e.g. "is:open is:pr author:@me archived:false"). Forbidden for
+      kind "notifications", which mirrors the GitHub notifications inbox.
+    - repos: optional list of "owner/repo" globs to keep (e.g. "acme/*").
+    - exclude_repos: optional list of globs to drop; excludes win.
+
+Constraints:
+- Each feed costs one GitHub API request per poll (about once a minute).
+  Keep the feed list lean; configs with more than 30 feeds are rejected
+  because they would exceed GitHub's search rate limit (30 requests/min).
+- repos/exclude_repos filter client-side after fetching — free of API
+  cost, so prefer one broad query plus glob filters over many narrow
+  query feeds.
+
+Current config:
+`)
+	b.WriteString("```yaml\n")
+	b.WriteString(strings.TrimRight(info.YAML, "\n"))
+	b.WriteString("\n```\n\n")
+	b.WriteString("What I want: <describe your workspaces and feeds here>\n")
+	return b.String()
+}

--- a/internal/desktop/feed/prompt_test.go
+++ b/internal/desktop/feed/prompt_test.go
@@ -1,0 +1,36 @@
+package feed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildConfigPrompt(t *testing.T) {
+	t.Parallel()
+
+	prompt := BuildConfigPrompt(ConfigInfo{
+		Path:   "/home/u/.config/hive/desktop/profiles.yaml",
+		Exists: true,
+		YAML:   "profiles:\n  - id: work\n",
+		Valid:  true,
+	})
+
+	assert.Contains(t, prompt, "/home/u/.config/hive/desktop/profiles.yaml")
+	assert.Contains(t, prompt, "- id: work")
+	assert.Contains(t, prompt, "exclude_repos")
+	assert.Contains(t, prompt, "hot-reloads")
+	assert.NotContains(t, prompt, "does not exist")
+}
+
+func TestBuildConfigPromptMissingFile(t *testing.T) {
+	t.Parallel()
+
+	prompt := BuildConfigPrompt(ConfigInfo{
+		Path: "/home/u/.config/hive/desktop/profiles.yaml",
+		YAML: ExampleConfig(),
+	})
+
+	assert.Contains(t, prompt, "does not exist yet")
+	assert.Contains(t, prompt, "kind: notifications")
+}

--- a/internal/desktop/feed/prompt_test.go
+++ b/internal/desktop/feed/prompt_test.go
@@ -18,9 +18,22 @@ func TestBuildConfigPrompt(t *testing.T) {
 
 	assert.Contains(t, prompt, "/home/u/.config/hive/desktop/profiles.yaml")
 	assert.Contains(t, prompt, "- id: work")
-	assert.Contains(t, prompt, "exclude_repos")
 	assert.Contains(t, prompt, "hot-reloads")
 	assert.NotContains(t, prompt, "does not exist")
+
+	// The schema contract: sources vs feeds, the filter vocabulary, and the
+	// rate-limit constraints the agent must respect.
+	assert.Contains(t, prompt, "sources:")
+	assert.Contains(t, prompt, "exclude_repos")
+	assert.Contains(t, prompt, "exclude_authors")
+	assert.Contains(t, prompt, "exclude_labels")
+	assert.Contains(t, prompt, "types:")
+	assert.Contains(t, prompt, "reasons:")
+	assert.Contains(t, prompt, "a reasons filter excludes them")
+	assert.Contains(t, prompt, "25 sources of kind \"search\"")
+	assert.Contains(t, prompt, "30 requests/min")
+	assert.Contains(t, prompt, "Feeds are unlimited and free")
+	assert.Contains(t, prompt, "304")
 }
 
 func TestBuildConfigPromptMissingFile(t *testing.T) {

--- a/internal/desktop/feed/store.go
+++ b/internal/desktop/feed/store.go
@@ -9,44 +9,31 @@ import (
 	"sync"
 	"time"
 	"unicode"
-
-	"github.com/google/uuid"
 )
 
-// FeedDef is a persisted feed definition inside a profile. The vocabulary
-// (kind + query) deliberately mirrors the saved-view schema proposed for TUI
-// sources (issue #370) so the two can converge on one definition later.
-type FeedDef struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Kind  string `json:"kind"` // "search" | "notifications"
-	Query string `json:"query,omitempty"`
-}
-
-// ProfileDef is a persisted profile ("workspace") definition.
-type ProfileDef struct {
-	ID    string    `json:"id"`
-	Name  string    `json:"name"`
-	Feeds []FeedDef `json:"feeds"`
-}
-
-// Store persists desktop feed state under one directory: profile
-// definitions (profiles.json) and app-local read state (readstate.json).
+// Store persists desktop feed data across two locations with different
+// ownership: profile definitions live in a user-editable YAML config file
+// (dotfiles territory — see desktop.ConfigPath), app-local read state lives
+// in the state dir (readstate.json). On config errors the last-good
+// profiles are retained so a half-saved edit degrades instead of blanking
+// the app.
 type Store struct {
-	dir string
+	configPath string
+	stateDir   string
 
-	mu        sync.Mutex
-	profiles  []ProfileDef
-	readState map[string]time.Time
-	loaded    bool
+	mu           sync.Mutex
+	profiles     []ProfileDef
+	configLoaded bool
+	readState    map[string]time.Time
+	stateLoaded  bool
 }
 
-func NewStore(dir string) *Store {
-	return &Store{dir: dir}
+func NewStore(configPath, stateDir string) *Store {
+	return &Store{configPath: configPath, stateDir: stateDir}
 }
 
-// DefaultFeeds are the feeds seeded into a new profile, matching the mock
-// roadmap: authored PRs, the notifications inbox, and cross-repo assignments.
+// DefaultFeeds are the feeds seeded into a new profile: authored PRs, the
+// notifications inbox, and cross-repo assignments.
 func DefaultFeeds() []FeedDef {
 	return []FeedDef{
 		{ID: "my-open-prs", Name: "My open PRs", Kind: "search", Query: "is:open is:pr author:@me archived:false"},
@@ -55,11 +42,14 @@ func DefaultFeeds() []FeedDef {
 	}
 }
 
-// Profiles returns the persisted profile definitions.
+// Profiles returns the profile definitions from the config file. When the
+// config is broken and no prior good load exists, the parse error is
+// returned so the failure is visible instead of looking like a fresh
+// install (which would route the user into onboarding).
 func (s *Store) Profiles() ([]ProfileDef, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.load(); err != nil {
+	if err := s.loadConfigLocked(false); err != nil {
 		return nil, err
 	}
 	out := make([]ProfileDef, len(s.profiles))
@@ -67,7 +57,41 @@ func (s *Store) Profiles() ([]ProfileDef, error) {
 	return out, nil
 }
 
-// CreateProfile persists a new profile with the default feeds.
+// Reload re-reads the config file, retaining the last-good profiles when
+// the new content fails to parse or validate.
+func (s *Store) Reload() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loadConfigLocked(true)
+}
+
+// ConfigInfo reports the config file's location and current content for the
+// frontend, parsing the on-disk bytes fresh so the verdict reflects what
+// the user's editor just saved, not a cached state.
+func (s *Store) ConfigInfo() ConfigInfo {
+	info := ConfigInfo{Path: s.configPath, Valid: true}
+	data, err := os.ReadFile(s.configPath)
+	switch {
+	case os.IsNotExist(err):
+		info.YAML = ExampleConfig()
+	case err != nil:
+		info.Valid = false
+		info.Error = err.Error()
+	default:
+		info.Exists = true
+		info.YAML = string(data)
+		if _, parseErr := parseConfig(data); parseErr != nil {
+			info.Valid = false
+			info.Error = parseErr.Error()
+		}
+	}
+	return info
+}
+
+// CreateProfile appends a profile seeded with the default feeds to the
+// config file, preserving any hand-written comments and formatting. It
+// refuses to touch a config that currently fails to parse: appending to a
+// broken document could compound the damage.
 func (s *Store) CreateProfile(name string) (ProfileDef, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -76,27 +100,53 @@ func (s *Store) CreateProfile(name string) (ProfileDef, error) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.load(); err != nil {
-		return ProfileDef{}, err
+	if err := s.loadConfigLocked(true); err != nil {
+		return ProfileDef{}, fmt.Errorf("feed: fix %s before creating profiles: %w", filepath.Base(s.configPath), err)
 	}
 
 	def := ProfileDef{
-		ID:    uuid.NewString(),
+		ID:    s.uniqueProfileID(slugify(name)),
 		Name:  name,
 		Feeds: DefaultFeeds(),
 	}
-	s.profiles = append(s.profiles, def)
-	if err := s.saveProfiles(); err != nil {
+
+	data, err := os.ReadFile(s.configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return ProfileDef{}, fmt.Errorf("feed: read config: %w", err)
+	}
+	updated, err := appendProfileToConfig(data, def)
+	if err != nil {
+		return ProfileDef{}, fmt.Errorf("feed: %w", err)
+	}
+	if err := writeFileAtomic(s.configPath, updated); err != nil {
 		return ProfileDef{}, err
 	}
+	s.profiles = append(s.profiles, def)
 	return def, nil
+}
+
+// uniqueProfileID suffixes the slug until it is unused, so two profiles
+// named "Work" do not collide.
+func (s *Store) uniqueProfileID(slug string) string {
+	if slug == "" {
+		slug = "profile"
+	}
+	taken := make(map[string]bool, len(s.profiles))
+	for _, def := range s.profiles {
+		taken[def.ID] = true
+	}
+	id := slug
+	for n := 2; taken[id]; n++ {
+		id = fmt.Sprintf("%s-%d", slug, n)
+	}
+	return id
 }
 
 // ReadAt returns when the item was last marked read.
 func (s *Store) ReadAt(itemID string) (time.Time, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.load(); err != nil {
+	if err := s.loadStateLocked(); err != nil {
 		return time.Time{}, false
 	}
 	at, ok := s.readState[itemID]
@@ -111,7 +161,7 @@ func (s *Store) MarkRead(itemID string, updatedAt time.Time) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.load(); err != nil {
+	if err := s.loadStateLocked(); err != nil {
 		return err
 	}
 	if s.readState == nil {
@@ -121,29 +171,49 @@ func (s *Store) MarkRead(itemID string, updatedAt time.Time) error {
 	return s.saveReadState()
 }
 
-func (s *Store) profilesPath() string  { return filepath.Join(s.dir, "profiles.json") }
-func (s *Store) readStatePath() string { return filepath.Join(s.dir, "readstate.json") }
+func (s *Store) readStatePath() string { return filepath.Join(s.stateDir, "readstate.json") }
 
-func (s *Store) load() error {
-	if s.loaded {
+// loadConfigLocked reads and parses the config file. Once a load has
+// succeeded, non-forced calls are no-ops and a failed forced reload leaves
+// the last-good profiles in place — the returned error is the caller's to
+// surface (the watcher pushes it to the frontend).
+func (s *Store) loadConfigLocked(force bool) error {
+	if s.configLoaded && !force {
 		return nil
 	}
-	if err := readJSONFile(s.profilesPath(), &s.profiles); err != nil {
-		return err
+	data, err := os.ReadFile(s.configPath)
+	if os.IsNotExist(err) {
+		data, err = nil, nil
+	}
+	var defs []ProfileDef
+	if err == nil {
+		defs, err = parseConfig(data)
+	}
+	if err != nil {
+		return fmt.Errorf("feed: %s: %w", filepath.Base(s.configPath), err)
+	}
+	s.profiles = defs
+	s.configLoaded = true
+	return nil
+}
+
+func (s *Store) loadStateLocked() error {
+	if s.stateLoaded {
+		return nil
 	}
 	if err := readJSONFile(s.readStatePath(), &s.readState); err != nil {
 		return err
 	}
-	s.loaded = true
+	s.stateLoaded = true
 	return nil
 }
 
-func (s *Store) saveProfiles() error {
-	return writeJSONFile(s.profilesPath(), s.profiles)
-}
-
 func (s *Store) saveReadState() error {
-	return writeJSONFile(s.readStatePath(), s.readState)
+	data, err := json.MarshalIndent(s.readState, "", "  ")
+	if err != nil {
+		return fmt.Errorf("feed: encode read state: %w", err)
+	}
+	return writeFileAtomic(s.readStatePath(), data)
 }
 
 func readJSONFile(path string, out any) error {
@@ -160,13 +230,9 @@ func readJSONFile(path string, out any) error {
 	return nil
 }
 
-func writeJSONFile(path string, value any) error {
+func writeFileAtomic(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("feed: create state dir: %w", err)
-	}
-	data, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		return fmt.Errorf("feed: encode %s: %w", filepath.Base(path), err)
+		return fmt.Errorf("feed: create %s dir: %w", filepath.Base(path), err)
 	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {

--- a/internal/desktop/feed/store.go
+++ b/internal/desktop/feed/store.go
@@ -281,6 +281,48 @@ func (s *Store) UpdateFeed(profileID, feedID string, def FeedDef) error {
 	return s.commitConfigLocked(updated)
 }
 
+// DeleteFeed removes the feed from the profile; the profile and its other
+// feeds are untouched.
+func (s *Store) DeleteFeed(profileID, feedID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(true); err != nil {
+		return fmt.Errorf("feed: fix %s before deleting feeds: %w", filepath.Base(s.configPath), err)
+	}
+
+	data, err := s.readConfigBytesLocked()
+	if err != nil {
+		return err
+	}
+	updated, err := deleteFeedFromConfig(data, profileID, feedID)
+	if err != nil {
+		return fmt.Errorf("feed: %w", err)
+	}
+	return s.commitConfigLocked(updated)
+}
+
+// DeleteProfile removes the profile and its feeds from the config. Sources
+// are left untouched: they are shared, decoupled definitions other profiles
+// may still reference. Deleting the last profile is allowed — it leaves an
+// empty profiles list, the same state a fresh install starts from.
+func (s *Store) DeleteProfile(profileID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(true); err != nil {
+		return fmt.Errorf("feed: fix %s before deleting profiles: %w", filepath.Base(s.configPath), err)
+	}
+
+	data, err := s.readConfigBytesLocked()
+	if err != nil {
+		return err
+	}
+	updated, err := deleteProfileFromConfig(data, profileID)
+	if err != nil {
+		return fmt.Errorf("feed: %w", err)
+	}
+	return s.commitConfigLocked(updated)
+}
+
 // readConfigBytesLocked reads the raw config file; a missing file reads as
 // empty, matching the append helpers' empty-document path.
 func (s *Store) readConfigBytesLocked() ([]byte, error) {

--- a/internal/desktop/feed/store.go
+++ b/internal/desktop/feed/store.go
@@ -12,16 +12,17 @@ import (
 )
 
 // Store persists desktop feed data across two locations with different
-// ownership: profile definitions live in a user-editable YAML config file
-// (dotfiles territory — see desktop.ConfigPath), app-local read state lives
-// in the state dir (readstate.json). On config errors the last-good
-// profiles are retained so a half-saved edit degrades instead of blanking
-// the app.
+// ownership: source and profile definitions live in a user-editable YAML
+// config file (dotfiles territory — see desktop.ConfigPath), app-local read
+// state lives in the state dir (readstate.json). On config errors the
+// last-good definitions are retained so a half-saved edit degrades instead of
+// blanking the app.
 type Store struct {
 	configPath string
 	stateDir   string
 
 	mu           sync.Mutex
+	sources      []SourceDef
 	profiles     []ProfileDef
 	configLoaded bool
 	readState    map[string]time.Time
@@ -32,13 +33,24 @@ func NewStore(configPath, stateDir string) *Store {
 	return &Store{configPath: configPath, stateDir: stateDir}
 }
 
-// DefaultFeeds are the feeds seeded into a new profile: authored PRs, the
-// notifications inbox, and cross-repo assignments.
+// DefaultSources are the sources seeded alongside a new profile when they do
+// not exist yet: authored PRs, cross-repo assignments, and the notifications
+// inbox.
+func DefaultSources() []SourceDef {
+	return []SourceDef{
+		{ID: "my-prs", Kind: "search", Query: "is:open is:pr author:@me archived:false"},
+		{ID: "assigned", Kind: "search", Query: "is:open assignee:@me archived:false"},
+		{ID: "inbox", Kind: "notifications"},
+	}
+}
+
+// DefaultFeeds are the feeds seeded into a new profile, one per default
+// source.
 func DefaultFeeds() []FeedDef {
 	return []FeedDef{
-		{ID: "my-open-prs", Name: "My open PRs", Kind: "search", Query: "is:open is:pr author:@me archived:false"},
-		{ID: "notifications-inbox", Name: "Notifications inbox", Kind: "notifications"},
-		{ID: "assigned-across-org", Name: "Assigned across org", Kind: "search", Query: "is:open assignee:@me archived:false"},
+		{ID: "my-open-prs", Name: "My open PRs", Sources: []string{"my-prs"}},
+		{ID: "notifications-inbox", Name: "Notifications inbox", Sources: []string{"inbox"}},
+		{ID: "assigned-across-org", Name: "Assigned across org", Sources: []string{"assigned"}},
 	}
 }
 
@@ -57,7 +69,41 @@ func (s *Store) Profiles() ([]ProfileDef, error) {
 	return out, nil
 }
 
-// Reload re-reads the config file, retaining the last-good profiles when
+// Sources returns the source definitions from the config file, with the same
+// last-good semantics as Profiles.
+func (s *Store) Sources() ([]SourceDef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(false); err != nil {
+		return nil, err
+	}
+	out := make([]SourceDef, len(s.sources))
+	copy(out, s.sources)
+	return out, nil
+}
+
+// FeedDefFor returns one feed's definition, for edit prefill.
+func (s *Store) FeedDefFor(profileID, feedID string) (FeedDef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(false); err != nil {
+		return FeedDef{}, err
+	}
+	for _, profile := range s.profiles {
+		if profile.ID != profileID {
+			continue
+		}
+		for _, feedDef := range profile.Feeds {
+			if feedDef.ID == feedID {
+				return feedDef, nil
+			}
+		}
+		return FeedDef{}, fmt.Errorf("feed: unknown feed %q in profile %q", feedID, profileID)
+	}
+	return FeedDef{}, fmt.Errorf("feed: unknown profile %q", profileID)
+}
+
+// Reload re-reads the config file, retaining the last-good definitions when
 // the new content fails to parse or validate.
 func (s *Store) Reload() error {
 	s.mu.Lock()
@@ -89,9 +135,10 @@ func (s *Store) ConfigInfo() ConfigInfo {
 }
 
 // CreateProfile appends a profile seeded with the default feeds to the
-// config file, preserving any hand-written comments and formatting. It
-// refuses to touch a config that currently fails to parse: appending to a
-// broken document could compound the damage.
+// config file, preserving any hand-written comments and formatting. Default
+// sources the feeds reference are appended first when absent. It refuses to
+// touch a config that currently fails to parse: appending to a broken
+// document could compound the damage.
 func (s *Store) CreateProfile(name string) (ProfileDef, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -110,19 +157,164 @@ func (s *Store) CreateProfile(name string) (ProfileDef, error) {
 		Feeds: DefaultFeeds(),
 	}
 
-	data, err := os.ReadFile(s.configPath)
-	if err != nil && !os.IsNotExist(err) {
-		return ProfileDef{}, fmt.Errorf("feed: read config: %w", err)
-	}
-	updated, err := appendProfileToConfig(data, def)
+	updated, err := s.readConfigBytesLocked()
 	if err != nil {
-		return ProfileDef{}, fmt.Errorf("feed: %w", err)
-	}
-	if err := writeFileAtomic(s.configPath, updated); err != nil {
 		return ProfileDef{}, err
 	}
-	s.profiles = append(s.profiles, def)
+	// Seed missing default sources by ID. An existing source with a default
+	// ID is left as the user defined it; the seeded feed then reads from it.
+	existing := make(map[string]bool, len(s.sources))
+	for _, src := range s.sources {
+		existing[src.ID] = true
+	}
+	for _, src := range DefaultSources() {
+		if existing[src.ID] {
+			continue
+		}
+		if updated, err = appendSourceToConfig(updated, src); err != nil {
+			return ProfileDef{}, fmt.Errorf("feed: %w", err)
+		}
+	}
+	if updated, err = appendProfileToConfig(updated, def); err != nil {
+		return ProfileDef{}, fmt.Errorf("feed: %w", err)
+	}
+	if err := s.commitConfigLocked(updated); err != nil {
+		return ProfileDef{}, err
+	}
 	return def, nil
+}
+
+// CreateSource appends a source to the config file. The caller-supplied ID is
+// slugified and uniquified (-2 suffix) against existing source IDs.
+func (s *Store) CreateSource(def SourceDef) (SourceDef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(true); err != nil {
+		return SourceDef{}, fmt.Errorf("feed: fix %s before creating sources: %w", filepath.Base(s.configPath), err)
+	}
+
+	slug := slugify(def.ID)
+	if slug == "" {
+		return SourceDef{}, fmt.Errorf("feed: source id is empty")
+	}
+	taken := make(map[string]bool, len(s.sources))
+	for _, src := range s.sources {
+		taken[src.ID] = true
+	}
+	def.ID = uniqueID(slug, taken)
+	if err := validateSource(def); err != nil {
+		return SourceDef{}, fmt.Errorf("feed: %w", err)
+	}
+
+	data, err := s.readConfigBytesLocked()
+	if err != nil {
+		return SourceDef{}, err
+	}
+	updated, err := appendSourceToConfig(data, def)
+	if err != nil {
+		return SourceDef{}, fmt.Errorf("feed: %w", err)
+	}
+	if err := s.commitConfigLocked(updated); err != nil {
+		return SourceDef{}, err
+	}
+	return def, nil
+}
+
+// CreateFeed appends a feed to the profile. The feed ID is derived from the
+// name, uniquified (-2 suffix) against the profile's existing feed IDs.
+func (s *Store) CreateFeed(profileID string, def FeedDef) (FeedDef, error) {
+	def.Name = strings.TrimSpace(def.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(true); err != nil {
+		return FeedDef{}, fmt.Errorf("feed: fix %s before creating feeds: %w", filepath.Base(s.configPath), err)
+	}
+
+	profile, ok := s.profileLocked(profileID)
+	if !ok {
+		return FeedDef{}, fmt.Errorf("feed: unknown profile %q", profileID)
+	}
+	slug := slugify(def.Name)
+	if slug == "" {
+		slug = "feed"
+	}
+	taken := make(map[string]bool, len(profile.Feeds))
+	for _, feedDef := range profile.Feeds {
+		taken[feedDef.ID] = true
+	}
+	def.ID = uniqueID(slug, taken)
+
+	data, err := s.readConfigBytesLocked()
+	if err != nil {
+		return FeedDef{}, err
+	}
+	updated, err := appendFeedToConfig(data, profileID, def)
+	if err != nil {
+		return FeedDef{}, fmt.Errorf("feed: %w", err)
+	}
+	if err := s.commitConfigLocked(updated); err != nil {
+		return FeedDef{}, err
+	}
+	return def, nil
+}
+
+// UpdateFeed replaces the feed's definition in place; the feed keeps its ID.
+func (s *Store) UpdateFeed(profileID, feedID string, def FeedDef) error {
+	def.ID = feedID
+	def.Name = strings.TrimSpace(def.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadConfigLocked(true); err != nil {
+		return fmt.Errorf("feed: fix %s before editing feeds: %w", filepath.Base(s.configPath), err)
+	}
+
+	data, err := s.readConfigBytesLocked()
+	if err != nil {
+		return err
+	}
+	updated, err := updateFeedInConfig(data, profileID, feedID, def)
+	if err != nil {
+		return fmt.Errorf("feed: %w", err)
+	}
+	return s.commitConfigLocked(updated)
+}
+
+// readConfigBytesLocked reads the raw config file; a missing file reads as
+// empty, matching the append helpers' empty-document path.
+func (s *Store) readConfigBytesLocked() ([]byte, error) {
+	data, err := os.ReadFile(s.configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("feed: read config: %w", err)
+	}
+	return data, nil
+}
+
+// commitConfigLocked validates the updated document, writes it atomically,
+// and adopts the parsed result as the in-memory state. A config that fails
+// validation is never written.
+func (s *Store) commitConfigLocked(updated []byte) error {
+	file, err := parseConfig(updated)
+	if err != nil {
+		return fmt.Errorf("feed: refusing to write invalid config: %w", err)
+	}
+	if err := writeFileAtomic(s.configPath, updated); err != nil {
+		return err
+	}
+	s.sources = file.Sources
+	s.profiles = file.Profiles
+	s.configLoaded = true
+	return nil
+}
+
+func (s *Store) profileLocked(profileID string) (ProfileDef, bool) {
+	for _, profile := range s.profiles {
+		if profile.ID == profileID {
+			return profile, true
+		}
+	}
+	return ProfileDef{}, false
 }
 
 // uniqueProfileID suffixes the slug until it is unused, so two profiles
@@ -135,6 +327,11 @@ func (s *Store) uniqueProfileID(slug string) string {
 	for _, def := range s.profiles {
 		taken[def.ID] = true
 	}
+	return uniqueID(slug, taken)
+}
+
+// uniqueID suffixes slug with -2, -3, … until it is not taken.
+func uniqueID(slug string, taken map[string]bool) string {
 	id := slug
 	for n := 2; taken[id]; n++ {
 		id = fmt.Sprintf("%s-%d", slug, n)
@@ -175,7 +372,7 @@ func (s *Store) readStatePath() string { return filepath.Join(s.stateDir, "reads
 
 // loadConfigLocked reads and parses the config file. Once a load has
 // succeeded, non-forced calls are no-ops and a failed forced reload leaves
-// the last-good profiles in place — the returned error is the caller's to
+// the last-good definitions in place — the returned error is the caller's to
 // surface (the watcher pushes it to the frontend).
 func (s *Store) loadConfigLocked(force bool) error {
 	if s.configLoaded && !force {
@@ -185,14 +382,15 @@ func (s *Store) loadConfigLocked(force bool) error {
 	if os.IsNotExist(err) {
 		data, err = nil, nil
 	}
-	var defs []ProfileDef
+	var file configFile
 	if err == nil {
-		defs, err = parseConfig(data)
+		file, err = parseConfig(data)
 	}
 	if err != nil {
 		return fmt.Errorf("feed: %s: %w", filepath.Base(s.configPath), err)
 	}
-	s.profiles = defs
+	s.sources = file.Sources
+	s.profiles = file.Profiles
 	s.configLoaded = true
 	return nil
 }

--- a/internal/desktop/feed/store_test.go
+++ b/internal/desktop/feed/store_test.go
@@ -28,12 +28,20 @@ func TestStoreCreateProfilePersists(t *testing.T) {
 	assert.Equal(t, "Frontend Triage", def.Name)
 	assert.Len(t, def.Feeds, 3)
 
-	// A fresh store instance reads the persisted file.
-	reloaded, err := newStoreAt(dir).Profiles()
+	// A fresh store instance reads the persisted file: the profile plus the
+	// seeded default sources its feeds reference.
+	fresh := newStoreAt(dir)
+	reloaded, err := fresh.Profiles()
 	require.NoError(t, err)
 	require.Len(t, reloaded, 1)
 	assert.Equal(t, def.ID, reloaded[0].ID)
 	assert.Equal(t, "notifications-inbox", reloaded[0].Feeds[1].ID)
+	assert.Equal(t, []string{"inbox"}, reloaded[0].Feeds[1].Sources)
+
+	sources, err := fresh.Sources()
+	require.NoError(t, err)
+	require.Len(t, sources, 3)
+	assert.Equal(t, "my-prs", sources[0].ID)
 
 	assert.FileExists(t, filepath.Join(dir, "profiles.yaml"))
 }
@@ -50,6 +58,11 @@ func TestStoreCreateProfileUniqueIDs(t *testing.T) {
 
 	assert.Equal(t, "work", first.ID)
 	assert.Equal(t, "work-2", second.ID)
+
+	// The second profile reuses the sources the first one seeded.
+	sources, err := store.Sources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 3)
 }
 
 func TestStoreCreateProfileRejectsEmptyName(t *testing.T) {
@@ -65,6 +78,11 @@ func TestStoreCreateProfilePreservesComments(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "profiles.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(`# my dotfiles-managed feeds
+sources:
+  # one broad query
+  - id: involving-me
+    kind: search
+    query: "is:open involves:@me"
 profiles:
   # the day job
   - id: work
@@ -72,8 +90,7 @@ profiles:
     feeds:
       - id: prs
         name: My PRs
-        kind: search
-        query: "is:open is:pr author:@me"
+        sources: [involving-me]
 `), 0o600))
 
 	store := newStoreAt(dir)
@@ -83,16 +100,24 @@ profiles:
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "# my dotfiles-managed feeds")
+	assert.Contains(t, string(data), "# one broad query")
 	assert.Contains(t, string(data), "# the day job")
 	assert.Contains(t, string(data), "side-projects")
 
 	// The appended document round-trips through a full load.
-	profiles, err := newStoreAt(dir).Profiles()
+	fresh := newStoreAt(dir)
+	profiles, err := fresh.Profiles()
 	require.NoError(t, err)
 	require.Len(t, profiles, 2)
 	assert.Equal(t, "work", profiles[0].ID)
 	assert.Equal(t, "side-projects", profiles[1].ID)
 	assert.Len(t, profiles[1].Feeds, 3)
+
+	// Default sources were appended after the user's own.
+	sources, err := fresh.Sources()
+	require.NoError(t, err)
+	require.Len(t, sources, 4)
+	assert.Equal(t, "involving-me", sources[0].ID)
 }
 
 func TestStoreCreateProfileRefusesBrokenConfig(t *testing.T) {
@@ -105,12 +130,189 @@ func TestStoreCreateProfileRefusesBrokenConfig(t *testing.T) {
 	require.ErrorContains(t, err, "profiles.yaml")
 }
 
+func TestStoreCreateSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	_, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	created, err := store.CreateSource(SourceDef{ID: "Team Reviews!", Kind: "search", Query: "is:open review-requested:@me"})
+	require.NoError(t, err)
+	assert.Equal(t, "team-reviews", created.ID, "id is slugified")
+
+	// Same requested ID uniquifies with a -2 suffix.
+	again, err := store.CreateSource(SourceDef{ID: "team-reviews", Kind: "search", Query: "is:open review-requested:@me org:acme"})
+	require.NoError(t, err)
+	assert.Equal(t, "team-reviews-2", again.ID)
+
+	sources, err := newStoreAt(dir).Sources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 5) // 3 defaults + 2 created
+}
+
+func TestStoreCreateSourceRejectsInvalidBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	_, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+	before, err := os.ReadFile(filepath.Join(dir, "profiles.yaml"))
+	require.NoError(t, err)
+
+	_, err = store.CreateSource(SourceDef{ID: "bad", Kind: "search"}) // no query
+	require.ErrorContains(t, err, "requires a query")
+	_, err = store.CreateSource(SourceDef{ID: "!!!", Kind: "notifications"})
+	require.ErrorContains(t, err, "id is empty")
+	_, err = store.CreateSource(SourceDef{ID: "big", Kind: "notifications", Limit: 51})
+	require.ErrorContains(t, err, "page cap")
+
+	after, err := os.ReadFile(filepath.Join(dir, "profiles.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "rejected creates leave the file untouched")
+}
+
+func TestStoreCreateFeed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	profile, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	created, err := store.CreateFeed(profile.ID, FeedDef{
+		Name:    "Bug Triage",
+		Sources: []string{"inbox"},
+		Filters: FilterDef{Labels: []string{"bug"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "bug-triage", created.ID, "id derives from the name")
+
+	// Same name uniquifies within the profile.
+	again, err := store.CreateFeed(profile.ID, FeedDef{Name: "Bug Triage", Sources: []string{"inbox"}})
+	require.NoError(t, err)
+	assert.Equal(t, "bug-triage-2", again.ID)
+
+	def, err := newStoreAt(dir).FeedDefFor(profile.ID, "bug-triage")
+	require.NoError(t, err)
+	assert.Equal(t, "Bug Triage", def.Name)
+	assert.Equal(t, []string{"inbox"}, def.Sources)
+	assert.Equal(t, []string{"bug"}, def.Filters.Labels)
+}
+
+func TestStoreCreateFeedRejectsInvalidBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	profile, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+	before, err := os.ReadFile(filepath.Join(dir, "profiles.yaml"))
+	require.NoError(t, err)
+
+	_, err = store.CreateFeed("ghost", FeedDef{Name: "X", Sources: []string{"inbox"}})
+	require.ErrorContains(t, err, "unknown profile")
+	_, err = store.CreateFeed(profile.ID, FeedDef{Name: "X", Sources: []string{"ghost"}})
+	require.ErrorContains(t, err, "unknown source")
+	_, err = store.CreateFeed(profile.ID, FeedDef{Name: "X"})
+	require.ErrorContains(t, err, "at least one source")
+	_, err = store.CreateFeed(profile.ID, FeedDef{Name: "  ", Sources: []string{"inbox"}})
+	require.ErrorContains(t, err, "name is required")
+
+	after, err := os.ReadFile(filepath.Join(dir, "profiles.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "rejected creates leave the file untouched")
+}
+
+func TestStoreUpdateFeed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profiles.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`# keep me
+sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [inbox]
+`), 0o600))
+	store := newStoreAt(dir)
+
+	err := store.UpdateFeed("work", "a", FeedDef{
+		ID:      "ignored", // the feed keeps its ID
+		Name:    "Mentions",
+		Sources: []string{"inbox"},
+		Filters: FilterDef{Reasons: []string{"mention"}},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "# keep me")
+
+	def, err := store.FeedDefFor("work", "a")
+	require.NoError(t, err)
+	assert.Equal(t, "a", def.ID)
+	assert.Equal(t, "Mentions", def.Name)
+	assert.Equal(t, []string{"mention"}, def.Filters.Reasons)
+
+	require.ErrorContains(t, store.UpdateFeed("work", "ghost", FeedDef{Name: "X", Sources: []string{"inbox"}}), "not found")
+	require.ErrorContains(t, store.UpdateFeed("ghost", "a", FeedDef{Name: "X", Sources: []string{"inbox"}}), "not found")
+}
+
+func TestStoreUpdateFeedRejectsInvalidBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	profile, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+	before, err := os.ReadFile(filepath.Join(dir, "profiles.yaml"))
+	require.NoError(t, err)
+
+	err = store.UpdateFeed(profile.ID, "my-open-prs", FeedDef{
+		Name:    "Broken",
+		Sources: []string{"my-prs"},
+		Filters: FilterDef{Repos: []string{"acme/["}},
+	})
+	require.ErrorContains(t, err, "invalid repos glob")
+
+	after, err := os.ReadFile(filepath.Join(dir, "profiles.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "rejected updates leave the file untouched")
+}
+
+func TestStoreFeedDefForUnknown(t *testing.T) {
+	t.Parallel()
+
+	store := newStoreAt(t.TempDir())
+	profile, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	_, err = store.FeedDefFor(profile.ID, "ghost")
+	require.ErrorContains(t, err, "unknown feed")
+	_, err = store.FeedDefFor("ghost", "my-open-prs")
+	require.ErrorContains(t, err, "unknown profile")
+}
+
 func TestStoreEmptyDirHasNoProfiles(t *testing.T) {
 	t.Parallel()
 
-	profiles, err := newStoreAt(t.TempDir()).Profiles()
+	store := newStoreAt(t.TempDir())
+	profiles, err := store.Profiles()
 	require.NoError(t, err)
 	assert.Empty(t, profiles)
+
+	sources, err := store.Sources()
+	require.NoError(t, err)
+	assert.Empty(t, sources)
 }
 
 func TestStoreReloadKeepsLastGoodOnError(t *testing.T) {
@@ -130,6 +332,10 @@ func TestStoreReloadKeepsLastGoodOnError(t *testing.T) {
 	require.Len(t, profiles, 1)
 	assert.Equal(t, def.ID, profiles[0].ID)
 
+	sources, err := store.Sources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 3, "last-good sources are retained too")
+
 	info := store.ConfigInfo()
 	assert.False(t, info.Valid)
 	assert.NotEmpty(t, info.Error)
@@ -143,14 +349,18 @@ func TestStoreReloadPicksUpExternalEdit(t *testing.T) {
 	_, err := store.CreateProfile("Work")
 	require.NoError(t, err)
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`profiles:
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`sources:
+  - id: inbox
+    kind: notifications
+profiles:
   - id: oss
     name: Open Source
     feeds:
-      - id: inbox
+      - id: inbox-feed
         name: Inbox
-        kind: notifications
-        repos: ["colonyops/*"]
+        sources: [inbox]
+        filters:
+          repos: ["colonyops/*"]
 `), 0o600))
 	require.NoError(t, store.Reload())
 
@@ -158,7 +368,7 @@ func TestStoreReloadPicksUpExternalEdit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, profiles, 1)
 	assert.Equal(t, "oss", profiles[0].ID)
-	assert.Equal(t, []string{"colonyops/*"}, profiles[0].Feeds[0].Repos)
+	assert.Equal(t, []string{"colonyops/*"}, profiles[0].Feeds[0].Filters.Repos)
 }
 
 func TestStoreConfigInfoMissingFile(t *testing.T) {
@@ -167,6 +377,7 @@ func TestStoreConfigInfoMissingFile(t *testing.T) {
 	info := newStoreAt(t.TempDir()).ConfigInfo()
 	assert.False(t, info.Exists)
 	assert.True(t, info.Valid)
+	assert.Contains(t, info.YAML, "sources:")
 	assert.Contains(t, info.YAML, "profiles:")
 }
 

--- a/internal/desktop/feed/store_test.go
+++ b/internal/desktop/feed/store_test.go
@@ -289,6 +289,117 @@ func TestStoreUpdateFeedRejectsInvalidBeforeWrite(t *testing.T) {
 	assert.Equal(t, string(before), string(after), "rejected updates leave the file untouched")
 }
 
+func TestStoreDeleteFeed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profiles.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`# keep me
+sources:
+  - id: inbox
+    kind: notifications
+profiles:
+  - id: work
+    name: Work
+    feeds:
+      - id: a
+        name: A
+        sources: [inbox]
+      - id: b
+        name: B
+        sources: [inbox]
+`), 0o600))
+	store := newStoreAt(dir)
+
+	require.NoError(t, store.DeleteFeed("work", "a"))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "# keep me")
+
+	fresh := newStoreAt(dir)
+	profiles, err := fresh.Profiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	require.Len(t, profiles[0].Feeds, 1)
+	assert.Equal(t, "b", profiles[0].Feeds[0].ID)
+
+	require.ErrorContains(t, store.DeleteFeed("work", "ghost"), "not found")
+	require.ErrorContains(t, store.DeleteFeed("ghost", "b"), "not found")
+}
+
+func TestStoreDeleteFeedOnlyFeedInProfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	profile, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	for _, feedDef := range profile.Feeds {
+		require.NoError(t, store.DeleteFeed(profile.ID, feedDef.ID))
+	}
+
+	fresh := newStoreAt(dir)
+	profiles, err := fresh.Profiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.Empty(t, profiles[0].Feeds)
+}
+
+func TestStoreDeleteProfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	work, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+	side, err := store.CreateProfile("Side Projects")
+	require.NoError(t, err)
+
+	sourcesBefore, err := store.Sources()
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteProfile(work.ID))
+
+	fresh := newStoreAt(dir)
+	profiles, err := fresh.Profiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.Equal(t, side.ID, profiles[0].ID)
+
+	// Sources are shared/decoupled: deleting a profile leaves them alone.
+	sourcesAfter, err := fresh.Sources()
+	require.NoError(t, err)
+	assert.Equal(t, sourcesBefore, sourcesAfter)
+
+	require.ErrorContains(t, store.DeleteProfile("ghost"), "not found")
+}
+
+func TestStoreDeleteLastProfileLeavesEmptyValidConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	profile, err := store.CreateProfile("Only One")
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteProfile(profile.ID))
+
+	fresh := newStoreAt(dir)
+	profiles, err := fresh.Profiles()
+	require.NoError(t, err)
+	assert.Empty(t, profiles)
+
+	// Sources persist even with zero profiles left to reference them.
+	sources, err := fresh.Sources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 3)
+
+	info := fresh.ConfigInfo()
+	assert.True(t, info.Valid)
+}
+
 func TestStoreFeedDefForUnknown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/desktop/feed/store_test.go
+++ b/internal/desktop/feed/store_test.go
@@ -1,6 +1,7 @@
 package feed
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -9,48 +10,171 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newStoreAt returns a store rooted in dir: the profiles config and the
+// state files live side by side, which is all tests need.
+func newStoreAt(dir string) *Store {
+	return NewStore(filepath.Join(dir, "profiles.yaml"), dir)
+}
+
 func TestStoreCreateProfilePersists(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	store := NewStore(dir)
+	store := newStoreAt(dir)
 
 	def, err := store.CreateProfile("  Frontend Triage  ")
 	require.NoError(t, err)
-	assert.NotEmpty(t, def.ID)
+	assert.Equal(t, "frontend-triage", def.ID)
 	assert.Equal(t, "Frontend Triage", def.Name)
 	assert.Len(t, def.Feeds, 3)
 
 	// A fresh store instance reads the persisted file.
-	reloaded, err := NewStore(dir).Profiles()
+	reloaded, err := newStoreAt(dir).Profiles()
 	require.NoError(t, err)
 	require.Len(t, reloaded, 1)
 	assert.Equal(t, def.ID, reloaded[0].ID)
 	assert.Equal(t, "notifications-inbox", reloaded[0].Feeds[1].ID)
 
-	assert.FileExists(t, filepath.Join(dir, "profiles.json"))
+	assert.FileExists(t, filepath.Join(dir, "profiles.yaml"))
+}
+
+func TestStoreCreateProfileUniqueIDs(t *testing.T) {
+	t.Parallel()
+
+	store := newStoreAt(t.TempDir())
+
+	first, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+	second, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	assert.Equal(t, "work", first.ID)
+	assert.Equal(t, "work-2", second.ID)
 }
 
 func TestStoreCreateProfileRejectsEmptyName(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewStore(t.TempDir()).CreateProfile("   ")
+	_, err := newStoreAt(t.TempDir()).CreateProfile("   ")
 	require.Error(t, err)
+}
+
+func TestStoreCreateProfilePreservesComments(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profiles.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`# my dotfiles-managed feeds
+profiles:
+  # the day job
+  - id: work
+    name: Work
+    feeds:
+      - id: prs
+        name: My PRs
+        kind: search
+        query: "is:open is:pr author:@me"
+`), 0o600))
+
+	store := newStoreAt(dir)
+	_, err := store.CreateProfile("Side Projects")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "# my dotfiles-managed feeds")
+	assert.Contains(t, string(data), "# the day job")
+	assert.Contains(t, string(data), "side-projects")
+
+	// The appended document round-trips through a full load.
+	profiles, err := newStoreAt(dir).Profiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+	assert.Equal(t, "work", profiles[0].ID)
+	assert.Equal(t, "side-projects", profiles[1].ID)
+	assert.Len(t, profiles[1].Feeds, 3)
+}
+
+func TestStoreCreateProfileRefusesBrokenConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte("profiles: ["), 0o600))
+
+	_, err := newStoreAt(dir).CreateProfile("Work")
+	require.ErrorContains(t, err, "profiles.yaml")
 }
 
 func TestStoreEmptyDirHasNoProfiles(t *testing.T) {
 	t.Parallel()
 
-	profiles, err := NewStore(t.TempDir()).Profiles()
+	profiles, err := newStoreAt(t.TempDir()).Profiles()
 	require.NoError(t, err)
 	assert.Empty(t, profiles)
+}
+
+func TestStoreReloadKeepsLastGoodOnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	def, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	// Break the file behind the store's back, as a live edit would.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte("profiles: ["), 0o600))
+	require.Error(t, store.Reload())
+
+	profiles, err := store.Profiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.Equal(t, def.ID, profiles[0].ID)
+
+	info := store.ConfigInfo()
+	assert.False(t, info.Valid)
+	assert.NotEmpty(t, info.Error)
+}
+
+func TestStoreReloadPicksUpExternalEdit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := newStoreAt(dir)
+	_, err := store.CreateProfile("Work")
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(`profiles:
+  - id: oss
+    name: Open Source
+    feeds:
+      - id: inbox
+        name: Inbox
+        kind: notifications
+        repos: ["colonyops/*"]
+`), 0o600))
+	require.NoError(t, store.Reload())
+
+	profiles, err := store.Profiles()
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.Equal(t, "oss", profiles[0].ID)
+	assert.Equal(t, []string{"colonyops/*"}, profiles[0].Feeds[0].Repos)
+}
+
+func TestStoreConfigInfoMissingFile(t *testing.T) {
+	t.Parallel()
+
+	info := newStoreAt(t.TempDir()).ConfigInfo()
+	assert.False(t, info.Exists)
+	assert.True(t, info.Valid)
+	assert.Contains(t, info.YAML, "profiles:")
 }
 
 func TestStoreMarkReadRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	store := NewStore(dir)
+	store := newStoreAt(dir)
 	readAt := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
 
 	_, ok := store.ReadAt("o/r#1")
@@ -63,7 +187,7 @@ func TestStoreMarkReadRoundTrip(t *testing.T) {
 	assert.True(t, got.Equal(readAt))
 
 	// Persisted across instances.
-	got, ok = NewStore(dir).ReadAt("o/r#1")
+	got, ok = newStoreAt(dir).ReadAt("o/r#1")
 	require.True(t, ok)
 	assert.True(t, got.Equal(readAt))
 }

--- a/internal/desktop/feed/watcher.go
+++ b/internal/desktop/feed/watcher.go
@@ -1,0 +1,99 @@
+package feed
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/rs/zerolog"
+)
+
+// watchDebounce coalesces editor save bursts (write + rename + chmod) into
+// one reload.
+const watchDebounce = 250 * time.Millisecond
+
+// ConfigWatcher invokes onChange when the profiles config file changes on
+// disk, so edits made outside the app apply live. It watches the parent
+// directory rather than the file: editors and atomic writers replace the
+// file by rename, which silently drops a watch registered on the file
+// itself — and lets the watch work before the file first exists.
+type ConfigWatcher struct {
+	path     string
+	onChange func()
+	logger   zerolog.Logger
+	watcher  *fsnotify.Watcher
+
+	stopOnce sync.Once
+	stop     chan struct{}
+}
+
+func NewConfigWatcher(path string, onChange func(), logger zerolog.Logger) (*ConfigWatcher, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("feed: create config dir: %w", err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("feed: start config watcher: %w", err)
+	}
+	if err := watcher.Add(dir); err != nil {
+		_ = watcher.Close()
+		return nil, fmt.Errorf("feed: watch %s: %w", dir, err)
+	}
+	return &ConfigWatcher{
+		path:     path,
+		onChange: onChange,
+		logger:   logger,
+		watcher:  watcher,
+		stop:     make(chan struct{}),
+	}, nil
+}
+
+// Start runs the watch loop in a goroutine until Close.
+func (w *ConfigWatcher) Start() {
+	go w.run()
+}
+
+func (w *ConfigWatcher) Close() {
+	w.stopOnce.Do(func() {
+		close(w.stop)
+		if err := w.watcher.Close(); err != nil {
+			w.logger.Debug().Err(err).Msg("config watcher close failed")
+		}
+	})
+}
+
+func (w *ConfigWatcher) run() {
+	var debounce <-chan time.Time
+	for {
+		select {
+		case <-w.stop:
+			return
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			// Only the watched directory feeds this channel, so basename
+			// equality identifies the config file across write/rename paths.
+			if filepath.Base(event.Name) != filepath.Base(w.path) {
+				continue
+			}
+			if !event.Op.Has(fsnotify.Create) && !event.Op.Has(fsnotify.Write) &&
+				!event.Op.Has(fsnotify.Rename) && !event.Op.Has(fsnotify.Remove) {
+				continue
+			}
+			debounce = time.After(watchDebounce)
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			w.logger.Warn().Err(err).Msg("config watch error")
+		case <-debounce:
+			debounce = nil
+			w.onChange()
+		}
+	}
+}

--- a/internal/desktop/feed/watcher_test.go
+++ b/internal/desktop/feed/watcher_test.go
@@ -1,0 +1,80 @@
+package feed
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func waitForChange(t *testing.T, changed <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-changed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not fire")
+	}
+}
+
+func TestConfigWatcherFiresOnWriteAndAtomicReplace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profiles.yaml")
+	changed := make(chan struct{}, 8)
+
+	watcher, err := NewConfigWatcher(path, func() { changed <- struct{}{} }, zerolog.Nop())
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Close)
+
+	// Plain create+write of the watched file.
+	require.NoError(t, os.WriteFile(path, []byte("profiles:\n"), 0o600))
+	waitForChange(t, changed)
+
+	// Atomic replace (write tmp, rename over) — how editors and the app
+	// itself save.
+	tmp := path + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, []byte("profiles: []\n"), 0o600))
+	require.NoError(t, os.Rename(tmp, path))
+	waitForChange(t, changed)
+}
+
+func TestConfigWatcherIgnoresOtherFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	changed := make(chan struct{}, 8)
+
+	watcher, err := NewConfigWatcher(filepath.Join(dir, "profiles.yaml"), func() { changed <- struct{}{} }, zerolog.Nop())
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Close)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated.yaml"), []byte("x: 1\n"), 0o600))
+	select {
+	case <-changed:
+		t.Fatal("watcher fired for an unrelated file")
+	case <-time.After(600 * time.Millisecond):
+	}
+}
+
+func TestConfigWatcherCreatesMissingDir(t *testing.T) {
+	t.Parallel()
+
+	// The config dir may not exist on first run; the watcher must create
+	// it so the watch is in place before the file is first written.
+	path := filepath.Join(t.TempDir(), "hive", "desktop", "profiles.yaml")
+	changed := make(chan struct{}, 8)
+
+	watcher, err := NewConfigWatcher(path, func() { changed <- struct{}{} }, zerolog.Nop())
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Close)
+
+	require.NoError(t, os.WriteFile(path, []byte("profiles:\n"), 0o600))
+	waitForChange(t, changed)
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -106,21 +106,58 @@ func (c *Client) SearchIssues(ctx context.Context, query string, limit int) (Sea
 	return result, nil
 }
 
+// NotificationsResult is one notifications poll. When NotModified is true the
+// inbox has not changed since the ifModifiedSince timestamp and Items is nil —
+// the caller keeps its cached copy. LastModified echoes the response's
+// Last-Modified header for the next conditional request, and PollInterval is
+// the server-mandated minimum seconds between polls (X-Poll-Interval, 0 when
+// the header is absent).
+type NotificationsResult struct {
+	Items        []Notification
+	NotModified  bool
+	LastModified string
+	PollInterval int
+}
+
 // Notifications lists the user's notification inbox, including read threads,
-// so the app can mirror the full inbox and keep triage state locally.
-func (c *Client) Notifications(ctx context.Context, limit int) ([]Notification, error) {
+// so the app can mirror the full inbox and keep triage state locally. A
+// non-empty ifModifiedSince makes the request conditional: authenticated 304
+// responses are free of rate-limit cost, so polling an unchanged inbox costs
+// nothing.
+func (c *Client) Notifications(ctx context.Context, limit int, ifModifiedSince string) (NotificationsResult, error) {
 	params := url.Values{}
 	params.Set("all", "true")
 	params.Set("per_page", strconv.Itoa(limit))
 
 	var notifications []Notification
-	if err := c.getJSON(ctx, "/notifications", params, &notifications); err != nil {
-		return nil, err
+	meta, err := c.getJSONConditional(ctx, "/notifications", params, ifModifiedSince, &notifications)
+	if err != nil {
+		return NotificationsResult{}, err
 	}
-	return notifications, nil
+	return NotificationsResult{
+		Items:        notifications,
+		NotModified:  meta.notModified,
+		LastModified: meta.lastModified,
+		PollInterval: meta.pollInterval,
+	}, nil
 }
 
 func (c *Client) getJSON(ctx context.Context, path string, params url.Values, out any) error {
+	_, err := c.getJSONConditional(ctx, path, params, "", out)
+	return err
+}
+
+// condMeta carries the conditional-request metadata of a response.
+type condMeta struct {
+	notModified  bool
+	lastModified string
+	pollInterval int
+}
+
+// getJSONConditional performs a GET, optionally conditional on
+// ifModifiedSince. A 304 response is a success with notModified set and out
+// untouched; every other non-2xx status maps through statusError.
+func (c *Client) getJSONConditional(ctx context.Context, path string, params url.Values, ifModifiedSince string, out any) (condMeta, error) {
 	endpoint := c.apiBase + path
 	if len(params) > 0 {
 		endpoint += "?" + params.Encode()
@@ -128,28 +165,53 @@ func (c *Client) getJSON(ctx context.Context, path string, params url.Values, ou
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return fmt.Errorf("github: build request: %w", err)
+		return condMeta{}, fmt.Errorf("github: build request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
+	if ifModifiedSince != "" {
+		req.Header.Set("If-Modified-Since", ifModifiedSince)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrUnreachable, err)
+		return condMeta{}, fmt.Errorf("%w: %w", ErrUnreachable, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // read-only body close
 
+	meta := condMeta{
+		lastModified: resp.Header.Get("Last-Modified"),
+		pollInterval: parsePollInterval(resp.Header.Get("X-Poll-Interval")),
+	}
+	if resp.StatusCode == http.StatusNotModified {
+		meta.notModified = true
+		return meta, nil
+	}
 	if err := statusError(resp); err != nil {
-		return err
+		return condMeta{}, err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return fmt.Errorf("github: decode %s: %w", path, err)
+		return condMeta{}, fmt.Errorf("github: decode %s: %w", path, err)
 	}
-	return nil
+	return meta, nil
+}
+
+// parsePollInterval parses the X-Poll-Interval header. A missing or
+// non-numeric value reads as 0 ("no server mandate"): the header is advisory
+// input, not a failure the caller could act on.
+func parsePollInterval(value string) int {
+	if value == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds < 0 {
+		return 0
+	}
+	return seconds
 }
 
 func statusError(resp *http.Response) error {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -154,7 +154,11 @@ func TestNotifications(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/notifications", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("all"))
+		assert.Equal(t, "50", r.URL.Query().Get("per_page"))
+		assert.Empty(t, r.Header.Get("If-Modified-Since"), "first poll is unconditional")
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Last-Modified", "Sat, 18 Jul 2026 08:00:00 GMT")
+		w.Header().Set("X-Poll-Interval", "60")
 		_, _ = w.Write([]byte(`[
 			{
 				"id": "3141",
@@ -168,15 +172,45 @@ func TestNotifications(t *testing.T) {
 	}))
 	defer server.Close()
 
-	notifications, err := NewClient(WithAPIBase(server.URL)).Notifications(t.Context(), 50)
+	result, err := NewClient(WithAPIBase(server.URL)).Notifications(t.Context(), 50, "")
 	require.NoError(t, err)
-	require.Len(t, notifications, 1)
+	require.Len(t, result.Items, 1)
+	assert.False(t, result.NotModified)
+	assert.Equal(t, "Sat, 18 Jul 2026 08:00:00 GMT", result.LastModified)
+	assert.Equal(t, 60, result.PollInterval)
 
-	n := notifications[0]
+	n := result.Items[0]
 	assert.True(t, n.Unread)
 	assert.Equal(t, "PullRequest", n.Subject.Type)
 	assert.Equal(t, 42, n.Subject.Number())
 	assert.Equal(t, "colonyops/hive", n.Repository.FullName)
+}
+
+func TestNotificationsConditionalNotModified(t *testing.T) {
+	t.Parallel()
+
+	const lastModified = "Sat, 18 Jul 2026 08:00:00 GMT"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, lastModified, r.Header.Get("If-Modified-Since"))
+		w.Header().Set("X-Poll-Interval", "120")
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	result, err := NewClient(WithAPIBase(server.URL)).Notifications(t.Context(), 50, lastModified)
+	require.NoError(t, err)
+	assert.True(t, result.NotModified)
+	assert.Empty(t, result.Items)
+	assert.Equal(t, 120, result.PollInterval)
+}
+
+func TestParsePollInterval(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 60, parsePollInterval("60"))
+	assert.Equal(t, 0, parsePollInterval(""))
+	assert.Equal(t, 0, parsePollInterval("soon"))
+	assert.Equal(t, 0, parsePollInterval("-5"))
 }
 
 func TestRepoFromAPIURL(t *testing.T) {


### PR DESCRIPTION
## Purpose

Make desktop profiles and feeds fully manageable: config lives as hand-editable YAML with hot reload, and the UI now supports the complete create/edit/delete lifecycle for feeds and profiles, styled to the latest design mockups.

## Proposed Changes

  - Profiles and feeds as code: YAML config with glob filters, hot reload, and comment-preserving edits; sources decoupled from feeds
  - Feed editor drawer per the updated mockups (selectable source cards, two-column filters, pinned footer) with live YAML preview; fixes broken overflow scrolling in the drawer, config sheet, and feed list
  - Delete support end-to-end: feeds (two-step confirm in the editor footer) and profiles (sidebar affordance + confirm modal); deleting the last profile returns to workspace onboarding
  - Severity-based toast stack and a blocking config-error overlay with line-numbered validation detail, replacing the single inline toast

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)