### PR TITLE
feat(desktop): configurable feed keyboard navigation

### DIFF
--- a/desktop/e2e/tests/feed.spec.ts
+++ b/desktop/e2e/tests/feed.spec.ts
@@ -92,6 +92,35 @@ test('opens, filters, runs, and dismisses the command palette', async ({ page })
   await expect(palette).toBeVisible()
 })
 
+test('navigates between items with j/k and the arrow keys', async ({ page }) => {
+  const detail = page.getByTestId('detail-pane')
+  await expect(detail).toContainText('batch_spawn: fix detached tmux env & PATH propagation')
+
+  await page.keyboard.press('ArrowDown')
+  await expect(detail).toContainText('Feed source: mirror GitHub notifications inbox')
+
+  await page.keyboard.press('j')
+  await expect(detail).toContainText('OAuth device flow for in-app GitHub auth')
+
+  await page.keyboard.press('k')
+  await expect(detail).toContainText('Feed source: mirror GitHub notifications inbox')
+
+  await page.keyboard.press('ArrowUp')
+  await expect(detail).toContainText('batch_spawn: fix detached tmux env & PATH propagation')
+})
+
+test('does not navigate while typing in the feed search box', async ({ page }) => {
+  const detail = page.getByTestId('detail-pane')
+  await expect(detail).toContainText('batch_spawn: fix detached tmux env & PATH propagation')
+
+  await page.getByTestId('feed-search').focus()
+  await page.keyboard.press('j')
+
+  // The 'j' lands in the search field and must not move the selection.
+  await expect(page.getByTestId('feed-search')).toHaveValue('j')
+  await expect(detail).toContainText('batch_spawn: fix detached tmux env & PATH propagation')
+})
+
 test('captures a full-window screenshot', async ({ page }, testInfo) => {
   const screenshots = join(here, '..', 'screenshots')
   await mkdir(screenshots, { recursive: true })

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -3,12 +3,9 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { Events, Window } from '@wailsio/runtime'
 import { useStorage } from '@vueuse/core'
 import { useRoute, useRouter } from 'vue-router'
-import IconEye from '~icons/lucide/eye'
 import IconLayoutGrid from '~icons/lucide/layout-grid'
 import IconList from '~icons/lucide/list'
-import IconMinus from '~icons/lucide/minus'
 import IconPalette from '~icons/lucide/palette'
-import IconRefreshCw from '~icons/lucide/refresh-cw'
 import IconRss from '~icons/lucide/rss'
 import IconShare2 from '~icons/lucide/share-2'
 import IconWorkflow from '~icons/lucide/workflow'
@@ -33,6 +30,8 @@ import { useAuth } from './composables/useAuth'
 import { useActivity } from './composables/useActivity'
 import { useFeedState } from './composables/useFeedState'
 import { useCommands, useCommandPalette, type Command } from './composables/useCommands'
+import { comboFromEvent, formatCombo, useKeybindings } from './composables/useKeybindings'
+import { commandCatalog } from './keybindings/catalog'
 import { setTheme, themeLabels, themes } from './composables/useTheme'
 import { useFlowsSession } from './pipeline/composables/useFlowsSession'
 import type { ApplicationSettingsSection, ProfileSettingsSection } from './router'
@@ -48,10 +47,10 @@ const {
 } = useAuth()
 
 const {
-  profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, loadError,
+  profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, visibleItems, unreadCount, search, loadError,
   selectedId, selectedItem, actions, pendingAction, actionRuns, sessionLaunchAction, sessionLaunchOptions, sessionLaunchBusy, sessionLaunchError, unreadOnly, title, toasts, dismissToast, clearToasts,
   creatingProfile, createProfileError, deletingProfile, loadProfiles, createProfile, deleteProfile,
-  reorderFeeds, selectProfile, selectSidebar, selectUnreadView, selectItem,
+  reorderFeeds, selectProfile, selectSidebar, selectUnreadView, selectItem, selectNext, selectPrev,
   toggleUnread, refresh, invokeAction, cancelSessionLaunch, submitSessionLaunch, notWired, openUrl, openSelectedInBrowser, hideWindow,
 } = useFeedState()
 
@@ -85,7 +84,10 @@ const activityActive = computed(() => route.name === 'activity')
 const applicationSettingsActive = computed(() => route.name === 'application-settings')
 const profileSettingsActive = computed(() => route.name === 'profile-settings')
 const applicationSettingsSection = computed<ApplicationSettingsSection>(() =>
-  route.params.section === 'integrations' ? 'integrations' : route.params.section === 'actions' ? 'actions' : 'appearance',
+  route.params.section === 'integrations' ? 'integrations'
+    : route.params.section === 'actions' ? 'actions'
+      : route.params.section === 'keybindings' ? 'keybindings'
+        : 'appearance',
 )
 const profileSettingsSection = computed<ProfileSettingsSection>(() =>
   route.params.section === 'danger' ? 'danger' : 'general',
@@ -381,10 +383,50 @@ async function toggleMaximise(): Promise<void> {
 // ── Command palette ──────────────────────────────────────────────────────────
 
 const { open: paletteOpen, toggle: togglePalette } = useCommandPalette()
+const kb = useKeybindings()
+
+// One handler per bindable command id. Both the keydown dispatcher and the
+// command palette run through this map, so each command has a single
+// implementation and the palette can show its live shortcut.
+const runMap: Record<string, () => void | Promise<void>> = {
+  'feed.next': selectNext,
+  'feed.prev': selectPrev,
+  'feed.open-in-browser': openSelectedInBrowser,
+  'feed.toggle-unread': navigateUnreadToggle,
+  'feed.refresh': refresh,
+  'palette.toggle': togglePalette,
+  'window.hide': hideWindow,
+}
+const catalogById = new Map(commandCatalog.map((command) => [command.id, command]))
+
+// The feed only accepts bare navigation keys when it is actually the on-screen
+// view (matches the condition under which <FeedList> renders below).
+const feedNavActive = computed(() =>
+  route.name === 'feed' && authenticated.value && !needsWorkspace.value && !!activeProfile.value,
+)
+
+// While an overlay owns the screen, only the palette toggle stays live.
+const anyOverlayOpen = computed(() =>
+  paletteOpen.value || newProfileOpen.value || deleteProfileOpen.value || !!sessionLaunchAction.value || !!pendingNavigation.value,
+)
 
 // Seed commands — reactive getter so they update when profiles/flows load
 useCommands(computed(() => {
   const cmds: Command[] = []
+
+  // Bindable app commands (nav, refresh, …) with their live shortcut hint.
+  for (const command of commandCatalog) {
+    if (command.paletteHidden) continue
+    cmds.push({
+      id: command.id,
+      title: command.title,
+      group: command.group,
+      keywords: command.keywords,
+      icon: command.icon,
+      hint: formatCombo(kb.bindings.value[command.id]?.[0] ?? ''),
+      run: () => runMap[command.id]?.(),
+    })
+  }
 
   // Profiles
   for (const p of profiles.value) {
@@ -419,23 +461,6 @@ useCommands(computed(() => {
       run: () => navigateSidebar({ type: 'feed', feedId: f.id }),
     })
   }
-
-  cmds.push({
-    id: 'feed:toggle-unread',
-    title: 'Toggle unread filter',
-    group: 'Feeds',
-    icon: IconEye,
-    run: navigateUnreadToggle,
-  })
-
-  cmds.push({
-    id: 'feed:refresh',
-    title: 'Refresh feeds',
-    group: 'Feeds',
-    keywords: ['reload', 'sync'],
-    icon: IconRefreshCw,
-    run: refresh,
-  })
 
   cmds.push({
     id: 'profile:new',
@@ -480,40 +505,38 @@ useCommands(computed(() => {
     })
   }
 
-  // Window
-  cmds.push({
-    id: 'window:hide',
-    title: 'Hide window',
-    group: 'Window',
-    icon: IconMinus,
-    run: hideWindow,
-  })
-
   return cmds
 }))
 
-// ── Global ⌘K / Ctrl+K listener ──────────────────────────────────────────────
+// ── Global keybinding dispatcher ─────────────────────────────────────────────
+// Resolves a keydown against the configurable keymap and runs the matched
+// command. Bare (modifier-less) keys are ignored while typing; feed commands
+// only fire on the feed; overlays suppress everything but the palette toggle.
 
 function onGlobalKeydown(e: KeyboardEvent): void {
-  if (e.key.toLowerCase() !== 'k' || (!e.metaKey && !e.ctrlKey)) return
+  if (kb.recording.value) return // the settings editor is capturing this key
+  const combo = comboFromEvent(e)
+  if (!combo) return
+  const id = kb.resolve(combo)
+  if (!id) return
+  const command = catalogById.get(id)
+  if (!command) return
 
-  // If palette is already open, always close it (even from inside the input)
-  if (paletteOpen.value) {
-    e.preventDefault()
-    togglePalette()
-    return
-  }
-
-  // Ignore ⌘K while focus is in any editable element other than the palette input
+  const mods = combo.split('+')
+  const hasModifier = mods.includes('mod') || mods.includes('ctrl') || mods.includes('alt')
   const target = e.target as HTMLElement
   const isEditable =
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
     target.isContentEditable
-  if (isEditable) return
+  if (isEditable && !hasModifier) return
+
+  if (anyOverlayOpen.value && id !== 'palette.toggle') return
+  if (command.context === 'feed' && !feedNavActive.value) return
 
   e.preventDefault()
-  togglePalette()
+  void runMap[id]?.()
 }
 
 onMounted(() => window.addEventListener('keydown', onGlobalKeydown))
@@ -600,11 +623,14 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
           <section v-if="activeProfile" class="flex min-w-0 flex-1">
             <FeedList
               :title="title"
-              :items="items"
+              :visible-items="visibleItems"
               :selected-id="selectedId"
               :unread-only="unreadOnly"
+              :unread-count="unreadCount"
+              :search="search"
               :load-error="loadError"
               @select="selectItem"
+              @update:search="(value) => (search = value)"
               @set-unread="navigateUnreadFilter"
               @refresh="refresh"
             />

--- a/desktop/frontend/src/components/FeedList.vue
+++ b/desktop/frontend/src/components/FeedList.vue
@@ -1,40 +1,42 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import FeedListItem from './FeedListItem.vue'
 import IconCheck from '~icons/lucide/check'
 import IconGitBranch from '~icons/lucide/git-branch'
 import IconRefreshCw from '~icons/lucide/refresh-cw'
 import IconSearch from '~icons/lucide/search'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
-import { bodySnippet, feedSource, typeLabel } from '../lib/feedPresentation'
 import type { FeedItem } from '../types/feed'
 
+// Presentation-only: the store (useFeedState) owns the search text and the
+// filtered `visibleItems`, so keyboard navigation and this list render the
+// exact same set. This component just renders and relays intent.
 const props = defineProps<{
   title: string
-  items: FeedItem[]
+  visibleItems: FeedItem[]
   selectedId: string | null
   unreadOnly: boolean
+  unreadCount: number
+  search: string
   loadError: string | null
 }>()
-const emit = defineEmits<{ select: [id: string]; 'set-unread': [value: boolean]; refresh: [] }>()
+const emit = defineEmits<{
+  select: [id: string]
+  'set-unread': [value: boolean]
+  refresh: []
+  'update:search': [value: string]
+}>()
 
-// Search is a pure view filter over the already-loaded list (like unreadOnly),
-// so it lives here rather than in the store composable.
-const search = ref('')
-const unreadCount = computed(() => props.items.filter((item) => item.unread).length)
-
-function matchesSearch(item: FeedItem): boolean {
-  const query = search.value.trim().toLowerCase()
-  if (!query) return true
-  const haystack = [item.title, item.repo, item.author, typeLabel(item.kind), feedSource(item).label, bodySnippet(item.body)]
-    .join(' ')
-    .toLowerCase()
-  return haystack.includes(query)
-}
-
-const visibleItems = computed(() =>
-  props.items.filter((item) => (!props.unreadOnly || item.unread) && matchesSearch(item)),
-)
+// Keep the selected row in view when navigation moves the cursor by keyboard
+// (mirrors CommandPalette's scrollIntoView on selection change).
+const listContainer = ref<HTMLElement | null>(null)
+watch(() => props.selectedId, async (id) => {
+  if (!id) return
+  await nextTick()
+  const rows = listContainer.value?.querySelectorAll('[data-testid="feed-item"]')
+  const row = rows && Array.from(rows).find((el) => el.getAttribute('data-id') === id)
+  ;(row as HTMLElement | undefined)?.scrollIntoView?.({ block: 'nearest' })
+})
 </script>
 
 <template>
@@ -45,11 +47,12 @@ const visibleItems = computed(() =>
       <label class="search-box">
         <IconSearch class="size-[14px] shrink-0 text-text-3" />
         <input
-          v-model="search"
+          :value="search"
           type="text"
           class="search-input"
           placeholder="Search items, sources, people…"
           data-testid="feed-search"
+          @input="emit('update:search', ($event.target as HTMLInputElement).value)"
         >
       </label>
       <div class="segmented" role="group" aria-label="Filter">
@@ -60,7 +63,7 @@ const visibleItems = computed(() =>
       </div>
       <button class="refresh-chip" aria-label="Refresh" data-testid="refresh-chip" @click="emit('refresh')"><IconRefreshCw class="size-3" /></button>
     </header>
-    <div class="hive-scroll min-h-0 flex-1 overflow-y-auto">
+    <div ref="listContainer" class="hive-scroll min-h-0 flex-1 overflow-y-auto">
       <!-- Load failure: the "GitHub unreachable" design state. -->
       <div v-if="loadError" class="state-frame" data-testid="feed-error">
         <div class="state-icon text-accent"><IconTriangleAlert class="size-5" /></div>

--- a/desktop/frontend/src/components/KeybindingSettingsView.vue
+++ b/desktop/frontend/src/components/KeybindingSettingsView.vue
@@ -1,0 +1,241 @@
+<script setup lang="ts">
+// Obsidian-style keybindings editor: every bindable command from the catalog,
+// grouped and filterable, each with its current bindings as removable chips, a
+// recorder to add a new combo, and a reset-to-default. Recording captures the
+// next keystroke on the window in the capture phase and suppresses it from the
+// global dispatcher (belt: kb.recording; suspenders: stopPropagation).
+import { computed, onUnmounted, ref } from 'vue'
+import IconPlus from '~icons/lucide/plus'
+import IconRotateCcw from '~icons/lucide/rotate-ccw'
+import IconSearch from '~icons/lucide/search'
+import IconTriangleAlert from '~icons/lucide/triangle-alert'
+import IconX from '~icons/lucide/x'
+import { commandCatalog } from '../keybindings/catalog'
+import { comboFromEvent, formatCombo, useKeybindings } from '../composables/useKeybindings'
+
+const kb = useKeybindings()
+const filter = ref('')
+const capturingId = ref<string | null>(null)
+
+const catalogById = new Map(commandCatalog.map((command) => [command.id, command]))
+const titleFor = (id: string) => catalogById.get(id)?.title ?? id
+
+interface Row { id: string; title: string; combos: string[]; overridden: boolean }
+interface Group { group: string; rows: Row[] }
+
+const groups = computed<Group[]>(() => {
+  const query = filter.value.trim().toLowerCase()
+  const byGroup = new Map<string, Row[]>()
+  for (const command of commandCatalog) {
+    const combos = kb.bindings.value[command.id] ?? []
+    if (query) {
+      const haystack = [command.title, command.group, ...(command.keywords ?? []), ...combos.map((c) => formatCombo(c))]
+        .join(' ')
+        .toLowerCase()
+      if (!haystack.includes(query)) continue
+    }
+    const row: Row = { id: command.id, title: command.title, combos, overridden: kb.isOverridden(command.id) }
+    if (!byGroup.has(command.group)) byGroup.set(command.group, [])
+    byGroup.get(command.group)!.push(row)
+  }
+  return [...byGroup.entries()].map(([group, rows]) => ({ group, rows }))
+})
+
+const empty = computed(() => groups.value.length === 0)
+
+function conflictTitles(id: string, combo: string): string[] {
+  return kb.conflicts(combo, id).map(titleFor)
+}
+
+// ── Combo recording ───────────────────────────────────────────────────────────
+
+function startCapture(id: string): void {
+  if (capturingId.value) endCapture()
+  capturingId.value = id
+  kb.recording.value = true
+  window.addEventListener('keydown', onCaptureKeydown, true) // capture phase
+}
+
+function endCapture(): void {
+  if (!capturingId.value) return
+  capturingId.value = null
+  kb.recording.value = false
+  window.removeEventListener('keydown', onCaptureKeydown, true)
+}
+
+function onCaptureKeydown(e: KeyboardEvent): void {
+  const id = capturingId.value
+  if (!id) return
+  e.preventDefault()
+  e.stopPropagation() // never reaches the global dispatcher or SettingsView's Escape
+  if (e.key === 'Escape') {
+    endCapture()
+    return
+  }
+  const combo = comboFromEvent(e)
+  if (!combo) return // lone modifier held — keep waiting for the full combo
+  kb.addBinding(id, combo)
+  endCapture()
+}
+
+function removeCombo(id: string, combo: string): void {
+  kb.removeBinding(id, combo)
+}
+
+function reset(id: string): void {
+  if (capturingId.value === id) endCapture()
+  kb.resetToDefault(id)
+}
+
+onUnmounted(endCapture)
+</script>
+
+<template>
+  <div class="mx-auto max-w-[640px]" data-testid="settings-keybindings">
+    <div class="mb-4">
+      <h2 class="text-[15px] font-semibold text-text">Keyboard shortcuts</h2>
+      <p class="mt-1 text-xs leading-relaxed text-text-3">
+        Rebind commands to your own keys. Bindings apply across the app; feed navigation keys work while the feed is open.
+      </p>
+    </div>
+
+    <label class="mb-4 flex items-center gap-2 rounded-lg border border-strong bg-app px-3 py-2 focus-within:border-accent">
+      <IconSearch class="size-[14px] shrink-0 text-text-3" />
+      <input
+        v-model="filter"
+        type="text"
+        class="min-w-0 flex-1 border-none bg-transparent text-[13px] text-text outline-none placeholder:text-text-4"
+        placeholder="Filter shortcuts…"
+        data-testid="keybinding-filter"
+      >
+    </label>
+
+    <div v-if="empty" class="rounded-lg border border-border bg-raised px-4 py-8 text-center text-xs text-text-3" data-testid="keybinding-empty">
+      No shortcuts match "{{ filter.trim() }}".
+    </div>
+
+    <div v-for="group in groups" :key="group.group" class="mb-5">
+      <div class="mb-1.5 px-1 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-text-3">{{ group.group }}</div>
+      <div class="overflow-hidden rounded-lg border border-border bg-raised">
+        <div
+          v-for="(row, index) in group.rows"
+          :key="row.id"
+          class="flex items-center gap-3 px-4 py-2.5"
+          :class="index > 0 ? 'border-t border-row' : ''"
+          data-testid="keybinding-row"
+          :data-command-id="row.id"
+        >
+          <div class="min-w-0 flex-1 text-[13px] text-text">{{ row.title }}</div>
+
+          <div class="flex flex-wrap items-center justify-end gap-2">
+            <span
+              v-for="combo in row.combos"
+              :key="combo"
+              class="combo"
+              :class="conflictTitles(row.id, combo).length ? 'combo-conflict' : ''"
+              :title="conflictTitles(row.id, combo).length ? `Also bound to ${conflictTitles(row.id, combo).join(', ')}` : undefined"
+              data-testid="keybinding-combo"
+            >
+              <IconTriangleAlert v-if="conflictTitles(row.id, combo).length" class="size-3 shrink-0 text-accent" />
+              <kbd class="keycap">{{ formatCombo(combo) }}</kbd>
+              <button
+                type="button"
+                class="combo-remove"
+                aria-label="Remove shortcut"
+                data-testid="keybinding-remove"
+                @click="removeCombo(row.id, combo)"
+              ><IconX class="size-3" /></button>
+            </span>
+
+            <span v-if="!row.combos.length && capturingId !== row.id" class="text-[11px] text-text-4">Blank</span>
+
+            <span v-if="capturingId === row.id" class="capture-chip" data-testid="keybinding-capture">
+              Press a key…&nbsp;<span class="text-text-4">Esc to cancel</span>
+            </span>
+
+            <button
+              v-else
+              type="button"
+              class="icon-btn"
+              aria-label="Add shortcut"
+              data-testid="keybinding-add"
+              @click="startCapture(row.id)"
+            ><IconPlus class="size-3.5" /></button>
+
+            <button
+              v-if="row.overridden"
+              type="button"
+              class="icon-btn"
+              aria-label="Reset to default"
+              title="Reset to default"
+              data-testid="keybinding-reset"
+              @click="reset(row.id)"
+            ><IconRotateCcw class="size-3.5" /></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.combo { display: inline-flex; align-items: center; gap: 3px; }
+/* A readable key cap: bright, mono, with a subtle physical-key bottom edge. */
+.keycap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 25px;
+  padding: 0 9px;
+  border: 1px solid var(--color-strong);
+  border-bottom-width: 2px;
+  border-radius: 6px;
+  background: var(--color-chip);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--color-text);
+}
+.combo-conflict .keycap { border-color: var(--color-accent); color: var(--color-accent); }
+/* The remove affordance is demoted so the key reads first; it lifts on hover. */
+.combo-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  border-radius: 5px;
+  color: var(--color-text-4);
+  opacity: 0.4;
+  transition: opacity 0.12s, color 0.12s, background 0.12s;
+}
+.combo:hover .combo-remove { opacity: 1; }
+.combo-remove:hover { color: var(--color-text); background: var(--color-hover); }
+.capture-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 25px;
+  padding: 0 10px;
+  border: 1px dashed var(--color-accent);
+  border-radius: 6px;
+  background: var(--color-chip);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text);
+}
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+  border: 1px solid var(--color-strong);
+  border-radius: 7px;
+  color: var(--color-text-2);
+}
+.icon-btn:hover { color: var(--color-text); border-color: var(--color-accent); }
+</style>

--- a/desktop/frontend/src/components/SettingsView.vue
+++ b/desktop/frontend/src/components/SettingsView.vue
@@ -2,12 +2,14 @@
 // Application-wide settings, opened from the persistent profile rail.
 // Only settings backed by real behavior or explicitly marked future
 // integrations belong here.
-import { onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import IconArrowLeft from '~icons/lucide/arrow-left'
+import IconKeyboard from '~icons/lucide/keyboard'
 import IconPalette from '~icons/lucide/palette'
 import IconPlug from '~icons/lucide/plug'
 import IconPlay from '~icons/lucide/play'
 import ActionSettingsView from './ActionSettingsView.vue'
+import KeybindingSettingsView from './KeybindingSettingsView.vue'
 import githubIcon from '../assets/integrations/github.svg'
 import grafanaIcon from '../assets/integrations/grafana.svg'
 import posthogIcon from '../assets/integrations/posthog.svg'
@@ -25,9 +27,17 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{ close: []; 'select-category': [category: ApplicationSettingsSection] }>()
 const categories = [
   { id: 'appearance' as const, label: 'Appearance', icon: IconPalette },
+  { id: 'keybindings' as const, label: 'Keyboard', icon: IconKeyboard },
   { id: 'integrations' as const, label: 'Integrations', icon: IconPlug },
   { id: 'actions' as const, label: 'Actions', icon: IconPlay },
 ]
+
+const sectionTitle = computed(() => ({
+  appearance: 'Appearance',
+  keybindings: 'Keyboard shortcuts',
+  integrations: 'Integrations',
+  actions: 'Actions',
+}[props.activeCategory]))
 
 const { theme } = useTheme()
 const themeOptions = themes.map((value) => ({ value, label: themeLabels[value] }))
@@ -71,7 +81,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 
     <section class="flex min-w-0 flex-1 flex-col">
       <header class="flex h-11 shrink-0 items-center gap-2.5 border-b border-row bg-canvas-toolbar px-4">
-        <span class="text-[13px] font-semibold text-text">{{ props.activeCategory === 'appearance' ? 'Appearance' : props.activeCategory === 'integrations' ? 'Integrations' : 'Actions' }}</span>
+        <span class="text-[13px] font-semibold text-text">{{ sectionTitle }}</span>
         <div class="flex-1" />
         <button
           type="button"
@@ -92,6 +102,8 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
             @update:model-value="onThemeChange"
           />
         </div>
+
+        <KeybindingSettingsView v-else-if="props.activeCategory === 'keybindings'" />
 
         <ActionSettingsView v-else-if="props.activeCategory === 'actions'" :known-types="props.knownFeedTypes" />
 

--- a/desktop/frontend/src/components/__tests__/FeedList.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedList.spec.ts
@@ -24,26 +24,44 @@ function item(id: string, title: string, unread: boolean): FeedItem {
 
 const items = [item('unread-1', 'Unread item', true), item('read-1', 'Read item', false)]
 
-function mountList(unreadOnly = false, loadError: string | null = null) {
+// The store owns filtering now, so FeedList renders exactly the `visibleItems`
+// it is given; these props describe the pre-filtered view.
+function mountList(overrides: Partial<{
+  title: string
+  visibleItems: FeedItem[]
+  selectedId: string | null
+  unreadOnly: boolean
+  unreadCount: number
+  search: string
+  loadError: string | null
+}> = {}) {
   return mount(FeedList, {
     props: {
       title: 'All items',
-      items,
+      visibleItems: items,
       selectedId: null,
-      unreadOnly,
-      loadError,
+      unreadOnly: false,
+      unreadCount: 1,
+      search: '',
+      loadError: null,
+      ...overrides,
     },
   })
 }
 
 describe('FeedList', () => {
-  it('hides read items when unreadOnly is true', () => {
-    const wrapper = mountList(true)
+  it('renders the visible items it is given', () => {
+    const wrapper = mountList({ visibleItems: [item('unread-1', 'Unread item', true)] })
     expect(wrapper.text()).toContain('Unread item')
     expect(wrapper.text()).not.toContain('Read item')
   })
 
-  it('emits select with the selected item id', async () => {
+  it('shows the unread count from its prop', () => {
+    const wrapper = mountList({ unreadCount: 3 })
+    expect(wrapper.find('[data-testid="filter-unread"]').text()).toContain('3')
+  })
+
+  it('emits select with the clicked item id', async () => {
     const wrapper = mountList()
     const itemButton = wrapper.findAll('button.feed-item').find((button) => button.text().includes('Read item'))
 
@@ -53,45 +71,38 @@ describe('FeedList', () => {
     expect(wrapper.emitted('select')).toEqual([['read-1']])
   })
 
+  it('emits update:search as the search box changes', async () => {
+    const wrapper = mountList()
+
+    await wrapper.find('[data-testid="feed-search"]').setValue('oauth')
+
+    expect(wrapper.emitted('update:search')).toEqual([['oauth']])
+  })
+
   it('shows the unreachable state with a retry that emits refresh', async () => {
-    const wrapper = mountList(false, "Can't reach GitHub right now.")
+    const wrapper = mountList({ visibleItems: [], loadError: "Can't reach GitHub right now." })
 
     const error = wrapper.get('[data-testid="feed-error"]')
     expect(error.text()).toContain('GitHub unreachable')
     expect(error.text()).toContain("Can't reach GitHub right now.")
-    expect(wrapper.text()).not.toContain('Unread item')
 
     await error.get('button').trigger('click')
     expect(wrapper.emitted('refresh')).toHaveLength(1)
   })
 
   it('shows the all-caught-up state when the unread filter drains the list', () => {
-    const wrapper = mount(FeedList, {
-      props: {
-        title: 'Unread',
-        items: [item('read-1', 'Read item', false)],
-        selectedId: null,
-        unreadOnly: true,
-        loadError: null,
-      },
-    })
-
-    const empty = wrapper.get('[data-testid="feed-empty"]')
-    expect(empty.text()).toContain("You're all caught up")
+    const wrapper = mountList({ visibleItems: [], unreadOnly: true, unreadCount: 0, title: 'Unread' })
+    expect(wrapper.get('[data-testid="feed-empty"]').text()).toContain("You're all caught up")
   })
 
   it('shows the plain empty state without the unread filter', () => {
-    const wrapper = mount(FeedList, {
-      props: {
-        title: 'All items',
-        items: [],
-        selectedId: null,
-        unreadOnly: false,
-        loadError: null,
-      },
-    })
-
+    const wrapper = mountList({ visibleItems: [], unreadCount: 0 })
     expect(wrapper.get('[data-testid="feed-empty"]').text()).toContain('No items yet')
+  })
+
+  it('shows a no-matches empty state when the search excludes everything', () => {
+    const wrapper = mountList({ visibleItems: [], search: 'zzz-nothing-here' })
+    expect(wrapper.get('[data-testid="feed-empty"]').text()).toContain('No matches')
   })
 
   it('emits explicit unread filter values and refresh from header controls', async () => {
@@ -103,22 +114,5 @@ describe('FeedList', () => {
 
     expect(wrapper.emitted('set-unread')).toEqual([[true], [false]])
     expect(wrapper.emitted('refresh')).toHaveLength(1)
-  })
-
-  it('filters the visible list by the search query', async () => {
-    const wrapper = mountList()
-
-    await wrapper.find('[data-testid="feed-search"]').setValue('Unread')
-
-    expect(wrapper.text()).toContain('Unread item')
-    expect(wrapper.text()).not.toContain('Read item')
-  })
-
-  it('shows a no-matches empty state when the search excludes everything', async () => {
-    const wrapper = mountList()
-
-    await wrapper.find('[data-testid="feed-search"]').setValue('zzz-nothing-here')
-
-    expect(wrapper.get('[data-testid="feed-empty"]').text()).toContain('No matches')
   })
 })

--- a/desktop/frontend/src/components/__tests__/KeybindingSettingsView.spec.ts
+++ b/desktop/frontend/src/components/__tests__/KeybindingSettingsView.spec.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import KeybindingSettingsView from '../KeybindingSettingsView.vue'
+import { useKeybindings } from '../../composables/useKeybindings'
+
+const kb = useKeybindings()
+
+beforeEach(() => {
+  kb.clearAll()
+  kb.recording.value = false
+})
+
+function row(wrapper: ReturnType<typeof mount>, id: string) {
+  return wrapper.get(`[data-command-id="${id}"]`)
+}
+
+describe('KeybindingSettingsView', () => {
+  it('lists commands grouped, showing default combos as formatted chips', () => {
+    const wrapper = mount(KeybindingSettingsView)
+    const next = row(wrapper, 'feed.next')
+    const chips = next.findAll('[data-testid="keybinding-combo"]').map((c) => c.text())
+    expect(chips.some((t) => t.includes('J'))).toBe(true)
+    expect(chips.some((t) => t.includes('↓'))).toBe(true)
+  })
+
+  it('filters the list by title, group, or key', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    await wrapper.get('[data-testid="keybinding-filter"]').setValue('refresh')
+
+    const rows = wrapper.findAll('[data-testid="keybinding-row"]')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].attributes('data-command-id')).toBe('feed.refresh')
+  })
+
+  it('records a new binding from the next keystroke', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    await row(wrapper, 'window.hide').get('[data-testid="keybinding-add"]').trigger('click')
+    expect(kb.recording.value).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'h' }))
+    await nextTick()
+
+    expect(kb.combosFor('window.hide')).toEqual(['h'])
+    expect(kb.recording.value).toBe(false)
+    expect(row(wrapper, 'window.hide').text()).toContain('H')
+  })
+
+  it('cancels recording on Escape without binding anything', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    await row(wrapper, 'window.hide').get('[data-testid="keybinding-add"]').trigger('click')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+
+    expect(kb.combosFor('window.hide')).toEqual([])
+    expect(kb.recording.value).toBe(false)
+    expect(row(wrapper, 'window.hide').find('[data-testid="keybinding-capture"]').exists()).toBe(false)
+  })
+
+  it('ignores a lone modifier and keeps waiting for the full combo', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    await row(wrapper, 'window.hide').get('[data-testid="keybinding-add"]').trigger('click')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }))
+    await nextTick()
+    expect(kb.recording.value).toBe(true) // still capturing
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p', metaKey: true }))
+    await nextTick()
+    expect(kb.combosFor('window.hide')).toEqual(['mod+p'])
+    expect(kb.recording.value).toBe(false)
+  })
+
+  it('removes an individual binding', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    await row(wrapper, 'feed.next').get('[data-testid="keybinding-remove"]').trigger('click')
+    expect(kb.combosFor('feed.next')).toEqual(['arrowdown']) // removed the first chip (j)
+  })
+
+  it('shows and applies reset-to-default once overridden', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    kb.removeBinding('feed.next', 'j')
+    await nextTick()
+
+    const reset = row(wrapper, 'feed.next').get('[data-testid="keybinding-reset"]')
+    await reset.trigger('click')
+
+    expect(kb.combosFor('feed.next')).toEqual(['j', 'arrowdown'])
+    expect(row(wrapper, 'feed.next').find('[data-testid="keybinding-reset"]').exists()).toBe(false)
+  })
+
+  it('flags a combo bound to more than one command', async () => {
+    const wrapper = mount(KeybindingSettingsView)
+    kb.addBinding('feed.refresh', 'j') // now j is on both feed.next and feed.refresh
+    await nextTick()
+
+    const conflictChips = wrapper.findAll('[data-testid="keybinding-combo"].combo-conflict')
+    expect(conflictChips.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/desktop/frontend/src/components/__tests__/SettingsView.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SettingsView.spec.ts
@@ -56,6 +56,13 @@ describe('SettingsView', () => {
     }
   })
 
+  it('exposes a keybindings section that renders the editor', () => {
+    const wrapper = mount(SettingsView, { props: { githubConnected: true, activeCategory: 'keybindings' } })
+
+    expect(wrapper.find('[data-testid="settings-category-keybindings"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="settings-keybindings"]').exists()).toBe(true)
+  })
+
   it('closes from the header action and Escape', async () => {
     const wrapper = mount(SettingsView, { props: { githubConnected: true, activeCategory: 'appearance' } })
 

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -495,4 +495,78 @@ describe('useFeedState', () => {
 
     expect(mocks.MarkFeedItemRead).toHaveBeenCalledWith('triage/my-prs', 'o/r#1')
   })
+
+  // ── Feed navigation ─────────────────────────────────────────────────────────
+
+  const threeItems = [
+    { feedId: 'triage/my-prs', itemId: 'a', unread: false, payload: { id: 'a', title: 'Alpha', kind: 'PR' } },
+    { feedId: 'triage/my-prs', itemId: 'b', unread: false, payload: { id: 'b', title: 'Bravo', kind: 'PR' } },
+    { feedId: 'triage/my-prs', itemId: 'c', unread: false, payload: { id: 'c', title: 'Charlie', kind: 'PR' } },
+  ]
+
+  it('filters visibleItems by the search text without touching the unread badge count', async () => {
+    mocks.FeedItems.mockResolvedValue([
+      { feedId: 'triage/my-prs', itemId: 'a', unread: true, payload: { id: 'a', title: 'Alpha', kind: 'PR' } },
+      { feedId: 'triage/my-prs', itemId: 'b', unread: false, payload: { id: 'b', title: 'Bravo', kind: 'PR' } },
+    ])
+    const get = mountState(); await flushPromises(); await get().selectSidebar({ type: 'all' }); await flushPromises()
+
+    get().search.value = 'bravo'
+    expect(get().visibleItems.value.map((i) => i.id)).toEqual(['b'])
+    expect(get().unreadCount.value).toBe(1) // badge counts the whole list, not the filtered view
+  })
+
+  it('moves the selection to the next and previous visible item, clamping at the ends', async () => {
+    mocks.FeedItems.mockResolvedValue(threeItems)
+    const get = mountState(); await flushPromises(); await get().selectSidebar({ type: 'all' }); await flushPromises()
+    expect(get().selectedId.value).toBe('a')
+
+    await get().selectNext(); expect(get().selectedId.value).toBe('b')
+    await get().selectNext(); expect(get().selectedId.value).toBe('c')
+    await get().selectNext(); expect(get().selectedId.value).toBe('c') // clamp, no wrap
+
+    await get().selectPrev(); expect(get().selectedId.value).toBe('b')
+    await get().selectPrev(); expect(get().selectedId.value).toBe('a')
+    await get().selectPrev(); expect(get().selectedId.value).toBe('a') // clamp, no wrap
+  })
+
+  it('navigates only within the searched subset', async () => {
+    mocks.FeedItems.mockResolvedValue([
+      { feedId: 'triage/my-prs', itemId: 'a', unread: false, payload: { id: 'a', title: 'Onboarding', kind: 'PR' } },
+      { feedId: 'triage/my-prs', itemId: 'b', unread: false, payload: { id: 'b', title: 'Deploy', kind: 'PR' } },
+      { feedId: 'triage/my-prs', itemId: 'c', unread: false, payload: { id: 'c', title: 'Onload', kind: 'PR' } },
+    ])
+    const get = mountState(); await flushPromises(); await get().selectSidebar({ type: 'all' }); await flushPromises()
+
+    get().search.value = 'on' // matches Onboarding + Onload, not Deploy
+    await get().selectItem('a')
+    await get().selectNext()
+    expect(get().selectedId.value).toBe('c') // skips the filtered-out Deploy
+  })
+
+  it('is a no-op when the visible list is empty', async () => {
+    mocks.FeedItems.mockResolvedValue([])
+    const get = mountState(); await flushPromises(); await get().selectSidebar({ type: 'all' }); await flushPromises()
+    expect(get().selectedId.value).toBeNull()
+
+    await get().selectNext()
+    expect(get().selectedId.value).toBeNull()
+  })
+
+  it('keeps walking down the unread list as read items drop out of the view', async () => {
+    mocks.FeedItems.mockResolvedValue([
+      { feedId: 'triage/my-prs', itemId: 'a', unread: true, payload: { id: 'a', title: 'Alpha', kind: 'PR' } },
+      { feedId: 'triage/my-prs', itemId: 'b', unread: true, payload: { id: 'b', title: 'Bravo', kind: 'PR' } },
+      { feedId: 'triage/my-prs', itemId: 'c', unread: true, payload: { id: 'c', title: 'Charlie', kind: 'PR' } },
+    ])
+    mocks.MarkFeedItemRead.mockResolvedValue(undefined)
+    const get = mountState(); await flushPromises()
+    await get().selectUnreadView(); await flushPromises()
+    expect(get().selectedId.value).toBe('a') // initial select does not mark read
+
+    // Each selection marks the landed item read, dropping it from the unread
+    // view; navigation still advances forward instead of snapping back.
+    await get().selectNext(); await flushPromises(); expect(get().selectedId.value).toBe('b')
+    await get().selectNext(); await flushPromises(); expect(get().selectedId.value).toBe('c')
+  })
 })

--- a/desktop/frontend/src/composables/__tests__/useKeybindings.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useKeybindings.spec.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+// The effective keymap is a module singleton whose overrides load from
+// localStorage (via VueUse useStorage) at import time, so — like useTheme —
+// each test clears storage, resets modules, and imports fresh.
+beforeEach(() => {
+  localStorage.clear()
+  vi.resetModules()
+})
+
+function ev(init: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    isComposing: false,
+    keyCode: 0,
+    key: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...init,
+  } as KeyboardEvent
+}
+
+describe('comboFromEvent', () => {
+  it('collapses Meta and Ctrl to a single mod token', async () => {
+    const { comboFromEvent } = await import('../useKeybindings')
+    expect(comboFromEvent(ev({ key: 'k', metaKey: true }))).toBe('mod+k')
+    expect(comboFromEvent(ev({ key: 'k', ctrlKey: true }))).toBe('mod+k')
+  })
+
+  it('lowercases letters and records Shift as an explicit token', async () => {
+    const { comboFromEvent } = await import('../useKeybindings')
+    expect(comboFromEvent(ev({ key: 'G', shiftKey: true }))).toBe('shift+g')
+    expect(comboFromEvent(ev({ key: 'j' }))).toBe('j')
+  })
+
+  it('does not double-count Shift for symbols whose character already changed', async () => {
+    const { comboFromEvent } = await import('../useKeybindings')
+    // Shift+/ produces '?'; the character encodes the shift already.
+    expect(comboFromEvent(ev({ key: '?', shiftKey: true }))).toBe('?')
+  })
+
+  it('names arrow, space, and enter keys', async () => {
+    const { comboFromEvent } = await import('../useKeybindings')
+    expect(comboFromEvent(ev({ key: 'ArrowDown' }))).toBe('arrowdown')
+    expect(comboFromEvent(ev({ key: 'ArrowUp' }))).toBe('arrowup')
+    expect(comboFromEvent(ev({ key: ' ' }))).toBe('space')
+    expect(comboFromEvent(ev({ key: 'Enter' }))).toBe('enter')
+  })
+
+  it('orders modifiers canonically regardless of which are held', async () => {
+    const { comboFromEvent } = await import('../useKeybindings')
+    expect(comboFromEvent(ev({ key: 'K', metaKey: true, altKey: true, shiftKey: true }))).toBe('mod+alt+shift+k')
+  })
+
+  it('returns null for lone modifiers, IME composition, and unidentified keys', async () => {
+    const { comboFromEvent } = await import('../useKeybindings')
+    expect(comboFromEvent(ev({ key: 'Shift', shiftKey: true }))).toBeNull()
+    expect(comboFromEvent(ev({ key: 'Meta', metaKey: true }))).toBeNull()
+    expect(comboFromEvent(ev({ key: 'a', isComposing: true }))).toBeNull()
+    expect(comboFromEvent(ev({ key: 'a', keyCode: 229 }))).toBeNull()
+    expect(comboFromEvent(ev({ key: 'Unidentified' }))).toBeNull()
+  })
+})
+
+describe('formatCombo', () => {
+  it('renders mac symbols and non-mac words', async () => {
+    const { formatCombo } = await import('../useKeybindings')
+    expect(formatCombo('mod+k', true)).toBe('⌘K')
+    expect(formatCombo('mod+k', false)).toBe('Ctrl+K')
+    expect(formatCombo('shift+g', true)).toBe('⇧G')
+    expect(formatCombo('shift+g', false)).toBe('Shift+G')
+    expect(formatCombo('mod+shift+k', true)).toBe('⌘⇧K')
+    expect(formatCombo('mod+shift+k', false)).toBe('Ctrl+Shift+K')
+  })
+
+  it('renders named keys with symbols and bare letters uppercased', async () => {
+    const { formatCombo } = await import('../useKeybindings')
+    expect(formatCombo('arrowdown', true)).toBe('↓')
+    expect(formatCombo('j', true)).toBe('J')
+    expect(formatCombo('enter', false)).toBe('↵')
+  })
+})
+
+describe('canonicalizeCombo', () => {
+  it('collapses and orders modifiers into the single spelling', async () => {
+    const { canonicalizeCombo } = await import('../useKeybindings')
+    expect(canonicalizeCombo('k+mod')).toBe('mod+k')
+    expect(canonicalizeCombo('ctrl+k')).toBe('mod+k')
+    expect(canonicalizeCombo('Meta+Shift+K')).toBe('mod+shift+k')
+    expect(canonicalizeCombo('shift')).toBe('')
+  })
+})
+
+describe('effective keymap', () => {
+  it('resolves default combos to their command ids', async () => {
+    const { useKeybindings } = await import('../useKeybindings')
+    const kb = useKeybindings()
+    expect(kb.bindings.value['feed.next']).toEqual(['j', 'arrowdown'])
+    expect(kb.resolve('j')).toBe('feed.next')
+    expect(kb.resolve('arrowdown')).toBe('feed.next')
+    expect(kb.resolve('mod+k')).toBe('palette.toggle')
+    expect(kb.resolve('nope')).toBeNull()
+  })
+
+  it('adds an override that shadows the default and persists it', async () => {
+    const { useKeybindings } = await import('../useKeybindings')
+    const kb = useKeybindings()
+    kb.addBinding('feed.next', 'g')
+
+    expect(kb.bindings.value['feed.next']).toEqual(['j', 'arrowdown', 'g'])
+    expect(kb.resolve('g')).toBe('feed.next')
+    expect(kb.isOverridden('feed.next')).toBe(true)
+    await nextTick()
+    expect(JSON.parse(localStorage.getItem('hive.keybindings') ?? '{}')).toMatchObject({
+      'feed.next': ['j', 'arrowdown', 'g'],
+    })
+  })
+
+  it('removes a binding, leaving an empty array as an explicit unbind', async () => {
+    const { useKeybindings } = await import('../useKeybindings')
+    const kb = useKeybindings()
+    kb.removeBinding('feed.next', 'j')
+    expect(kb.bindings.value['feed.next']).toEqual(['arrowdown'])
+    expect(kb.resolve('j')).toBeNull()
+
+    kb.removeBinding('feed.next', 'arrowdown')
+    expect(kb.bindings.value['feed.next']).toEqual([])
+    expect(kb.isOverridden('feed.next')).toBe(true)
+  })
+
+  it('restores catalog defaults on reset', async () => {
+    const { useKeybindings } = await import('../useKeybindings')
+    const kb = useKeybindings()
+    kb.removeBinding('feed.next', 'j')
+    kb.resetToDefault('feed.next')
+    expect(kb.bindings.value['feed.next']).toEqual(['j', 'arrowdown'])
+    expect(kb.isOverridden('feed.next')).toBe(false)
+    expect(kb.resolve('j')).toBe('feed.next')
+  })
+
+  it('reports conflicts, honoring the excluded id', async () => {
+    const { useKeybindings } = await import('../useKeybindings')
+    const kb = useKeybindings()
+    kb.addBinding('feed.refresh', 'j')
+    expect(kb.conflicts('j').sort()).toEqual(['feed.next', 'feed.refresh'])
+    expect(kb.conflicts('j', 'feed.refresh')).toEqual(['feed.next'])
+  })
+})
+
+describe('override storage sanitization', () => {
+  it('drops unknown ids, non-arrays, and non-string combos on load', async () => {
+    localStorage.setItem('hive.keybindings', JSON.stringify({
+      'feed.next': ['g'],
+      'unknown.id': ['x'],
+      'feed.prev': 'not-an-array',
+      'feed.refresh': [123, 'r', 'r'],
+    }))
+    const { useKeybindings } = await import('../useKeybindings')
+    const kb = useKeybindings()
+    expect(kb.bindings.value['feed.next']).toEqual(['g'])
+    expect(kb.bindings.value['feed.refresh']).toEqual(['r']) // 123 dropped, dupe collapsed
+    expect(kb.bindings.value['feed.prev']).toEqual(['k', 'arrowup']) // invalid → default
+    expect(kb.resolve('x')).toBeNull() // unknown id never bound
+  })
+
+  it('falls back to defaults for malformed or non-object storage', async () => {
+    localStorage.setItem('hive.keybindings', 'not json')
+    const { useKeybindings } = await import('../useKeybindings')
+    expect(useKeybindings().bindings.value['feed.next']).toEqual(['j', 'arrowdown'])
+  })
+})

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -3,6 +3,7 @@ import { Browser, Events, Window } from '@wailsio/runtime'
 import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
 import { ActionRun, ActionViews, FeedItemCounts, FeedItems, InvokeAction, MarkFeedItemRead, SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/desktop/pipelineservice'
 import type { ActionRunView, SessionLaunchOptions as SessionLaunchOptionsView } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
+import { bodySnippet, feedSource, typeLabel } from '../lib/feedPresentation'
 import { useActivity } from './useActivity'
 import { buildFeedTree, treeToLayout } from '../lib/feedTree'
 import type { ActionView } from '../types/action'
@@ -27,6 +28,10 @@ export function useFeedState() {
   const activeProfileId = ref('')
   const selection = ref<SidebarSelection>({ type: 'all' })
   const unreadOnly = ref(false)
+  // Search is a pure view filter over the loaded list (like unreadOnly). It
+  // lives here — not in FeedList — so keyboard navigation moves over exactly
+  // the rows the user sees. Cleared on feed/profile switch (see selectSidebar).
+  const search = ref('')
   const items = ref<FeedItem[]>([])
   const loadError = ref<string | null>(null)
   const selectedId = ref<string | null>(null)
@@ -109,6 +114,24 @@ export function useFeedState() {
     if (sel.type === 'feed') return activeProfile.value?.feeds.find((f) => f.id === sel.feedId)?.name ?? 'Feed'
     return unreadOnly.value ? 'Unread' : 'All items'
   })
+
+  // The Unread badge counts the whole loaded list, independent of search.
+  const unreadCount = computed(() => items.value.filter((item) => item.unread).length)
+
+  function matchesSearch(item: FeedItem): boolean {
+    const query = search.value.trim().toLowerCase()
+    if (!query) return true
+    const haystack = [item.title, item.repo, item.author, typeLabel(item.kind), feedSource(item).label, bodySnippet(item.body)]
+      .join(' ')
+      .toLowerCase()
+    return haystack.includes(query)
+  }
+
+  // The rows actually rendered: the loaded list narrowed by the unread filter
+  // and the search box. Keyboard navigation walks this same set.
+  const visibleItems = computed(() =>
+    items.value.filter((item) => (!unreadOnly.value || item.unread) && matchesSearch(item)),
+  )
 
   // ── Toasts ──────────────────────────────────────────────────────────────────
 
@@ -393,6 +416,32 @@ export function useFeedState() {
     await loadFeeds(activeProfileId.value)
   }
 
+  // Move the selection to the next/previous visible item. Navigation walks the
+  // full `items` list (whose order and membership are stable) filtered by the
+  // same predicate as visibleItems — this keeps the cursor's anchor valid even
+  // when selectItem marks the current item read and it drops out of the unread
+  // view. Clamps at both ends (no wrap).
+  async function moveSelection(delta: 1 | -1) {
+    const all = items.value
+    const passes = (item: FeedItem) => (!unreadOnly.value || item.unread) && matchesSearch(item)
+    const currentIndex = all.findIndex((item) => item.id === selectedId.value)
+    if (currentIndex === -1) {
+      const visible = all.filter(passes)
+      const target = delta > 0 ? visible[0] : visible[visible.length - 1]
+      if (target) await selectItem(target.id)
+      return
+    }
+    for (let i = currentIndex + delta; i >= 0 && i < all.length; i += delta) {
+      if (passes(all[i])) {
+        await selectItem(all[i].id)
+        return
+      }
+    }
+  }
+
+  const selectNext = () => moveSelection(1)
+  const selectPrev = () => moveSelection(-1)
+
   // ── Navigation ──────────────────────────────────────────────────────────────
 
   async function selectProfile(profileID: string) {
@@ -404,6 +453,7 @@ export function useFeedState() {
 
   async function selectSidebar(nextSelection: SidebarSelection) {
     unreadOnly.value = false
+    search.value = '' // a switched feed starts unfiltered
     await applySelection(nextSelection)
   }
 
@@ -584,6 +634,9 @@ export function useFeedState() {
     activeProfileId,
     selection,
     items,
+    visibleItems,
+    unreadCount,
+    search,
     loadError,
     selectedId,
     selectedItem,
@@ -612,6 +665,8 @@ export function useFeedState() {
     selectSidebar,
     selectUnreadView,
     selectItem,
+    selectNext,
+    selectPrev,
     toggleUnread,
     refresh,
     invokeAction,

--- a/desktop/frontend/src/composables/useKeybindings.ts
+++ b/desktop/frontend/src/composables/useKeybindings.ts
@@ -1,0 +1,253 @@
+import { computed, ref } from 'vue'
+import { useStorage } from '@vueuse/core'
+import { commandCatalog } from '../keybindings/catalog'
+
+// The frontend keybinding layer. Pure normalization (comboFromEvent /
+// formatCombo) is separate from the effective keymap so both are unit-testable
+// without mounting a component. Only *overrides* are persisted (localStorage
+// key `hive.keybindings`, mirroring useTheme): an id absent from the store
+// falls back to its catalog default, an id mapped to `[]` is explicitly
+// unbound. Bindings target the stable command ids in keybindings/catalog.ts.
+
+type Overrides = Record<string, string[]>
+
+const KNOWN_IDS = new Set(commandCatalog.map((c) => c.id))
+const DEFAULT_COMBOS: Record<string, string[]> = Object.fromEntries(
+  commandCatalog.map((c) => [c.id, c.defaultCombos]),
+)
+
+const MODIFIER_ORDER = ['mod', 'ctrl', 'alt', 'shift'] as const
+
+// event.key values that are modifiers or otherwise not real bindable keys.
+const IGNORED_KEYS = new Set([
+  'Shift', 'Control', 'Alt', 'Meta', 'CapsLock', 'NumLock', 'ScrollLock',
+  'OS', 'AltGraph', 'Fn', 'FnLock', 'Hyper', 'Super', 'Symbol', 'SymbolLock',
+  'Dead', 'Unidentified',
+])
+
+const KEY_SYMBOLS: Record<string, string> = {
+  arrowdown: '↓', arrowup: '↑', arrowleft: '←', arrowright: '→',
+  enter: '↵', space: 'Space', escape: 'Esc', backspace: '⌫',
+  tab: 'Tab', delete: 'Del', plus: '+',
+}
+
+// ─── Pure helpers (exported for tests) ─────────────────────────────────────────
+
+/** Meta/Ctrl → `mod`, Alt/Option → `alt`; anything else is not a modifier. */
+function normalizeModifier(token: string): string | null {
+  switch (token) {
+    case 'mod': case 'meta': case 'cmd': case 'command': case 'ctrl': case 'control':
+      return 'mod'
+    case 'alt': case 'option': case 'opt':
+      return 'alt'
+    case 'shift':
+      return 'shift'
+    default:
+      return null
+  }
+}
+
+function normalizeKey(key: string): string {
+  if (key === ' ' || key === 'Spacebar') return 'space'
+  if (key === '+') return 'plus'
+  return key.toLowerCase()
+}
+
+// Add an explicit `shift` token only when Shift didn't already change the
+// produced character: single latin letters (`g` → `shift+g`) and named keys
+// (`arrowdown` → `shift+arrowdown`). For symbols/digits the character itself
+// already encodes Shift (Shift+/ yields `?`), so `shift` is not doubled on.
+function shouldRecordShift(base: string): boolean {
+  return /^[a-z]$/.test(base) || base.length > 1
+}
+
+/**
+ * Canonicalize a combo string to its single spelling: modifiers collapsed
+ * (Meta/Ctrl → `mod`), lowercased, ordered `mod, ctrl, alt, shift`, then the
+ * base key. Returns '' for a combo with no base key.
+ */
+export function canonicalizeCombo(combo: string): string {
+  const parts = combo.split('+').map((p) => p.trim().toLowerCase()).filter(Boolean)
+  const mods = new Set<string>()
+  let key = ''
+  for (const part of parts) {
+    const mod = normalizeModifier(part)
+    if (mod) mods.add(mod)
+    else key = normalizeKey(part)
+  }
+  if (!key) return ''
+  const ordered = MODIFIER_ORDER.filter((m) => mods.has(m))
+  return [...ordered, key].join('+')
+}
+
+/**
+ * Canonical combo for a keydown, or null when the event is not a bindable
+ * keystroke (lone modifier, IME composition, unidentified key).
+ */
+export function comboFromEvent(e: KeyboardEvent): string | null {
+  if (e.isComposing || e.keyCode === 229) return null
+  const rawKey = e.key
+  if (!rawKey || IGNORED_KEYS.has(rawKey)) return null
+  const base = normalizeKey(rawKey)
+  if (!base) return null
+
+  const mods = new Set<string>()
+  if (e.metaKey || e.ctrlKey) mods.add('mod')
+  if (e.altKey) mods.add('alt')
+  if (e.shiftKey && shouldRecordShift(base)) mods.add('shift')
+
+  const ordered = MODIFIER_ORDER.filter((m) => mods.has(m))
+  return [...ordered, base].join('+')
+}
+
+function detectMac(): boolean {
+  return typeof navigator !== 'undefined' && /Mac/i.test(navigator.userAgent)
+}
+
+function formatModifier(mod: string, isMac: boolean): string {
+  switch (mod) {
+    case 'mod': return isMac ? '⌘' : 'Ctrl'
+    case 'alt': return isMac ? '⌥' : 'Alt'
+    case 'shift': return isMac ? '⇧' : 'Shift'
+    case 'ctrl': return 'Ctrl'
+    default: return mod
+  }
+}
+
+/** Human-readable label for a combo — `⌘K` on macOS, `Ctrl+K` elsewhere. */
+export function formatCombo(combo: string, isMac: boolean = detectMac()): string {
+  const canon = canonicalizeCombo(combo)
+  if (!canon) return ''
+  const parts = canon.split('+')
+  const key = parts[parts.length - 1]
+  const mods = parts.slice(0, -1).map((m) => formatModifier(m, isMac))
+  const keyLabel = KEY_SYMBOLS[key] ?? (key.length === 1 ? key.toUpperCase() : capitalize(key))
+  return isMac ? [...mods, keyLabel].join('') : [...mods, keyLabel].join('+')
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+// ─── Persisted overrides (module singleton) ────────────────────────────────────
+
+function sanitizeOverrides(value: unknown): Overrides {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const out: Overrides = {}
+  for (const [id, combos] of Object.entries(value as Record<string, unknown>)) {
+    if (!KNOWN_IDS.has(id) || !Array.isArray(combos)) continue
+    const clean: string[] = []
+    for (const combo of combos) {
+      if (typeof combo !== 'string') continue
+      const canon = canonicalizeCombo(combo)
+      if (canon && !clean.includes(canon)) clean.push(canon)
+    }
+    out[id] = clean // may be [] to mean "explicitly unbound"
+  }
+  return out
+}
+
+const overrides = useStorage<Overrides>('hive.keybindings', {}, undefined, {
+  serializer: {
+    read: (raw: string): Overrides => {
+      try {
+        return sanitizeOverrides(JSON.parse(raw))
+      } catch {
+        return {}
+      }
+    },
+    write: (value: Overrides): string => JSON.stringify(value),
+  },
+})
+
+// True while the settings editor is capturing a keystroke; the global
+// dispatcher checks this so a combo being recorded never also fires a command.
+const recording = ref(false)
+
+const effectiveBindings = computed<Record<string, string[]>>(() => {
+  const result: Record<string, string[]> = {}
+  for (const command of commandCatalog) {
+    const override = overrides.value[command.id]
+    result[command.id] = override !== undefined ? override : DEFAULT_COMBOS[command.id]
+  }
+  return result
+})
+
+// combo → command id. Catalog order makes resolution deterministic when two
+// commands share a combo (the conflict is surfaced in the settings UI).
+const reverseMap = computed<Map<string, string>>(() => {
+  const map = new Map<string, string>()
+  for (const command of commandCatalog) {
+    for (const combo of effectiveBindings.value[command.id]) {
+      if (!map.has(combo)) map.set(combo, command.id)
+    }
+  }
+  return map
+})
+
+function combosFor(id: string): string[] {
+  return effectiveBindings.value[id] ?? []
+}
+
+function resolve(combo: string): string | null {
+  return reverseMap.value.get(combo) ?? null
+}
+
+function setCombos(id: string, combos: string[]): void {
+  overrides.value = { ...overrides.value, [id]: combos }
+}
+
+function addBinding(id: string, combo: string): void {
+  const canon = canonicalizeCombo(combo)
+  if (!canon || !KNOWN_IDS.has(id)) return
+  const current = combosFor(id)
+  if (current.includes(canon)) return
+  setCombos(id, [...current, canon])
+}
+
+function removeBinding(id: string, combo: string): void {
+  const canon = canonicalizeCombo(combo)
+  setCombos(id, combosFor(id).filter((c) => c !== canon)) // [] = explicitly unbound
+}
+
+function resetToDefault(id: string): void {
+  const next = { ...overrides.value }
+  delete next[id]
+  overrides.value = next
+}
+
+function clearAll(): void {
+  overrides.value = {}
+}
+
+function isOverridden(id: string): boolean {
+  return overrides.value[id] !== undefined
+}
+
+/** Command ids (other than excludeId) that also bind `combo`. */
+function conflicts(combo: string, excludeId?: string): string[] {
+  const canon = canonicalizeCombo(combo)
+  if (!canon) return []
+  const ids: string[] = []
+  for (const command of commandCatalog) {
+    if (command.id === excludeId) continue
+    if (effectiveBindings.value[command.id].includes(canon)) ids.push(command.id)
+  }
+  return ids
+}
+
+export function useKeybindings() {
+  return {
+    /** Effective id → combos[] map (defaults ⊕ overrides). */
+    bindings: effectiveBindings,
+    recording,
+    combosFor,
+    resolve,
+    addBinding,
+    removeBinding,
+    resetToDefault,
+    clearAll,
+    isOverridden,
+    conflicts,
+  }
+}

--- a/desktop/frontend/src/keybindings/catalog.ts
+++ b/desktop/frontend/src/keybindings/catalog.ts
@@ -1,0 +1,104 @@
+import type { Component } from 'vue'
+import IconArrowDown from '~icons/lucide/arrow-down'
+import IconArrowUp from '~icons/lucide/arrow-up'
+import IconCommand from '~icons/lucide/command'
+import IconExternalLink from '~icons/lucide/external-link'
+import IconEye from '~icons/lucide/eye'
+import IconMinus from '~icons/lucide/minus'
+import IconRefreshCw from '~icons/lucide/refresh-cw'
+
+// The single declarative source of truth for *bindable* commands — the stable
+// app actions a user can rebind from Settings ▸ Keybindings and that also seed
+// the command palette. Dynamic palette entries (switch profile, select feed,
+// jump to node) are data, not commands, and are NOT bindable, so they live in
+// App.vue's palette registration rather than here.
+//
+// `context` gates where a bare (modifier-less) binding fires: `feed` commands
+// only run when the feed is actually on screen; `global` commands run anywhere.
+// `defaultCombos` are canonical combo strings (see useKeybindings.comboFromEvent)
+// — an empty array means "bindable, but unbound by default".
+export type CommandContext = 'global' | 'feed'
+
+export interface BindableCommand {
+  id: string
+  /** Human label shown in the palette row and the keybindings editor. */
+  title: string
+  /** Section header, shared with the palette grouping. */
+  group: string
+  /** Extra palette match terms. */
+  keywords?: string[]
+  /** Leading icon for the palette row / settings row. */
+  icon?: Component
+  /** Canonical default combos; `[]` = bindable but unbound. */
+  defaultCombos: string[]
+  context: CommandContext
+  /** Omit from the command palette (still bindable + listed in settings). */
+  paletteHidden?: boolean
+}
+
+export const commandCatalog: BindableCommand[] = [
+  {
+    id: 'feed.next',
+    title: 'Next item',
+    group: 'Feeds',
+    keywords: ['down', 'next', 'navigate'],
+    icon: IconArrowDown,
+    defaultCombos: ['j', 'arrowdown'],
+    context: 'feed',
+  },
+  {
+    id: 'feed.prev',
+    title: 'Previous item',
+    group: 'Feeds',
+    keywords: ['up', 'previous', 'navigate'],
+    icon: IconArrowUp,
+    defaultCombos: ['k', 'arrowup'],
+    context: 'feed',
+  },
+  {
+    id: 'feed.open-in-browser',
+    title: 'Open item in browser',
+    group: 'Feeds',
+    keywords: ['open', 'browser', 'github', 'link'],
+    icon: IconExternalLink,
+    defaultCombos: ['o', 'enter'],
+    context: 'feed',
+  },
+  {
+    id: 'feed.toggle-unread',
+    title: 'Toggle unread filter',
+    group: 'Feeds',
+    keywords: ['unread', 'filter'],
+    icon: IconEye,
+    defaultCombos: ['u'],
+    context: 'feed',
+  },
+  {
+    id: 'feed.refresh',
+    title: 'Refresh feeds',
+    group: 'Feeds',
+    keywords: ['reload', 'sync'],
+    icon: IconRefreshCw,
+    defaultCombos: ['r'],
+    context: 'feed',
+  },
+  {
+    id: 'palette.toggle',
+    title: 'Command palette',
+    group: 'General',
+    keywords: ['search', 'commands', 'palette'],
+    icon: IconCommand,
+    defaultCombos: ['mod+k'],
+    context: 'global',
+    paletteHidden: true,
+  },
+  {
+    id: 'window.hide',
+    title: 'Hide window',
+    group: 'Window',
+    keywords: ['minimize', 'close'],
+    icon: IconMinus,
+    defaultCombos: [],
+    context: 'global',
+  },
+]

--- a/desktop/frontend/src/router.ts
+++ b/desktop/frontend/src/router.ts
@@ -7,7 +7,7 @@ import {
 } from 'vue-router'
 
 export type AppRouteName = 'feed' | 'flows' | 'activity' | 'application-settings' | 'profile-settings'
-export type ApplicationSettingsSection = 'appearance' | 'integrations' | 'actions'
+export type ApplicationSettingsSection = 'appearance' | 'integrations' | 'actions' | 'keybindings'
 export type ProfileSettingsSection = 'general' | 'danger'
 
 // App.vue owns the persistent desktop shell and renders the matched page in
@@ -37,7 +37,7 @@ export function createAppRouter(history: RouterHistory = createWebHashHistory())
         component: ShellPage,
       },
       {
-        path: '/settings/:section(appearance|integrations|actions)?',
+        path: '/settings/:section(appearance|integrations|actions|keybindings)?',
         name: 'application-settings',
         component: ShellPage,
       },


### PR DESCRIPTION
## Purpose

Add keyboard navigation to the feed — `j`/`k` and arrow keys move between inbox items — and make shortcuts user-configurable from an Obsidian-style **Settings ▸ Keyboard** panel. The app previously had no keybinding system, only a hardcoded ⌘K for the command palette.

## Proposed Changes

  - New frontend keybinding subsystem: `keybindings/catalog.ts` (the bindable commands) + `composables/useKeybindings.ts` (pure key normalization + the effective keymap; overrides persist to `localStorage`, defaults fall through).
  - Feed nav lives in `useFeedState` (`search`/`visibleItems`, `selectNext`/`selectPrev`, clamped and unread-view aware); `App.vue`'s hardcoded ⌘K is replaced by a general dispatcher — bare keys ignored while typing, feed keys gated to the feed, overlays suppressed. `mod` accepts both ⌘ and Ctrl.
  - **Settings ▸ Keyboard**: filterable, grouped command list with record / remove / reset-to-default and conflict flagging.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
