### PR TITLE
feat(desktop): Slack-inspired title bar + per-branch dev bar color

### DIFF
--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import { Events } from '@wailsio/runtime'
+import { Events, Window } from '@wailsio/runtime'
+import { useStorage } from '@vueuse/core'
 import { useRoute, useRouter } from 'vue-router'
 import IconEye from '~icons/lucide/eye'
 import IconLayoutGrid from '~icons/lucide/layout-grid'
@@ -62,8 +63,8 @@ const knownFeedTypes = computed(() => [...new Set(items.value.map((item) => item
 // A profile IS a flow, so the flows canvas is a per-profile sub-view: it swaps
 // the sidebar+main region while the spaces rail and titlebar stay mounted (so
 // the user is never stranded — see the template). Reached from the sidebar's
-// "Flows" pill / "Edit flow" footer and the ⌘K command; exited via the
-// titlebar breadcrumb.
+// "Flows" pill / "Edit flow" footer and the ⌘K command; exited by selecting a
+// profile in the spaces rail or the ⌘K "Back to feed" command.
 //
 // The session (useFlowsSession) is a module singleton shared with
 // FlowsView.vue: it owns the pipeline editor and a runtime for every enabled
@@ -350,6 +351,33 @@ watch(() => (authenticated.value ? authStatus.value?.login ?? '' : null), (key) 
 // Step 2 of onboarding: authenticated but no workspace exists yet.
 const needsWorkspace = computed(() => authenticated.value && profilesLoaded.value && profiles.value.length === 0)
 
+// ── Layout chrome ─────────────────────────────────────────────────────────────
+// The feed sidebar collapses to reclaim horizontal space (handy in split
+// screens); the choice is persisted. Its toggle only appears in the feed view —
+// the one place a sidebar renders — so it never dangles over settings or flows.
+const sidebarCollapsed = useStorage('hive.panel.sidebar.collapsed', false)
+const feedViewActive = computed(() =>
+  authenticated.value && !needsWorkspace.value &&
+  !applicationSettingsActive.value && !profileSettingsActive.value &&
+  !flowsActive.value && !activityActive.value &&
+  !!activeProfile.value,
+)
+
+function toggleSidebar(): void {
+  sidebarCollapsed.value = !sidebarCollapsed.value
+}
+
+// We draw our own hidden-inset title bar, so the native double-click-to-zoom
+// gesture has to be re-implemented. Guarded for the non-Wails test/browser
+// context, matching hideWindow's posture.
+async function toggleMaximise(): Promise<void> {
+  try {
+    if (typeof Window?.ToggleMaximise === 'function') await Window.ToggleMaximise()
+  } catch (error) {
+    console.debug('Window maximise is unavailable outside Wails', error)
+  }
+}
+
 // ── Command palette ──────────────────────────────────────────────────────────
 
 const { open: paletteOpen, toggle: togglePalette } = useCommandPalette()
@@ -497,17 +525,20 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
     <div class="flex h-full min-h-0 flex-col overflow-hidden">
       <TitleBar
         :profile-name="authenticated && !needsWorkspace ? activeProfile?.name ?? 'Loading' : undefined"
-        :flows-active="flowsActive"
         :activity-active="activityActive"
         :error-count="errorCount"
         :unseen-activity="unseenActivity"
         :can-go-back="canGoBack"
         :can-go-forward="canGoForward"
+        :sidebar-collapsed="sidebarCollapsed"
+        :can-toggle-sidebar="feedViewActive"
         @back="router.back()"
         @forward="router.forward()"
-        @exit-flows="requestExitFlows"
         @open-error-node="openErrorNode"
         @open-activity="openActivity"
+        @toggle-sidebar="toggleSidebar"
+        @open-palette="togglePalette"
+        @toggle-maximise="toggleMaximise"
       />
       <!-- Hold an empty frame until auth status resolves so an authenticated
            user never sees onboarding flash by. -->
@@ -527,7 +558,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
       <!-- The spaces rail (ProfileRail) and TitleBar stay mounted across the
            feed<->flows switch; only the sidebar+main region swaps. This is
            what keeps the user from being stranded in the flows canvas — the
-           rail and the breadcrumb are always there to navigate back. -->
+           spaces rail is always there to navigate back. -->
       <div v-else class="flex min-h-0 flex-1">
         <ProfileRail
           :profiles="profiles"
@@ -557,7 +588,7 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
         <ActivityView v-else-if="activityActive" @close="closeSettings" />
         <template v-else>
           <SideBar
-            v-if="activeProfile"
+            v-if="activeProfile && !sidebarCollapsed"
             :profile="activeProfile"
             :selection="selection"
             :flows-dirty="session.dirty.value"

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -117,6 +117,9 @@ describe('App', () => {
     // watch hooks from that test's wrapper.unmount().
     resetFlowsSessionForTests()
     vi.clearAllMocks()
+    // Panel collapse / width state persists via useStorage; clear it so one
+    // test's collapsed sidebar can't leak into the next.
+    localStorage.clear()
     mocks.Status.mockResolvedValue({ state: 'authenticated', login: 'hay', name: 'Hay', avatarUrl: '', message: '' })
     mocks.ListFlows.mockResolvedValue([{ id: 'personal', name: 'Personal', enabled: true, valid: true }])
     mocks.GetFlow.mockResolvedValue(flow)
@@ -151,7 +154,7 @@ describe('App', () => {
     wrapper.unmount()
   })
 
-  it('opens the flows canvas from the sidebar and exits via the breadcrumb, keeping the rail mounted', async () => {
+  it('opens the flows canvas from the sidebar and exits via the profile rail, keeping the rail mounted', async () => {
     const wrapper = await mountApp()
 
     // Feed view first: sidebar present, no flows canvas.
@@ -161,16 +164,30 @@ describe('App', () => {
     await wrapper.find('[data-testid="sidebar-edit-flow"]').trigger('click')
     await flushPromises()
 
-    // Flows canvas is up; the spaces rail stays; the breadcrumb offers a way back.
+    // Flows canvas is up; the spaces rail stays mounted as the way back.
     expect(wrapper.find('[data-testid="flows-view"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="profile-tile"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="breadcrumb-flows"]').exists()).toBe(true)
 
-    await wrapper.find('[data-testid="breadcrumb-profile-name"]').trigger('click')
+    await wrapper.find('[data-testid="profile-tile"][data-id="personal"]').trigger('click')
     await flushPromises()
 
     // Back to the feed view.
     expect(wrapper.find('[data-testid="flows-view"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="sidebar-profile-header"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('collapses and restores the feed sidebar from the title-bar toggle', async () => {
+    const wrapper = await mountApp()
+    expect(wrapper.find('[data-testid="sidebar-profile-header"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="titlebar-toggle-sidebar"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="sidebar-profile-header"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="titlebar-toggle-sidebar"]').trigger('click')
+    await flushPromises()
     expect(wrapper.find('[data-testid="sidebar-profile-header"]').exists()).toBe(true)
 
     wrapper.unmount()
@@ -422,7 +439,7 @@ describe('App', () => {
     wrapper.unmount()
   })
 
-  it('exiting the canvas via the breadcrumb while dirty prompts a confirm instead of leaving immediately; Cancel stays in the canvas', async () => {
+  it('exiting the canvas via the profile rail while dirty prompts a confirm instead of leaving immediately; Cancel stays in the canvas', async () => {
     const wrapper = await mountApp()
     await wrapper.find('[data-testid="sidebar-edit-flow"]').trigger('click')
     await flushPromises()
@@ -432,7 +449,7 @@ describe('App', () => {
     session.addNode('feed')
     expect(session.dirty.value).toBe(true)
 
-    await wrapper.find('[data-testid="breadcrumb-profile-name"]').trigger('click')
+    await wrapper.find('[data-testid="profile-tile"][data-id="personal"]').trigger('click')
     await flushPromises()
 
     // Still in the canvas — the exit was deferred behind the confirm modal.
@@ -449,7 +466,7 @@ describe('App', () => {
     wrapper.unmount()
   })
 
-  it('exiting the canvas via the breadcrumb while dirty: Deploy saves the draft then returns to the feed view', async () => {
+  it('exiting the canvas via the profile rail while dirty: Deploy saves the draft then returns to the feed view', async () => {
     const wrapper = await mountApp()
     await wrapper.find('[data-testid="sidebar-edit-flow"]').trigger('click')
     await flushPromises()
@@ -457,7 +474,7 @@ describe('App', () => {
     const session = useFlowsSession()
     session.addNode('feed')
 
-    await wrapper.find('[data-testid="breadcrumb-profile-name"]').trigger('click')
+    await wrapper.find('[data-testid="profile-tile"][data-id="personal"]').trigger('click')
     await flushPromises()
 
     document.querySelector<HTMLButtonElement>('[data-testid="unsaved-flow-deploy"]')?.click()
@@ -472,7 +489,7 @@ describe('App', () => {
     wrapper.unmount()
   })
 
-  it('exiting the canvas via the breadcrumb while dirty: Discard drops the draft (reloads from disk) then returns to the feed view', async () => {
+  it('exiting the canvas via the profile rail while dirty: Discard drops the draft (reloads from disk) then returns to the feed view', async () => {
     const wrapper = await mountApp()
     await wrapper.find('[data-testid="sidebar-edit-flow"]').trigger('click')
     await flushPromises()
@@ -481,7 +498,7 @@ describe('App', () => {
     session.addNode('feed')
     const getFlowCallsBefore = mocks.GetFlow.mock.calls.length
 
-    await wrapper.find('[data-testid="breadcrumb-profile-name"]').trigger('click')
+    await wrapper.find('[data-testid="profile-tile"][data-id="personal"]').trigger('click')
     await flushPromises()
 
     document.querySelector<HTMLButtonElement>('[data-testid="unsaved-flow-discard"]')?.click()

--- a/desktop/frontend/src/components/DevBar.vue
+++ b/desktop/frontend/src/components/DevBar.vue
@@ -1,21 +1,32 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { colorForBranch, readableTextColor } from '../lib/devBarColor'
+
 // Dev-only status strip pinned to the bottom of the window. Rendered only when
 // Vite serves the app in dev mode (import.meta.env.DEV) — i.e. under
 // `wails3 dev` — so it can never appear in a production `wails3 build`, the
 // headless server build, or e2e. It exists to make concurrently-running dev
 // instances distinguishable at a glance: the branch is injected at launch by
 // the dev task, and the port is the Vite dev server this window loaded from.
+//
+// The bar's color is derived from the branch name (see devBarColor.ts), so each
+// branch/worktree window gets a stable, distinct accent — no more guessing
+// which window is which.
 const branch = import.meta.env.VITE_HIVE_DEV_BRANCH || 'unknown'
 const port = window.location.port
+
+const barColor = computed(() => colorForBranch(branch))
+const textColor = computed(() => readableTextColor(barColor.value))
 </script>
 
 <template>
   <footer
-    class="flex shrink-0 select-none items-center gap-2.5 border-t border-black/20 bg-yellow-400 px-3 py-1.5 font-mono text-xs leading-none text-black"
+    class="flex shrink-0 select-none items-center gap-2.5 border-t border-black/20 px-3 py-1.5 font-mono text-xs leading-none"
+    :style="{ background: barColor, color: textColor }"
   >
-    <span class="rounded bg-black px-2 py-1 text-[11px] font-bold uppercase tracking-wider text-yellow-400">Dev</span>
+    <span class="rounded px-2 py-1 text-[11px] font-bold uppercase tracking-wider" :style="{ background: textColor, color: barColor }">Dev</span>
     <span class="font-semibold">{{ branch }}</span>
-    <span v-if="port" class="text-black/60">:{{ port }}</span>
-    <span class="ml-auto text-black/70">dev instance</span>
+    <span v-if="port" class="opacity-60">:{{ port }}</span>
+    <span class="ml-auto opacity-70">dev instance</span>
   </footer>
 </template>

--- a/desktop/frontend/src/components/TitleBar.vue
+++ b/desktop/frontend/src/components/TitleBar.vue
@@ -2,112 +2,145 @@
 import IconActivity from '~icons/lucide/activity'
 import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconArrowRight from '~icons/lucide/arrow-right'
+import IconPanelLeftClose from '~icons/lucide/panel-left-close'
+import IconPanelLeftOpen from '~icons/lucide/panel-left-open'
+import IconSearch from '~icons/lucide/search'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 
-// profileName is empty during onboarding: the bar shows just the wordmark.
-// flowsActive adds a "/ Flows" breadcrumb crumb and turns the profile crumb
-// into a button that exits back to the feed view (the fix for being "stuck"
-// in the flows canvas).
-// errorCount (8d) is the count of the active flow's nodes whose last run
-// failed — sourced app-wide from useFlowsSession, so the chip renders and
-// deep-links even with the flows canvas closed.
-// activityActive highlights the Activity link when the audit-log page is open;
-// unseenActivity (6d) is the number of activity events recorded since the user
-// last opened that page, shown as a pulsing dot.
+// The bar is a three-column grid: a left cluster (sidebar toggle), a center
+// cluster (history + command-palette launcher) that stays centered in the
+// window regardless of how wide the side clusters grow, and a right cluster
+// (error/activity chips). Each column is flex-1 so the center is the middle
+// third of the full window width — the Slack-style centered search.
+//
+// profileName is empty during onboarding: the bar shows no profile controls —
+// no toggle, no center/right clusters. errorCount (8d) is the count of the active flow's
+// nodes whose last run failed. activityActive highlights the Activity link when
+// the audit-log page is open; unseenActivity (6d) is the number of activity
+// events recorded since the user last opened that page, shown as a pulsing dot.
+// sidebarCollapsed drives the panel-toggle glyph; canToggleSidebar hides the
+// toggle in views that have no feed sidebar (settings, flows, onboarding).
 defineProps<{
   profileName?: string
-  flowsActive?: boolean
   activityActive?: boolean
   errorCount?: number
   unseenActivity?: number
   canGoBack?: boolean
   canGoForward?: boolean
+  sidebarCollapsed?: boolean
+  canToggleSidebar?: boolean
 }>()
 const emit = defineEmits<{
   back: []
   forward: []
-  'exit-flows': []
   'open-error-node': []
   'open-activity': []
+  'toggle-sidebar': []
+  'open-palette': []
+  'toggle-maximise': []
 }>()
 
 // macOS draws its native traffic lights over the top-left of this bar
-// (hidden-inset chrome configured in desktop/main.go). Pad past them and keep
-// the height in sync with InvisibleTitleBarHeight (42) in main.go so the
-// buttons stay vertically centered.
+// (hidden-inset chrome configured in desktop/main.go). Pad the left cluster past
+// them and keep the height in sync with InvisibleTitleBarHeight (42) in main.go
+// so the controls stay vertically centered.
 const isMac = navigator.userAgent.includes('Mac')
+
+// Double-clicking the draggable title bar zooms the window, matching the native
+// macOS title-bar gesture (we draw our own chrome, so we implement it). Clicks
+// that land on an interactive control are ignored.
+function onTitlebarDblclick(event: MouseEvent): void {
+  if ((event.target as HTMLElement).closest('button, input, a')) return
+  emit('toggle-maximise')
+}
 </script>
 
 <template>
   <header
-    class="flex shrink-0 items-center gap-3 border-b border-border bg-raised px-3.5"
-    :class="isMac ? 'h-[42px] pl-[84px]' : 'h-10'"
+    class="relative flex shrink-0 items-center border-b border-border bg-raised"
+    :class="isMac ? 'h-[42px]' : 'h-10'"
     style="--wails-draggable: drag"
+    @dblclick="onTitlebarDblclick"
   >
-    <span class="font-mono text-[12.5px] font-semibold">hive</span>
-    <nav class="flex items-center gap-0.5" aria-label="Page history" style="--wails-draggable: no-drag">
+    <!-- Left: sidebar toggle -->
+    <div class="flex min-w-0 flex-1 items-center gap-2 pr-2" :class="isMac ? 'pl-[84px]' : 'pl-3'">
       <button
+        v-if="canToggleSidebar"
         type="button"
-        class="flex size-6 items-center justify-center rounded text-text-3 enabled:cursor-pointer enabled:hover:bg-chip enabled:hover:text-text disabled:opacity-30"
-        :disabled="!canGoBack"
-        aria-label="Go back"
-        data-testid="titlebar-back"
-        @click="emit('back')"
-      ><IconArrowLeft class="size-3.5" /></button>
-      <button
-        type="button"
-        class="flex size-6 items-center justify-center rounded text-text-3 enabled:cursor-pointer enabled:hover:bg-chip enabled:hover:text-text disabled:opacity-30"
-        :disabled="!canGoForward"
-        aria-label="Go forward"
-        data-testid="titlebar-forward"
-        @click="emit('forward')"
-      ><IconArrowRight class="size-3.5" /></button>
-    </nav>
-    <template v-if="profileName">
-      <span class="text-[13px] text-text-3">/</span>
-      <!-- In flows mode the profile crumb is a button back to the feed. -->
-      <button
-        v-if="flowsActive"
-        class="cursor-pointer text-[13px] text-text-2 hover:text-text"
+        class="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-chip hover:text-text"
         style="--wails-draggable: no-drag"
-        data-testid="breadcrumb-profile-name"
-        @click="emit('exit-flows')"
-      >{{ profileName }}</button>
-      <span v-else class="text-[13px] text-text-2" data-testid="breadcrumb-profile-name">{{ profileName }}</span>
-      <template v-if="flowsActive">
-        <span class="text-[13px] text-text-3">/</span>
-        <span class="text-[13px] text-accent" data-testid="breadcrumb-flows">Flows</span>
-      </template>
-    </template>
-    <div class="flex-1" />
-    <button
-      v-if="errorCount && errorCount > 0"
-      class="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-severity-error-border bg-severity-error-tint px-2 py-1 text-[11.5px] font-semibold text-severity-error hover:opacity-85"
-      style="--wails-draggable: no-drag"
-      data-testid="titlebar-error-chip"
-      @click="emit('open-error-node')"
-    ><IconTriangleAlert class="size-3" />{{ errorCount }} error<template v-if="errorCount !== 1">s</template></button>
-    <!-- Replaces the old decorative "polling github" indicator: a link to the
-         Activity audit log. A pulsing dot flags activity recorded since the
-         page was last opened. -->
-    <button
-      v-if="profileName"
-      class="relative flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11.5px] font-medium"
-      :class="activityActive
-        ? 'border-accent bg-accent text-accent-contrast'
-        : 'border-border text-text-2 hover:border-strong hover:text-text'"
-      style="--wails-draggable: no-drag"
-      data-testid="titlebar-activity"
-      aria-label="Open activity"
-      @click="emit('open-activity')"
-    >
-      <IconActivity class="size-3.5" />
-      Activity
-      <span
-        v-if="unseenActivity && unseenActivity > 0 && !activityActive"
-        class="size-[7px] rounded-full bg-accent [animation:hivePulse_2.4s_ease-in-out_infinite]"
-        data-testid="titlebar-activity-unseen"
-      />
-    </button>
+        :aria-label="sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'"
+        :title="sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'"
+        data-testid="titlebar-toggle-sidebar"
+        @click="emit('toggle-sidebar')"
+      ><component :is="sidebarCollapsed ? IconPanelLeftOpen : IconPanelLeftClose" class="size-3.5" /></button>
+    </div>
+
+    <!-- Center: history controls + command-palette launcher, window-centered -->
+    <div v-if="profileName" class="flex min-w-0 flex-1 items-center justify-center gap-1.5 px-2">
+      <nav class="flex shrink-0 items-center gap-0.5" aria-label="Page history" style="--wails-draggable: no-drag">
+        <button
+          type="button"
+          class="flex size-6 items-center justify-center rounded text-text-3 enabled:cursor-pointer enabled:hover:bg-chip enabled:hover:text-text disabled:opacity-30"
+          :disabled="!canGoBack"
+          aria-label="Go back"
+          data-testid="titlebar-back"
+          @click="emit('back')"
+        ><IconArrowLeft class="size-3.5" /></button>
+        <button
+          type="button"
+          class="flex size-6 items-center justify-center rounded text-text-3 enabled:cursor-pointer enabled:hover:bg-chip enabled:hover:text-text disabled:opacity-30"
+          :disabled="!canGoForward"
+          aria-label="Go forward"
+          data-testid="titlebar-forward"
+          @click="emit('forward')"
+        ><IconArrowRight class="size-3.5" /></button>
+      </nav>
+      <button
+        type="button"
+        class="flex h-7 min-w-0 max-w-[460px] flex-1 cursor-pointer items-center gap-2 rounded-md border border-border bg-app px-2.5 text-text-3 hover:border-strong hover:text-text-2"
+        style="--wails-draggable: no-drag"
+        aria-label="Open command palette"
+        data-testid="titlebar-command-palette"
+        @click="emit('open-palette')"
+      >
+        <IconSearch class="size-3.5 shrink-0" />
+        <span class="min-w-0 flex-1 truncate text-left text-[12.5px]">Search or run a command…</span>
+        <kbd class="shrink-0 rounded border border-card px-1.5 py-0.5 font-mono text-[10.5px] leading-none text-text-3">{{ isMac ? '⌘' : 'Ctrl ' }}K</kbd>
+      </button>
+    </div>
+    <div v-else class="flex-1" />
+
+    <!-- Right: error / activity chips -->
+    <div class="flex min-w-0 flex-1 items-center justify-end gap-2 pl-2 pr-3">
+      <button
+        v-if="errorCount && errorCount > 0"
+        class="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-severity-error-border bg-severity-error-tint px-2 py-1 text-[11.5px] font-semibold text-severity-error hover:opacity-85"
+        style="--wails-draggable: no-drag"
+        data-testid="titlebar-error-chip"
+        @click="emit('open-error-node')"
+      ><IconTriangleAlert class="size-3" />{{ errorCount }} error<template v-if="errorCount !== 1">s</template></button>
+      <!-- A link to the Activity audit log. A pulsing dot flags activity
+           recorded since the page was last opened. -->
+      <button
+        v-if="profileName"
+        class="relative flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11.5px] font-medium"
+        :class="activityActive
+          ? 'border-accent bg-accent text-accent-contrast'
+          : 'border-border text-text-2 hover:border-strong hover:text-text'"
+        style="--wails-draggable: no-drag"
+        data-testid="titlebar-activity"
+        aria-label="Open activity"
+        @click="emit('open-activity')"
+      >
+        <IconActivity class="size-3.5" />
+        Activity
+        <span
+          v-if="unseenActivity && unseenActivity > 0 && !activityActive"
+          class="size-[7px] rounded-full bg-accent [animation:hivePulse_2.4s_ease-in-out_infinite]"
+          data-testid="titlebar-activity-unseen"
+        />
+      </button>
+    </div>
   </header>
 </template>

--- a/desktop/frontend/src/components/__tests__/TitleBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/TitleBar.spec.ts
@@ -3,10 +3,11 @@ import { mount } from '@vue/test-utils'
 import TitleBar from '../TitleBar.vue'
 
 describe('TitleBar', () => {
-  it('shows only the wordmark during onboarding (no profile)', () => {
+  it('renders no profile controls during onboarding (no profile)', () => {
     const wrapper = mount(TitleBar, { props: {} })
-    expect(wrapper.text()).toContain('hive')
-    expect(wrapper.find('[data-testid="breadcrumb-profile-name"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="titlebar-toggle-sidebar"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="titlebar-activity"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="titlebar-command-palette"]').exists()).toBe(false)
   })
 
   it('shows the Activity link once a profile is loaded and emits open-activity on click', async () => {
@@ -33,22 +34,55 @@ describe('TitleBar', () => {
     expect(active.find('[data-testid="titlebar-activity-unseen"]').exists()).toBe(false)
   })
 
-  it('adds a Flows breadcrumb and exits via the profile crumb in flows mode', async () => {
-    const wrapper = mount(TitleBar, { props: { profileName: 'Triage', flowsActive: true } })
-    expect(wrapper.find('[data-testid="breadcrumb-flows"]').text()).toBe('Flows')
-
-    await wrapper.find('[data-testid="breadcrumb-profile-name"]').trigger('click')
-    expect(wrapper.emitted('exit-flows')).toHaveLength(1)
-  })
-
   it('exposes enabled back and forward history controls', async () => {
-    const wrapper = mount(TitleBar, { props: { canGoBack: true, canGoForward: true } })
+    const wrapper = mount(TitleBar, { props: { profileName: 'Triage', canGoBack: true, canGoForward: true } })
 
     await wrapper.find('[data-testid="titlebar-back"]').trigger('click')
     await wrapper.find('[data-testid="titlebar-forward"]').trigger('click')
 
     expect(wrapper.emitted('back')).toHaveLength(1)
     expect(wrapper.emitted('forward')).toHaveLength(1)
+  })
+
+  it('hides the centered history + command-palette cluster during onboarding', () => {
+    const onboarding = mount(TitleBar, { props: {} })
+    expect(onboarding.find('[data-testid="titlebar-back"]').exists()).toBe(false)
+    expect(onboarding.find('[data-testid="titlebar-command-palette"]').exists()).toBe(false)
+
+    const loaded = mount(TitleBar, { props: { profileName: 'Triage' } })
+    expect(loaded.find('[data-testid="titlebar-command-palette"]').exists()).toBe(true)
+  })
+
+  it('opens the command palette from the centered launcher', async () => {
+    const wrapper = mount(TitleBar, { props: { profileName: 'Triage' } })
+    await wrapper.find('[data-testid="titlebar-command-palette"]').trigger('click')
+    expect(wrapper.emitted('open-palette')).toHaveLength(1)
+  })
+
+  it('shows the sidebar toggle only when a sidebar exists and reflects the collapsed state', async () => {
+    const hidden = mount(TitleBar, { props: { profileName: 'Triage' } })
+    expect(hidden.find('[data-testid="titlebar-toggle-sidebar"]').exists()).toBe(false)
+
+    const expanded = mount(TitleBar, { props: { profileName: 'Triage', canToggleSidebar: true } })
+    const toggle = expanded.find('[data-testid="titlebar-toggle-sidebar"]')
+    expect(toggle.exists()).toBe(true)
+    expect(toggle.attributes('aria-label')).toBe('Hide sidebar')
+
+    await toggle.trigger('click')
+    expect(expanded.emitted('toggle-sidebar')).toHaveLength(1)
+
+    const collapsed = mount(TitleBar, { props: { profileName: 'Triage', canToggleSidebar: true, sidebarCollapsed: true } })
+    expect(collapsed.find('[data-testid="titlebar-toggle-sidebar"]').attributes('aria-label')).toBe('Show sidebar')
+  })
+
+  it('zooms on a double-click of the bar itself, but not on its controls', async () => {
+    const wrapper = mount(TitleBar, { props: { profileName: 'Triage', canToggleSidebar: true } })
+
+    await wrapper.find('header').trigger('dblclick')
+    expect(wrapper.emitted('toggle-maximise')).toHaveLength(1)
+
+    await wrapper.find('[data-testid="titlebar-command-palette"]').trigger('dblclick')
+    expect(wrapper.emitted('toggle-maximise')).toHaveLength(1)
   })
 
   it('renders the error chip only when errorCount > 0 and emits open-error-node on click', async () => {

--- a/desktop/frontend/src/lib/__tests__/devBarColor.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/devBarColor.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { colorForBranch, DEV_BAR_COLORS, hashBranch, readableTextColor } from '../devBarColor'
+
+describe('devBarColor', () => {
+  it('is deterministic — the same branch always maps to the same color', () => {
+    expect(colorForBranch('main')).toBe(colorForBranch('main'))
+    expect(hashBranch('feat/foo')).toBe(hashBranch('feat/foo'))
+  })
+
+  it('always returns a color from the palette', () => {
+    for (const branch of ['main', 'feat/slack-titlebar', 'hay-kot/fix', 'unknown', '', 'x']) {
+      expect(DEV_BAR_COLORS).toContain(colorForBranch(branch))
+    }
+  })
+
+  it('spreads distinct branches across multiple colors', () => {
+    const branches = Array.from({ length: 60 }, (_, i) => `feat/branch-${i}`)
+    const distinct = new Set(branches.map(colorForBranch))
+    // A good hash should light up most of the palette across 60 names.
+    expect(distinct.size).toBeGreaterThan(DEV_BAR_COLORS.length / 2)
+  })
+
+  it('picks a readable text color by luminance', () => {
+    expect(readableTextColor('#a3e635')).toBe('#0b0b0c') // bright lime → dark text
+    expect(readableTextColor('#1e3a8a')).toBe('#ffffff') // deep blue → light text
+    expect(readableTextColor('not-a-hex')).toBe('#0b0b0c') // safe fallback
+  })
+
+  it('every palette color is bright enough for dark text', () => {
+    // The palette is intentionally all-bright, so the bar reads like the
+    // original yellow strip; if a darker color is ever added, DevBar still
+    // stays legible because readableTextColor would flip it to white.
+    for (const color of DEV_BAR_COLORS) {
+      expect(readableTextColor(color)).toBe('#0b0b0c')
+    }
+  })
+})

--- a/desktop/frontend/src/lib/devBarColor.ts
+++ b/desktop/frontend/src/lib/devBarColor.ts
@@ -1,0 +1,55 @@
+// Deterministic branch → color mapping for the dev bar. Concurrently-running
+// dev instances (one per branch/worktree) each get a stable, distinct accent so
+// they're tellable apart at a glance — the same branch always lands on the same
+// color across restarts and windows.
+
+// A spread of bright hues (Tailwind ~400 values). All are light enough that
+// readableTextColor picks dark text for most, keeping the bar legible.
+export const DEV_BAR_COLORS = [
+  '#f59e0b', // amber
+  '#fb923c', // orange
+  '#f87171', // red
+  '#fb7185', // rose
+  '#f472b6', // pink
+  '#e879f9', // fuchsia
+  '#a78bfa', // violet
+  '#818cf8', // indigo
+  '#60a5fa', // blue
+  '#38bdf8', // sky
+  '#22d3ee', // cyan
+  '#2dd4bf', // teal
+  '#34d399', // emerald
+  '#4ade80', // green
+  '#a3e635', // lime
+] as const
+
+// FNV-1a (32-bit): a small, well-distributed string hash. Math.imul keeps the
+// multiply in 32-bit space; the final `>>> 0` yields an unsigned int.
+export function hashBranch(branch: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < branch.length; i++) {
+    h ^= branch.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/** The palette color assigned to a branch — stable for a given name. */
+export function colorForBranch(branch: string): string {
+  return DEV_BAR_COLORS[hashBranch(branch) % DEV_BAR_COLORS.length]
+}
+
+/**
+ * Black or white, whichever reads better on `hex` (a `#rrggbb` string).
+ * Uses the YIQ brightness heuristic; falls back to dark text on a bad input.
+ */
+export function readableTextColor(hex: string): '#0b0b0c' | '#ffffff' {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex)
+  if (!m) return '#0b0b0c'
+  const n = parseInt(m[1], 16)
+  const r = (n >> 16) & 0xff
+  const g = (n >> 8) & 0xff
+  const b = n & 0xff
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000
+  return yiq >= 140 ? '#0b0b0c' : '#ffffff'
+}


### PR DESCRIPTION
Redesigns the desktop window title bar (Slack-inspired) and adds per-branch coloring to the dev bar.

## Title bar

Rebuilt as a three-column layout that keeps the center cluster window-centered regardless of side-cluster width:

- **Collapsible sidebar** — a panel toggle (left) hides/shows the feed sidebar to reclaim horizontal space in split screens. The choice is persisted (`useStorage`), and the toggle only appears in the feed view where a sidebar exists.
- **Centered command palette** — the `←` `→` history controls sit left of a Slack-style command-palette launcher (`Search or run a command…` + `⌘K`/`Ctrl K` hint). Clicking it opens the existing command palette.
- **Double-click to zoom** — double-clicking the bar (not a control) calls `Window.ToggleMaximise()`, re-implementing the native macOS title-bar gesture since we draw our own hidden-inset chrome.
- **Removed** the `hive` wordmark and the profile/flows breadcrumb. Flows is still exited via the spaces rail or the ⌘K "Back to feed" command.

## Dev bar

Each concurrent dev instance now gets a distinct, stable color derived from its branch name:

- `devBarColor.ts` — FNV-1a hash → 15-color palette; `readableTextColor()` picks black/white text by luminance.
- Same branch always maps to the same color across restarts and windows.

## Tests

- `TitleBar.spec.ts` — sidebar toggle (icon/aria state), palette launcher, double-click-vs-controls, onboarding gating.
- `App.spec.ts` — end-to-end collapse/restore of the sidebar; flows-exit tests reworked to use the spaces rail (the breadcrumb they used is gone); `localStorage.clear()` added to `beforeEach` so persisted panel state can't leak between tests.
- `devBarColor.spec.ts` — determinism, palette membership, hash spread, contrast selection.

All 529 frontend tests pass; `vue-tsc` type-check and production build are clean.

## Notes / open questions

- **Double-click-to-zoom** maps to `ToggleMaximise` (macOS "zoom"). The webview can't read the user's System Settings "double-click title bar to…" preference, so this is a fixed default.
- The two changes are unrelated; happy to split into separate PRs if preferred.
