### PR TITLE
feat(desktop): concurrent dev instances + dev bar

### DIFF
--- a/desktop/Taskfile.yml
+++ b/desktop/Taskfile.yml
@@ -35,6 +35,15 @@ tasks:
 
   dev:
     summary: Runs the application in development mode
+    # Resolve a free Vite port (honoring an explicit WAILS_VITE_PORT) so multiple
+    # dev instances can run at once, and inject the git branch for the dev bar.
+    vars:
+      VITE_PORT:
+        sh: ./build/scripts/dev-port.sh
+      DEV_BRANCH:
+        sh: git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown
+    env:
+      VITE_HIVE_DEV_BRANCH: '{{.DEV_BRANCH}}'
     cmds:
       - wails3 dev -config ./build/config.yml -port {{.VITE_PORT}}
 

--- a/desktop/build/scripts/dev-port.sh
+++ b/desktop/build/scripts/dev-port.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# Prints the TCP port the Vite dev server should bind for `wails3 dev`.
+#
+# Honors an explicit WAILS_VITE_PORT (so a port can be pinned); otherwise asks
+# the OS for a free ephemeral port. This is what lets multiple `hive` desktop
+# dev instances run at once instead of colliding on the default 9245 — `wails3
+# dev` prechecks the port with net.Listen and hard-errors if it is already in
+# use. node is always present here (the frontend build depends on it).
+if [ -n "${WAILS_VITE_PORT}" ]; then
+  printf '%s\n' "${WAILS_VITE_PORT}"
+else
+  node -e 'const s=require("net").createServer();s.listen(0,"127.0.0.1",()=>{const p=s.address().port;s.close(()=>console.log(p))})'
+fi

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -25,6 +25,7 @@ import NewProfileModal from './components/NewProfileModal.vue'
 import UnsavedFlowChangesModal from './components/UnsavedFlowChangesModal.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
 import ToastStack from './components/ToastStack.vue'
+import DevBar from './components/DevBar.vue'
 import { useAuth } from './composables/useAuth'
 import { useFeedState } from './composables/useFeedState'
 import { useCommands, useCommandPalette, type Command } from './composables/useCommands'
@@ -32,6 +33,10 @@ import { setTheme, themeLabels, themes } from './composables/useTheme'
 import { useFlowsSession } from './pipeline/composables/useFlowsSession'
 import type { ApplicationSettingsSection, ProfileSettingsSection } from './router'
 import type { SidebarSelection } from './types/feed'
+
+// Only true when Vite is serving in dev mode (under `wails3 dev`); statically
+// false in production/server builds, so DevBar is compiled out of them.
+const devMode = import.meta.env.DEV
 
 const {
   status: authStatus, authenticated, deviceFlow, card: authCard, error: authError, busy: authBusy,
@@ -557,6 +562,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
           </div>
         </template>
       </div>
+      <DevBar v-if="devMode" />
     </div>
     <ToastStack :toasts="toasts" @dismiss="dismissToast" @clear-all="clearToasts" />
     <CommandPalette />

--- a/desktop/frontend/src/components/DevBar.vue
+++ b/desktop/frontend/src/components/DevBar.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+// Dev-only status strip pinned to the bottom of the window. Rendered only when
+// Vite serves the app in dev mode (import.meta.env.DEV) — i.e. under
+// `wails3 dev` — so it can never appear in a production `wails3 build`, the
+// headless server build, or e2e. It exists to make concurrently-running dev
+// instances distinguishable at a glance: the branch is injected at launch by
+// the dev task, and the port is the Vite dev server this window loaded from.
+const branch = import.meta.env.VITE_HIVE_DEV_BRANCH || 'unknown'
+const port = window.location.port
+</script>
+
+<template>
+  <footer
+    class="flex shrink-0 select-none items-center gap-2.5 border-t border-black/20 bg-yellow-400 px-3 py-1.5 font-mono text-xs leading-none text-black"
+  >
+    <span class="rounded bg-black px-2 py-1 text-[11px] font-bold uppercase tracking-wider text-yellow-400">Dev</span>
+    <span class="font-semibold">{{ branch }}</span>
+    <span v-if="port" class="text-black/60">:{{ port }}</span>
+    <span class="ml-auto text-black/70">dev instance</span>
+  </footer>
+</template>

--- a/desktop/frontend/src/vite-env.d.ts
+++ b/desktop/frontend/src/vite-env.d.ts
@@ -1,2 +1,10 @@
 /// <reference types="vite/client" />
 /// <reference types="unplugin-icons/types/vue3" />
+
+interface ImportMetaEnv {
+  /**
+   * Git branch injected by the dev launch task (mise `desktop:dev` / Task
+   * `dev`). Present only under `wails3 dev`; drives the dev bar's branch label.
+   */
+  readonly VITE_HIVE_DEV_BRANCH?: string
+}

--- a/mise.toml
+++ b/mise.toml
@@ -100,9 +100,14 @@ env = { HIVE_CONFIG = "./dev/config.invalid.yaml" }
 run = "go run . doctor || true"
 
 [tasks."desktop:dev"]
-description = "Run the desktop app in dev mode (wails3 dev)"
+description = "Run the desktop app in dev mode (wails3 dev). Picks a free Vite port so instances run concurrently; injects the git branch for the dev bar."
 dir = "desktop"
-run = "wails3 dev -config ./build/config.yml"
+run = """
+port="$(./build/scripts/dev-port.sh)"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+echo "hive desktop dev: vite port ${port}, branch ${branch}"
+WAILS_VITE_PORT="${port}" VITE_HIVE_DEV_BRANCH="${branch}" wails3 dev -config ./build/config.yml
+"""
 
 [tasks."desktop:build"]
 description = "Build the desktop app"


### PR DESCRIPTION
## Purpose

Enable running multiple `hive` desktop dev instances at once. The blocker isn't an "API port" — Wails v3 has no HTTP server in GUI dev mode — it's the Vite dev-server port (9245), which `wails3 dev` prechecks and hard-errors on when a second instance grabs it.

## Proposed Changes

  - Resolve a free Vite port at launch (`desktop/build/scripts/dev-port.sh`) in both dev entrypoints (mise `desktop:dev`, Task `dev`); honors an explicit `WAILS_VITE_PORT` to pin one.
  - Add a yellow dev bar (branch + Vite port + "dev instance") gated on `import.meta.env.DEV`, so it can only appear under `wails3 dev` and is compiled out of production/server/e2e builds.
  - Inject the git branch at launch via `VITE_HIVE_DEV_BRANCH` — no Go changes, no binding regen.

Note: instances still share desktop state (pipeline DB, GitHub polling) by design for now; `HIVE_DATA_DIR` can isolate that later without code changes.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)