### PR TITLE
feat(desktop): sidebar feed folders + reordering

### DIFF
--- a/desktop/e2e/tests/onboarding.spec.ts
+++ b/desktop/e2e/tests/onboarding.spec.ts
@@ -110,10 +110,10 @@ test('first-run onboarding: token fallback card, then device flow to the feed', 
   const teamRow = page.locator('[data-testid="sidebar-feed"][data-id="backend-triage/my-open-prs"]')
   await expect(teamRow).toContainText('Team PRs')
 
-  // "Reveal in flow" (replaces the old edit pencil) jumps back into the
-  // canvas, focused on the renamed node.
-  await teamRow.hover()
-  await teamRow.getByTestId('sidebar-reveal-in-flow').click()
+  // The "Edit flow" footer jumps back into the canvas, where the renamed node
+  // lives. (There is no per-feed reveal-in-flow icon anymore — a feed is edited
+  // by opening its node in the canvas.)
+  await page.getByTestId('sidebar-edit-flow').click()
   await expect(flowsView).toBeVisible()
   await expect(page.locator('[data-testid="flow-node-my-open-prs"]')).toBeVisible()
   await page.getByTestId('breadcrumb-profile-name').click()

--- a/desktop/flowsservice.go
+++ b/desktop/flowsservice.go
@@ -90,3 +90,16 @@ func (s *FlowsService) GetLayout(id string) flow.Layout {
 func (s *FlowsService) SaveLayout(id string, layout flow.Layout) error {
 	return s.store.SaveLayout(id, layout)
 }
+
+// GetSidebar returns a flow's sidebar layout: how its feed nodes are grouped
+// into folders and ordered in the sidebar's FEEDS section. A missing or broken
+// file is not an error — it returns an empty layout so the sidebar falls back
+// to flow-node order.
+func (s *FlowsService) GetSidebar(id string) flow.SidebarLayout {
+	return s.store.GetSidebar(id)
+}
+
+// SaveSidebar persists a flow's sidebar layout (feed folders + ordering).
+func (s *FlowsService) SaveSidebar(id string, layout flow.SidebarLayout) error {
+	return s.store.SaveSidebar(id, layout)
+}

--- a/desktop/frontend/bindings/github.com/colonyops/hive/desktop/flowsservice.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/desktop/flowsservice.ts
@@ -53,6 +53,16 @@ export function GetLayout(id: string): $CancellablePromise<flow$0.Layout> {
 }
 
 /**
+ * GetSidebar returns a flow's sidebar layout: how its feed nodes are grouped
+ * into folders and ordered in the sidebar's FEEDS section. A missing or broken
+ * file is not an error — it returns an empty layout so the sidebar falls back
+ * to flow-node order.
+ */
+export function GetSidebar(id: string): $CancellablePromise<flow$0.SidebarLayout> {
+    return $Call.ByID(378136572, id);
+}
+
+/**
  * ListFlows returns one summary per flow file — valid and invalid alike —
  * for the flows picker.
  */
@@ -74,4 +84,11 @@ export function SaveFlow(f: flow$0.Flow): $CancellablePromise<void> {
  */
 export function SaveLayout(id: string, layout: flow$0.Layout): $CancellablePromise<void> {
     return $Call.ByID(4232063923, id, layout);
+}
+
+/**
+ * SaveSidebar persists a flow's sidebar layout (feed folders + ordering).
+ */
+export function SaveSidebar(id: string, layout: flow$0.SidebarLayout): $CancellablePromise<void> {
+    return $Call.ByID(3551590419, id, layout);
 }

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/index.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/index.ts
@@ -6,5 +6,8 @@ export type {
     Layout,
     Node,
     NodePosition,
+    SidebarFolder,
+    SidebarItem,
+    SidebarLayout,
     Wire
 } from "./models.js";

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/models.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/models.ts
@@ -51,13 +51,15 @@ export interface NodePosition {
 }
 
 /**
- * SidebarFolder is one named, collapsible group of feeds in a profile's
- * sidebar. Feeds lists the member feed node ids in display order.
+ * SidebarFolder is one named group of feeds in a profile's sidebar. Feeds
+ * lists the member feed node ids in display order. Note there is no collapsed
+ * field: whether a folder is expanded is transient view state the frontend
+ * keeps in localStorage, not configuration — this file records structure and
+ * order only.
  */
 export interface SidebarFolder {
     "id": string;
     "name": string;
-    "collapsed": boolean;
     "feeds": string[] | null;
 }
 

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/models.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/models.ts
@@ -51,6 +51,43 @@ export interface NodePosition {
 }
 
 /**
+ * SidebarFolder is one named, collapsible group of feeds in a profile's
+ * sidebar. Feeds lists the member feed node ids in display order.
+ */
+export interface SidebarFolder {
+    "id": string;
+    "name": string;
+    "collapsed": boolean;
+    "feeds": string[] | null;
+}
+
+/**
+ * SidebarItem is one entry in the sidebar's ordered top level: either a bare
+ * feed (Feed set to a feed node id) or a folder (Folder set). Exactly one is
+ * meant to be non-empty; a malformed item with neither is ignored by the
+ * frontend when it reconciles the layout against the flow's actual feed nodes.
+ */
+export interface SidebarItem {
+    "feed"?: string;
+    "folder"?: SidebarFolder | null;
+}
+
+/**
+ * SidebarLayout is the machine-written, non-authoritative sibling of a flow —
+ * the on-disk shape of a <id>.sidebar.yaml file. It records how a profile's
+ * feed nodes are grouped into folders and ordered in the sidebar's FEEDS
+ * section. Like Layout (.ui.yaml) it is purely cosmetic and keyed by node id:
+ * a missing or broken file just means the sidebar falls back to listing feeds
+ * in flow-node order, feed nodes absent from the layout are appended (so a
+ * newly added feed is never hidden), and entries for feeds that no longer
+ * exist are dropped. It is never consulted by LoadFlow/validation and never
+ * blocks a flow from loading.
+ */
+export interface SidebarLayout {
+    "items": SidebarItem[] | null;
+}
+
+/**
  * Wire is a directed edge from one node's output port to another node's
  * (sole) input. Out defaults to 0 when omitted in YAML.
  */

--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/ibm-plex-sans": "5.2.8",
+        "@vueuse/core": "^14.3.0",
         "@wailsio/runtime": "3.0.0-alpha.97",
         "markdown-it": "^14.3.0",
         "markdown-it-task-lists": "^2.1.1",
@@ -931,6 +932,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
@@ -1270,6 +1277,44 @@
         "@vue/server-renderer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.3.0",
+        "@vueuse/shared": "14.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/@wailsio/runtime": {

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/ibm-plex-sans": "5.2.8",
+    "@vueuse/core": "^14.3.0",
     "@wailsio/runtime": "3.0.0-alpha.97",
     "markdown-it": "^14.3.0",
     "markdown-it-task-lists": "^2.1.1",

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -42,7 +42,7 @@ const {
   profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, loadError,
   selectedId, selectedItem, actions, unreadOnly, title, toasts, dismissToast, clearToasts,
   creatingProfile, createProfileError, deletingProfile, loadProfiles, createProfile, deleteProfile,
-  selectProfile, selectSidebar, selectUnreadView, selectItem,
+  reorderFeeds, selectProfile, selectSidebar, selectUnreadView, selectItem,
   toggleUnread, refresh, invokeAction, notWired, openUrl, openSelectedInBrowser, hideWindow,
 } = useFeedState()
 
@@ -545,6 +545,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
             @open-flows="openFlows()"
             @open-settings="requestOpenSettings('profile')"
             @reveal-in-flow="revealInFlow"
+            @reorder="(t) => activeProfile && reorderFeeds(activeProfile.id, t)"
           />
           <section v-if="activeProfile" class="flex min-w-0 flex-1">
             <FeedList

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -243,17 +243,6 @@ function selectProfileSettingsSection(section: ProfileSettingsSection): void {
   void router.push({ name: 'profile-settings', params: { profileId: activeProfileId.value, section } })
 }
 
-// ── Reveal in flow (8d) ───────────────────────────────────────────────────────
-// A sidebar feed row's id is flow-qualified ("<activeProfileId>/<nodeId>" —
-// see useFeedState's loadFeeds), so the node id is everything after the
-// profile id's own "/" separator. openFlows() both opens the canvas and sets
-// flowFocusNodeId, which FlowsCanvas's existing focus watch turns into a
-// select + center-pan (see FlowsView.vue's :focus-node-id binding).
-function revealInFlow(feedId: string): void {
-  const nodeId = feedId.slice(activeProfileId.value.length + 1)
-  openFlows(nodeId)
-}
-
 // ── Titlebar error chip (8d) ──────────────────────────────────────────────────
 // Sourced from the always-on session (not FlowsView), so the chip renders and
 // deep-links correctly even with the canvas closed.
@@ -544,7 +533,6 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
             @select="navigateSidebar"
             @open-flows="openFlows()"
             @open-settings="requestOpenSettings('profile')"
-            @reveal-in-flow="revealInFlow"
             @reorder="(t) => activeProfile && reorderFeeds(activeProfile.id, t)"
           />
           <section v-if="activeProfile" class="flex min-w-0 flex-1">

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   GetLayout: vi.fn(),
   SaveFlow: vi.fn(),
   SaveLayout: vi.fn(),
+  GetSidebar: vi.fn(),
+  SaveSidebar: vi.fn(),
   // pipelineservice
   FeedItems: vi.fn(),
   FeedItemCounts: vi.fn(),
@@ -43,6 +45,8 @@ vi.mock('../../bindings/github.com/colonyops/hive/desktop/flowsservice', () => (
   GetLayout: mocks.GetLayout,
   SaveFlow: mocks.SaveFlow,
   SaveLayout: mocks.SaveLayout,
+  GetSidebar: mocks.GetSidebar,
+  SaveSidebar: mocks.SaveSidebar,
 }))
 
 vi.mock('../../bindings/github.com/colonyops/hive/desktop/pipelineservice', () => ({
@@ -105,6 +109,8 @@ describe('App', () => {
     mocks.ListFlows.mockResolvedValue([{ id: 'personal', name: 'Personal', enabled: true, valid: true }])
     mocks.GetFlow.mockResolvedValue(flow)
     mocks.GetLayout.mockResolvedValue({ nodes: {} })
+    mocks.GetSidebar.mockResolvedValue({ items: [] })
+    mocks.SaveSidebar.mockResolvedValue(undefined)
     mocks.FeedItems.mockResolvedValue([])
     mocks.FeedItemCounts.mockResolvedValue([{ feedId: 'personal/desktop', total: 1, unread: 0 }])
     mocks.ActionViews.mockResolvedValue([])

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -315,24 +315,6 @@ describe('App', () => {
     wrapper.unmount()
   })
 
-  it('reveals a feed in the flow: maps the flow-qualified feed id to its node id and opens the canvas focused on it', async () => {
-    const wrapper = await mountApp()
-
-    expect(wrapper.find('[data-testid="flows-view"]').exists()).toBe(false)
-
-    // "personal/desktop" (feedId) -> "desktop" (nodeId) — see useFeedState's loadFeeds.
-    await wrapper.find('[data-testid="sidebar-feed"][data-id="personal/desktop"] [data-testid="sidebar-reveal-in-flow"]').trigger('click')
-    await flushPromises()
-
-    expect(wrapper.find('[data-testid="flows-view"]').exists()).toBe(true)
-
-    const session = useFlowsSession()
-    expect(session.flowsOpen.value).toBe(true)
-    expect(session.flowFocusNodeId.value).toBe('desktop')
-
-    wrapper.unmount()
-  })
-
   it('the titlebar error chip deep-links to the first failing node, even with the canvas closed', async () => {
     mocks.NodeRuns.mockResolvedValue([
       { flowId: 'personal', nodeId: 'src', ok: false, inCount: 0, outCount: 0, dropCount: 0, err: 'boom', durMs: 1, endedAt: 0 },

--- a/desktop/frontend/src/components/SideBar.vue
+++ b/desktop/frontend/src/components/SideBar.vue
@@ -22,7 +22,6 @@ const emit = defineEmits<{
   select: [sel: SidebarSelection]
   'open-flows': []
   'open-settings': []
-  'reveal-in-flow': [feedId: string]
   reorder: [tree: FeedTree]
 }>()
 
@@ -265,7 +264,6 @@ function deleteFolder(folder: FeedFolder): void {
             :feed="node.feed"
             :selected="feedSelected(node.feed.id)"
             @select="emit('select', { type: 'feed', feedId: node.feed.id })"
-            @reveal="emit('reveal-in-flow', node.feed.id)"
           />
         </div>
 
@@ -286,8 +284,10 @@ function deleteFolder(folder: FeedFolder): void {
             @dragend="onDragEnd"
             @click="onHeaderClick(node.folder)"
           >
-            <span class="folder-chevron text-text-4"><component :is="node.folder.collapsed ? IconChevronRight : IconChevronDown" class="size-3" /></span>
-            <span class="nav-icon"><IconFolder class="size-3" /></span>
+            <span class="nav-icon">
+              <IconFolder class="folder-glyph size-3" />
+              <component :is="node.folder.collapsed ? IconChevronRight : IconChevronDown" class="folder-chevron size-3" />
+            </span>
             <input
               v-if="renamingId === node.folder.id"
               v-model="draftName"
@@ -332,7 +332,6 @@ function deleteFolder(folder: FeedFolder): void {
                 :feed="feed"
                 :selected="feedSelected(feed.id)"
                 @select="emit('select', { type: 'feed', feedId: feed.id })"
-                @reveal="emit('reveal-in-flow', feed.id)"
               />
             </div>
             <div v-if="node.folder.feeds.length === 0" class="folder-empty">Drop feeds here</div>
@@ -385,18 +384,24 @@ function deleteFolder(folder: FeedFolder): void {
 /* An item wrapper carries the drag handle + insertion indicator; the row/header
    inside it stays visually unchanged. */
 .sb-item { border-radius: 7px; }
-.sb-item.indented { padding-left: 16px; }
+.sb-item.indented { padding-left: 12px; }
 .drop-before { box-shadow: inset 0 2px 0 0 var(--color-accent); }
 .drop-after { box-shadow: inset 0 -2px 0 0 var(--color-accent); }
 
-.folder-header { display: flex; align-items: center; gap: 7px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
+.folder-header { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
 .folder-header:hover { background: var(--color-chip); color: var(--color-text); }
-.folder-chevron { display: inline-flex; flex: none; }
+/* The leading icon slot shows the folder glyph by default and swaps to a
+   collapse/expand chevron on hover — no permanent chevron column, so the
+   folder header aligns with the feed rows above it. */
+.folder-glyph { display: inline-flex; }
+.folder-chevron { display: none; }
+.folder-header:hover .folder-glyph { display: none; }
+.folder-header:hover .folder-chevron { display: inline-flex; }
 .folder-action { opacity: 0; }
 .folder-header:hover .folder-action, .folder-action:focus-visible { opacity: 1; }
 .folder-rename { background: var(--color-app); border: 1px solid var(--color-accent); border-radius: 5px; padding: 1px 5px; font-size: 13px; color: var(--color-text); outline: none; }
 .folder-body { margin-top: 1px; }
-.folder-empty { padding: 6px 8px 6px 24px; font-size: 11.5px; color: var(--color-text-4); font-style: italic; }
+.folder-empty { padding: 6px 8px 6px 20px; font-size: 11.5px; color: var(--color-text-4); font-style: italic; }
 .sb-folder.drop-into { background: var(--color-accent-tint); border-radius: 7px; }
 .sb-folder.drop-before { box-shadow: inset 0 2px 0 0 var(--color-accent); }
 .sb-folder.drop-after { box-shadow: inset 0 -2px 0 0 var(--color-accent); }

--- a/desktop/frontend/src/components/SideBar.vue
+++ b/desktop/frontend/src/components/SideBar.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
+import IconChevronDown from '~icons/lucide/chevron-down'
 import IconChevronRight from '~icons/lucide/chevron-right'
+import IconFolder from '~icons/lucide/folder'
+import IconFolderPlus from '~icons/lucide/folder-plus'
 import IconGitBranch from '~icons/lucide/git-branch'
 import IconList from '~icons/lucide/list'
+import IconPencil from '~icons/lucide/pencil'
 import IconRss from '~icons/lucide/rss'
 import IconSettings from '~icons/lucide/settings'
-import IconShare2 from '~icons/lucide/share-2'
+import IconTrash from '~icons/lucide/trash-2'
 import IconWorkflow from '~icons/lucide/workflow'
 import PanelResizeHandle from './PanelResizeHandle.vue'
+import SidebarFeedRow from './SidebarFeedRow.vue'
 import { useResizablePanel } from '../composables/useResizablePanel'
-import type { Profile, SidebarSelection } from '../types/feed'
+import { applyMove, SIDEBAR_DRAG_MIME, type DragRef, type DropTarget } from '../lib/feedTree'
+import type { FeedFolder, FeedSummary, FeedTree, Profile, SidebarSelection } from '../types/feed'
 
 const props = defineProps<{ profile: Profile; selection: SidebarSelection; flowsDirty?: boolean }>()
 const emit = defineEmits<{
@@ -16,6 +23,7 @@ const emit = defineEmits<{
   'open-flows': []
   'open-settings': []
   'reveal-in-flow': [feedId: string]
+  reorder: [tree: FeedTree]
 }>()
 
 const { size, startResize, step } = useResizablePanel({
@@ -26,15 +34,180 @@ const { size, startResize, step } = useResizablePanel({
   edge: 'right',
 })
 
-// "All items" is the all-scope entry; the All / Unread filter now lives on the
-// list itself, so the sidebar no longer carries an Unread shortcut. A feed
-// entry highlights when it's the active selection.
+// The rendered tree. A profile with no saved sidebar layout falls back to a
+// flat list of its feeds, so nothing changes until the user groups/reorders.
+const tree = computed<FeedTree>(() =>
+  props.profile.tree ?? props.profile.feeds.map((f) => ({ kind: 'feed', feed: f })),
+)
+
 function allSelected(): boolean {
   return props.selection.type === 'all'
 }
-
 function feedSelected(feedId: string): boolean {
   return props.selection.type === 'feed' && props.selection.feedId === feedId
+}
+
+function feedRef(feed: FeedSummary): DragRef {
+  return { kind: 'feed', id: feed.id }
+}
+function folderDragRef(folder: FeedFolder): DragRef {
+  return { kind: 'folder', id: folder.id }
+}
+
+function folderNew(folder: FeedFolder): number {
+  return folder.feeds.reduce((sum, f) => sum + f.newCount, 0)
+}
+function folderTotal(folder: FeedFolder): number {
+  return folder.feeds.reduce((sum, f) => sum + f.count, 0)
+}
+
+// ── drag-and-drop ─────────────────────────────────────────────────────────
+// Same native HTML5 DnD approach as the flow palette; the dragged item is
+// tracked in a local ref (dataTransfer can't be read during dragover), and a
+// drop target drives the insertion indicators.
+const dragging = ref<DragRef | null>(null)
+const dropTarget = ref<DropTarget | null>(null)
+
+function onDragStart(e: DragEvent, ref: DragRef): void {
+  dragging.value = ref
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData(SIDEBAR_DRAG_MIME, ref.id)
+  }
+}
+
+function edge(e: DragEvent): 'before' | 'after' {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  return e.clientY < rect.top + rect.height / 2 ? 'before' : 'after'
+}
+
+function allowDrop(e: DragEvent): boolean {
+  if (!dragging.value) return false
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+  return true
+}
+
+function onItemDragOver(e: DragEvent, ref: DragRef): void {
+  if (!allowDrop(e)) return
+  dropTarget.value = { kind: edge(e), ref }
+}
+
+function onFolderDragOver(e: DragEvent, folder: FeedFolder): void {
+  if (!allowDrop(e)) return
+  if (dragging.value?.kind === 'folder') {
+    dropTarget.value = { kind: edge(e), ref: folderDragRef(folder) }
+    return
+  }
+  // A feed onto a folder header: top slice drops before the folder, bottom
+  // slice after it (both top level), the middle drops into the folder.
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  const y = e.clientY - rect.top
+  if (y < rect.height * 0.25) dropTarget.value = { kind: 'before', ref: folderDragRef(folder) }
+  else if (y > rect.height * 0.75) dropTarget.value = { kind: 'after', ref: folderDragRef(folder) }
+  else dropTarget.value = { kind: 'into', folderId: folder.id }
+}
+
+function onEndDragOver(e: DragEvent): void {
+  if (!allowDrop(e)) return
+  dropTarget.value = { kind: 'top-end' }
+}
+
+function onDrop(): void {
+  if (dragging.value && dropTarget.value) {
+    emit('reorder', applyMove(tree.value, dragging.value, dropTarget.value))
+  }
+  onDragEnd()
+}
+
+function onDragEnd(): void {
+  dragging.value = null
+  dropTarget.value = null
+}
+
+function sameRef(a: DragRef, b: DragRef): boolean {
+  return a.kind === b.kind && a.id === b.id
+}
+function showBefore(ref: DragRef): boolean {
+  const t = dropTarget.value
+  return !!t && t.kind === 'before' && sameRef(t.ref, ref)
+}
+function showAfter(ref: DragRef): boolean {
+  const t = dropTarget.value
+  return !!t && t.kind === 'after' && sameRef(t.ref, ref)
+}
+function showInto(folderId: string): boolean {
+  const t = dropTarget.value
+  return !!t && t.kind === 'into' && t.folderId === folderId
+}
+const showEnd = computed(() => dropTarget.value?.kind === 'top-end')
+
+// ── folder operations ───────────────────────────────────────────────────────
+const renamingId = ref<string | null>(null)
+const draftName = ref('')
+
+function replaceFolder(folder: FeedFolder, patch: Partial<FeedFolder>): void {
+  emit(
+    'reorder',
+    tree.value.map((n) =>
+      n.kind === 'folder' && n.folder.id === folder.id
+        ? { kind: 'folder', folder: { ...n.folder, ...patch } }
+        : n,
+    ),
+  )
+}
+
+function onHeaderClick(folder: FeedFolder): void {
+  if (renamingId.value === folder.id) return
+  replaceFolder(folder, { collapsed: !folder.collapsed })
+}
+
+function newFolderId(): string {
+  const taken = new Set(tree.value.flatMap((n) => (n.kind === 'folder' ? [n.folder.id] : [])))
+  let i = 1
+  while (taken.has(`folder-${i}`)) i++
+  return `folder-${i}`
+}
+
+function addFolder(): void {
+  const id = newFolderId()
+  emit('reorder', [...tree.value, { kind: 'folder', folder: { id, name: 'New folder', collapsed: false, feeds: [] } }])
+  renamingId.value = id
+  draftName.value = 'New folder'
+}
+
+function startRename(folder: FeedFolder): void {
+  renamingId.value = folder.id
+  draftName.value = folder.name
+}
+
+function commitRename(folder: FeedFolder): void {
+  const name = draftName.value.trim()
+  renamingId.value = null
+  if (name && name !== folder.name) replaceFolder(folder, { name })
+}
+
+function cancelRename(): void {
+  renamingId.value = null
+}
+
+function focusInput(vnode: { el?: unknown }): void {
+  const el = vnode.el as HTMLInputElement | undefined
+  el?.focus()
+  el?.select()
+}
+
+// Deleting a folder ungroups it: its feeds re-enter the top level at the
+// folder's slot (no feed is destroyed), so no confirm is needed.
+function deleteFolder(folder: FeedFolder): void {
+  const next: FeedTree = []
+  for (const n of tree.value) {
+    if (n.kind === 'folder' && n.folder.id === folder.id) {
+      for (const feed of n.folder.feeds) next.push({ kind: 'feed', feed })
+    } else {
+      next.push(n)
+    }
+  }
+  emit('reorder', next)
 }
 </script>
 
@@ -63,29 +236,119 @@ function feedSelected(feedId: string): boolean {
       </button>
     </div>
 
-    <section class="px-2.5 pb-1.5 pt-2">
+    <section class="px-2.5 pb-1.5 pt-2" data-testid="sidebar-feeds">
       <div class="section-label">
-        <IconRss class="size-3 text-feeds" />FEEDS
+        <IconRss class="size-3 text-feeds" /><span>FEEDS</span>
+        <button
+          class="folder-add ml-auto flex size-5 items-center justify-center rounded-md text-text-4 hover:bg-chip hover:text-text"
+          title="New folder"
+          aria-label="New folder"
+          data-testid="sidebar-new-folder"
+          @click="addFolder"
+        ><IconFolderPlus class="size-3" /></button>
       </div>
-      <button
-        v-for="feed in profile.feeds ?? []"
-        :key="feed.id"
-        type="button"
-        class="sidebar-entry"
-        :class="{ 'sidebar-entry-selected': feedSelected(feed.id) }"
-        data-testid="sidebar-feed"
-        :data-id="feed.id"
-        @click="emit('select', { type: 'feed', feedId: feed.id })"
-      >
-        <span class="nav-icon"><IconGitBranch class="size-3" /></span><span class="min-w-0 flex-1 truncate text-left">{{ feed.name }}</span>
-        <span
-          class="feed-reveal flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-accent hover:bg-accent/20"
-          title="Reveal in flow"
-          data-testid="sidebar-reveal-in-flow"
-          @click.stop="emit('reveal-in-flow', feed.id)"
-        ><IconShare2 class="size-3" /></span>
-        <span class="font-mono text-[11px]" :class="feed.newCount ? 'text-accent' : 'text-text-3'">{{ feed.newCount || feed.count }}</span>
-      </button>
+
+      <template v-for="node in tree" :key="node.kind === 'feed' ? node.feed.id : node.folder.id">
+        <!-- top-level feed -->
+        <div
+          v-if="node.kind === 'feed'"
+          class="sb-item"
+          :class="{ 'drop-before': showBefore(feedRef(node.feed)), 'drop-after': showAfter(feedRef(node.feed)) }"
+          draggable="true"
+          data-testid="sidebar-item"
+          @dragstart="onDragStart($event, feedRef(node.feed))"
+          @dragover.prevent="onItemDragOver($event, feedRef(node.feed))"
+          @drop.prevent="onDrop"
+          @dragend="onDragEnd"
+        >
+          <SidebarFeedRow
+            :feed="node.feed"
+            :selected="feedSelected(node.feed.id)"
+            @select="emit('select', { type: 'feed', feedId: node.feed.id })"
+            @reveal="emit('reveal-in-flow', node.feed.id)"
+          />
+        </div>
+
+        <!-- folder -->
+        <div
+          v-else
+          class="sb-folder"
+          data-testid="sidebar-folder"
+          :data-id="node.folder.id"
+          :class="{ 'drop-before': showBefore(folderDragRef(node.folder)), 'drop-after': showAfter(folderDragRef(node.folder)), 'drop-into': showInto(node.folder.id) }"
+        >
+          <div
+            class="folder-header"
+            draggable="true"
+            @dragstart="onDragStart($event, folderDragRef(node.folder))"
+            @dragover.prevent="onFolderDragOver($event, node.folder)"
+            @drop.prevent="onDrop"
+            @dragend="onDragEnd"
+            @click="onHeaderClick(node.folder)"
+          >
+            <span class="folder-chevron text-text-4"><component :is="node.folder.collapsed ? IconChevronRight : IconChevronDown" class="size-3" /></span>
+            <span class="nav-icon"><IconFolder class="size-3" /></span>
+            <input
+              v-if="renamingId === node.folder.id"
+              v-model="draftName"
+              class="folder-rename min-w-0 flex-1"
+              data-testid="folder-rename-input"
+              @click.stop
+              @vue:mounted="focusInput"
+              @keydown.enter.prevent="commitRename(node.folder)"
+              @keydown.esc.prevent="cancelRename"
+              @blur="commitRename(node.folder)"
+            >
+            <span v-else class="min-w-0 flex-1 truncate text-left font-medium" data-testid="folder-name">{{ node.folder.name }}</span>
+            <button
+              class="folder-action flex size-5 shrink-0 items-center justify-center rounded-md text-text-4 hover:bg-chip hover:text-text"
+              title="Rename folder"
+              data-testid="folder-rename"
+              @click.stop="startRename(node.folder)"
+            ><IconPencil class="size-3" /></button>
+            <button
+              class="folder-action flex size-5 shrink-0 items-center justify-center rounded-md text-text-4 hover:bg-danger/15 hover:text-danger"
+              title="Delete folder"
+              data-testid="folder-delete"
+              @click.stop="deleteFolder(node.folder)"
+            ><IconTrash class="size-3" /></button>
+            <span class="font-mono text-[11px]" :class="folderNew(node.folder) ? 'text-accent' : 'text-text-3'">{{ folderNew(node.folder) || folderTotal(node.folder) }}</span>
+          </div>
+
+          <div v-if="!node.folder.collapsed" class="folder-body">
+            <div
+              v-for="feed in node.folder.feeds"
+              :key="feed.id"
+              class="sb-item indented"
+              :class="{ 'drop-before': showBefore(feedRef(feed)), 'drop-after': showAfter(feedRef(feed)) }"
+              draggable="true"
+              data-testid="sidebar-item"
+              @dragstart="onDragStart($event, feedRef(feed))"
+              @dragover.prevent="onItemDragOver($event, feedRef(feed))"
+              @drop.prevent="onDrop"
+              @dragend="onDragEnd"
+            >
+              <SidebarFeedRow
+                :feed="feed"
+                :selected="feedSelected(feed.id)"
+                @select="emit('select', { type: 'feed', feedId: feed.id })"
+                @reveal="emit('reveal-in-flow', feed.id)"
+              />
+            </div>
+            <div v-if="node.folder.feeds.length === 0" class="folder-empty">Drop feeds here</div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Trailing drop zone: drop here to move an item to the end / out of a folder. -->
+      <div
+        class="sb-end"
+        :class="{ 'drop-end': showEnd }"
+        data-testid="sidebar-drop-end"
+        @dragover.prevent="onEndDragOver"
+        @drop.prevent="onDrop"
+        @dragend="onDragEnd"
+      />
     </section>
 
     <button
@@ -114,10 +377,30 @@ function feedSelected(feedId: string): boolean {
 .sidebar-entry { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
 .sidebar-entry:hover { background: var(--color-chip); color: var(--color-text); }
 .sidebar-entry-selected { background: var(--color-hover); color: var(--color-accent); font-weight: 500; }
-/* Reveal-in-flow holds its space (opacity, not display) so hovering never shifts the count badge — same pattern the old feed-edit pencil used. */
-.feed-reveal { display: inline-flex; opacity: 0; }
-.sidebar-entry:hover .feed-reveal, .feed-reveal:focus-visible { opacity: 1; }
-.sidebar-entry-selected .nav-icon { border-color: var(--color-accent-tint); color: var(--color-accent); }
 .nav-icon { display: inline-flex; flex: none; align-items: center; justify-content: center; width: 18px; height: 18px; border: 1px solid var(--color-strong); border-radius: 5px; background: var(--color-app); color: var(--color-text-2); }
 .section-label { display: flex; align-items: center; gap: 7px; padding: 0 6px 8px; color: var(--color-text-4); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .12em; }
+.folder-add { opacity: 0; }
+.section-label:hover .folder-add, .folder-add:focus-visible { opacity: 1; }
+
+/* An item wrapper carries the drag handle + insertion indicator; the row/header
+   inside it stays visually unchanged. */
+.sb-item { border-radius: 7px; }
+.sb-item.indented { padding-left: 16px; }
+.drop-before { box-shadow: inset 0 2px 0 0 var(--color-accent); }
+.drop-after { box-shadow: inset 0 -2px 0 0 var(--color-accent); }
+
+.folder-header { display: flex; align-items: center; gap: 7px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
+.folder-header:hover { background: var(--color-chip); color: var(--color-text); }
+.folder-chevron { display: inline-flex; flex: none; }
+.folder-action { opacity: 0; }
+.folder-header:hover .folder-action, .folder-action:focus-visible { opacity: 1; }
+.folder-rename { background: var(--color-app); border: 1px solid var(--color-accent); border-radius: 5px; padding: 1px 5px; font-size: 13px; color: var(--color-text); outline: none; }
+.folder-body { margin-top: 1px; }
+.folder-empty { padding: 6px 8px 6px 24px; font-size: 11.5px; color: var(--color-text-4); font-style: italic; }
+.sb-folder.drop-into { background: var(--color-accent-tint); border-radius: 7px; }
+.sb-folder.drop-before { box-shadow: inset 0 2px 0 0 var(--color-accent); }
+.sb-folder.drop-after { box-shadow: inset 0 -2px 0 0 var(--color-accent); }
+
+.sb-end { height: 14px; border-radius: 5px; }
+.sb-end.drop-end { box-shadow: inset 0 2px 0 0 var(--color-accent); }
 </style>

--- a/desktop/frontend/src/components/SideBar.vue
+++ b/desktop/frontend/src/components/SideBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useStorage } from '@vueuse/core'
 import IconChevronDown from '~icons/lucide/chevron-down'
 import IconChevronRight from '~icons/lucide/chevron-right'
 import IconFolder from '~icons/lucide/folder'
@@ -140,7 +141,28 @@ function showInto(folderId: string): boolean {
 }
 const showEnd = computed(() => dropTarget.value?.kind === 'top-end')
 
-// ── folder operations ───────────────────────────────────────────────────────
+// ── folder collapse (view state) ────────────────────────────────────────────
+// Expand/collapse is transient view state, not configuration — it lives in
+// localStorage (keyed by flow id, then folder id), never in the persisted
+// sidebar layout. VueUse's useStorage handles serialization + defaults so a
+// toggle never touches the backend and never causes a flow reload.
+const collapsedByFlow = useStorage<Record<string, string[]>>('hive.sidebar.collapsed', {})
+
+function isCollapsed(folderId: string): boolean {
+  return (collapsedByFlow.value[props.profile.id] ?? []).includes(folderId)
+}
+
+function onHeaderClick(folder: FeedFolder): void {
+  if (renamingId.value === folder.id) return
+  const flowId = props.profile.id
+  const current = collapsedByFlow.value[flowId] ?? []
+  collapsedByFlow.value = {
+    ...collapsedByFlow.value,
+    [flowId]: isCollapsed(folder.id) ? current.filter((id) => id !== folder.id) : [...current, folder.id],
+  }
+}
+
+// ── folder structure (persisted) ────────────────────────────────────────────
 const renamingId = ref<string | null>(null)
 const draftName = ref('')
 
@@ -155,11 +177,6 @@ function replaceFolder(folder: FeedFolder, patch: Partial<FeedFolder>): void {
   )
 }
 
-function onHeaderClick(folder: FeedFolder): void {
-  if (renamingId.value === folder.id) return
-  replaceFolder(folder, { collapsed: !folder.collapsed })
-}
-
 function newFolderId(): string {
   const taken = new Set(tree.value.flatMap((n) => (n.kind === 'folder' ? [n.folder.id] : [])))
   let i = 1
@@ -169,7 +186,7 @@ function newFolderId(): string {
 
 function addFolder(): void {
   const id = newFolderId()
-  emit('reorder', [...tree.value, { kind: 'folder', folder: { id, name: 'New folder', collapsed: false, feeds: [] } }])
+  emit('reorder', [...tree.value, { kind: 'folder', folder: { id, name: 'New folder', feeds: [] } }])
   renamingId.value = id
   draftName.value = 'New folder'
 }
@@ -286,7 +303,7 @@ function deleteFolder(folder: FeedFolder): void {
           >
             <span class="nav-icon">
               <IconFolder class="folder-glyph size-3" />
-              <component :is="node.folder.collapsed ? IconChevronRight : IconChevronDown" class="folder-chevron size-3" />
+              <component :is="isCollapsed(node.folder.id) ? IconChevronRight : IconChevronDown" class="folder-chevron size-3" />
             </span>
             <input
               v-if="renamingId === node.folder.id"
@@ -315,7 +332,7 @@ function deleteFolder(folder: FeedFolder): void {
             <span class="font-mono text-[11px]" :class="folderNew(node.folder) ? 'text-accent' : 'text-text-3'">{{ folderNew(node.folder) || folderTotal(node.folder) }}</span>
           </div>
 
-          <div v-if="!node.folder.collapsed" class="folder-body">
+          <div v-if="!isCollapsed(node.folder.id)" class="folder-body">
             <div
               v-for="feed in node.folder.feeds"
               :key="feed.id"

--- a/desktop/frontend/src/components/SidebarFeedRow.vue
+++ b/desktop/frontend/src/components/SidebarFeedRow.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 // One feed entry in the sidebar's FEEDS section. Presentational: it renders a
-// feed and emits select/reveal, but drag-and-drop and grouping are the parent
+// feed and emits select, but drag-and-drop and grouping are the parent
 // SideBar's concern (the parent wraps this row in a draggable drop zone).
 import IconGitBranch from '~icons/lucide/git-branch'
-import IconShare2 from '~icons/lucide/share-2'
 import type { FeedSummary } from '../types/feed'
 
 defineProps<{ feed: FeedSummary; selected: boolean }>()
-const emit = defineEmits<{ select: []; reveal: [] }>()
+const emit = defineEmits<{ select: [] }>()
 </script>
 
 <template>
@@ -21,12 +20,6 @@ const emit = defineEmits<{ select: []; reveal: [] }>()
   >
     <span class="nav-icon"><IconGitBranch class="size-3" /></span>
     <span class="min-w-0 flex-1 truncate text-left">{{ feed.name }}</span>
-    <span
-      class="feed-reveal flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-accent hover:bg-accent/20"
-      title="Reveal in flow"
-      data-testid="sidebar-reveal-in-flow"
-      @click.stop="emit('reveal')"
-    ><IconShare2 class="size-3" /></span>
     <span class="font-mono text-[11px]" :class="feed.newCount ? 'text-accent' : 'text-text-3'">{{ feed.newCount || feed.count }}</span>
   </button>
 </template>
@@ -35,9 +28,6 @@ const emit = defineEmits<{ select: []; reveal: [] }>()
 .sidebar-entry { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
 .sidebar-entry:hover { background: var(--color-chip); color: var(--color-text); }
 .sidebar-entry-selected { background: var(--color-hover); color: var(--color-accent); font-weight: 500; }
-/* Reveal-in-flow holds its space (opacity, not display) so hovering never shifts the count badge — same pattern the old feed-edit pencil used. */
-.feed-reveal { display: inline-flex; opacity: 0; }
-.sidebar-entry:hover .feed-reveal, .feed-reveal:focus-visible { opacity: 1; }
 .sidebar-entry-selected .nav-icon { border-color: var(--color-accent-tint); color: var(--color-accent); }
 .nav-icon { display: inline-flex; flex: none; align-items: center; justify-content: center; width: 18px; height: 18px; border: 1px solid var(--color-strong); border-radius: 5px; background: var(--color-app); color: var(--color-text-2); }
 </style>

--- a/desktop/frontend/src/components/SidebarFeedRow.vue
+++ b/desktop/frontend/src/components/SidebarFeedRow.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+// One feed entry in the sidebar's FEEDS section. Presentational: it renders a
+// feed and emits select/reveal, but drag-and-drop and grouping are the parent
+// SideBar's concern (the parent wraps this row in a draggable drop zone).
+import IconGitBranch from '~icons/lucide/git-branch'
+import IconShare2 from '~icons/lucide/share-2'
+import type { FeedSummary } from '../types/feed'
+
+defineProps<{ feed: FeedSummary; selected: boolean }>()
+const emit = defineEmits<{ select: []; reveal: [] }>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="sidebar-entry"
+    :class="{ 'sidebar-entry-selected': selected }"
+    data-testid="sidebar-feed"
+    :data-id="feed.id"
+    @click="emit('select')"
+  >
+    <span class="nav-icon"><IconGitBranch class="size-3" /></span>
+    <span class="min-w-0 flex-1 truncate text-left">{{ feed.name }}</span>
+    <span
+      class="feed-reveal flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-accent hover:bg-accent/20"
+      title="Reveal in flow"
+      data-testid="sidebar-reveal-in-flow"
+      @click.stop="emit('reveal')"
+    ><IconShare2 class="size-3" /></span>
+    <span class="font-mono text-[11px]" :class="feed.newCount ? 'text-accent' : 'text-text-3'">{{ feed.newCount || feed.count }}</span>
+  </button>
+</template>
+
+<style scoped>
+.sidebar-entry { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 8px; border-radius: 7px; color: var(--color-text-2); font-size: 13px; cursor: pointer; }
+.sidebar-entry:hover { background: var(--color-chip); color: var(--color-text); }
+.sidebar-entry-selected { background: var(--color-hover); color: var(--color-accent); font-weight: 500; }
+/* Reveal-in-flow holds its space (opacity, not display) so hovering never shifts the count badge — same pattern the old feed-edit pencil used. */
+.feed-reveal { display: inline-flex; opacity: 0; }
+.sidebar-entry:hover .feed-reveal, .feed-reveal:focus-visible { opacity: 1; }
+.sidebar-entry-selected .nav-icon { border-color: var(--color-accent-tint); color: var(--color-accent); }
+.nav-icon { display: inline-flex; flex: none; align-items: center; justify-content: center; width: 18px; height: 18px; border: 1px solid var(--color-strong); border-radius: 5px; background: var(--color-app); color: var(--color-text-2); }
+</style>

--- a/desktop/frontend/src/components/__tests__/SettingsView.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SettingsView.spec.ts
@@ -1,26 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import SettingsView from '../SettingsView.vue'
 import { setTheme } from '../../composables/useTheme'
 
 beforeEach(() => {
-  vi.stubGlobal('localStorage', (() => {
-    const values = new Map<string, string>()
-    return {
-      get length() { return values.size },
-      clear: () => values.clear(),
-      getItem: (key: string) => values.get(key) ?? null,
-      key: (index: number) => [...values.keys()][index] ?? null,
-      removeItem: (key: string) => values.delete(key),
-      setItem: (key: string, value: string) => values.set(key, value),
-    }
-  })())
+  localStorage.clear()
   setTheme('dark')
 })
 
 afterEach(() => {
   delete document.documentElement.dataset.theme
-  vi.unstubAllGlobals()
 })
 
 describe('SettingsView', () => {
@@ -46,6 +36,7 @@ describe('SettingsView', () => {
     expect(wrapper.find('[data-testid="settings-theme-toggle-gruvbox"]').attributes('aria-selected')).toBe('true')
     expect(wrapper.find('[data-testid="settings-theme-toggle-dark"]').attributes('aria-selected')).toBe('false')
     expect(document.documentElement.dataset.theme).toBe('gruvbox')
+    await nextTick()
     expect(localStorage.getItem('hive.theme')).toBe('gruvbox')
   })
 

--- a/desktop/frontend/src/components/__tests__/SideBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SideBar.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import SideBar from '../SideBar.vue'
-import type { Profile } from '../../types/feed'
+import type { FeedTree, Profile, SidebarNode } from '../../types/feed'
 
 const profile: Profile = {
   id: 'personal',
@@ -101,5 +101,100 @@ describe('SideBar', () => {
 
     window.dispatchEvent(new PointerEvent('pointerup', { clientX: 300, pointerId: 1 }))
     expect(localStorage.getItem('hive.panel.sidebar')).toBe('300')
+  })
+})
+
+// ── folders + reordering ──────────────────────────────────────────────────────
+
+const desktopFeed = { id: 'desktop', name: 'Desktop UI', count: 2, newCount: 1 }
+const backendFeed = { id: 'backend', name: 'Backend', count: 1, newCount: 0 }
+
+const grouped: Profile = {
+  ...profile,
+  tree: [
+    { kind: 'feed', feed: desktopFeed },
+    { kind: 'folder', folder: { id: 'work', name: 'Work', collapsed: false, feeds: [backendFeed] } },
+  ],
+}
+
+function mountGrouped() {
+  return mount(SideBar, { props: { profile: grouped, selection: { type: 'all' } } })
+}
+
+// The tree carried by the most recent 'reorder' emit.
+function lastReorder(wrapper: ReturnType<typeof mountGrouped>): FeedTree {
+  const events = wrapper.emitted('reorder')
+  return events![events!.length - 1][0] as FeedTree
+}
+
+function folderNamed(tree: FeedTree, id: string) {
+  const node = tree.find((n): n is Extract<SidebarNode, { kind: 'folder' }> => n.kind === 'folder' && n.folder.id === id)
+  return node?.folder
+}
+
+describe('SideBar folders', () => {
+  it('renders folders with their nested feeds', () => {
+    const wrapper = mountGrouped()
+    expect(wrapper.find('[data-testid="sidebar-folder"][data-id="work"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-name"]').text()).toBe('Work')
+    // The nested feed renders inside the folder.
+    expect(wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').exists()).toBe(true)
+  })
+
+  it('hides a collapsed folder\'s feeds', () => {
+    const collapsed: Profile = {
+      ...profile,
+      tree: [{ kind: 'folder', folder: { id: 'work', name: 'Work', collapsed: true, feeds: [backendFeed] } }],
+    }
+    const wrapper = mount(SideBar, { props: { profile: collapsed, selection: { type: 'all' } } })
+    expect(wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').exists()).toBe(false)
+  })
+
+  it('toggles a folder collapsed when its header is clicked', async () => {
+    const wrapper = mountGrouped()
+    await wrapper.find('[data-testid="sidebar-folder"][data-id="work"] .folder-header').trigger('click')
+    expect(folderNamed(lastReorder(wrapper), 'work')?.collapsed).toBe(true)
+  })
+
+  it('appends a new empty folder when the new-folder button is clicked', async () => {
+    const wrapper = mountGrouped()
+    await wrapper.find('[data-testid="sidebar-new-folder"]').trigger('click')
+    const folders = lastReorder(wrapper).filter((n) => n.kind === 'folder')
+    expect(folders).toHaveLength(2)
+  })
+
+  it('renames a folder, emitting the new name', async () => {
+    const wrapper = mountGrouped()
+    await wrapper.find('[data-testid="folder-rename"]').trigger('click')
+    const input = wrapper.find('[data-testid="folder-rename-input"]')
+    expect(input.exists()).toBe(true)
+    await input.setValue('Projects')
+    await input.trigger('keydown.enter')
+    expect(folderNamed(lastReorder(wrapper), 'work')?.name).toBe('Projects')
+  })
+
+  it('deleting a folder ungroups its feeds back to the top level', async () => {
+    const wrapper = mountGrouped()
+    await wrapper.find('[data-testid="folder-delete"]').trigger('click')
+    const tree = lastReorder(wrapper)
+    expect(tree.some((n) => n.kind === 'folder')).toBe(false)
+    expect(tree.some((n) => n.kind === 'feed' && n.feed.id === 'backend')).toBe(true)
+  })
+
+  it('emits a reorder when a feed is dragged to the trailing drop zone', async () => {
+    const wrapper = mountGrouped()
+    // Drag the top-level "desktop" feed to the end.
+    await wrapper.find('[data-testid="sidebar-item"]').trigger('dragstart')
+    await wrapper.find('[data-testid="sidebar-drop-end"]').trigger('dragover')
+    await wrapper.find('[data-testid="sidebar-drop-end"]').trigger('drop')
+
+    const tree = lastReorder(wrapper)
+    expect(tree[tree.length - 1]).toMatchObject({ kind: 'feed', feed: { id: 'desktop' } })
+  })
+
+  it('falls back to a flat list of feeds when the profile has no tree', () => {
+    const wrapper = mountSideBar()
+    expect(wrapper.findAll('[data-testid="sidebar-item"]')).toHaveLength(2)
+    expect(wrapper.find('[data-testid="sidebar-folder"]').exists()).toBe(false)
   })
 })

--- a/desktop/frontend/src/components/__tests__/SideBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SideBar.spec.ts
@@ -63,15 +63,6 @@ describe('SideBar', () => {
   })
 
 
-  it('emits reveal-in-flow with the feed id from the per-feed icon, without also selecting the row', async () => {
-    const wrapper = mountSideBar()
-
-    await wrapper.find('[data-testid="sidebar-feed"][data-id="backend"] [data-testid="sidebar-reveal-in-flow"]').trigger('click')
-
-    expect(wrapper.emitted('reveal-in-flow')).toEqual([['backend']])
-    expect(wrapper.emitted('select')).toBeUndefined()
-  })
-
   it('shows the un-deployed changes badge only when flowsDirty is true', () => {
     const clean = mountSideBar({ flowsDirty: false })
     expect(clean.find('[data-testid="undeployed-badge"]').exists()).toBe(false)

--- a/desktop/frontend/src/components/__tests__/SideBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SideBar.spec.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import SideBar from '../SideBar.vue'
 import type { FeedTree, Profile, SidebarNode } from '../../types/feed'
+
+// Collapse state and panel width live in localStorage; isolate every test.
+beforeEach(() => localStorage.clear())
 
 const profile: Profile = {
   id: 'personal',
@@ -104,7 +107,7 @@ const grouped: Profile = {
   ...profile,
   tree: [
     { kind: 'feed', feed: desktopFeed },
-    { kind: 'folder', folder: { id: 'work', name: 'Work', collapsed: false, feeds: [backendFeed] } },
+    { kind: 'folder', folder: { id: 'work', name: 'Work', feeds: [backendFeed] } },
   ],
 }
 
@@ -132,19 +135,24 @@ describe('SideBar folders', () => {
     expect(wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').exists()).toBe(true)
   })
 
-  it('hides a collapsed folder\'s feeds', () => {
-    const collapsed: Profile = {
-      ...profile,
-      tree: [{ kind: 'folder', folder: { id: 'work', name: 'Work', collapsed: true, feeds: [backendFeed] } }],
-    }
-    const wrapper = mount(SideBar, { props: { profile: collapsed, selection: { type: 'all' } } })
+  it('hides a folder\'s feeds when its collapsed state is set in localStorage', () => {
+    // Collapse is view state persisted in localStorage (keyed by flow then
+    // folder id), not part of the tree/layout.
+    localStorage.setItem('hive.sidebar.collapsed', JSON.stringify({ personal: ['work'] }))
+    const wrapper = mountGrouped()
     expect(wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').exists()).toBe(false)
   })
 
-  it('toggles a folder collapsed when its header is clicked', async () => {
+  it('toggles collapse via localStorage on header click, without emitting a reorder', async () => {
     const wrapper = mountGrouped()
+    expect(wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').exists()).toBe(true)
+
     await wrapper.find('[data-testid="sidebar-folder"][data-id="work"] .folder-header').trigger('click')
-    expect(folderNamed(lastReorder(wrapper), 'work')?.collapsed).toBe(true)
+
+    // Feeds hidden, state persisted, and no layout write (collapse is not config).
+    expect(wrapper.find('[data-testid="sidebar-feed"][data-id="backend"]').exists()).toBe(false)
+    expect(JSON.parse(localStorage.getItem('hive.sidebar.collapsed') ?? '{}')).toEqual({ personal: ['work'] })
+    expect(wrapper.emitted('reorder')).toBeUndefined()
   })
 
   it('appends a new empty folder when the new-folder button is clicked', async () => {

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -100,7 +100,7 @@ describe('useFeedState', () => {
 
   it('reconciles the saved sidebar layout (folders, node-id keyed) into the tree', async () => {
     mocks.GetSidebar.mockResolvedValue({
-      items: [{ folder: { id: 'work', name: 'Work', collapsed: true, feeds: ['my-prs'] } }],
+      items: [{ folder: { id: 'work', name: 'Work', feeds: ['my-prs'] } }],
     })
     const get = mountState()
     await flushPromises()
@@ -108,7 +108,7 @@ describe('useFeedState', () => {
     expect(get().activeProfile.value?.tree).toEqual([
       {
         kind: 'folder',
-        folder: { id: 'work', name: 'Work', collapsed: true, feeds: [{ id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 }] },
+        folder: { id: 'work', name: 'Work', feeds: [{ id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 }] },
       },
     ])
   })
@@ -120,11 +120,11 @@ describe('useFeedState', () => {
 
     const feed = { id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 }
     await get().reorderFeeds('triage', [
-      { kind: 'folder', folder: { id: 'work', name: 'Work', collapsed: false, feeds: [feed] } },
+      { kind: 'folder', folder: { id: 'work', name: 'Work', feeds: [feed] } },
     ])
 
     expect(mocks.SaveSidebar).toHaveBeenCalledWith('triage', {
-      items: [{ folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['my-prs'] } }],
+      items: [{ folder: { id: 'work', name: 'Work', feeds: ['my-prs'] } }],
     })
     // The in-memory tree updates optimistically.
     expect(get().activeProfile.value?.tree?.[0]).toMatchObject({ kind: 'folder', folder: { id: 'work' } })

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   GetFlow: vi.fn(),
   CreateFlow: vi.fn(),
   DeleteFlow: vi.fn(),
+  GetSidebar: vi.fn(),
+  SaveSidebar: vi.fn(),
   FeedItems: vi.fn(),
   FeedItemCounts: vi.fn(),
   MarkFeedItemRead: vi.fn(),
@@ -22,6 +24,8 @@ vi.mock('../../../bindings/github.com/colonyops/hive/desktop/flowsservice', () =
   GetFlow: mocks.GetFlow,
   CreateFlow: mocks.CreateFlow,
   DeleteFlow: mocks.DeleteFlow,
+  GetSidebar: mocks.GetSidebar,
+  SaveSidebar: mocks.SaveSidebar,
 }))
 
 vi.mock('../../../bindings/github.com/colonyops/hive/desktop/pipelineservice', () => ({
@@ -61,6 +65,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   mocks.ListFlows.mockResolvedValue([flowSummary])
   mocks.GetFlow.mockResolvedValue(flow)
+  mocks.GetSidebar.mockResolvedValue({ items: [] })
+  mocks.SaveSidebar.mockResolvedValue(undefined)
   mocks.FeedItemCounts.mockResolvedValue([{ feedId: 'triage/my-prs', total: 3, unread: 2 }])
   mocks.FeedItems.mockResolvedValue([])
   mocks.ActionViews.mockResolvedValue([])
@@ -82,6 +88,46 @@ describe('useFeedState', () => {
     expect(state.activeProfile.value?.totalCount).toBe(3)
     expect(state.activeProfile.value?.unreadCount).toBe(2)
     expect(state.activeProfile.value?.sourceSummary).toBe('GitHub · 1 source')
+  })
+
+  it('builds a flat sidebar tree from feeds when there is no saved layout', async () => {
+    const get = mountState()
+    await flushPromises()
+    expect(get().activeProfile.value?.tree).toEqual([
+      { kind: 'feed', feed: { id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 } },
+    ])
+  })
+
+  it('reconciles the saved sidebar layout (folders, node-id keyed) into the tree', async () => {
+    mocks.GetSidebar.mockResolvedValue({
+      items: [{ folder: { id: 'work', name: 'Work', collapsed: true, feeds: ['my-prs'] } }],
+    })
+    const get = mountState()
+    await flushPromises()
+
+    expect(get().activeProfile.value?.tree).toEqual([
+      {
+        kind: 'folder',
+        folder: { id: 'work', name: 'Work', collapsed: true, feeds: [{ id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 }] },
+      },
+    ])
+  })
+
+  it('persists a reordered tree via SaveSidebar, keyed by feed node id', async () => {
+    mocks.SaveSidebar.mockResolvedValue(undefined)
+    const get = mountState()
+    await flushPromises()
+
+    const feed = { id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 }
+    await get().reorderFeeds('triage', [
+      { kind: 'folder', folder: { id: 'work', name: 'Work', collapsed: false, feeds: [feed] } },
+    ])
+
+    expect(mocks.SaveSidebar).toHaveBeenCalledWith('triage', {
+      items: [{ folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['my-prs'] } }],
+    })
+    // The in-memory tree updates optimistically.
+    expect(get().activeProfile.value?.tree?.[0]).toMatchObject({ kind: 'folder', folder: { id: 'work' } })
   })
 
   it('loads a feed\'s items from feed_item, decoding the payload', async () => {

--- a/desktop/frontend/src/composables/__tests__/useResizablePanel.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useResizablePanel.spec.ts
@@ -1,25 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 import { useResizablePanel } from '../useResizablePanel'
 
-function memoryStorage(): Storage {
-  const values = new Map<string, string>()
-  return {
-    get length() { return values.size },
-    clear: () => values.clear(),
-    getItem: (key) => values.get(key) ?? null,
-    key: (index) => [...values.keys()][index] ?? null,
-    removeItem: (key) => values.delete(key),
-    setItem: (key, value) => values.set(key, value),
-  }
-}
-
-beforeEach(() => {
-  vi.stubGlobal('localStorage', memoryStorage())
-})
-
-afterEach(() => {
-  vi.unstubAllGlobals()
-})
+// Size persists to localStorage (via VueUse useStorage); isolate each test.
+beforeEach(() => localStorage.clear())
 
 function pointerEvent(type: string, clientX: number): PointerEvent {
   return new PointerEvent(type, { pointerId: 1, clientX, bubbles: true, cancelable: true })
@@ -60,32 +44,31 @@ describe('useResizablePanel', () => {
     expect(size.value).toBe(250)
   })
 
-  it('a right-edge drag grows the panel as the pointer moves right, and persists only on pointerup', () => {
+  it('a right-edge drag grows the panel as the pointer moves right, and persists', async () => {
     const { size, startResize } = useResizablePanel({ storageKey: 'hive.panel.e', defaultSize: 250, min: 190, max: 480, edge: 'right' })
 
     beginDrag(startResize, 100)
     window.dispatchEvent(pointerEvent('pointermove', 150))
+    window.dispatchEvent(pointerEvent('pointerup', 150))
 
     expect(size.value).toBe(300)
-    expect(localStorage.getItem('hive.panel.e')).toBeNull() // not yet persisted mid-drag
-
-    window.dispatchEvent(pointerEvent('pointerup', 150))
+    await nextTick()
     expect(localStorage.getItem('hive.panel.e')).toBe('300')
   })
 
-  it('a left-edge drag grows the panel as the pointer moves left', () => {
+  it('a left-edge drag grows the panel as the pointer moves left', async () => {
     const { size, startResize } = useResizablePanel({ storageKey: 'hive.panel.f', defaultSize: 440, min: 360, max: 760, edge: 'left' })
 
     beginDrag(startResize, 500)
     window.dispatchEvent(pointerEvent('pointermove', 450)) // moved left by 50
+    window.dispatchEvent(pointerEvent('pointerup', 450))
 
     expect(size.value).toBe(490)
-
-    window.dispatchEvent(pointerEvent('pointerup', 450))
+    await nextTick()
     expect(localStorage.getItem('hive.panel.f')).toBe('490')
   })
 
-  it('clamps the dragged width to [min, max]', () => {
+  it('clamps the dragged width to [min, max]', async () => {
     const { size, startResize } = useResizablePanel({ storageKey: 'hive.panel.g', defaultSize: 250, min: 190, max: 480, edge: 'right' })
 
     beginDrag(startResize, 0)
@@ -96,25 +79,28 @@ describe('useResizablePanel', () => {
     expect(size.value).toBe(190)
 
     window.dispatchEvent(pointerEvent('pointerup', -10000))
+    await nextTick()
     expect(localStorage.getItem('hive.panel.g')).toBe('190')
   })
 
-  it('step() nudges and clamps the width and persists immediately', () => {
+  it('step() nudges and clamps the width and persists', async () => {
     const { size, step } = useResizablePanel({ storageKey: 'hive.panel.h', defaultSize: 250, min: 190, max: 480, edge: 'right' })
 
     step(12)
     expect(size.value).toBe(262)
+    await nextTick()
     expect(localStorage.getItem('hive.panel.h')).toBe('262')
 
     step(-1000)
     expect(size.value).toBe(190)
+    await nextTick()
     expect(localStorage.getItem('hive.panel.h')).toBe('190')
 
     step(1000)
     expect(size.value).toBe(480)
   })
 
-  it('a bottom-edge drag grows the panel as the pointer moves down (vertical axis)', () => {
+  it('a bottom-edge drag grows the panel as the pointer moves down (vertical axis)', async () => {
     const { size, startResize } = useResizablePanel({ storageKey: 'hive.panel.v', defaultSize: 240, min: 96, max: 640, edge: 'bottom' })
 
     const handle = document.createElement('div')
@@ -122,10 +108,10 @@ describe('useResizablePanel', () => {
     handle.addEventListener('pointerdown', (e) => startResize(e as PointerEvent))
     handle.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, clientY: 100, bubbles: true, cancelable: true }))
     window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientY: 160 })) // moved down by 60
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, clientY: 160 }))
 
     expect(size.value).toBe(300)
-
-    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, clientY: 160 }))
+    await nextTick()
     expect(localStorage.getItem('hive.panel.v')).toBe('300')
   })
 

--- a/desktop/frontend/src/composables/__tests__/useTheme.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useTheme.spec.ts
@@ -1,53 +1,49 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { initializeTheme, setTheme } from '../useTheme'
+import { nextTick } from 'vue'
 
-function memoryStorage(): Storage {
-  const values = new Map<string, string>()
-  return {
-    get length() { return values.size },
-    clear: () => values.clear(),
-    getItem: (key) => values.get(key) ?? null,
-    key: (index) => [...values.keys()][index] ?? null,
-    removeItem: (key) => values.delete(key),
-    setItem: (key, value) => values.set(key, value),
-  }
-}
-
+// currentTheme is a module singleton that loads the persisted theme (via VueUse
+// useStorage) at import time, so each test sets localStorage first, then resets
+// modules and imports fresh to exercise the startup-restore path.
 beforeEach(() => {
-  vi.stubGlobal('localStorage', memoryStorage())
+  localStorage.clear()
+  vi.resetModules()
 })
 
 afterEach(() => {
   delete document.documentElement.dataset.theme
-  vi.unstubAllGlobals()
 })
 
 describe('useTheme', () => {
-  it('initializes from localStorage and applies the saved theme', () => {
+  it('restores the persisted theme at startup', async () => {
     localStorage.setItem('hive.theme', 'midnight')
+    const { initializeTheme } = await import('../useTheme')
 
     initializeTheme()
 
     expect(document.documentElement.dataset.theme).toBe('midnight')
   })
 
-  it('falls back to dark for unknown stored themes', () => {
+  it('falls back to dark for unknown stored themes', async () => {
     localStorage.setItem('hive.theme', 'solarized')
+    const { initializeTheme } = await import('../useTheme')
 
     initializeTheme()
 
     expect(document.documentElement.dataset.theme).toBe('dark')
+    await nextTick()
     expect(localStorage.getItem('hive.theme')).toBe('dark')
   })
 
-  it('defaults to dark and persists a selected theme', () => {
-    initializeTheme()
+  it('defaults to dark and persists a selected theme', async () => {
+    const { initializeTheme, setTheme } = await import('../useTheme')
 
+    initializeTheme()
     expect(document.documentElement.dataset.theme).toBe('dark')
 
     setTheme('gruvbox')
 
     expect(document.documentElement.dataset.theme).toBe('gruvbox')
+    await nextTick()
     expect(localStorage.getItem('hive.theme')).toBe('gruvbox')
   })
 })

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,9 +1,10 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { Browser, Events, Window } from '@wailsio/runtime'
-import { CreateFlow, DeleteFlow, GetFlow, ListFlows } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
+import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
 import { ActionViews, FeedItemCounts, FeedItems, InvokeAction, MarkFeedItemRead } from '../../bindings/github.com/colonyops/hive/desktop/pipelineservice'
+import { buildFeedTree, treeToLayout } from '../lib/feedTree'
 import type { ActionView } from '../types/action'
-import type { FeedItem, FeedSummary, Profile, SidebarSelection } from '../types/feed'
+import type { FeedItem, FeedSummary, FeedTree, Profile, SidebarSelection } from '../types/feed'
 import type { ToastInstance, ToastOptions } from '../types/toast'
 
 // A profile IS a flow: the profiles list comes from FlowsService.ListFlows, a
@@ -121,7 +122,7 @@ export function useFeedState() {
   // feed nodes, with per-feed counts from feed_item.
   async function loadFeeds(flowId: string) {
     try {
-      const [flow, counts] = await Promise.all([GetFlow(flowId), FeedItemCounts(flowId)])
+      const [flow, counts, sidebar] = await Promise.all([GetFlow(flowId), FeedItemCounts(flowId), GetSidebar(flowId)])
       const countByFeed = new Map((counts ?? []).map((c) => [c.feedId, c]))
       const nodes = (flow.nodes ?? []) as Array<{ id: string; type: string; name?: string }>
       const feeds: FeedSummary[] = nodes
@@ -135,12 +136,29 @@ export function useFeedState() {
       const profile = profiles.value.find((p) => p.id === flowId)
       if (profile) {
         profile.feeds = feeds
+        // Rebuild the sidebar tree from current feeds + saved layout on every
+        // load so counts stay fresh and added/removed feeds reconcile in.
+        profile.tree = buildFeedTree(feeds, sidebar, flowId)
         profile.sourceSummary = `GitHub · ${sourceCount} source${sourceCount === 1 ? '' : 's'}`
         profile.totalCount = feeds.reduce((sum, f) => sum + f.count, 0)
         profile.unreadCount = feeds.reduce((sum, f) => sum + f.newCount, 0)
       }
     } catch (error) {
       console.warn('Unable to load flow feeds', error)
+    }
+  }
+
+  // reorderFeeds persists a new sidebar grouping/order for a profile: it
+  // updates the in-memory tree optimistically, then writes the layout. The
+  // saved <id>.sidebar.yaml is keyed by feed node id (see lib/feedTree).
+  async function reorderFeeds(flowId: string, tree: FeedTree) {
+    const profile = profiles.value.find((p) => p.id === flowId)
+    if (profile) profile.tree = tree
+    try {
+      await SaveSidebar(flowId, treeToLayout(tree, flowId))
+    } catch (error) {
+      console.warn('Unable to save sidebar layout', error)
+      showToast('Could not save the sidebar layout', { severity: 'error' })
     }
   }
 
@@ -421,6 +439,7 @@ export function useFeedState() {
     loadProfiles,
     createProfile,
     deleteProfile,
+    reorderFeeds,
     selectProfile,
     selectSidebar,
     selectUnreadView,

--- a/desktop/frontend/src/composables/useResizablePanel.ts
+++ b/desktop/frontend/src/composables/useResizablePanel.ts
@@ -1,4 +1,5 @@
-import { ref, type Ref } from 'vue'
+import { useStorage } from '@vueuse/core'
+import type { Ref } from 'vue'
 
 /** Which edge of the panel the drag handle sits on. This picks both the drag
  * axis and the sign of the delta:
@@ -36,24 +37,18 @@ function clamp(value: number, min: number, max: number): number {
 export function useResizablePanel(options: UseResizablePanelOptions): UseResizablePanelReturn {
   const { storageKey, defaultSize, min, max, edge } = options
 
-  function readStored(): number {
-    const raw = localStorage.getItem(storageKey)
-    if (raw === null) return defaultSize
-    const parsed = Number(raw)
-    if (!Number.isFinite(parsed) || parsed < min || parsed > max) return defaultSize
-    return parsed
-  }
-
-  const size = ref(readStored())
+  // size is the persisted, reactive px size — VueUse's useStorage mirrors it to
+  // localStorage, so a drag or keyboard nudge is saved without any explicit
+  // read/write plumbing.
+  const size = useStorage(storageKey, defaultSize)
+  // Guard a stale/garbage stored value (e.g. from an older min/max) so the
+  // panel never opens out of range.
+  if (!Number.isFinite(size.value) || size.value < min || size.value > max) size.value = defaultSize
 
   const vertical = edge === 'top' || edge === 'bottom'
   // See ResizeEdge above: the 'left'/'top' edges invert the delta so dragging
   // toward the panel's interior shrinks it.
   const sign = edge === 'left' || edge === 'top' ? -1 : 1
-
-  function persist(): void {
-    localStorage.setItem(storageKey, String(size.value))
-  }
 
   function startResize(event: PointerEvent): void {
     const target = event.target as Element | null
@@ -72,7 +67,6 @@ export function useResizablePanel(options: UseResizablePanelOptions): UseResizab
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       target?.releasePointerCapture?.(pointerId)
-      persist()
     }
 
     window.addEventListener('pointermove', onMove)
@@ -81,7 +75,6 @@ export function useResizablePanel(options: UseResizablePanelOptions): UseResizab
 
   function step(deltaPx: number): void {
     size.value = clamp(size.value + deltaPx, min, max)
-    persist()
   }
 
   return { size, startResize, step }

--- a/desktop/frontend/src/composables/useTheme.ts
+++ b/desktop/frontend/src/composables/useTheme.ts
@@ -1,4 +1,5 @@
-import { ref, type Ref } from 'vue'
+import { useStorage } from '@vueuse/core'
+import type { Ref } from 'vue'
 
 export const themes = ['dark', 'light', 'midnight', 'gruvbox'] as const
 export type Theme = (typeof themes)[number]
@@ -10,30 +11,27 @@ export const themeLabels: Record<Theme, string> = {
   gruvbox: 'Gruvbox',
 }
 
-const storageKey = 'hive.theme'
-
 function isTheme(value: string | null): value is Theme {
   return themes.includes(value as Theme)
 }
 
-// Reactive mirror of document.documentElement.dataset.theme — a module
-// singleton (like useFlowsSession's shared session) so every caller (the
-// command palette's theme:* commands, SettingsView's Appearance section)
-// reads/drives the same live value instead of each holding a stale local
-// copy. Starts at the setTheme() default; initializeTheme() (called once in
-// main.ts before mount) overwrites it with the persisted value.
-const currentTheme: Ref<Theme> = ref('dark')
+// The live theme, persisted in localStorage via VueUse. A module singleton
+// (like useFlowsSession's shared session) so every caller — the command
+// palette's theme:* commands, SettingsView's Appearance section — reads/drives
+// the same value. useStorage loads the persisted theme at import; the dataset
+// mirror is applied by initializeTheme() (called once in main.ts before mount)
+// and thereafter by setTheme().
+const currentTheme: Ref<Theme> = useStorage<Theme>('hive.theme', 'dark')
 
 export function setTheme(nextTheme: Theme): void {
   document.documentElement.dataset.theme = nextTheme
-  localStorage.setItem(storageKey, nextTheme)
-  currentTheme.value = nextTheme
+  currentTheme.value = nextTheme // persisted by useStorage
 }
 
-// Called once before mount so the first paint uses the persisted theme.
+// Called once before mount so the first paint uses the persisted theme, and to
+// heal a garbage stored value back to the default.
 export function initializeTheme(): void {
-  const storedTheme = localStorage.getItem(storageKey)
-  setTheme(isTheme(storedTheme) ? storedTheme : 'dark')
+  setTheme(isTheme(currentTheme.value) ? currentTheme.value : 'dark')
 }
 
 /** The live theme, kept in sync by every setTheme()/initializeTheme() call. */

--- a/desktop/frontend/src/lib/__tests__/feedTree.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/feedTree.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { SidebarLayout } from '../../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/models'
+import type { FeedSummary, FeedTree } from '../../types/feed'
+import { applyMove, buildFeedTree, feedNodeId, treeToLayout } from '../feedTree'
+
+const FLOW = 'triage'
+
+function feed(node: string, name = node): FeedSummary {
+  return { id: `${FLOW}/${node}`, name, count: 0, newCount: 0 }
+}
+
+// Convenience: the flat list of node ids a tree renders, folders flagged with
+// a "dir/" prefix, for compact assertions.
+function shape(tree: FeedTree): string[] {
+  return tree.map((n) =>
+    n.kind === 'feed'
+      ? feedNodeId(n.feed.id, FLOW)
+      : `${n.folder.id}[${n.folder.feeds.map((f) => feedNodeId(f.id, FLOW)).join(',')}]`,
+  )
+}
+
+describe('feedNodeId', () => {
+  it('strips the flow prefix', () => {
+    expect(feedNodeId('triage/my-prs', 'triage')).toBe('my-prs')
+  })
+  it('leaves an unprefixed id unchanged', () => {
+    expect(feedNodeId('my-prs', 'triage')).toBe('my-prs')
+  })
+})
+
+describe('buildFeedTree', () => {
+  const feeds = [feed('a'), feed('b'), feed('c')]
+
+  it('renders a flat list in feed order when there is no layout', () => {
+    expect(shape(buildFeedTree(feeds, null, FLOW))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('honors saved order and folders', () => {
+    const layout: SidebarLayout = {
+      items: [
+        { feed: 'c' },
+        { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['a', 'b'] } },
+      ],
+    }
+    expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['c', 'work[a,b]'])
+  })
+
+  it('appends feeds the layout does not mention, in feed order', () => {
+    const layout: SidebarLayout = { items: [{ feed: 'b' }] }
+    expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['b', 'a', 'c'])
+  })
+
+  it('drops layout references to feeds that no longer exist', () => {
+    const layout: SidebarLayout = {
+      items: [
+        { feed: 'gone' },
+        { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['a', 'ghost'] } },
+      ],
+    }
+    expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['work[a]', 'b', 'c'])
+  })
+
+  it('keeps a folder that has become empty as a drop target', () => {
+    const layout: SidebarLayout = {
+      items: [{ folder: { id: 'empty', name: 'Empty', collapsed: false, feeds: ['gone'] } }],
+    }
+    expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['empty[]', 'a', 'b', 'c'])
+  })
+
+  it('dedupes a feed referenced twice, first placement wins', () => {
+    const layout: SidebarLayout = {
+      items: [
+        { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['a'] } },
+        { feed: 'a' },
+      ],
+    }
+    expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['work[a]', 'b', 'c'])
+  })
+
+  it('round-trips through treeToLayout', () => {
+    const layout: SidebarLayout = {
+      items: [
+        { feed: 'c' },
+        { folder: { id: 'work', name: 'Work', collapsed: true, feeds: ['a', 'b'] } },
+      ],
+    }
+    const tree = buildFeedTree(feeds, layout, FLOW)
+    expect(treeToLayout(tree, FLOW)).toEqual(layout)
+  })
+})
+
+describe('applyMove', () => {
+  const feeds = [feed('a'), feed('b'), feed('c'), feed('d')]
+  const withFolder: SidebarLayout = {
+    items: [
+      { feed: 'a' },
+      { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['b', 'c'] } },
+      { feed: 'd' },
+    ],
+  }
+  const tree = () => buildFeedTree(feeds, withFolder, FLOW)
+
+  it('reorders a top-level feed before another', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/d` }, { kind: 'before', ref: { kind: 'feed', id: `${FLOW}/a` } })
+    expect(shape(out)).toEqual(['d', 'a', 'work[b,c]'])
+  })
+
+  it('moves a feed into a folder', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/a` }, { kind: 'into', folderId: 'work' })
+    expect(shape(out)).toEqual(['work[b,c,a]', 'd'])
+  })
+
+  it('moves a feed out of a folder to the top level', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/b` }, { kind: 'after', ref: { kind: 'feed', id: `${FLOW}/d` } })
+    expect(shape(out)).toEqual(['a', 'work[c]', 'd', 'b'])
+  })
+
+  it('reorders feeds within a folder', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/c` }, { kind: 'before', ref: { kind: 'feed', id: `${FLOW}/b` } })
+    expect(shape(out)).toEqual(['a', 'work[c,b]', 'd'])
+  })
+
+  it('reorders folders among top-level items', () => {
+    const out = applyMove(tree(), { kind: 'folder', id: 'work' }, { kind: 'before', ref: { kind: 'feed', id: `${FLOW}/a` } })
+    expect(shape(out)).toEqual(['work[b,c]', 'a', 'd'])
+  })
+
+  it('appends to the top level end', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/a` }, { kind: 'top-end' })
+    expect(shape(out)).toEqual(['work[b,c]', 'd', 'a'])
+  })
+
+  it('refuses to nest a folder inside a folder (no-op)', () => {
+    const out = applyMove(tree(), { kind: 'folder', id: 'work' }, { kind: 'into', folderId: 'work' })
+    expect(shape(out)).toEqual(['a', 'work[b,c]', 'd'])
+  })
+
+  it('is a no-op when dropped onto itself', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/a` }, { kind: 'before', ref: { kind: 'feed', id: `${FLOW}/a` } })
+    expect(shape(out)).toEqual(['a', 'work[b,c]', 'd'])
+  })
+
+  it('is a no-op when the dragged item is unknown', () => {
+    const out = applyMove(tree(), { kind: 'feed', id: `${FLOW}/nope` }, { kind: 'top-end' })
+    expect(shape(out)).toEqual(['a', 'work[b,c]', 'd'])
+  })
+
+  it('does not mutate the input tree', () => {
+    const original = tree()
+    const snapshot = shape(original)
+    applyMove(original, { kind: 'feed', id: `${FLOW}/a` }, { kind: 'into', folderId: 'work' })
+    expect(shape(original)).toEqual(snapshot)
+  })
+})

--- a/desktop/frontend/src/lib/__tests__/feedTree.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/feedTree.spec.ts
@@ -39,7 +39,7 @@ describe('buildFeedTree', () => {
     const layout: SidebarLayout = {
       items: [
         { feed: 'c' },
-        { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['a', 'b'] } },
+        { folder: { id: 'work', name: 'Work', feeds: ['a', 'b'] } },
       ],
     }
     expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['c', 'work[a,b]'])
@@ -54,7 +54,7 @@ describe('buildFeedTree', () => {
     const layout: SidebarLayout = {
       items: [
         { feed: 'gone' },
-        { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['a', 'ghost'] } },
+        { folder: { id: 'work', name: 'Work', feeds: ['a', 'ghost'] } },
       ],
     }
     expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['work[a]', 'b', 'c'])
@@ -62,7 +62,7 @@ describe('buildFeedTree', () => {
 
   it('keeps a folder that has become empty as a drop target', () => {
     const layout: SidebarLayout = {
-      items: [{ folder: { id: 'empty', name: 'Empty', collapsed: false, feeds: ['gone'] } }],
+      items: [{ folder: { id: 'empty', name: 'Empty', feeds: ['gone'] } }],
     }
     expect(shape(buildFeedTree(feeds, layout, FLOW))).toEqual(['empty[]', 'a', 'b', 'c'])
   })
@@ -70,7 +70,7 @@ describe('buildFeedTree', () => {
   it('dedupes a feed referenced twice, first placement wins', () => {
     const layout: SidebarLayout = {
       items: [
-        { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['a'] } },
+        { folder: { id: 'work', name: 'Work', feeds: ['a'] } },
         { feed: 'a' },
       ],
     }
@@ -81,7 +81,7 @@ describe('buildFeedTree', () => {
     const layout: SidebarLayout = {
       items: [
         { feed: 'c' },
-        { folder: { id: 'work', name: 'Work', collapsed: true, feeds: ['a', 'b'] } },
+        { folder: { id: 'work', name: 'Work', feeds: ['a', 'b'] } },
       ],
     }
     const tree = buildFeedTree(feeds, layout, FLOW)
@@ -94,7 +94,7 @@ describe('applyMove', () => {
   const withFolder: SidebarLayout = {
     items: [
       { feed: 'a' },
-      { folder: { id: 'work', name: 'Work', collapsed: false, feeds: ['b', 'c'] } },
+      { folder: { id: 'work', name: 'Work', feeds: ['b', 'c'] } },
       { feed: 'd' },
     ],
   }

--- a/desktop/frontend/src/lib/feedTree.ts
+++ b/desktop/frontend/src/lib/feedTree.ts
@@ -63,12 +63,7 @@ export function buildFeedTree(
       // after its feeds are removed — it stays as a drop target.
       tree.push({
         kind: 'folder',
-        folder: {
-          id: item.folder.id,
-          name: item.folder.name,
-          collapsed: item.folder.collapsed,
-          feeds: folderFeeds,
-        },
+        folder: { id: item.folder.id, name: item.folder.name, feeds: folderFeeds },
       })
     } else if (item?.feed) {
       const feed = take(item.feed)
@@ -93,7 +88,6 @@ export function treeToLayout(tree: FeedTree, flowId: string): WireSidebarLayout 
             folder: {
               id: node.folder.id,
               name: node.folder.name,
-              collapsed: node.folder.collapsed,
               feeds: node.folder.feeds.map((f) => feedNodeId(f.id, flowId)),
             },
           }

--- a/desktop/frontend/src/lib/feedTree.ts
+++ b/desktop/frontend/src/lib/feedTree.ts
@@ -1,0 +1,192 @@
+// Pure logic for the sidebar's feed grouping/ordering. Kept free of Vue and
+// Wails so it can be unit-tested in isolation.
+//
+// The persisted shape (flow.SidebarLayout, per-flow <id>.sidebar.yaml) is
+// keyed by feed *node* id. The rendered shape (FeedTree) carries resolved
+// FeedSummary objects. buildFeedTree reconciles the two — honoring saved
+// order/folders, appending feeds the layout doesn't mention (so a newly added
+// feed is never hidden) and dropping references to feeds that no longer exist.
+import type { SidebarLayout as WireSidebarLayout } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/flow/models'
+import type { FeedSummary, FeedTree, SidebarNode } from '../types/feed'
+
+// The dataTransfer MIME type for a sidebar drag. Set on dragstart so a drop
+// from outside the sidebar (e.g. a palette node) is never mistaken for a feed.
+export const SIDEBAR_DRAG_MIME = 'application/x-hive-sidebar-item'
+
+// DragRef identifies what is being dragged: a feed (by flow-qualified feed id)
+// or a folder (by folder id).
+export type DragRef = { kind: 'feed'; id: string } | { kind: 'folder'; id: string }
+
+// DropTarget is where a drag lands:
+//  - before/after an existing item (top-level, or a feed inside a folder),
+//  - into a folder (append), or
+//  - at the end of the top level.
+export type DropTarget =
+  | { kind: 'before' | 'after'; ref: DragRef }
+  | { kind: 'into'; folderId: string }
+  | { kind: 'top-end' }
+
+// feedNodeId strips the "<flowId>/" prefix off a flow-qualified feed id to get
+// the flow-relative node id used in the persisted layout. A feed id without
+// the prefix (shouldn't happen) is returned unchanged.
+export function feedNodeId(feedId: string, flowId: string): string {
+  const prefix = `${flowId}/`
+  return feedId.startsWith(prefix) ? feedId.slice(prefix.length) : feedId
+}
+
+// buildFeedTree resolves the saved layout against the profile's live feeds.
+export function buildFeedTree(
+  feeds: FeedSummary[],
+  layout: WireSidebarLayout | null | undefined,
+  flowId: string,
+): FeedTree {
+  const byNode = new Map<string, FeedSummary>()
+  for (const feed of feeds) byNode.set(feedNodeId(feed.id, flowId), feed)
+
+  const used = new Set<string>()
+  const take = (nodeId: string): FeedSummary | undefined => {
+    if (used.has(nodeId)) return undefined
+    const feed = byNode.get(nodeId)
+    if (feed) used.add(nodeId)
+    return feed
+  }
+
+  const tree: FeedTree = []
+  for (const item of layout?.items ?? []) {
+    if (item?.folder) {
+      const folderFeeds: FeedSummary[] = []
+      for (const nodeId of item.folder.feeds ?? []) {
+        const feed = take(nodeId)
+        if (feed) folderFeeds.push(feed)
+      }
+      // Keep folders even when empty so a user-made folder isn't silently lost
+      // after its feeds are removed — it stays as a drop target.
+      tree.push({
+        kind: 'folder',
+        folder: {
+          id: item.folder.id,
+          name: item.folder.name,
+          collapsed: item.folder.collapsed,
+          feeds: folderFeeds,
+        },
+      })
+    } else if (item?.feed) {
+      const feed = take(item.feed)
+      if (feed) tree.push({ kind: 'feed', feed })
+    }
+  }
+
+  // Append any feeds the layout didn't place, in the flow's feed order.
+  for (const feed of feeds) {
+    if (!used.has(feedNodeId(feed.id, flowId))) tree.push({ kind: 'feed', feed })
+  }
+  return tree
+}
+
+// treeToLayout serializes a resolved tree back to the node-id-keyed persisted
+// shape.
+export function treeToLayout(tree: FeedTree, flowId: string): WireSidebarLayout {
+  return {
+    items: tree.map((node) =>
+      node.kind === 'folder'
+        ? {
+            folder: {
+              id: node.folder.id,
+              name: node.folder.name,
+              collapsed: node.folder.collapsed,
+              feeds: node.folder.feeds.map((f) => feedNodeId(f.id, flowId)),
+            },
+          }
+        : { feed: feedNodeId(node.feed.id, flowId) },
+    ),
+  }
+}
+
+function cloneTree(tree: FeedTree): FeedTree {
+  return tree.map((n) =>
+    n.kind === 'feed'
+      ? { kind: 'feed', feed: n.feed }
+      : { kind: 'folder', folder: { ...n.folder, feeds: [...n.folder.feeds] } },
+  )
+}
+
+// extract removes the dragged node (top-level or inside a folder) and returns
+// it. Mutates the passed (already-cloned) tree's folders in place.
+function extract(tree: FeedTree, drag: DragRef): { tree: FeedTree; node: SidebarNode | null } {
+  const out: FeedTree = []
+  let removed: SidebarNode | null = null
+  for (const node of tree) {
+    if (drag.kind === 'folder' && node.kind === 'folder' && node.folder.id === drag.id) {
+      removed = node
+      continue
+    }
+    if (drag.kind === 'feed' && node.kind === 'feed' && node.feed.id === drag.id) {
+      removed = node
+      continue
+    }
+    if (drag.kind === 'feed' && node.kind === 'folder') {
+      const idx = node.folder.feeds.findIndex((f) => f.id === drag.id)
+      if (idx !== -1) {
+        removed = { kind: 'feed', feed: node.folder.feeds[idx] }
+        node.folder.feeds.splice(idx, 1)
+      }
+    }
+    out.push(node)
+  }
+  return { tree: out, node: removed }
+}
+
+function insert(tree: FeedTree, node: SidebarNode, target: DropTarget): FeedTree {
+  if (target.kind === 'top-end') return [...tree, node]
+
+  if (target.kind === 'into') {
+    if (node.kind !== 'feed') return tree // folders don't nest
+    return tree.map((n) =>
+      n.kind === 'folder' && n.folder.id === target.folderId
+        ? { kind: 'folder', folder: { ...n.folder, feeds: [...n.folder.feeds, node.feed] } }
+        : n,
+    )
+  }
+
+  const ref = target.ref
+  const topIdx = tree.findIndex(
+    (n) =>
+      (ref.kind === 'feed' && n.kind === 'feed' && n.feed.id === ref.id) ||
+      (ref.kind === 'folder' && n.kind === 'folder' && n.folder.id === ref.id),
+  )
+  if (topIdx !== -1) {
+    const out = [...tree]
+    out.splice(target.kind === 'before' ? topIdx : topIdx + 1, 0, node)
+    return out
+  }
+
+  // ref is a feed nested in a folder — only meaningful when moving a feed.
+  if (ref.kind === 'feed' && node.kind === 'feed') {
+    return tree.map((n) => {
+      if (n.kind !== 'folder') return n
+      const idx = n.folder.feeds.findIndex((f) => f.id === ref.id)
+      if (idx === -1) return n
+      const feeds = [...n.folder.feeds]
+      feeds.splice(target.kind === 'before' ? idx : idx + 1, 0, node.feed)
+      return { kind: 'folder', folder: { ...n.folder, feeds } }
+    })
+  }
+
+  // Unresolvable target — append rather than drop the node.
+  return [...tree, node]
+}
+
+function sameRef(a: DragRef, b: DragRef): boolean {
+  return a.kind === b.kind && a.id === b.id
+}
+
+// applyMove returns a new tree with `drag` moved to `target`. Invalid or no-op
+// moves (dropping onto itself, nesting a folder) return the input unchanged.
+export function applyMove(tree: FeedTree, drag: DragRef, target: DropTarget): FeedTree {
+  if ((target.kind === 'before' || target.kind === 'after') && sameRef(drag, target.ref)) return tree
+  if (drag.kind === 'folder' && target.kind === 'into') return tree
+
+  const { tree: without, node } = extract(cloneTree(tree), drag)
+  if (!node) return tree
+  return insert(without, node, target)
+}

--- a/desktop/frontend/src/test-setup.ts
+++ b/desktop/frontend/src/test-setup.ts
@@ -3,13 +3,16 @@ import { beforeEach } from 'vitest'
 // Node (22+) ships its own global `localStorage`/`sessionStorage`, which
 // shadows happy-dom's Storage implementation in this Vitest environment and
 // throws ("getItem is not a function") without a `--localstorage-file`
-// backing path. Every real runtime target (a browser, the Wails webview)
-// has a working localStorage, so this in-memory stand-in exists purely so
-// tests exercise the same code paths (useTheme, useResizablePanel, ...) as
-// production. A fresh instance per test keeps specs isolated; individual
-// specs may still layer their own `vi.stubGlobal('localStorage', ...)` on
-// top (see SettingsView.spec.ts) — `vi.unstubAllGlobals()` there simply
-// reverts to whatever this hook set for that test.
+// backing path. Every real runtime target (a browser, the Wails webview) has a
+// working localStorage, so this in-memory stand-in exists purely so tests
+// exercise the same code paths (useTheme, useResizablePanel, ...) as
+// production.
+//
+// It is installed ONCE, at setup-module load — before any test file (and its
+// module-singleton `useStorage` calls, e.g. useTheme) evaluates — so those
+// capture a working, stable Storage reference. beforeEach then `clear()`s that
+// same instance (rather than swapping in a new one) to keep specs isolated
+// without invalidating references already captured by singletons.
 function memoryStorage(): Storage {
   const values = new Map<string, string>()
   return {
@@ -22,10 +25,12 @@ function memoryStorage(): Storage {
   }
 }
 
+Object.defineProperty(globalThis, 'localStorage', {
+  value: memoryStorage(),
+  writable: true,
+  configurable: true,
+})
+
 beforeEach(() => {
-  Object.defineProperty(globalThis, 'localStorage', {
-    value: memoryStorage(),
-    writable: true,
-    configurable: true,
-  })
+  localStorage.clear()
 })

--- a/desktop/frontend/src/types/feed.ts
+++ b/desktop/frontend/src/types/feed.ts
@@ -32,6 +32,25 @@ export interface FeedSummary {
   newCount: number
 }
 
+// FeedFolder is a named, collapsible group of feeds in the sidebar. It carries
+// resolved FeedSummary objects (not ids) so the sidebar can render counts
+// directly. Persisted (per-flow, by node id) as a flow.SidebarFolder.
+export interface FeedFolder {
+  id: string
+  name: string
+  collapsed: boolean
+  feeds: FeedSummary[]
+}
+
+// SidebarNode is one entry in the sidebar's ordered FEEDS section: a bare feed
+// or a folder. FeedTree is the resolved, ordered tree the SideBar renders — the
+// reconciliation of a profile's live feeds with its saved flow.SidebarLayout
+// (see lib/feedTree.ts).
+export type SidebarNode =
+  | { kind: 'feed'; feed: FeedSummary }
+  | { kind: 'folder'; folder: FeedFolder }
+export type FeedTree = SidebarNode[]
+
 // Profile is a workspace in the UI — backed by a flow.
 export interface Profile {
   id: string
@@ -41,6 +60,10 @@ export interface Profile {
   totalCount: number
   unreadCount: number
   feeds: FeedSummary[]
+  // tree is the resolved sidebar grouping/order for `feeds`. Absent until the
+  // profile's feeds have loaded; the SideBar falls back to a flat list of
+  // `feeds` when it is missing.
+  tree?: FeedTree
 }
 
 // Scope only: the unread filter is an independent axis (unreadOnly in

--- a/desktop/frontend/src/types/feed.ts
+++ b/desktop/frontend/src/types/feed.ts
@@ -32,13 +32,14 @@ export interface FeedSummary {
   newCount: number
 }
 
-// FeedFolder is a named, collapsible group of feeds in the sidebar. It carries
-// resolved FeedSummary objects (not ids) so the sidebar can render counts
-// directly. Persisted (per-flow, by node id) as a flow.SidebarFolder.
+// FeedFolder is a named group of feeds in the sidebar. It carries resolved
+// FeedSummary objects (not ids) so the sidebar can render counts directly.
+// Persisted (per-flow, by node id) as a flow.SidebarFolder. Note there is no
+// collapsed flag: expand/collapse is transient view state kept in localStorage
+// (see SideBar.vue), not part of the persisted layout.
 export interface FeedFolder {
   id: string
   name: string
-  collapsed: boolean
   feeds: FeedSummary[]
 }
 

--- a/docs/source-pipeline.md
+++ b/docs/source-pipeline.md
@@ -370,6 +370,18 @@ broken layout file is not an error (the editor just lays nodes out fresh).
 `LoadFlows` explicitly skips `*.ui.yaml`/`*.ui.yml` files when scanning the
 flows directory for flow definitions.
 
+A second machine-written sibling, `<id>.sidebar.yaml` (`flow/sidebar.go`),
+records how the profile's feed nodes are grouped into **folders** and ordered
+in the sidebar's FEEDS section (`SaveSidebar`/`GetSidebar` on `FlowsService`,
+driven by drag-and-drop in `SideBar.vue`). Like the layout file it is
+node-id-keyed, purely cosmetic, and skipped by `LoadFlows`; a missing or broken
+file falls back to listing feeds in flow-node order. It is a *separate* file
+from `.ui.yaml` so the canvas editor's whole-layout writes can never clobber
+the sidebar grouping. The frontend resolves it against the flow's live feed
+nodes in `lib/feedTree.ts` — appending feeds the file doesn't mention (so a
+newly added feed is never hidden) and dropping references to feeds that no
+longer exist.
+
 **Worked example** (a similar package-local fixture — with
 `msg.payload` written lowercase, since it's a pure YAML round-trip test that
 never actually executes the JS — lives in `flow/loader_test.go`'s
@@ -746,7 +758,8 @@ own profile tile).
 | `flows/*.yaml` schema | `internal/desktop/pipeline/flow/` |
 | `actions.yml` schema | `internal/desktop/pipeline/actions/` |
 | Wails services | `desktop/pipelineservice.go`, `desktop/flowsservice.go`, `desktop/flowsrefs.go`, `desktop/main.go` |
-| Sidebar (profile = flow, `feed_item` reads) | `desktop/frontend/src/composables/useFeedState.ts`, `desktop/frontend/src/components/SideBar.vue` |
+| Sidebar (profile = flow, `feed_item` reads) | `desktop/frontend/src/composables/useFeedState.ts`, `desktop/frontend/src/components/SideBar.vue`, `SidebarFeedRow.vue` |
+| Sidebar feed folders + ordering | `internal/desktop/pipeline/flow/sidebar.go` (`<id>.sidebar.yaml`), `desktop/frontend/src/lib/feedTree.ts` |
 | Always-on per-enabled-flow runtime manager | `desktop/frontend/src/pipeline/composables/useFlowsSession.ts`, `usePipelineRuntime.ts` |
 | Frontend node-type contract | `desktop/frontend/src/pipeline/nodeType.ts`, `registry.ts`, `nodes/*/` |
 | Frontend engine | `desktop/frontend/src/pipeline/engine/` (`graph.ts`, `runGraph.ts`, `transport.ts`, `webWorkerTransport.ts`) |

--- a/docs/source-pipeline.md
+++ b/docs/source-pipeline.md
@@ -373,14 +373,22 @@ flows directory for flow definitions.
 A second machine-written sibling, `<id>.sidebar.yaml` (`flow/sidebar.go`),
 records how the profile's feed nodes are grouped into **folders** and ordered
 in the sidebar's FEEDS section (`SaveSidebar`/`GetSidebar` on `FlowsService`,
-driven by drag-and-drop in `SideBar.vue`). Like the layout file it is
-node-id-keyed, purely cosmetic, and skipped by `LoadFlows`; a missing or broken
-file falls back to listing feeds in flow-node order. It is a *separate* file
-from `.ui.yaml` so the canvas editor's whole-layout writes can never clobber
-the sidebar grouping. The frontend resolves it against the flow's live feed
-nodes in `lib/feedTree.ts` — appending feeds the file doesn't mention (so a
-newly added feed is never hidden) and dropping references to feeds that no
-longer exist.
+driven by drag-and-drop in `SideBar.vue`). It stores **structure and order
+only** — folder names and their member/top-level feed ids — not view state:
+whether a folder is currently expanded is transient UI, kept in `localStorage`
+via VueUse `useStorage` (keyed by flow id → folder ids), never in the file. So
+`SidebarFolder` has no `collapsed` field, and collapsing a folder never writes
+to disk. Like the layout file it is node-id-keyed, purely cosmetic, and skipped
+by `LoadFlows`; a missing or broken file falls back to listing feeds in
+flow-node order. It is a *separate* file from `.ui.yaml` so the canvas editor's
+whole-layout writes can never clobber the sidebar grouping, and — unlike
+`.ui.yaml` — the `FlowsWatcher` deliberately **ignores** `.sidebar.yaml`
+(`isFlowFile`): a sidebar-layout write is frontend-owned UI state, so reloading
+the store and emitting `flows:updated` for it would pointlessly blank and
+refetch the sidebar (a visible flash on every reorder). The frontend resolves
+the file against the flow's live feed nodes in `lib/feedTree.ts` — appending
+feeds the file doesn't mention (so a newly added feed is never hidden) and
+dropping references to feeds that no longer exist.
 
 **Worked example** (a similar package-local fixture — with
 `msg.payload` written lowercase, since it's a pure YAML round-trip test that

--- a/docs/source-pipeline.md
+++ b/docs/source-pipeline.md
@@ -669,11 +669,10 @@ is gone.
   `App.vue` no longer has a `mode` ref toggling `'feed'`/`'flows'`; it
   renders either `SideBar`+`FeedList` or `FlowsView` based on
   `useFlowsSession().flowsOpen` (a shared session's `shallowRef<boolean>` —
-  see below), reached from the sidebar's "Flows" pill/footer row, a
-  jump-to-node command, or a feed row's "Reveal in flow" icon
-  (`SideBar.vue`'s `data-testid="sidebar-reveal-in-flow"` — there is no
-  pencil/edit affordance any more; a feed is edited by opening its node in
-  the canvas), and exited via the titlebar breadcrumb (`TitleBar.vue`'s
+  see below), reached from the sidebar's "Flows" pill/footer row or the
+  ⌘K jump-to-node command (there is no per-feed "reveal in flow" / edit
+  affordance in the sidebar; a feed is edited by opening its node in the
+  canvas), and exited via the titlebar breadcrumb (`TitleBar.vue`'s
   `data-testid="breadcrumb-profile-name"` becomes a button back to the feed
   while flows are active).
 - **The sidebar reads `feed_item`.** `useFeedState.ts`'s `loadFeeds`/

--- a/internal/desktop/pipeline/flow/loader.go
+++ b/internal/desktop/pipeline/flow/loader.go
@@ -51,6 +51,9 @@ func LoadFlows(dir string, refs Refs) (flows []Flow, perFileErrors map[string]er
 		if strings.HasSuffix(name, ".ui.yaml") || strings.HasSuffix(name, ".ui.yml") {
 			continue
 		}
+		if strings.HasSuffix(name, ".sidebar.yaml") || strings.HasSuffix(name, ".sidebar.yml") {
+			continue
+		}
 		if ext := filepath.Ext(name); ext != ".yaml" && ext != ".yml" {
 			continue
 		}

--- a/internal/desktop/pipeline/flow/sidebar.go
+++ b/internal/desktop/pipeline/flow/sidebar.go
@@ -1,0 +1,72 @@
+package flow
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SidebarFolder is one named, collapsible group of feeds in a profile's
+// sidebar. Feeds lists the member feed node ids in display order.
+type SidebarFolder struct {
+	ID        string   `json:"id"        yaml:"id"`
+	Name      string   `json:"name"      yaml:"name"`
+	Collapsed bool     `json:"collapsed" yaml:"collapsed"`
+	Feeds     []string `json:"feeds"     yaml:"feeds"`
+}
+
+// SidebarItem is one entry in the sidebar's ordered top level: either a bare
+// feed (Feed set to a feed node id) or a folder (Folder set). Exactly one is
+// meant to be non-empty; a malformed item with neither is ignored by the
+// frontend when it reconciles the layout against the flow's actual feed nodes.
+type SidebarItem struct {
+	Feed   string         `json:"feed,omitempty"   yaml:"feed,omitempty"`
+	Folder *SidebarFolder `json:"folder,omitempty" yaml:"folder,omitempty"`
+}
+
+// SidebarLayout is the machine-written, non-authoritative sibling of a flow —
+// the on-disk shape of a <id>.sidebar.yaml file. It records how a profile's
+// feed nodes are grouped into folders and ordered in the sidebar's FEEDS
+// section. Like Layout (.ui.yaml) it is purely cosmetic and keyed by node id:
+// a missing or broken file just means the sidebar falls back to listing feeds
+// in flow-node order, feed nodes absent from the layout are appended (so a
+// newly added feed is never hidden), and entries for feeds that no longer
+// exist are dropped. It is never consulted by LoadFlow/validation and never
+// blocks a flow from loading.
+type SidebarLayout struct {
+	Items []SidebarItem `json:"items" yaml:"items"`
+}
+
+// LoadSidebar reads a flow's sibling sidebar-layout file. A missing file, or
+// one that fails to parse, is not an error — the layout is purely cosmetic —
+// it returns an empty SidebarLayout instead so the caller always has an
+// (empty) slice to range over.
+func LoadSidebar(path string) SidebarLayout {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SidebarLayout{Items: []SidebarItem{}}
+	}
+	var layout SidebarLayout
+	if err := yaml.Unmarshal(data, &layout); err != nil {
+		return SidebarLayout{Items: []SidebarItem{}}
+	}
+	if layout.Items == nil {
+		layout.Items = []SidebarItem{}
+	}
+	return layout
+}
+
+// SaveSidebar writes a flow's sidebar layout atomically. Like SaveUI it always
+// marshals a clean document: sidebar-layout files are machine-written only and
+// carry no hand-authored comments worth preserving.
+func SaveSidebar(path string, layout SidebarLayout) error {
+	if layout.Items == nil {
+		layout.Items = []SidebarItem{}
+	}
+	data, err := yaml.Marshal(layout)
+	if err != nil {
+		return fmt.Errorf("flow: encode sidebar layout: %w", err)
+	}
+	return writeFileAtomic(path, data)
+}

--- a/internal/desktop/pipeline/flow/sidebar.go
+++ b/internal/desktop/pipeline/flow/sidebar.go
@@ -7,13 +7,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// SidebarFolder is one named, collapsible group of feeds in a profile's
-// sidebar. Feeds lists the member feed node ids in display order.
+// SidebarFolder is one named group of feeds in a profile's sidebar. Feeds
+// lists the member feed node ids in display order. Note there is no collapsed
+// field: whether a folder is expanded is transient view state the frontend
+// keeps in localStorage, not configuration — this file records structure and
+// order only.
 type SidebarFolder struct {
-	ID        string   `json:"id"        yaml:"id"`
-	Name      string   `json:"name"      yaml:"name"`
-	Collapsed bool     `json:"collapsed" yaml:"collapsed"`
-	Feeds     []string `json:"feeds"     yaml:"feeds"`
+	ID    string   `json:"id"    yaml:"id"`
+	Name  string   `json:"name"  yaml:"name"`
+	Feeds []string `json:"feeds" yaml:"feeds"`
 }
 
 // SidebarItem is one entry in the sidebar's ordered top level: either a bare

--- a/internal/desktop/pipeline/flow/sidebar_test.go
+++ b/internal/desktop/pipeline/flow/sidebar_test.go
@@ -1,0 +1,90 @@
+package flow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleSidebar() SidebarLayout {
+	return SidebarLayout{Items: []SidebarItem{
+		{Feed: "my-open-prs"},
+		{Folder: &SidebarFolder{ID: "work", Name: "Work", Collapsed: true, Feeds: []string{"assigned", "notifications"}}},
+		{Feed: "misc"},
+	}}
+}
+
+func TestSaveSidebar_LoadSidebar_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "triage.sidebar.yaml")
+
+	layout := sampleSidebar()
+	require.NoError(t, SaveSidebar(path, layout))
+	assert.Equal(t, layout, LoadSidebar(path))
+}
+
+func TestLoadSidebar_MissingFile_ReturnsEmptyNoError(t *testing.T) {
+	dir := t.TempDir()
+	layout := LoadSidebar(filepath.Join(dir, "nope.sidebar.yaml"))
+	assert.Equal(t, SidebarLayout{Items: []SidebarItem{}}, layout)
+}
+
+func TestLoadSidebar_BrokenFile_ReturnsEmptyNoError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "triage.sidebar.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("items: [folder: {"), 0o644))
+
+	assert.Equal(t, SidebarLayout{Items: []SidebarItem{}}, LoadSidebar(path))
+}
+
+func TestSaveSidebar_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "triage.sidebar.yaml")
+	require.NoError(t, SaveSidebar(path, sampleSidebar()))
+
+	loaded := LoadSidebar(path)
+	require.Len(t, loaded.Items, 3)
+	assert.Equal(t, "my-open-prs", loaded.Items[0].Feed)
+}
+
+func TestFlowStore_SidebarRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFlowStore(dir, minimalRefs())
+
+	layout := sampleSidebar()
+	require.NoError(t, store.SaveSidebar("triage", layout))
+	assert.Equal(t, layout, store.GetSidebar("triage"))
+
+	// A flow with no sidebar file yet gets an empty layout, not an error.
+	assert.Equal(t, SidebarLayout{Items: []SidebarItem{}}, store.GetSidebar("no-sidebar-yet"))
+}
+
+func TestFlowStore_Delete_RemovesSidebarFile(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFlowStore(dir, minimalRefs())
+	f, err := store.Create("Triage")
+	require.NoError(t, err)
+	require.NoError(t, store.SaveSidebar(f.ID, sampleSidebar()))
+
+	require.NoError(t, store.Delete(f.ID))
+
+	_, err = os.Stat(filepath.Join(dir, f.ID+".sidebar.yaml"))
+	assert.True(t, os.IsNotExist(err), "sidebar layout file must be removed with the flow")
+}
+
+func TestLoadFlows_SkipsSidebarFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFlow(t, dir, "triage.yaml", minimalValidFlowYAML())
+	// A sibling .sidebar.yaml must be ignored by the flow loader — not parsed
+	// as a flow (which would surface a spurious broken-file error).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "triage.sidebar.yaml"),
+		[]byte("items:\n  - feed: my-open-prs\n"), 0o644))
+
+	flows, perFileErrors, _ := LoadFlows(dir, minimalRefs())
+	require.Len(t, flows, 1)
+	assert.Equal(t, "triage", flows[0].ID)
+	assert.Empty(t, perFileErrors)
+}

--- a/internal/desktop/pipeline/flow/sidebar_test.go
+++ b/internal/desktop/pipeline/flow/sidebar_test.go
@@ -12,7 +12,7 @@ import (
 func sampleSidebar() SidebarLayout {
 	return SidebarLayout{Items: []SidebarItem{
 		{Feed: "my-open-prs"},
-		{Folder: &SidebarFolder{ID: "work", Name: "Work", Collapsed: true, Feeds: []string{"assigned", "notifications"}}},
+		{Folder: &SidebarFolder{ID: "work", Name: "Work", Feeds: []string{"assigned", "notifications"}}},
 		{Feed: "misc"},
 	}}
 }

--- a/internal/desktop/pipeline/flow/store.go
+++ b/internal/desktop/pipeline/flow/store.go
@@ -153,7 +153,8 @@ func (s *FlowStore) Delete(id string) error {
 	if err := os.Remove(filepath.Join(s.dir, id+".yaml")); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("flow: delete %q: %w", id, err)
 	}
-	_ = os.Remove(s.uiPath(id)) // layout is cosmetic; its absence is fine
+	_ = os.Remove(s.uiPath(id))      // layout is cosmetic; its absence is fine
+	_ = os.Remove(s.sidebarPath(id)) // sidebar layout is cosmetic too
 	return s.reloadLocked()
 }
 
@@ -213,6 +214,18 @@ func (s *FlowStore) SaveLayout(id string, layout Layout) error {
 	return SaveUI(s.uiPath(id), layout)
 }
 
+// GetSidebar returns id's sidebar layout (feed folders + ordering) — see
+// LoadSidebar for missing/broken-file semantics (an empty layout, never an
+// error).
+func (s *FlowStore) GetSidebar(id string) SidebarLayout {
+	return LoadSidebar(s.sidebarPath(id))
+}
+
+// SaveSidebar persists id's sidebar layout.
+func (s *FlowStore) SaveSidebar(id string, layout SidebarLayout) error {
+	return SaveSidebar(s.sidebarPath(id), layout)
+}
+
 // Reload re-reads every flow file in the directory. It only returns an
 // error when the directory itself can't be created/read (rare — the flows
 // dir is created on demand); a broken individual flow file is never a
@@ -253,4 +266,8 @@ func (s *FlowStore) ensureLoadedLocked() {
 
 func (s *FlowStore) uiPath(id string) string {
 	return filepath.Join(s.dir, id+".ui.yaml")
+}
+
+func (s *FlowStore) sidebarPath(id string) string {
+	return filepath.Join(s.dir, id+".sidebar.yaml")
 }

--- a/internal/desktop/pipeline/flow/watcher.go
+++ b/internal/desktop/pipeline/flow/watcher.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -98,11 +99,18 @@ func (w *FlowsWatcher) run() {
 }
 
 // isFlowFile reports whether name (as delivered by fsnotify — a path inside
-// the watched directory) is a *.yaml/*.yml file. This matches both flow
-// definitions and their sibling .ui.yaml layouts: a layout-only edit
-// triggers the same (cheap, idempotent) Reload as a flow edit, rather than
-// needing to distinguish the two.
+// the watched directory) is worth a reload. It matches *.yaml/*.yml — flow
+// definitions and their sibling .ui.yaml layouts, where a layout-only edit
+// triggers the same (cheap, idempotent) Reload as a flow edit — but excludes
+// .sidebar.yaml files. The sidebar layout (feed folders + order) is per-profile
+// UI state the frontend owns and applies optimistically; reloading + emitting
+// flows:updated on its writes would make the frontend blank and refetch the
+// sidebar, causing a visible flash on every folder toggle or reorder.
 func isFlowFile(name string) bool {
-	ext := filepath.Ext(name)
+	base := filepath.Base(name)
+	if strings.HasSuffix(base, ".sidebar.yaml") || strings.HasSuffix(base, ".sidebar.yml") {
+		return false
+	}
+	ext := filepath.Ext(base)
 	return ext == ".yaml" || ext == ".yml"
 }

--- a/internal/desktop/pipeline/flow/watcher_test.go
+++ b/internal/desktop/pipeline/flow/watcher_test.go
@@ -1,0 +1,31 @@
+package flow
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsFlowFile(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"triage.yaml", true},
+		{"triage.yml", true},
+		{"triage.ui.yaml", true}, // layout edits still trigger a reload
+		{"triage.ui.yml", true},
+		{"triage.sidebar.yaml", false}, // sidebar layout is frontend-owned UI state
+		{"triage.sidebar.yml", false},
+		{"triage.sidebar.yaml.tmp", false}, // atomic-write temp file
+		{"triage.yaml.tmp", false},
+		{"notes.txt", false},
+		{"triage", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isFlowFile(filepath.Join("/flows", tc.name)))
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

Let users organize a profile's feeds into folders and reorder feeds/folders in the sidebar's FEEDS section via drag-and-drop.

## Proposed Changes

  - New per-flow `<id>.sidebar.yaml` (`flow/sidebar.go`) stores folder grouping + order, keyed by feed node id — a separate file from `.ui.yaml` so the canvas editor can't clobber it, skipped by `LoadFlows` and the flow watcher. Exposed via `FlowsService.GetSidebar`/`SaveSidebar`.
  - Frontend: `lib/feedTree.ts` reconciles the saved layout against live feed nodes (appends new feeds, drops deleted ones) and applies pure drag-move ops; `SideBar.vue` renders the tree with native drag-and-drop, folder create/rename/delete, and a hover chevron.
  - Folder collapse is view state, not config → kept in `localStorage` (VueUse `useStorage`), never in YAML. Also migrated `useTheme`/`useResizablePanel` onto `useStorage` for consistency.
  - Removed the per-feed "reveal in flow" icon (canvas still reachable via the Flows footer + ⌘K jump-to-node).

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
