### PR TITLE
feat(session): full CRUD CLI for orchestrator agents

### DIFF
--- a/internal/commands/cmd_new.go
+++ b/internal/commands/cmd_new.go
@@ -3,22 +3,107 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
+	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/hive"
 	"github.com/urfave/cli/v3"
 )
 
-type NewCmd struct {
-	flags         *Flags
-	app           *hive.App
+// createSessionFlags holds the flag values shared by 'hive new' and
+// 'hive session create'.
+type createSessionFlags struct {
 	remote        string
 	source        string
 	background    bool
 	cloneStrategy string
 	agent         string
 	tags          []string
+}
+
+// sessionCreateFlags returns the flag set shared by 'hive new' and
+// 'hive session create', bound to f.
+func sessionCreateFlags(f *createSessionFlags) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "remote",
+			Aliases:     []string{"r"},
+			Usage:       "git remote URL (defaults to current directory's origin)",
+			Destination: &f.remote,
+		},
+		&cli.StringFlag{
+			Name:        "source",
+			Aliases:     []string{"s"},
+			Usage:       "source directory for file copying (defaults to current directory)",
+			Destination: &f.source,
+		},
+		&cli.BoolFlag{
+			Name:        "background",
+			Aliases:     []string{"bg"},
+			Usage:       "create session without attaching to tmux",
+			Destination: &f.background,
+		},
+		&cli.StringFlag{
+			Name:        "clone-strategy",
+			Usage:       "clone strategy: full or worktree",
+			Destination: &f.cloneStrategy,
+		},
+		&cli.StringFlag{
+			Name:        "agent",
+			Aliases:     []string{"a"},
+			Usage:       "agent profile key from agents config",
+			Destination: &f.agent,
+		},
+		&cli.StringSliceFlag{
+			Name:        "tags",
+			Aliases:     []string{"t"},
+			Usage:       "tags to attach to the session (repeatable)",
+			Destination: &f.tags,
+		},
+	}
+}
+
+// createSessionFromFlags validates the shared create flags and creates the
+// session. Progress may be nil (service output then goes to the service's
+// default writers).
+func createSessionFromFlags(ctx context.Context, app *hive.App, name string, f *createSessionFlags, progress io.Writer) (*session.Session, error) {
+	if f.agent != "" {
+		if _, ok := app.Config.Agents.Profiles[f.agent]; !ok {
+			return nil, fmt.Errorf("unknown agent %q", f.agent)
+		}
+	}
+
+	source := f.source
+	if source == "" {
+		var err error
+		source, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("determine source directory: %w", err)
+		}
+	}
+
+	sess, err := app.Sessions.CreateSession(ctx, hive.CreateOptions{
+		Name:          name,
+		Remote:        f.remote,
+		Source:        source,
+		Background:    f.background,
+		CloneStrategy: f.cloneStrategy,
+		AgentKey:      f.agent,
+		Tags:          f.tags,
+		Progress:      progress,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+	return sess, nil
+}
+
+type NewCmd struct {
+	flags       *Flags
+	app         *hive.App
+	createFlags createSessionFlags
 }
 
 // NewNewCmd creates a new new command
@@ -44,43 +129,7 @@ Example:
   hive new Fix Auth Bug
   hive new --agent claude Refactor Utils
   hive new bugfix --source /some/path`,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:        "remote",
-				Aliases:     []string{"r"},
-				Usage:       "git remote URL (defaults to current directory's origin)",
-				Destination: &cmd.remote,
-			},
-			&cli.StringFlag{
-				Name:        "source",
-				Aliases:     []string{"s"},
-				Usage:       "source directory for file copying (defaults to current directory)",
-				Destination: &cmd.source,
-			},
-			&cli.BoolFlag{
-				Name:        "background",
-				Aliases:     []string{"bg"},
-				Usage:       "create session without attaching to tmux",
-				Destination: &cmd.background,
-			},
-			&cli.StringFlag{
-				Name:        "clone-strategy",
-				Usage:       "clone strategy: full or worktree",
-				Destination: &cmd.cloneStrategy,
-			},
-			&cli.StringFlag{
-				Name:        "agent",
-				Aliases:     []string{"a"},
-				Usage:       "agent profile key from agents config",
-				Destination: &cmd.agent,
-			},
-			&cli.StringSliceFlag{
-				Name:        "tags",
-				Aliases:     []string{"t"},
-				Usage:       "tags to attach to the session (repeatable)",
-				Destination: &cmd.tags,
-			},
-		},
+		Flags:  sessionCreateFlags(&cmd.createFlags),
 		Action: cmd.run,
 	})
 
@@ -94,34 +143,9 @@ func (cmd *NewCmd) run(ctx context.Context, c *cli.Command) error {
 	}
 	name := strings.Join(args, " ")
 
-	if cmd.agent != "" {
-		if _, ok := cmd.app.Config.Agents.Profiles[cmd.agent]; !ok {
-			return fmt.Errorf("unknown agent %q", cmd.agent)
-		}
-	}
-
-	source := cmd.source
-	if source == "" {
-		var err error
-		source, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("determine source directory: %w", err)
-		}
-	}
-
-	opts := hive.CreateOptions{
-		Name:          name,
-		Remote:        cmd.remote,
-		Source:        source,
-		Background:    cmd.background,
-		CloneStrategy: cmd.cloneStrategy,
-		AgentKey:      cmd.agent,
-		Tags:          cmd.tags,
-	}
-
-	sess, err := cmd.app.Sessions.CreateSession(ctx, opts)
+	sess, err := createSessionFromFlags(ctx, cmd.app, name, &cmd.createFlags, nil)
 	if err != nil {
-		return fmt.Errorf("create session: %w", err)
+		return err
 	}
 
 	fmt.Fprintf(os.Stderr, "Session created\n  %s\n", sess.Path)

--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,13 +29,8 @@ type SessionCmd struct {
 
 	showJSON bool
 
-	createJSON          bool
-	createRemote        string
-	createSource        string
-	createBackground    bool
-	createCloneStrategy string
-	createAgent         string
-	createTags          []string
+	createJSON  bool
+	createFlags createSessionFlags
 
 	updateJSON       bool
 	updateName       string
@@ -276,48 +272,13 @@ stdout while progress output goes to stderr.
 
 Example:
   hive session create --json --background --remote <url> worker-1`,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:        "remote",
-				Aliases:     []string{"r"},
-				Usage:       "git remote URL (defaults to current directory's origin)",
-				Destination: &cmd.createRemote,
-			},
-			&cli.StringFlag{
-				Name:        "source",
-				Aliases:     []string{"s"},
-				Usage:       "source directory for file copying (defaults to current directory)",
-				Destination: &cmd.createSource,
-			},
-			&cli.BoolFlag{
-				Name:        "background",
-				Aliases:     []string{"bg"},
-				Usage:       "create session without attaching to tmux",
-				Destination: &cmd.createBackground,
-			},
-			&cli.StringFlag{
-				Name:        "clone-strategy",
-				Usage:       "clone strategy: full or worktree",
-				Destination: &cmd.createCloneStrategy,
-			},
-			&cli.StringFlag{
-				Name:        "agent",
-				Aliases:     []string{"a"},
-				Usage:       "agent profile key from agents config",
-				Destination: &cmd.createAgent,
-			},
-			&cli.StringSliceFlag{
-				Name:        "tags",
-				Aliases:     []string{"t"},
-				Usage:       "tags to attach to the session (repeatable)",
-				Destination: &cmd.createTags,
-			},
+		Flags: append(sessionCreateFlags(&cmd.createFlags),
 			&cli.BoolFlag{
 				Name:        "json",
 				Usage:       "write the created session as JSON to stdout",
 				Destination: &cmd.createJSON,
 			},
-		},
+		),
 		Action: cmd.runCreate,
 	}
 }
@@ -329,36 +290,10 @@ func (cmd *SessionCmd) runCreate(ctx context.Context, c *cli.Command) error {
 	}
 	name := strings.Join(args, " ")
 
-	if cmd.createAgent != "" {
-		if _, ok := cmd.app.Config.Agents.Profiles[cmd.createAgent]; !ok {
-			return fmt.Errorf("unknown agent %q", cmd.createAgent)
-		}
-	}
-
-	source := cmd.createSource
-	if source == "" {
-		var err error
-		source, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("determine source directory: %w", err)
-		}
-	}
-
-	opts := hive.CreateOptions{
-		Name:          name,
-		Remote:        cmd.createRemote,
-		Source:        source,
-		Background:    cmd.createBackground,
-		CloneStrategy: cmd.createCloneStrategy,
-		AgentKey:      cmd.createAgent,
-		Tags:          cmd.createTags,
-		// Keep stdout clean for --json output; progress goes to stderr.
-		Progress: os.Stderr,
-	}
-
-	sess, err := cmd.app.Sessions.CreateSession(ctx, opts)
+	// Keep stdout clean for --json output; progress goes to stderr.
+	sess, err := createSessionFromFlags(ctx, cmd.app, name, &cmd.createFlags, os.Stderr)
 	if err != nil {
-		return fmt.Errorf("create session: %w", err)
+		return err
 	}
 
 	if cmd.createJSON {
@@ -540,7 +475,10 @@ func (cmd *SessionCmd) deleteCmd() *cli.Command {
 		Description: `Permanently removes a session, its cloned directory, and any associated tmux session.
 
 If the session has uncommitted changes or unpushed commits, the delete is
-refused unless --force is passed.
+refused unless --force is passed. For worktree sessions the check can report
+false positives: the shared bare clone has no remote-tracking refs, so a
+feature branch that was pushed but not merged still counts as unpushed. Use
+--force after verifying the push.
 
 This action cannot be undone. Use 'hive session recycle' to preserve the directory for reuse.`,
 		Flags: []cli.Flag{
@@ -594,7 +532,10 @@ func (cmd *SessionCmd) recycleCmd() *cli.Command {
 For worktree sessions, removes the checkout and session record while retaining the shared bare clone. This keeps future worktree creation fast without retaining stale session state.
 
 If the session has uncommitted changes or unpushed commits, the recycle is
-refused unless --force is passed.`,
+refused unless --force is passed. For worktree sessions the check can report
+false positives: the shared bare clone has no remote-tracking refs, so a
+feature branch that was pushed but not merged still counts as unpushed. Use
+--force after verifying the push.`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "force",
@@ -631,8 +572,11 @@ func (cmd *SessionCmd) runRecycle(ctx context.Context, c *cli.Command) error {
 	if cmd.recycleJSON {
 		// Worktree sessions are deleted on recycle, so the record may be gone.
 		sess, err := cmd.app.Sessions.GetSession(ctx, id)
-		if err != nil {
+		switch {
+		case errors.Is(err, session.ErrNotFound):
 			return iojson.WriteLine(c.Root().Writer, map[string]any{"id": id, "deleted": true})
+		case err != nil:
+			return fmt.Errorf("get session after recycle: %w", err)
 		}
 		return iojson.WriteLine(c.Root().Writer, buildSessionJSON(sess))
 	}

--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/colonyops/hive/internal/core/git"
 	"github.com/colonyops/hive/internal/core/session"
@@ -23,6 +25,26 @@ type SessionCmd struct {
 	infoJSON bool
 	lsJSON   bool
 	lsTags   []string
+
+	showJSON bool
+
+	createJSON          bool
+	createRemote        string
+	createSource        string
+	createBackground    bool
+	createCloneStrategy string
+	createAgent         string
+	createTags          []string
+
+	updateJSON       bool
+	updateName       string
+	updateGroup      string
+	updateClearGroup bool
+
+	deleteJSON  bool
+	deleteForce bool
+
+	recycleJSON bool
 }
 
 // NewSessionCmd creates a new session command
@@ -45,6 +67,9 @@ Use 'hive session info' to get details about the current session.`,
 			Commands: []*cli.Command{
 				lsCommand,
 				cmd.infoCmd(),
+				cmd.showCmd(),
+				cmd.createCmd(),
+				cmd.updateCmd(),
 				cmd.deleteCmd(),
 				cmd.recycleCmd(),
 			},
@@ -110,16 +135,59 @@ Example output (--json):
 	}
 }
 
-// sessionInfoOutput is the JSON output format for hive session info.
-type sessionInfoOutput struct {
-	ID     string   `json:"id"`
-	Name   string   `json:"name"`
-	Repo   string   `json:"repo"`
-	Remote string   `json:"remote"`
-	Path   string   `json:"path"`
-	Inbox  string   `json:"inbox"`
-	State  string   `json:"state"`
-	Tags   []string `json:"tags"`
+// sessionJSON is the machine-readable representation of a session used by
+// session info/show/create/update/recycle --json output.
+type sessionJSON struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	Slug          string    `json:"slug"`
+	Repo          string    `json:"repo"`
+	Remote        string    `json:"remote"`
+	Path          string    `json:"path"`
+	Inbox         string    `json:"inbox"`
+	State         string    `json:"state"`
+	Group         string    `json:"group,omitempty"`
+	CloneStrategy string    `json:"clone_strategy,omitempty"`
+	Tags          []string  `json:"tags"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func buildSessionJSON(s session.Session) sessionJSON {
+	tags := s.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+	return sessionJSON{
+		ID:            s.ID,
+		Name:          s.Name,
+		Slug:          s.Slug,
+		Repo:          git.ExtractRepoName(s.Remote),
+		Remote:        s.Remote,
+		Path:          s.Path,
+		Inbox:         s.InboxTopic(),
+		State:         string(s.State),
+		Group:         s.GetMeta(session.MetaGroup),
+		CloneStrategy: s.CloneStrategy,
+		Tags:          tags,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
+	}
+}
+
+func printSessionHuman(out io.Writer, sess session.Session) {
+	_, _ = fmt.Fprintf(out, "Session ID:  %s\n", sess.ID)
+	_, _ = fmt.Fprintf(out, "Name:        %s\n", sess.Name)
+	_, _ = fmt.Fprintf(out, "Repository:  %s\n", git.ExtractRepoName(sess.Remote))
+	_, _ = fmt.Fprintf(out, "Inbox:       %s\n", sess.InboxTopic())
+	_, _ = fmt.Fprintf(out, "Path:        %s\n", sess.Path)
+	_, _ = fmt.Fprintf(out, "State:       %s\n", sess.State)
+	if group := sess.GetMeta(session.MetaGroup); group != "" {
+		_, _ = fmt.Fprintf(out, "Group:       %s\n", group)
+	}
+	if len(sess.Tags) > 0 {
+		_, _ = fmt.Fprintf(out, "Tags:        %s\n", strings.Join(sess.Tags, ", "))
+	}
 }
 
 func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
@@ -147,31 +215,237 @@ func (cmd *SessionCmd) runInfo(ctx context.Context, c *cli.Command) error {
 	out := c.Root().Writer
 
 	if cmd.infoJSON {
-		tags := sess.Tags
-		if tags == nil {
-			tags = []string{}
-		}
-		info := sessionInfoOutput{
-			ID:     sess.ID,
-			Name:   sess.Name,
-			Repo:   git.ExtractRepoName(sess.Remote),
-			Remote: sess.Remote,
-			Path:   sess.Path,
-			Inbox:  sess.InboxTopic(),
-			State:  string(sess.State),
-			Tags:   tags,
-		}
-		return iojson.WriteLine(out, info)
+		return iojson.WriteLine(out, buildSessionJSON(sess))
 	}
 
-	// Human-readable output
-	_, _ = fmt.Fprintf(out, "Session ID:  %s\n", sess.ID)
-	_, _ = fmt.Fprintf(out, "Name:        %s\n", sess.Name)
-	_, _ = fmt.Fprintf(out, "Repository:  %s\n", git.ExtractRepoName(sess.Remote))
-	_, _ = fmt.Fprintf(out, "Inbox:       %s\n", sess.InboxTopic())
-	_, _ = fmt.Fprintf(out, "Path:        %s\n", sess.Path)
-	_, _ = fmt.Fprintf(out, "State:       %s\n", sess.State)
+	printSessionHuman(out, sess)
+	return nil
+}
 
+func (cmd *SessionCmd) showCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "show",
+		Usage:     "Show details for a session by ID",
+		UsageText: "hive session show <id> [--json]",
+		Description: `Displays details for a specific session.
+
+Unlike 'hive session info', which detects the session from the current
+working directory, this command looks up a session by its ID.`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "json",
+				Usage:       "output as JSON (recommended for LLMs)",
+				Destination: &cmd.showJSON,
+			},
+		},
+		Action: cmd.runShow,
+	}
+}
+
+func (cmd *SessionCmd) runShow(ctx context.Context, c *cli.Command) error {
+	id := c.Args().First()
+	if id == "" {
+		return fmt.Errorf("session ID required")
+	}
+
+	sess, err := cmd.app.Sessions.GetSession(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get session: %w", err)
+	}
+
+	out := c.Root().Writer
+	if cmd.showJSON {
+		return iojson.WriteLine(out, buildSessionJSON(sess))
+	}
+
+	printSessionHuman(out, sess)
+	return nil
+}
+
+func (cmd *SessionCmd) createCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "create",
+		Usage:     "Create a new agent session",
+		UsageText: "hive session create <name...> [--json]",
+		Description: `Creates a new isolated git environment for an AI agent session.
+
+Equivalent to 'hive new', but designed for machine consumption: with --json
+the created session record (including its ID and inbox topic) is written to
+stdout while progress output goes to stderr.
+
+Example:
+  hive session create --json --background --remote <url> worker-1`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "remote",
+				Aliases:     []string{"r"},
+				Usage:       "git remote URL (defaults to current directory's origin)",
+				Destination: &cmd.createRemote,
+			},
+			&cli.StringFlag{
+				Name:        "source",
+				Aliases:     []string{"s"},
+				Usage:       "source directory for file copying (defaults to current directory)",
+				Destination: &cmd.createSource,
+			},
+			&cli.BoolFlag{
+				Name:        "background",
+				Aliases:     []string{"bg"},
+				Usage:       "create session without attaching to tmux",
+				Destination: &cmd.createBackground,
+			},
+			&cli.StringFlag{
+				Name:        "clone-strategy",
+				Usage:       "clone strategy: full or worktree",
+				Destination: &cmd.createCloneStrategy,
+			},
+			&cli.StringFlag{
+				Name:        "agent",
+				Aliases:     []string{"a"},
+				Usage:       "agent profile key from agents config",
+				Destination: &cmd.createAgent,
+			},
+			&cli.StringSliceFlag{
+				Name:        "tags",
+				Aliases:     []string{"t"},
+				Usage:       "tags to attach to the session (repeatable)",
+				Destination: &cmd.createTags,
+			},
+			&cli.BoolFlag{
+				Name:        "json",
+				Usage:       "write the created session as JSON to stdout",
+				Destination: &cmd.createJSON,
+			},
+		},
+		Action: cmd.runCreate,
+	}
+}
+
+func (cmd *SessionCmd) runCreate(ctx context.Context, c *cli.Command) error {
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		return fmt.Errorf("session name required\n\nUsage: hive session create <name...>")
+	}
+	name := strings.Join(args, " ")
+
+	if cmd.createAgent != "" {
+		if _, ok := cmd.app.Config.Agents.Profiles[cmd.createAgent]; !ok {
+			return fmt.Errorf("unknown agent %q", cmd.createAgent)
+		}
+	}
+
+	source := cmd.createSource
+	if source == "" {
+		var err error
+		source, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("determine source directory: %w", err)
+		}
+	}
+
+	opts := hive.CreateOptions{
+		Name:          name,
+		Remote:        cmd.createRemote,
+		Source:        source,
+		Background:    cmd.createBackground,
+		CloneStrategy: cmd.createCloneStrategy,
+		AgentKey:      cmd.createAgent,
+		Tags:          cmd.createTags,
+		// Keep stdout clean for --json output; progress goes to stderr.
+		Progress: os.Stderr,
+	}
+
+	sess, err := cmd.app.Sessions.CreateSession(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("create session: %w", err)
+	}
+
+	if cmd.createJSON {
+		return iojson.WriteLine(c.Root().Writer, buildSessionJSON(*sess))
+	}
+
+	fmt.Fprintf(os.Stderr, "Session created\n  %s\n", sess.Path)
+	return nil
+}
+
+func (cmd *SessionCmd) updateCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "update",
+		Usage:     "Update a session's name or group",
+		UsageText: "hive session update <id> [--name <name>] [--group <group> | --clear-group] [--json]",
+		Description: `Updates mutable fields on an existing session.
+
+At least one of --name, --group, or --clear-group is required.
+
+Examples:
+  hive session update abc123 --name "New Name"
+  hive session update abc123 --group backend
+  hive session update abc123 --clear-group`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "name",
+				Usage:       "new session name (also updates slug)",
+				Destination: &cmd.updateName,
+			},
+			&cli.StringFlag{
+				Name:        "group",
+				Usage:       "assign the session to a group",
+				Destination: &cmd.updateGroup,
+			},
+			&cli.BoolFlag{
+				Name:        "clear-group",
+				Usage:       "clear the session's group assignment",
+				Destination: &cmd.updateClearGroup,
+			},
+			&cli.BoolFlag{
+				Name:        "json",
+				Usage:       "write the updated session as JSON to stdout",
+				Destination: &cmd.updateJSON,
+			},
+		},
+		Action: cmd.runUpdate,
+	}
+}
+
+func (cmd *SessionCmd) runUpdate(ctx context.Context, c *cli.Command) error {
+	id := c.Args().First()
+	if id == "" {
+		return fmt.Errorf("session ID required")
+	}
+
+	if cmd.updateGroup != "" && cmd.updateClearGroup {
+		return fmt.Errorf("--group and --clear-group are mutually exclusive")
+	}
+	if cmd.updateName == "" && cmd.updateGroup == "" && !cmd.updateClearGroup {
+		return fmt.Errorf("nothing to update: provide --name, --group, or --clear-group")
+	}
+
+	if cmd.updateName != "" {
+		if err := cmd.app.Sessions.RenameSession(ctx, id, cmd.updateName); err != nil {
+			return fmt.Errorf("rename session: %w", err)
+		}
+	}
+
+	if cmd.updateGroup != "" || cmd.updateClearGroup {
+		group := cmd.updateGroup
+		if cmd.updateClearGroup {
+			group = ""
+		}
+		if err := cmd.app.Sessions.SetSessionGroup(ctx, id, group); err != nil {
+			return fmt.Errorf("set session group: %w", err)
+		}
+	}
+
+	sess, err := cmd.app.Sessions.GetSession(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get session: %w", err)
+	}
+
+	if cmd.updateJSON {
+		return iojson.WriteLine(c.Root().Writer, buildSessionJSON(sess))
+	}
+
+	fmt.Fprintf(os.Stderr, "Session %s updated\n", id)
 	return nil
 }
 
@@ -264,7 +538,23 @@ func (cmd *SessionCmd) deleteCmd() *cli.Command {
 		UsageText: "hive session delete <id>",
 		Description: `Permanently removes a session, its cloned directory, and any associated tmux session.
 
+If the session has uncommitted changes or unpushed commits, the delete is
+refused unless --force is passed.
+
 This action cannot be undone. Use 'hive session recycle' to preserve the directory for reuse.`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "force",
+				Aliases:     []string{"f"},
+				Usage:       "delete even if the session has uncommitted or unpushed work",
+				Destination: &cmd.deleteForce,
+			},
+			&cli.BoolFlag{
+				Name:        "json",
+				Usage:       "write the delete result as JSON to stdout",
+				Destination: &cmd.deleteJSON,
+			},
+		},
 		Action: cmd.runDelete,
 	}
 }
@@ -275,8 +565,29 @@ func (cmd *SessionCmd) runDelete(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("session ID required")
 	}
 
+	if !cmd.deleteForce {
+		risk, err := cmd.app.Sessions.CheckSessionRisk(ctx, id)
+		if err != nil {
+			return fmt.Errorf("check session risk: %w", err)
+		}
+		if risk.HasRisk() {
+			var reasons []string
+			if risk.UncommittedChanges {
+				reasons = append(reasons, "uncommitted changes")
+			}
+			if risk.UnpushedCommits {
+				reasons = append(reasons, "unpushed commits")
+			}
+			return fmt.Errorf("session %s has %s; use --force to delete anyway", id, strings.Join(reasons, " and "))
+		}
+	}
+
 	if err := cmd.app.Sessions.DeleteSession(ctx, id); err != nil {
 		return fmt.Errorf("delete session: %w", err)
+	}
+
+	if cmd.deleteJSON {
+		return iojson.WriteLine(c.Root().Writer, map[string]any{"id": id, "deleted": true})
 	}
 
 	fmt.Fprintf(os.Stderr, "Session %s deleted\n", id)
@@ -291,6 +602,13 @@ func (cmd *SessionCmd) recycleCmd() *cli.Command {
 		Description: `Recycles a full-clone session so its checkout can be reused for a new task.
 
 For worktree sessions, removes the checkout and session record while retaining the shared bare clone. This keeps future worktree creation fast without retaining stale session state.`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "json",
+				Usage:       "write the recycle result as JSON to stdout",
+				Destination: &cmd.recycleJSON,
+			},
+		},
 		Action: cmd.runRecycle,
 	}
 }
@@ -303,6 +621,15 @@ func (cmd *SessionCmd) runRecycle(ctx context.Context, c *cli.Command) error {
 
 	if err := cmd.app.Sessions.RecycleSession(ctx, id, os.Stderr); err != nil {
 		return fmt.Errorf("recycle session: %w", err)
+	}
+
+	if cmd.recycleJSON {
+		// Worktree sessions are deleted on recycle, so the record may be gone.
+		sess, err := cmd.app.Sessions.GetSession(ctx, id)
+		if err != nil {
+			return iojson.WriteLine(c.Root().Writer, map[string]any{"id": id, "deleted": true})
+		}
+		return iojson.WriteLine(c.Root().Writer, buildSessionJSON(sess))
 	}
 
 	fmt.Fprintf(os.Stderr, "Session %s recycled\n", id)

--- a/internal/commands/cmd_session.go
+++ b/internal/commands/cmd_session.go
@@ -44,7 +44,8 @@ type SessionCmd struct {
 	deleteJSON  bool
 	deleteForce bool
 
-	recycleJSON bool
+	recycleJSON  bool
+	recycleForce bool
 }
 
 // NewSessionCmd creates a new session command
@@ -566,19 +567,8 @@ func (cmd *SessionCmd) runDelete(ctx context.Context, c *cli.Command) error {
 	}
 
 	if !cmd.deleteForce {
-		risk, err := cmd.app.Sessions.CheckSessionRisk(ctx, id)
-		if err != nil {
-			return fmt.Errorf("check session risk: %w", err)
-		}
-		if risk.HasRisk() {
-			var reasons []string
-			if risk.UncommittedChanges {
-				reasons = append(reasons, "uncommitted changes")
-			}
-			if risk.UnpushedCommits {
-				reasons = append(reasons, "unpushed commits")
-			}
-			return fmt.Errorf("session %s has %s; use --force to delete anyway", id, strings.Join(reasons, " and "))
+		if err := cmd.checkRisk(ctx, id, "delete"); err != nil {
+			return err
 		}
 	}
 
@@ -601,8 +591,17 @@ func (cmd *SessionCmd) recycleCmd() *cli.Command {
 		UsageText: "hive session recycle <id>",
 		Description: `Recycles a full-clone session so its checkout can be reused for a new task.
 
-For worktree sessions, removes the checkout and session record while retaining the shared bare clone. This keeps future worktree creation fast without retaining stale session state.`,
+For worktree sessions, removes the checkout and session record while retaining the shared bare clone. This keeps future worktree creation fast without retaining stale session state.
+
+If the session has uncommitted changes or unpushed commits, the recycle is
+refused unless --force is passed.`,
 		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "force",
+				Aliases:     []string{"f"},
+				Usage:       "recycle even if the session has uncommitted or unpushed work",
+				Destination: &cmd.recycleForce,
+			},
 			&cli.BoolFlag{
 				Name:        "json",
 				Usage:       "write the recycle result as JSON to stdout",
@@ -617,6 +616,12 @@ func (cmd *SessionCmd) runRecycle(ctx context.Context, c *cli.Command) error {
 	id := c.Args().First()
 	if id == "" {
 		return fmt.Errorf("session ID required")
+	}
+
+	if !cmd.recycleForce {
+		if err := cmd.checkRisk(ctx, id, "recycle"); err != nil {
+			return err
+		}
 	}
 
 	if err := cmd.app.Sessions.RecycleSession(ctx, id, os.Stderr); err != nil {
@@ -657,6 +662,26 @@ func (cmd *SessionCmd) buildLsSessionInfo(ctx context.Context, s session.Session
 	}
 
 	return info
+}
+
+// checkRisk returns an error describing uncommitted or unpushed work that
+// would be lost if the session were destroyed by the given action.
+func (cmd *SessionCmd) checkRisk(ctx context.Context, id, action string) error {
+	risk, err := cmd.app.Sessions.CheckSessionRisk(ctx, id)
+	if err != nil {
+		return fmt.Errorf("check session risk: %w", err)
+	}
+	if !risk.HasRisk() {
+		return nil
+	}
+	var reasons []string
+	if risk.UncommittedChanges {
+		reasons = append(reasons, "uncommitted changes")
+	}
+	if risk.UnpushedCommits {
+		reasons = append(reasons, "unpushed commits")
+	}
+	return fmt.Errorf("session %s has %s; use --force to %s anyway", id, strings.Join(reasons, " and "), action)
 }
 
 // sessionHasAllTags returns true if the session has every tag in required.

--- a/internal/core/git/executor.go
+++ b/internal/core/git/executor.go
@@ -90,7 +90,18 @@ func (e *Executor) DefaultBranch(ctx context.Context, dir string) (string, error
 	// Get the default branch from origin's HEAD reference
 	out, err := e.exec.RunDir(ctx, dir, e.gitPath, "--no-optional-locks", "symbolic-ref", "refs/remotes/origin/HEAD", "--short")
 	if err != nil {
-		return "", fmt.Errorf("git symbolic-ref: %w", err)
+		// Bare clones (worktree sessions) have no refs/remotes/origin/*; the bare
+		// repo's own HEAD tracks the remote default branch, so resolve it via the
+		// common git dir.
+		commonDir, cerr := e.exec.RunDir(ctx, dir, e.gitPath, "--no-optional-locks", "rev-parse", "--path-format=absolute", "--git-common-dir")
+		if cerr != nil {
+			return "", fmt.Errorf("git symbolic-ref: %w", err)
+		}
+		head, herr := e.exec.RunDir(ctx, strings.TrimSpace(string(commonDir)), e.gitPath, "--no-optional-locks", "symbolic-ref", "HEAD", "--short")
+		if herr != nil {
+			return "", fmt.Errorf("git symbolic-ref: %w", err)
+		}
+		return strings.TrimSpace(string(head)), nil
 	}
 
 	// Output is "origin/main" or "origin/master", strip the "origin/" prefix
@@ -229,7 +240,12 @@ func (e *Executor) HasUnpushedCommits(ctx context.Context, dir string) (bool, er
 
 	out, err = e.exec.RunDir(ctx, dir, e.gitPath, "--no-optional-locks", "rev-list", "--count", "origin/"+defaultBranch+"..HEAD")
 	if err != nil {
-		return false, fmt.Errorf("rev-list unpushed: %w", err)
+		// Bare clones (worktree sessions) have no refs/remotes/origin/*; their
+		// local default branch mirrors the remote, so compare against it instead.
+		out, err = e.exec.RunDir(ctx, dir, e.gitPath, "--no-optional-locks", "rev-list", "--count", defaultBranch+"..HEAD")
+		if err != nil {
+			return false, fmt.Errorf("rev-list unpushed: %w", err)
+		}
 	}
 
 	n, _ := parseInt(strings.TrimSpace(string(out)))

--- a/internal/core/git/executor.go
+++ b/internal/core/git/executor.go
@@ -92,12 +92,18 @@ func (e *Executor) DefaultBranch(ctx context.Context, dir string) (string, error
 	if err != nil {
 		// Bare clones (worktree sessions) have no refs/remotes/origin/*; the bare
 		// repo's own HEAD tracks the remote default branch, so resolve it via the
-		// common git dir.
+		// common git dir. Only bare repos qualify: in a non-bare repo the common
+		// dir's HEAD is the checked-out branch, not the default branch.
 		commonDir, cerr := e.exec.RunDir(ctx, dir, e.gitPath, "--no-optional-locks", "rev-parse", "--path-format=absolute", "--git-common-dir")
 		if cerr != nil {
 			return "", fmt.Errorf("git symbolic-ref: %w", err)
 		}
-		head, herr := e.exec.RunDir(ctx, strings.TrimSpace(string(commonDir)), e.gitPath, "--no-optional-locks", "symbolic-ref", "HEAD", "--short")
+		bareDir := strings.TrimSpace(string(commonDir))
+		bare, berr := e.exec.RunDir(ctx, bareDir, e.gitPath, "--no-optional-locks", "rev-parse", "--is-bare-repository")
+		if berr != nil || strings.TrimSpace(string(bare)) != "true" {
+			return "", fmt.Errorf("git symbolic-ref: %w", err)
+		}
+		head, herr := e.exec.RunDir(ctx, bareDir, e.gitPath, "--no-optional-locks", "symbolic-ref", "HEAD", "--short")
 		if herr != nil {
 			return "", fmt.Errorf("git symbolic-ref: %w", err)
 		}

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -237,6 +237,48 @@ func TestSessionDeleteRiskGate(t *testing.T) {
 	assert.Empty(t, lines, "session should be gone after forced delete")
 }
 
+func TestSessionRecycleRiskGate(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "recycle-risk-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "risky-recycle")
+	require.NoError(t, err)
+	id := created["id"].(string)
+	path := created["path"].(string)
+
+	// Introduce uncommitted changes.
+	require.NoError(t, os.WriteFile(filepath.Join(path, "dirty.txt"), []byte("wip"), 0o644))
+
+	_, err = h.Run("session", "recycle", id)
+	require.Error(t, err, "recycle of dirty session without --force should fail")
+
+	entry, err := h.RunJSON("session", "recycle", id, "--force", "--json")
+	require.NoError(t, err)
+	assert.Equal(t, "recycled", entry["state"])
+}
+
+func TestSessionRecycleRiskGateWorktree(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "recycle-risk-wt-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--clone-strategy", "worktree", "--remote", repo, "risky-wt")
+	require.NoError(t, err)
+	id := created["id"].(string)
+	path := created["path"].(string)
+
+	// Introduce uncommitted changes. (The clean-worktree case — recycle without
+	// --force succeeding despite bare clones lacking origin/* refs — is covered
+	// by TestWorktreeRecycleDeletesSessionAndNextCreateIsFresh.)
+	require.NoError(t, os.WriteFile(filepath.Join(path, "dirty.txt"), []byte("wip"), 0o644))
+
+	_, err = h.Run("session", "recycle", id)
+	require.Error(t, err, "recycle of dirty worktree session without --force should fail")
+
+	entry, err := h.RunJSON("session", "recycle", id, "--force", "--json")
+	require.NoError(t, err)
+	assert.Equal(t, true, entry["deleted"], "worktree sessions are deleted on recycle")
+}
+
 func TestSessionRecycleJSON(t *testing.T) {
 	h := NewHarness(t)
 	repo := createBareRepo(t, "recycle-json-repo")

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -3,6 +3,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,4 +124,129 @@ func TestSessionRecycleMissingID(t *testing.T) {
 
 	_, err := h.Run("session", "recycle")
 	require.Error(t, err, "recycle without ID should fail")
+}
+
+func TestSessionCreateSubcommandJSON(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "create-json-repo")
+
+	entry, err := h.RunJSON("session", "create", "--json", "--remote", repo, "orchestrated")
+	require.NoError(t, err)
+
+	assert.Equal(t, "orchestrated", entry["name"])
+	assert.Equal(t, "active", entry["state"])
+	assert.NotEmpty(t, entry["id"])
+	assert.NotEmpty(t, entry["path"])
+	assert.NotEmpty(t, entry["inbox"])
+	assert.NotEmpty(t, entry["slug"])
+
+	// The created session must be discoverable by the returned ID.
+	id := entry["id"].(string)
+	shown, err := h.RunJSON("session", "show", id, "--json")
+	require.NoError(t, err)
+	assert.Equal(t, id, shown["id"])
+}
+
+func TestSessionShow(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "show-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "show-me", "--tags", "a", "--tags", "b")
+	require.NoError(t, err)
+	id := created["id"].(string)
+
+	entry, err := h.RunJSON("session", "show", id, "--json")
+	require.NoError(t, err)
+	assert.Equal(t, "show-me", entry["name"])
+	assert.Equal(t, "active", entry["state"])
+	assert.ElementsMatch(t, []any{"a", "b"}, entry["tags"])
+}
+
+func TestSessionShowUnknownID(t *testing.T) {
+	h := NewHarness(t)
+
+	_, err := h.Run("session", "show", "nonexistent")
+	require.Error(t, err, "show with unknown ID should fail")
+}
+
+func TestSessionUpdateName(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "update-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "old-name")
+	require.NoError(t, err)
+	id := created["id"].(string)
+
+	entry, err := h.RunJSON("session", "update", id, "--name", "new-name", "--json")
+	require.NoError(t, err)
+	assert.Equal(t, "new-name", entry["name"])
+	assert.Equal(t, "new-name", entry["slug"])
+}
+
+func TestSessionUpdateGroup(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "group-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "grouped")
+	require.NoError(t, err)
+	id := created["id"].(string)
+
+	entry, err := h.RunJSON("session", "update", id, "--group", "backend", "--json")
+	require.NoError(t, err)
+	assert.Equal(t, "backend", entry["group"])
+
+	entry, err = h.RunJSON("session", "update", id, "--clear-group", "--json")
+	require.NoError(t, err)
+	_, hasGroup := entry["group"]
+	assert.False(t, hasGroup, "group should be omitted after clearing")
+}
+
+func TestSessionUpdateNoFlags(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "noflags-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "noop")
+	require.NoError(t, err)
+	id := created["id"].(string)
+
+	_, err = h.Run("session", "update", id)
+	require.Error(t, err, "update without modification flags should fail")
+}
+
+func TestSessionDeleteRiskGate(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "risk-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "risky")
+	require.NoError(t, err)
+	id := created["id"].(string)
+	path := created["path"].(string)
+
+	// Introduce uncommitted changes.
+	require.NoError(t, os.WriteFile(filepath.Join(path, "dirty.txt"), []byte("wip"), 0o644))
+
+	_, err = h.Run("session", "delete", id)
+	require.Error(t, err, "delete of dirty session without --force should fail")
+
+	entry, err := h.RunJSON("session", "delete", id, "--force", "--json")
+	require.NoError(t, err)
+	assert.Equal(t, true, entry["deleted"])
+
+	lines, err := h.RunJSONLines("ls", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, lines, "session should be gone after forced delete")
+}
+
+func TestSessionRecycleJSON(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "recycle-json-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "recycle-json")
+	require.NoError(t, err)
+	id := created["id"].(string)
+
+	entry, err := h.RunJSON("session", "recycle", id, "--json")
+	require.NoError(t, err)
+	assert.Equal(t, "recycled", entry["state"])
+	assert.Equal(t, id, entry["id"])
 }

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -213,6 +213,42 @@ func TestSessionUpdateNoFlags(t *testing.T) {
 	require.Error(t, err, "update without modification flags should fail")
 }
 
+func TestSessionDeleteRiskGateUnpushed(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "unpushed-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--clone-strategy", "worktree", "--remote", repo, "unpushed-wt")
+	require.NoError(t, err)
+	id := created["id"].(string)
+	path := created["path"].(string)
+
+	// Commit without pushing — the risk gate must detect unpushed commits even
+	// in worktree sessions, where the bare clone has no refs/remotes/origin/*.
+	require.NoError(t, os.WriteFile(filepath.Join(path, "work.txt"), []byte("done"), 0o644))
+	runInDir(t, path, "git", "add", ".")
+	runInDir(t, path, "git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "unpushed work")
+
+	out, err := h.Run("session", "delete", id)
+	require.Error(t, err, "delete of session with unpushed commits should fail: %s", out)
+	assert.Contains(t, out, "unpushed commits")
+
+	entry, err := h.RunJSON("session", "delete", id, "--force", "--json")
+	require.NoError(t, err)
+	assert.Equal(t, true, entry["deleted"])
+}
+
+func TestSessionUpdateGroupFlagConflict(t *testing.T) {
+	h := NewHarness(t)
+	repo := createBareRepo(t, "conflict-repo")
+
+	created, err := h.RunJSON("session", "create", "--json", "--remote", repo, "conflicted")
+	require.NoError(t, err)
+	id := created["id"].(string)
+
+	_, err = h.Run("session", "update", id, "--group", "x", "--clear-group")
+	require.Error(t, err, "--group and --clear-group together should fail")
+}
+
 func TestSessionDeleteRiskGate(t *testing.T) {
 	h := NewHarness(t)
 	repo := createBareRepo(t, "risk-repo")


### PR DESCRIPTION
## Purpose

Let orchestrator-style agents manage the full lifecycle of other sessions from the CLI: create sessions and capture the new ID from machine-readable output, inspect/update them by ID, and destroy them safely.

## Proposed Changes

  - New `session create` (shares flags with `hive new` via a common helper), `session show <id>`, and `session update <id>` (`--name`, `--group`/`--clear-group`); all mutations support `--json` on stdout with progress on stderr
  - `session delete` and `session recycle` now refuse when the session has uncommitted changes or unpushed commits, unless `--force`
  - Fixes risk detection for worktree sessions: bare clones have no `refs/remotes/origin/*`, so `DefaultBranch`/`HasUnpushedCommits` always errored and every worktree session was conservatively flagged risky. `DefaultBranch` falls back to the bare common dir's `HEAD` (gated on `--is-bare-repository`), `HasUnpushedCommits` falls back to the local default-branch ref

Known limitation (documented in help text): a pushed-but-unmerged worktree branch still counts as unpushed since the bare clone has no remote-tracking refs — use `--force` after verifying the push.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
