### PR TITLE
Improve desktop feed and navigation controls

### DIFF
--- a/desktop/flowsservice.go
+++ b/desktop/flowsservice.go
@@ -58,6 +58,16 @@ func (s *FlowsService) CreateFlow(name string) (FlowSummary, error) {
 	return FlowSummary{ID: f.ID, Name: f.Name, Enabled: f.Enabled, Valid: true}, nil
 }
 
+// RenameFlow changes a flow's profile-facing display name while preserving its
+// stable id and graph definition.
+func (s *FlowsService) RenameFlow(id, name string) (FlowSummary, error) {
+	f, err := s.store.Rename(id, name)
+	if err != nil {
+		return FlowSummary{}, err
+	}
+	return FlowSummary{ID: f.ID, Name: f.Name, Enabled: f.Enabled, Valid: true}, nil
+}
+
 // DeleteFlow removes a flow (a "profile") and its layout.
 func (s *FlowsService) DeleteFlow(id string) error {
 	return s.store.Delete(id)

--- a/desktop/frontend/bindings/github.com/colonyops/hive/desktop/flowsservice.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/desktop/flowsservice.ts
@@ -71,6 +71,14 @@ export function ListFlows(): $CancellablePromise<$models.FlowSummary[] | null> {
 }
 
 /**
+ * RenameFlow changes a flow's profile-facing display name while preserving its
+ * stable id and graph definition.
+ */
+export function RenameFlow(id: string, name: string): $CancellablePromise<$models.FlowSummary> {
+    return $Call.ByID(1672705850, id, name);
+}
+
+/**
  * SaveFlow validates and persists a flow's definition. An invalid flow is
  * rejected and the last-good file on disk — and the store's served flow —
  * are left untouched.

--- a/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/models.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/internal/desktop/feed/models.ts
@@ -18,6 +18,11 @@ export interface Item {
     "title": string;
     "author": string;
     "age": string;
+
+    /**
+     * GitHub's last-updated time, unix milliseconds
+     */
+    "updatedAt": number;
     "unread": boolean;
 
     /**

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -514,12 +514,24 @@ useCommands(computed(() => {
   return cmds
 }))
 
-// ── Global keybinding dispatcher ─────────────────────────────────────────────
+// ── Global input navigation ──────────────────────────────────────────────────
 // Resolves a keydown against the configurable keymap and runs the matched
 // command. Bare (modifier-less) keys are ignored while typing; feed commands
 // only fire on the feed; overlays suppress everything but the palette toggle.
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+}
+
 function onGlobalKeydown(e: KeyboardEvent): void {
+  // WebKit can treat an unhandled Backspace as browser Back. Suppress that
+  // default outside editors while still allowing components such as the flow
+  // canvas to use Backspace for their own actions.
+  if (e.key === 'Backspace' && !isEditableTarget(e.target)) e.preventDefault()
+
   if (kb.recording.value) return // the settings editor is capturing this key
   const combo = comboFromEvent(e)
   if (!combo) return
@@ -530,13 +542,7 @@ function onGlobalKeydown(e: KeyboardEvent): void {
 
   const mods = combo.split('+')
   const hasModifier = mods.includes('mod') || mods.includes('ctrl') || mods.includes('alt')
-  const target = e.target as HTMLElement
-  const isEditable =
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target instanceof HTMLSelectElement ||
-    target.isContentEditable
-  if (isEditable && !hasModifier) return
+  if (isEditableTarget(e.target) && !hasModifier) return
 
   if (anyOverlayOpen.value && id !== 'palette.toggle') return
   if (command.context === 'feed' && !feedNavActive.value) return
@@ -545,8 +551,37 @@ function onGlobalKeydown(e: KeyboardEvent): void {
   void runMap[id]?.()
 }
 
-onMounted(() => window.addEventListener('keydown', onGlobalKeydown))
-onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
+function isHistoryMouseButton(e: MouseEvent): boolean {
+  return e.button === 3 || e.button === 4
+}
+
+// MouseEvent buttons 3 and 4 are conventionally Browser Back and Browser
+// Forward. Handle them through Vue Router so they use the same dirty-flow
+// guard as the title-bar controls. Cancel both press and auxiliary-click
+// defaults because WebViews differ on which event performs native navigation.
+function preventNativeMouseHistory(e: MouseEvent): void {
+  if (isHistoryMouseButton(e)) e.preventDefault()
+}
+
+function onGlobalMouseUp(e: MouseEvent): void {
+  if (!isHistoryMouseButton(e)) return
+  e.preventDefault()
+  if (e.button === 3) router.back()
+  else router.forward()
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onGlobalKeydown)
+  window.addEventListener('mousedown', preventNativeMouseHistory)
+  window.addEventListener('mouseup', onGlobalMouseUp)
+  window.addEventListener('auxclick', preventNativeMouseHistory)
+})
+onUnmounted(() => {
+  window.removeEventListener('keydown', onGlobalKeydown)
+  window.removeEventListener('mousedown', preventNativeMouseHistory)
+  window.removeEventListener('mouseup', onGlobalMouseUp)
+  window.removeEventListener('auxclick', preventNativeMouseHistory)
+})
 </script>
 
 <template>

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -49,7 +49,7 @@ const {
 const {
   profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, visibleItems, unreadCount, search, loadError,
   selectedId, selectedItem, actions, pendingAction, actionRuns, sessionLaunchAction, sessionLaunchOptions, sessionLaunchBusy, sessionLaunchError, unreadOnly, title, toasts, dismissToast, clearToasts,
-  creatingProfile, createProfileError, deletingProfile, loadProfiles, createProfile, deleteProfile,
+  creatingProfile, createProfileError, renamingProfile, renameProfileError, deletingProfile, loadProfiles, createProfile, renameProfile, deleteProfile,
   reorderFeeds, selectProfile, selectSidebar, selectUnreadView, selectItem, selectNext, selectPrev,
   toggleUnread, refresh, invokeAction, cancelSessionLaunch, submitSessionLaunch, notWired, openUrl, openSelectedInBrowser, hideWindow,
 } = useFeedState()
@@ -330,6 +330,11 @@ async function submitNewProfile(name: string) {
   }
 }
 
+async function submitProfileRename(name: string) {
+  if (!activeProfileId.value) return
+  await renameProfile(activeProfileId.value, name)
+}
+
 const deleteProfileOpen = ref(false)
 
 function openDeleteProfile() {
@@ -604,7 +609,10 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
           v-else-if="profileSettingsActive && activeProfile"
           :profile="activeProfile"
           :active-section="profileSettingsSection"
+          :renaming="renamingProfile"
+          :rename-error="renameProfileError"
           @close="closeSettings"
+          @rename="submitProfileRename"
           @delete="openDeleteProfile"
           @select-section="selectProfileSettingsSection"
         />

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -48,7 +48,7 @@ const {
 
 const {
   profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, visibleItems, unreadCount, search, loadError,
-  selectedId, selectedItem, actions, pendingAction, actionRuns, sessionLaunchAction, sessionLaunchOptions, sessionLaunchBusy, sessionLaunchError, unreadOnly, title, toasts, dismissToast, clearToasts,
+  selectedId, selectedItem, actions, pendingAction, actionRuns, sessionLaunchAction, sessionLaunchOptions, sessionLaunchBusy, sessionLaunchError, unreadOnly, feedSort, setFeedSort, title, toasts, dismissToast, clearToasts,
   creatingProfile, createProfileError, renamingProfile, renameProfileError, deletingProfile, loadProfiles, createProfile, renameProfile, deleteProfile,
   reorderFeeds, selectProfile, selectSidebar, selectUnreadView, selectItem, selectNext, selectPrev,
   toggleUnread, refresh, invokeAction, cancelSessionLaunch, submitSessionLaunch, notWired, openUrl, openSelectedInBrowser, hideWindow,
@@ -637,9 +637,11 @@ onUnmounted(() => window.removeEventListener('keydown', onGlobalKeydown))
               :unread-only="unreadOnly"
               :unread-count="unreadCount"
               :search="search"
+              :sort="feedSort"
               :load-error="loadError"
               @select="selectItem"
               @update:search="(value) => (search = value)"
+              @set-sort="setFeedSort"
               @set-unread="navigateUnreadFilter"
               @refresh="refresh"
             />

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -263,6 +263,60 @@ describe('App', () => {
     wrapper.unmount()
   })
 
+  it('uses mouse back and forward buttons for route history', async () => {
+    const { wrapper, router } = await mountAppWithRouter()
+
+    await wrapper.find('[data-testid="application-settings"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('application-settings')
+
+    const backDown = new MouseEvent('mousedown', { button: 3, cancelable: true })
+    window.dispatchEvent(backDown)
+    expect(backDown.defaultPrevented).toBe(true)
+
+    const backUp = new MouseEvent('mouseup', { button: 3, cancelable: true })
+    window.dispatchEvent(backUp)
+    await flushPromises()
+    expect(backUp.defaultPrevented).toBe(true)
+    expect(router.currentRoute.value.name).toBe('feed')
+
+    const forwardUp = new MouseEvent('mouseup', { button: 4, cancelable: true })
+    window.dispatchEvent(forwardUp)
+    await flushPromises()
+    expect(forwardUp.defaultPrevented).toBe(true)
+    expect(router.currentRoute.value.name).toBe('application-settings')
+
+    wrapper.unmount()
+  })
+
+  it('suppresses Backspace history navigation outside editable fields', async () => {
+    const { wrapper, router } = await mountAppWithRouter()
+
+    await wrapper.find('[data-testid="application-settings"]').trigger('click')
+    await flushPromises()
+    const routeBefore = router.currentRoute.value.fullPath
+
+    const backspace = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true })
+    window.dispatchEvent(backspace)
+    await flushPromises()
+
+    expect(backspace.defaultPrevented).toBe(true)
+    expect(router.currentRoute.value.fullPath).toBe(routeBefore)
+
+    wrapper.unmount()
+  })
+
+  it('allows Backspace to edit text inputs', async () => {
+    const { wrapper } = await mountAppWithRouter()
+    const search = wrapper.get('[data-testid="feed-search"]').element
+    const backspace = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true })
+
+    search.dispatchEvent(backspace)
+
+    expect(backspace.defaultPrevented).toBe(false)
+    wrapper.unmount()
+  })
+
   it('routes DetailPane Edit to actions settings', async () => {
     const router = createAppRouter(createMemoryHistory())
     await router.push('/')

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   ListFlows: vi.fn(),
   GetFlow: vi.fn(),
   CreateFlow: vi.fn(),
+  RenameFlow: vi.fn(),
   DeleteFlow: vi.fn(),
   GetLayout: vi.fn(),
   SaveFlow: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock('../../bindings/github.com/colonyops/hive/desktop/flowsservice', () => (
   ListFlows: mocks.ListFlows,
   GetFlow: mocks.GetFlow,
   CreateFlow: mocks.CreateFlow,
+  RenameFlow: mocks.RenameFlow,
   DeleteFlow: mocks.DeleteFlow,
   GetLayout: mocks.GetLayout,
   SaveFlow: mocks.SaveFlow,
@@ -132,6 +134,7 @@ describe('App', () => {
     mocks.InvokeAction.mockResolvedValue(undefined)
     mocks.ListActions.mockResolvedValue({ actions: [], error: '' })
     mocks.NodeRuns.mockResolvedValue([])
+    mocks.RenameFlow.mockResolvedValue({ id: 'personal', name: 'Team', enabled: true, valid: true })
     mocks.DeleteFlow.mockResolvedValue(undefined)
     mocks.On.mockReturnValue(() => {})
   })
@@ -174,6 +177,21 @@ describe('App', () => {
     // Back to the feed view.
     expect(wrapper.find('[data-testid="flows-view"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="sidebar-profile-header"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('renames the active profile from profile settings', async () => {
+    const wrapper = await mountApp()
+
+    await wrapper.get('[data-testid="sidebar-open-settings"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="profile-settings-name"]').setValue('Team')
+    await wrapper.get('[data-testid="profile-settings-view"] form').trigger('submit')
+    await flushPromises()
+
+    expect(mocks.RenameFlow).toHaveBeenCalledWith('personal', 'Team')
+    expect((wrapper.get('[data-testid="profile-settings-name"]').element as HTMLInputElement).value).toBe('Team')
 
     wrapper.unmount()
   })

--- a/desktop/frontend/src/components/DetailPane.vue
+++ b/desktop/frontend/src/components/DetailPane.vue
@@ -18,8 +18,9 @@ import type { ActionRunView } from '../../bindings/github.com/colonyops/hive/int
 const props = defineProps<{ item: FeedItem | null; actions: ActionView[]; pendingAction?: string | null; actionRuns?: Record<string, ActionRunView> }>()
 const emit = defineEmits<{ 'run-action': [actionId: string]; 'open-browser': []; 'open-url': [url: string]; edit: [] }>()
 
-// The detail header leads with the item's source (brand badge) and its type,
-// mirroring the inbox row.
+// The detail header leads with the item's source badge and type. The badge
+// already identifies the provider, so the adjacent context stays focused on
+// the repository and item number.
 const source = computed(() => feedSource(props.item ?? undefined))
 
 // Issue/PR bodies are GitHub-flavored markdown from untrusted authors;
@@ -70,12 +71,12 @@ const { size: bodyHeight, startResize: startBodyResize, step: stepBody } = useRe
       <div class="relative border-b border-border px-5 pb-4 pt-[18px]">
         <div class="mb-[11px] flex items-center gap-[9px]">
           <span class="source-badge" :data-source="source.key" data-testid="source-badge"><SourceMark :source="source" class="size-[15px]" /></span>
-          <span class="kind-pill" :class="item.kind === 'PR' ? 'kind-pill-pr' : 'kind-pill-issue'">
+          <span class="kind-pill shrink-0 whitespace-nowrap" :class="item.kind === 'PR' ? 'kind-pill-pr' : 'kind-pill-issue'">
             <IconGitPullRequest v-if="item.kind === 'PR'" class="size-[13px]" />
             <IconCircleDot v-else class="size-[13px]" />
             {{ item.kind === 'PR' ? 'Pull Request' : 'Issue' }}
           </span>
-          <span class="min-w-0 truncate font-mono text-xs text-text-3">{{ source.label }} · {{ item.repo }} #{{ item.num }}</span>
+          <span class="min-w-0 truncate font-mono text-xs text-text-3">{{ item.repo }} #{{ item.num }}</span>
           <span class="flex-1" />
           <button class="open-button shrink-0" @click="emit('open-browser')">open <IconExternalLink class="size-3" /></button>
         </div>

--- a/desktop/frontend/src/components/FeedList.vue
+++ b/desktop/frontend/src/components/FeedList.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue'
-import AppSelect from './AppSelect.vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import FeedListItem from './FeedListItem.vue'
 import IconCheck from '~icons/lucide/check'
+import IconChevronDown from '~icons/lucide/chevron-down'
 import IconGitBranch from '~icons/lucide/git-branch'
 import IconRefreshCw from '~icons/lucide/refresh-cw'
 import IconSearch from '~icons/lucide/search'
+import IconSlidersHorizontal from '~icons/lucide/sliders-horizontal'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import type { FeedItem, FeedSort } from '../types/feed'
 
@@ -30,11 +31,34 @@ const emit = defineEmits<{
   'set-sort': [value: FeedSort]
 }>()
 
-const sortOptions = [
+const sortOptions: { value: FeedSort; label: string }[] = [
   { value: 'newest', label: 'Newest' },
   { value: 'oldest', label: 'Oldest' },
   { value: 'unread', label: 'Unread first' },
 ]
+
+const viewMenu = ref<HTMLElement | null>(null)
+const viewMenuOpen = ref(false)
+const activeViewOptionCount = computed(() => props.sort === 'newest' ? 0 : 1)
+
+function closeViewMenu(): void { viewMenuOpen.value = false }
+function chooseSort(value: FeedSort): void { emit('set-sort', value); closeViewMenu() }
+function refreshFromMenu(): void { emit('refresh'); closeViewMenu() }
+function onDocumentPointer(event: PointerEvent): void {
+  if (viewMenuOpen.value && viewMenu.value && !viewMenu.value.contains(event.target as Node)) closeViewMenu()
+}
+function onDocumentKeydown(event: KeyboardEvent): void {
+  if (viewMenuOpen.value && event.key === 'Escape') closeViewMenu()
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', onDocumentPointer)
+  document.addEventListener('keydown', onDocumentKeydown)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', onDocumentPointer)
+  document.removeEventListener('keydown', onDocumentKeydown)
+})
 
 // Keep the selected row in view when navigation moves the cursor by keyboard
 // (mirrors CommandPalette's scrollIntoView on selection change).
@@ -64,21 +88,48 @@ watch(() => props.selectedId, async (id) => {
           @input="emit('update:search', ($event.target as HTMLInputElement).value)"
         >
       </label>
-      <AppSelect
-        class="w-[118px] shrink-0 text-xs"
-        :model-value="sort"
-        :options="sortOptions"
-        testid="feed-sort"
-        aria-label="Sort inbox"
-        @update:model-value="emit('set-sort', $event as FeedSort)"
-      />
       <div class="segmented" role="group" aria-label="Filter">
         <button class="seg" :class="{ active: !unreadOnly }" data-testid="filter-all" @click="emit('set-unread', false)">All</button>
         <button class="seg" :class="{ active: unreadOnly }" data-testid="filter-unread" @click="emit('set-unread', true)">
           Unread<span class="seg-count">{{ unreadCount }}</span>
         </button>
       </div>
-      <button class="refresh-chip" aria-label="Refresh" data-testid="refresh-chip" @click="emit('refresh')"><IconRefreshCw class="size-3" /></button>
+      <div ref="viewMenu" class="relative shrink-0">
+        <button
+          type="button"
+          class="view-trigger"
+          data-testid="view-menu-toggle"
+          aria-haspopup="menu"
+          :aria-expanded="viewMenuOpen"
+          @click="viewMenuOpen = !viewMenuOpen"
+        >
+          <IconSlidersHorizontal class="size-3.5" />
+          <span>View</span>
+          <span v-if="activeViewOptionCount" class="view-count" data-testid="view-active-count">{{ activeViewOptionCount }}</span>
+          <IconChevronDown class="size-3.5 text-text-3 transition-transform" :class="{ 'rotate-180': viewMenuOpen }" />
+        </button>
+        <div v-if="viewMenuOpen" class="view-menu" role="menu" data-testid="view-menu">
+          <div class="view-menu-label">Sort by</div>
+          <button
+            v-for="option in sortOptions"
+            :key="option.value"
+            type="button"
+            class="view-menu-item"
+            role="menuitemradio"
+            :aria-checked="option.value === sort"
+            :data-testid="`view-sort-${option.value}`"
+            @click="chooseSort(option.value)"
+          >
+            <IconCheck class="size-3.5" :class="option.value === sort ? 'text-accent' : 'opacity-0'" :stroke-width="3" />
+            <span>{{ option.label }}</span>
+          </button>
+          <div class="view-menu-divider" />
+          <button type="button" class="view-menu-item" role="menuitem" data-testid="view-menu-refresh" @click="refreshFromMenu">
+            <IconRefreshCw class="size-3.5 text-text-3" />
+            <span>Refresh</span>
+          </button>
+        </div>
+      </div>
     </header>
     <div ref="listContainer" class="hive-scroll min-h-0 flex-1 overflow-y-auto">
       <!-- Load failure: the "GitHub unreachable" design state. -->
@@ -132,8 +183,15 @@ watch(() => props.selectedId, async (id) => {
 .seg:hover:not(.active) { color: var(--color-text); }
 .seg.active { background: var(--color-accent); color: var(--color-accent-contrast); }
 .seg-count { font-family: var(--font-mono); font-size: 10px; opacity: .85; }
-.refresh-chip { display: inline-flex; flex: none; align-items: center; justify-content: center; width: 32px; height: 32px; cursor: pointer; border: 1px solid var(--color-strong); border-radius: 8px; color: var(--color-text-2); }
-.refresh-chip:hover { color: var(--color-text); }
+.view-trigger { display: inline-flex; height: 32px; align-items: center; gap: 6px; cursor: pointer; border: 1px solid var(--color-strong); border-radius: 8px; padding: 0 9px; color: var(--color-text-2); font-size: 12px; font-weight: 500; }
+.view-trigger:hover, .view-trigger[aria-expanded="true"] { color: var(--color-text); }
+.view-trigger[aria-expanded="true"] { border-color: var(--color-accent); }
+.view-count { display: inline-flex; min-width: 16px; height: 16px; align-items: center; justify-content: center; border-radius: 999px; background: var(--color-accent); padding: 0 4px; color: var(--color-accent-contrast); font-family: var(--font-mono); font-size: 9px; font-weight: 600; }
+.view-menu { position: absolute; top: calc(100% + 6px); right: 0; z-index: 20; width: 170px; border: 1px solid var(--color-strong); border-radius: 8px; background: var(--color-pane); padding: 5px; box-shadow: 0 20px 50px -14px rgb(0 0 0 / .5); }
+.view-menu-label { padding: 5px 9px 4px; color: var(--color-text-3); font-size: 10px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase; }
+.view-menu-item { display: flex; width: 100%; align-items: center; gap: 8px; cursor: pointer; border-radius: 6px; padding: 7px 9px; color: var(--color-text-2); font-size: 12.5px; text-align: left; }
+.view-menu-item:hover { background: var(--color-hover); color: var(--color-text); }
+.view-menu-divider { height: 1px; background: var(--color-row); margin: 4px; }
 .state-frame { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; height: 100%; padding: 24px; text-align: center; }
 .state-icon { display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; border: 1px solid var(--color-strong); border-radius: 12px; background: var(--color-chip); margin-bottom: 4px; }
 .state-action { margin-top: 8px; padding: 6px 14px; border: 1px solid var(--color-strong); border-radius: 7px; color: var(--color-text-2); font-size: 12px; cursor: pointer; }

--- a/desktop/frontend/src/components/FeedList.vue
+++ b/desktop/frontend/src/components/FeedList.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { nextTick, ref, watch } from 'vue'
+import AppSelect from './AppSelect.vue'
 import FeedListItem from './FeedListItem.vue'
 import IconCheck from '~icons/lucide/check'
 import IconGitBranch from '~icons/lucide/git-branch'
 import IconRefreshCw from '~icons/lucide/refresh-cw'
 import IconSearch from '~icons/lucide/search'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
-import type { FeedItem } from '../types/feed'
+import type { FeedItem, FeedSort } from '../types/feed'
 
 // Presentation-only: the store (useFeedState) owns the search text and the
 // filtered `visibleItems`, so keyboard navigation and this list render the
@@ -18,6 +19,7 @@ const props = defineProps<{
   unreadOnly: boolean
   unreadCount: number
   search: string
+  sort: FeedSort
   loadError: string | null
 }>()
 const emit = defineEmits<{
@@ -25,7 +27,14 @@ const emit = defineEmits<{
   'set-unread': [value: boolean]
   refresh: []
   'update:search': [value: string]
+  'set-sort': [value: FeedSort]
 }>()
+
+const sortOptions = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'unread', label: 'Unread first' },
+]
 
 // Keep the selected row in view when navigation moves the cursor by keyboard
 // (mirrors CommandPalette's scrollIntoView on selection change).
@@ -55,6 +64,14 @@ watch(() => props.selectedId, async (id) => {
           @input="emit('update:search', ($event.target as HTMLInputElement).value)"
         >
       </label>
+      <AppSelect
+        class="w-[118px] shrink-0 text-xs"
+        :model-value="sort"
+        :options="sortOptions"
+        testid="feed-sort"
+        aria-label="Sort inbox"
+        @update:model-value="emit('set-sort', $event as FeedSort)"
+      />
       <div class="segmented" role="group" aria-label="Filter">
         <button class="seg" :class="{ active: !unreadOnly }" data-testid="filter-all" @click="emit('set-unread', false)">All</button>
         <button class="seg" :class="{ active: unreadOnly }" data-testid="filter-unread" @click="emit('set-unread', true)">

--- a/desktop/frontend/src/components/ProfileSettingsView.vue
+++ b/desktop/frontend/src/components/ProfileSettingsView.vue
@@ -1,13 +1,28 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconSlidersHorizontal from '~icons/lucide/sliders-horizontal'
 import IconTrash2 from '~icons/lucide/trash-2'
 import type { Profile } from '../types/feed'
 import type { ProfileSettingsSection } from '../router'
 
-const props = defineProps<{ profile: Profile; activeSection: ProfileSettingsSection }>()
-const emit = defineEmits<{ close: []; delete: []; 'select-section': [section: ProfileSettingsSection] }>()
+const props = withDefaults(defineProps<{ profile: Profile; activeSection: ProfileSettingsSection; renaming?: boolean; renameError?: string | null }>(), {
+  renaming: false,
+  renameError: null,
+})
+const emit = defineEmits<{ close: []; delete: []; rename: [name: string]; 'select-section': [section: ProfileSettingsSection] }>()
+
+const name = ref(props.profile.name)
+
+watch(() => [props.profile.id, props.profile.name], () => {
+  name.value = props.profile.name
+})
+
+function submitRename(): void {
+  const trimmed = name.value.trim()
+  if (!trimmed || trimmed === props.profile.name || props.renaming) return
+  emit('rename', trimmed)
+}
 
 function onKeydown(e: KeyboardEvent): void {
   if (e.key === 'Escape') emit('close')
@@ -58,11 +73,27 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 
       <div class="hive-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6">
         <div class="mx-auto max-w-[560px]">
-          <div v-if="props.activeSection === 'general'" class="rounded-lg border border-border bg-raised p-4">
-            <div class="text-[12.5px] text-text-3">Profile name</div>
-            <div class="mt-1 text-[15px] font-semibold text-text" data-testid="profile-settings-name">{{ props.profile.name }}</div>
+          <form v-if="props.activeSection === 'general'" class="rounded-lg border border-border bg-raised p-4" @submit.prevent="submitRename">
+            <label for="profile-settings-name" class="text-[12.5px] text-text-3">Profile name</label>
+            <div class="mt-2 flex items-center gap-2.5">
+              <input
+                id="profile-settings-name"
+                v-model="name"
+                type="text"
+                class="min-w-0 flex-1 rounded-lg border border-strong bg-app px-3 py-2 text-[13.5px] text-text outline-none focus:border-accent disabled:opacity-60"
+                :disabled="props.renaming"
+                data-testid="profile-settings-name"
+              >
+              <button
+                type="submit"
+                class="cursor-pointer rounded-lg bg-accent px-3.5 py-2 text-[12.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
+                :disabled="props.renaming || !name.trim() || name.trim() === props.profile.name"
+                data-testid="profile-settings-save-name"
+              >{{ props.renaming ? 'Saving…' : 'Save' }}</button>
+            </div>
+            <p v-if="props.renameError" class="mt-2 text-xs text-severity-error" data-testid="profile-settings-rename-error">{{ props.renameError }}</p>
             <div class="mt-3 border-t border-border pt-3 text-xs text-text-3">{{ props.profile.sourceSummary }}</div>
-          </div>
+          </form>
 
           <div v-else class="rounded-lg border border-severity-error/35 bg-raised p-4">
             <div class="text-[14px] font-semibold text-text">Delete profile</div>

--- a/desktop/frontend/src/components/__tests__/DetailPane.spec.ts
+++ b/desktop/frontend/src/components/__tests__/DetailPane.spec.ts
@@ -33,13 +33,15 @@ describe('DetailPane', () => {
     expect(wrapper.findAll('[data-testid="action-card"]')).toHaveLength(2)
   })
 
-  it('leads the header with the source badge and source-qualified context', () => {
+  it('leads the header with the source badge, a non-wrapping type, and repository context', () => {
     const wrapper = mount(DetailPane, { props: { item, actions } })
 
     const badge = wrapper.find('[data-testid="source-badge"]')
     expect(badge.exists()).toBe(true)
     expect(badge.attributes('data-source')).toBe('github')
-    expect(wrapper.text()).toContain('GitHub · colonyops/hive #42')
+    expect(wrapper.get('.kind-pill').classes()).toEqual(expect.arrayContaining(['shrink-0', 'whitespace-nowrap']))
+    expect(wrapper.text()).toContain('colonyops/hive #42')
+    expect(wrapper.text()).not.toContain('GitHub ·')
   })
 
   it('emits run-action with the action id', async () => {

--- a/desktop/frontend/src/components/__tests__/DetailPane.spec.ts
+++ b/desktop/frontend/src/components/__tests__/DetailPane.spec.ts
@@ -12,6 +12,7 @@ const item: FeedItem = {
   title: 'Add desktop shell',
   author: 'hayden',
   age: '5m',
+  updatedAt: 1,
   unread: true,
   feedId: 'triage/desktop',
   labels: [],

--- a/desktop/frontend/src/components/__tests__/FeedList.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedList.spec.ts
@@ -82,13 +82,24 @@ describe('FeedList', () => {
     expect(wrapper.emitted('update:search')).toEqual([['oauth']])
   })
 
-  it('offers newest, oldest, and unread-first sorting', async () => {
+  it('offers newest, oldest, and unread-first sorting in the View menu', async () => {
     const wrapper = mountList()
 
-    await wrapper.get('[data-testid="feed-sort"]').trigger('click')
-    await wrapper.get('[data-testid="feed-sort-option-oldest"]').trigger('click')
+    expect(wrapper.find('[data-testid="view-menu"]').exists()).toBe(false)
+    await wrapper.get('[data-testid="view-menu-toggle"]').trigger('click')
+
+    expect(wrapper.get('[data-testid="view-sort-newest"]').attributes('aria-checked')).toBe('true')
+    expect(wrapper.get('[data-testid="view-sort-unread"]').text()).toContain('Unread first')
+    await wrapper.get('[data-testid="view-sort-oldest"]').trigger('click')
 
     expect(wrapper.emitted('set-sort')).toEqual([['oldest']])
+    expect(wrapper.find('[data-testid="view-menu"]').exists()).toBe(false)
+  })
+
+  it('shows when a non-default View option is active', () => {
+    const wrapper = mountList({ sort: 'oldest' })
+
+    expect(wrapper.get('[data-testid="view-active-count"]').text()).toBe('1')
   })
 
   it('shows the unreachable state with a retry that emits refresh', async () => {
@@ -117,14 +128,16 @@ describe('FeedList', () => {
     expect(wrapper.get('[data-testid="feed-empty"]').text()).toContain('No matches')
   })
 
-  it('emits explicit unread filter values and refresh from header controls', async () => {
+  it('keeps unread filters visible and emits refresh from the View menu', async () => {
     const wrapper = mountList()
 
     await wrapper.find('[data-testid="filter-unread"]').trigger('click')
     await wrapper.find('[data-testid="filter-all"]').trigger('click')
-    await wrapper.find('[data-testid="refresh-chip"]').trigger('click')
+    await wrapper.get('[data-testid="view-menu-toggle"]').trigger('click')
+    await wrapper.get('[data-testid="view-menu-refresh"]').trigger('click')
 
     expect(wrapper.emitted('set-unread')).toEqual([[true], [false]])
     expect(wrapper.emitted('refresh')).toHaveLength(1)
+    expect(wrapper.find('[data-testid="view-menu"]').exists()).toBe(false)
   })
 })

--- a/desktop/frontend/src/components/__tests__/FeedList.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedList.spec.ts
@@ -12,6 +12,7 @@ function item(id: string, title: string, unread: boolean): FeedItem {
     title,
     author: 'hayden',
     age: '5m',
+    updatedAt: 1,
     unread,
     feedId: 'triage/desktop',
     labels: [],
@@ -33,6 +34,7 @@ function mountList(overrides: Partial<{
   unreadOnly: boolean
   unreadCount: number
   search: string
+  sort: 'newest' | 'oldest' | 'unread'
   loadError: string | null
 }> = {}) {
   return mount(FeedList, {
@@ -43,6 +45,7 @@ function mountList(overrides: Partial<{
       unreadOnly: false,
       unreadCount: 1,
       search: '',
+      sort: 'newest',
       loadError: null,
       ...overrides,
     },
@@ -77,6 +80,15 @@ describe('FeedList', () => {
     await wrapper.find('[data-testid="feed-search"]').setValue('oauth')
 
     expect(wrapper.emitted('update:search')).toEqual([['oauth']])
+  })
+
+  it('offers newest, oldest, and unread-first sorting', async () => {
+    const wrapper = mountList()
+
+    await wrapper.get('[data-testid="feed-sort"]').trigger('click')
+    await wrapper.get('[data-testid="feed-sort-option-oldest"]').trigger('click')
+
+    expect(wrapper.emitted('set-sort')).toEqual([['oldest']])
   })
 
   it('shows the unreachable state with a retry that emits refresh', async () => {

--- a/desktop/frontend/src/components/__tests__/FeedListItem.spec.ts
+++ b/desktop/frontend/src/components/__tests__/FeedListItem.spec.ts
@@ -12,6 +12,7 @@ const baseItem: FeedItem = {
   title: 'Add desktop shell',
   author: 'hayden',
   age: '5m',
+  updatedAt: 1,
   unread: true,
   labels: ['frontend'],
   branch: 'feat/desktop-ui-shell',

--- a/desktop/frontend/src/components/__tests__/ProfileSettingsView.spec.ts
+++ b/desktop/frontend/src/components/__tests__/ProfileSettingsView.spec.ts
@@ -16,7 +16,7 @@ describe('ProfileSettingsView', () => {
   it('shows profile details and keeps delete in the danger zone', async () => {
     const wrapper = mount(ProfileSettingsView, { props: { profile, activeSection: 'general' } })
 
-    expect(wrapper.find('[data-testid="profile-settings-name"]').text()).toBe('Personal')
+    expect((wrapper.get('[data-testid="profile-settings-name"]').element as HTMLInputElement).value).toBe('Personal')
     expect(wrapper.find('[data-testid="profile-settings-delete"]').exists()).toBe(false)
 
     await wrapper.find('[data-testid="profile-settings-danger"]').trigger('click')
@@ -25,6 +25,29 @@ describe('ProfileSettingsView', () => {
     await wrapper.find('[data-testid="profile-settings-delete"]').trigger('click')
 
     expect(wrapper.emitted('delete')).toHaveLength(1)
+  })
+
+  it('edits and submits the profile name', async () => {
+    const wrapper = mount(ProfileSettingsView, { props: { profile, activeSection: 'general' } })
+    const input = wrapper.get('[data-testid="profile-settings-name"]')
+    const save = wrapper.get('[data-testid="profile-settings-save-name"]')
+
+    expect(save.attributes('disabled')).toBeDefined()
+    await input.setValue('Team Triage')
+    expect(save.attributes('disabled')).toBeUndefined()
+    await wrapper.get('form').trigger('submit')
+
+    expect(wrapper.emitted('rename')).toEqual([['Team Triage']])
+  })
+
+  it('shows rename progress and errors', async () => {
+    const wrapper = mount(ProfileSettingsView, {
+      props: { profile, activeSection: 'general', renaming: true, renameError: 'Could not save' },
+    })
+
+    expect(wrapper.get('[data-testid="profile-settings-save-name"]').text()).toBe('Saving…')
+    expect(wrapper.get('[data-testid="profile-settings-name"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('[data-testid="profile-settings-rename-error"]').text()).toBe('Could not save')
   })
 
   it('closes from the header action', async () => {

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   ListFlows: vi.fn(),
   GetFlow: vi.fn(),
   CreateFlow: vi.fn(),
+  RenameFlow: vi.fn(),
   DeleteFlow: vi.fn(),
   GetSidebar: vi.fn(),
   SaveSidebar: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock('../../../bindings/github.com/colonyops/hive/desktop/flowsservice', () =
   ListFlows: mocks.ListFlows,
   GetFlow: mocks.GetFlow,
   CreateFlow: mocks.CreateFlow,
+  RenameFlow: mocks.RenameFlow,
   DeleteFlow: mocks.DeleteFlow,
   GetSidebar: mocks.GetSidebar,
   SaveSidebar: mocks.SaveSidebar,
@@ -205,6 +207,30 @@ describe('useFeedState', () => {
 
     expect(mocks.CreateFlow).toHaveBeenCalledWith('New')
     expect(get().profiles.value.some((p) => p.id === 'new')).toBe(true)
+  })
+
+  it('renames a profile and updates its rail presentation', async () => {
+    mocks.RenameFlow.mockResolvedValue({ id: 'triage', name: 'Team Triage', enabled: true, valid: true })
+    const get = mountState()
+    await flushPromises()
+
+    const renamed = await get().renameProfile('triage', '  Team Triage  ')
+
+    expect(renamed).toBe(true)
+    expect(mocks.RenameFlow).toHaveBeenCalledWith('triage', 'Team Triage')
+    expect(get().activeProfile.value).toMatchObject({ name: 'Team Triage', letter: 'T' })
+  })
+
+  it('surfaces a profile rename failure without changing the current name', async () => {
+    mocks.RenameFlow.mockRejectedValue(new Error('disk is read-only'))
+    const get = mountState()
+    await flushPromises()
+
+    const renamed = await get().renameProfile('triage', 'Team Triage')
+
+    expect(renamed).toBe(false)
+    expect(get().renameProfileError.value).toBe('disk is read-only')
+    expect(get().activeProfile.value?.name).toBe('Frontend Triage')
   })
 
   it('deletes a profile by deleting its flow', async () => {

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -178,6 +178,26 @@ describe('useFeedState', () => {
     expect(get().activeProfile.value?.tree?.[0]).toMatchObject({ kind: 'folder', folder: { id: 'work' } })
   })
 
+  it('sorts inbox items by newest, oldest, or unread-first recency and persists the choice', async () => {
+    mocks.FeedItems.mockResolvedValue([
+      { feedId: 'triage/my-prs', itemId: 'oldest', unread: false, payload: { id: 'oldest', title: 'Oldest', kind: 'PR', updatedAt: 100 } },
+      { feedId: 'triage/my-prs', itemId: 'newest', unread: false, payload: { id: 'newest', title: 'Newest', kind: 'PR', updatedAt: 300 } },
+      { feedId: 'triage/my-prs', itemId: 'unread', unread: true, payload: { id: 'unread', title: 'Unread', kind: 'PR', updatedAt: 200 } },
+    ])
+    const get = mountState()
+    await flushPromises()
+
+    expect(get().visibleItems.value.map((item) => item.id)).toEqual(['newest', 'unread', 'oldest'])
+
+    get().setFeedSort('oldest')
+    expect(get().visibleItems.value.map((item) => item.id)).toEqual(['oldest', 'unread', 'newest'])
+
+    get().setFeedSort('unread')
+    expect(get().visibleItems.value.map((item) => item.id)).toEqual(['unread', 'newest', 'oldest'])
+    await flushPromises()
+    expect(localStorage.getItem('hive.feed.sort')).toBe('unread')
+  })
+
   it('loads a feed\'s items from feed_item, decoding the payload', async () => {
     mocks.FeedItems.mockImplementation((feedID: string) =>
       Promise.resolve(

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,4 +1,5 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useStorage } from '@vueuse/core'
 import { Browser, Events, Window } from '@wailsio/runtime'
 import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, RenameFlow, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
 import { ActionRun, ActionViews, FeedItemCounts, FeedItems, InvokeAction, MarkFeedItemRead, SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/desktop/pipelineservice'
@@ -7,7 +8,7 @@ import { bodySnippet, feedSource, typeLabel } from '../lib/feedPresentation'
 import { useActivity } from './useActivity'
 import { buildFeedTree, treeToLayout } from '../lib/feedTree'
 import type { ActionView } from '../types/action'
-import type { FeedItem, FeedSummary, FeedTree, Profile, SidebarSelection } from '../types/feed'
+import type { FeedItem, FeedSort, FeedSummary, FeedTree, Profile, SidebarSelection } from '../types/feed'
 import type { ToastInstance, ToastOptions } from '../types/toast'
 
 // A profile IS a flow: the profiles list comes from FlowsService.ListFlows, a
@@ -21,6 +22,16 @@ import type { ToastInstance, ToastOptions } from '../types/toast'
 // this module. It runs every enabled flow independently; refresh() here just
 // re-reads the selected profile after App.vue's "log:appended" handler has
 // pumped all committed work.
+const feedSortStorageKey = 'hive.feed.sort'
+
+function timestampFromAge(age: string): number {
+  if (age === 'now') return Date.now()
+  const match = /^(\d+)([mhdw])$/.exec(age)
+  if (!match) return 0
+  const units: Record<string, number> = { m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 }
+  return Date.now() - Number(match[1]) * units[match[2]]
+}
+
 export function useFeedState() {
   const profiles = ref<Profile[]>([])
   const profilesLoaded = ref(false)
@@ -28,6 +39,7 @@ export function useFeedState() {
   const activeProfileId = ref('')
   const selection = ref<SidebarSelection>({ type: 'all' })
   const unreadOnly = ref(false)
+  const feedSort = useStorage<FeedSort>(feedSortStorageKey, 'newest')
   // Search is a pure view filter over the loaded list (like unreadOnly). It
   // lives here — not in FeedList — so keyboard navigation moves over exactly
   // the rows the user sees. Cleared on feed/profile switch (see selectSidebar).
@@ -129,11 +141,23 @@ export function useFeedState() {
     return haystack.includes(query)
   }
 
-  // The rows actually rendered: the loaded list narrowed by the unread filter
-  // and the search box. Keyboard navigation walks this same set.
+  function compareItems(a: FeedItem, b: FeedItem): number {
+    if (feedSort.value === 'unread' && a.unread !== b.unread) return a.unread ? -1 : 1
+    const recency = b.updatedAt - a.updatedAt
+    return feedSort.value === 'oldest' ? -recency : recency
+  }
+
+  const sortedItems = computed(() => [...items.value].sort(compareItems))
+
+  // The rows actually rendered: sorted first, then narrowed by the unread
+  // filter and search box. Keyboard navigation walks this same ordering.
   const visibleItems = computed(() =>
-    items.value.filter((item) => (!unreadOnly.value || item.unread) && matchesSearch(item)),
+    sortedItems.value.filter((item) => (!unreadOnly.value || item.unread) && matchesSearch(item)),
   )
+
+  function setFeedSort(value: FeedSort): void {
+    feedSort.value = value
+  }
 
   // ── Toasts ──────────────────────────────────────────────────────────────────
 
@@ -342,7 +366,7 @@ export function useFeedState() {
 
   // ── Items (feed_item) ─────────────────────────────────────────────────────────
 
-  function parseItem(view: { feedId: string; itemId: string; payload: any; unread: boolean }): FeedItem {
+  function parseItem(view: { feedId: string; itemId: string; payload: any; updatedAt?: number; unread: boolean }): FeedItem {
     const p = view.payload ?? {}
     return {
       id: p.id ?? view.itemId,
@@ -353,6 +377,7 @@ export function useFeedState() {
       title: p.title ?? view.itemId,
       author: p.author ?? '',
       age: p.age ?? '',
+      updatedAt: Number(p.updatedAt) || timestampFromAge(p.age ?? '') || Math.floor((view.updatedAt ?? 0) / 1_000_000),
       unread: view.unread,
       reason: p.reason,
       labels: p.labels ?? [],
@@ -367,7 +392,7 @@ export function useFeedState() {
     if (!activeProfileId.value) return
     const seq = ++loadSeq
     try {
-      let views: Array<{ feedId: string; itemId: string; payload: any; unread: boolean }> = []
+      let views: Array<{ feedId: string; itemId: string; payload: any; updatedAt?: number; unread: boolean }> = []
       if (feedID) {
         views = (await FeedItems(feedID)) ?? []
       } else {
@@ -391,7 +416,8 @@ export function useFeedState() {
       items.value = parsed
 
       if (selectedId.value && parsed.some((i) => i.id === selectedId.value)) return
-      const first = (unreadOnly.value ? parsed.find((i) => i.unread) : parsed[0]) ?? null
+      const ordered = [...parsed].sort(compareItems)
+      const first = (unreadOnly.value ? ordered.find((i) => i.unread) : ordered[0]) ?? null
       selectedId.value = first?.id ?? null
       await loadActions(first)
     } catch (error) {
@@ -455,7 +481,7 @@ export function useFeedState() {
   // when selectItem marks the current item read and it drops out of the unread
   // view. Clamps at both ends (no wrap).
   async function moveSelection(delta: 1 | -1) {
-    const all = items.value
+    const all = sortedItems.value
     const passes = (item: FeedItem) => (!unreadOnly.value || item.unread) && matchesSearch(item)
     const currentIndex = all.findIndex((item) => item.id === selectedId.value)
     if (currentIndex === -1) {
@@ -682,6 +708,8 @@ export function useFeedState() {
     sessionLaunchBusy,
     sessionLaunchError,
     unreadOnly,
+    feedSort,
+    setFeedSort,
     title,
     toasts,
     showToast,

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,6 +1,6 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { Browser, Events, Window } from '@wailsio/runtime'
-import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
+import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, RenameFlow, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
 import { ActionRun, ActionViews, FeedItemCounts, FeedItems, InvokeAction, MarkFeedItemRead, SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/desktop/pipelineservice'
 import type { ActionRunView, SessionLaunchOptions as SessionLaunchOptionsView } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
 import { bodySnippet, feedSource, typeLabel } from '../lib/feedPresentation'
@@ -51,6 +51,8 @@ export function useFeedState() {
   const toasts = ref<ToastInstance[]>([])
   const creatingProfile = ref(false)
   const createProfileError = ref<string | null>(null)
+  const renamingProfile = ref(false)
+  const renameProfileError = ref<string | null>(null)
   const deletingProfile = ref(false)
   let nextToastId = 1
   const toastTimers = new Map<number, ReturnType<typeof setTimeout>>()
@@ -278,6 +280,37 @@ export function useFeedState() {
       createProfileError.value = error instanceof Error && error.message ? error.message : 'Could not create the workspace.'
     } finally {
       creatingProfile.value = false
+    }
+  }
+
+  async function renameProfile(profileID: string, name: string): Promise<boolean> {
+    if (renamingProfile.value) return false
+    const trimmed = name.trim()
+    if (!trimmed) {
+      renameProfileError.value = 'Profile name cannot be empty.'
+      return false
+    }
+
+    const current = profiles.value.find((profile) => profile.id === profileID)
+    if (current?.name === trimmed) return true
+
+    renamingProfile.value = true
+    renameProfileError.value = null
+    try {
+      const renamed = await RenameFlow(profileID, trimmed)
+      const profile = profiles.value.find((candidate) => candidate.id === profileID)
+      if (profile) {
+        profile.name = renamed.name
+        profile.letter = letter(renamed.name)
+      }
+      showToast('Profile renamed', { severity: 'success' })
+      return true
+    } catch (error) {
+      console.warn('Unable to rename flow', error)
+      renameProfileError.value = error instanceof Error && error.message ? error.message : 'Could not rename the profile.'
+      return false
+    } finally {
+      renamingProfile.value = false
     }
   }
 
@@ -656,9 +689,12 @@ export function useFeedState() {
     clearToasts,
     creatingProfile,
     createProfileError,
+    renamingProfile,
+    renameProfileError,
     deletingProfile,
     loadProfiles,
     createProfile,
+    renameProfile,
     deleteProfile,
     reorderFeeds,
     selectProfile,

--- a/desktop/frontend/src/pipeline/components/FlowsCanvas.vue
+++ b/desktop/frontend/src/pipeline/components/FlowsCanvas.vue
@@ -2,8 +2,10 @@
 // The flows canvas (8a/8c): node cards at their layout position (falling
 // back to a deterministic grid slot when unpositioned — see
 // lib/wireFlow.ts's gridPosition), SVG wires between ports, drag-to-
-// reposition, zoom/fit (exposed for FlowsView's toolbar — see defineExpose
-// below), live per-node status from nodeRuns, and a single-click-selects /
+// reposition, click-drag and scroll panning, pointer-anchored Ctrl/Cmd+scroll
+// zoom, and zoom/fit controls (exposed for FlowsView's toolbar — see
+// defineExpose below), live per-node status from
+// nodeRuns, and a single-click-selects /
 // double-click-opens-the-NodeEditorDrawer flow for add/edit/delete. There is
 // no floating inspector — selection is just the accent highlight ring
 // (cardShadow) on the selected card; opening the editor is a distinct,
@@ -352,14 +354,76 @@ function onDrop(e: DragEvent) {
   emit('add-node-at', type, Math.round(world.x), Math.round(world.y))
 }
 
-// ── Zoom / fit — a basic scale transform; panning only happens as a side
-// effect of Fit/focus centering content, there's no click-drag-to-pan in
-// v1. The buttons themselves live in FlowsView's canvas toolbar (8a) —
-// zoom/zoomIn/zoomOut/fit are exposed below for that toolbar to drive. ────
+// ── Pan / zoom / fit ─────────────────────────────────────────────────────
+// Dragging empty canvas space pans in screen pixels, so the graph follows the
+// hand at the same speed regardless of zoom. Node and port pointer handlers
+// remain separate and stop a surface pan from starting.
 
 const viewportRef = ref<HTMLElement | null>(null)
 const zoom = ref(1)
 const pan = ref({ x: 0, y: 0 })
+const isPanning = ref(false)
+let stopPanTracking: (() => void) | null = null
+
+function onSurfacePointerDown(e: PointerEvent) {
+  if (e.button !== 0) return
+  e.preventDefault()
+  stopPanTracking?.()
+
+  const startClientX = e.clientX
+  const startClientY = e.clientY
+  const origin = pan.value
+  isPanning.value = true
+
+  function onMove(ev: PointerEvent) {
+    pan.value = {
+      x: origin.x + ev.clientX - startClientX,
+      y: origin.y + ev.clientY - startClientY,
+    }
+  }
+  function cleanup() {
+    window.removeEventListener('pointermove', onMove)
+    window.removeEventListener('pointerup', onUp)
+    isPanning.value = false
+    stopPanTracking = null
+  }
+  function onUp() {
+    cleanup()
+  }
+
+  stopPanTracking = cleanup
+  window.addEventListener('pointermove', onMove)
+  window.addEventListener('pointerup', onUp)
+}
+
+function onWheel(e: WheelEvent) {
+  // The established infinite-canvas mapping keeps unmodified trackpad/mouse
+  // scrolling as pan. Ctrl/Cmd+scroll (including a trackpad pinch, which
+  // browsers report as ctrl+wheel) zooms around the pointer rather than the
+  // viewport origin. Shift converts a vertical mouse wheel into horizontal pan.
+  if (!e.ctrlKey && !e.metaKey) {
+    const deltaX = e.shiftKey && e.deltaX === 0 ? e.deltaY : e.deltaX
+    const deltaY = e.shiftKey && e.deltaX === 0 ? 0 : e.deltaY
+    pan.value = { x: pan.value.x - deltaX, y: pan.value.y - deltaY }
+    return
+  }
+
+  const oldZoom = zoom.value
+  const nextZoom = Math.min(2, Math.max(0.2, oldZoom * Math.exp(-e.deltaY * 0.002)))
+  if (nextZoom === oldZoom) return
+
+  const rect = viewportRef.value?.getBoundingClientRect()
+  const pointerX = e.clientX - (rect?.left ?? 0)
+  const pointerY = e.clientY - (rect?.top ?? 0)
+  const worldX = (pointerX - pan.value.x) / oldZoom
+  const worldY = (pointerY - pan.value.y) / oldZoom
+
+  zoom.value = nextZoom
+  pan.value = {
+    x: pointerX - worldX * nextZoom,
+    y: pointerY - worldY * nextZoom,
+  }
+}
 
 function zoomIn() {
   zoom.value = Math.min(2, Math.round((zoom.value + 0.1) * 100) / 100)
@@ -475,6 +539,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeyDown)
+  stopPanTracking?.()
 })
 </script>
 
@@ -483,7 +548,7 @@ onBeforeUnmount(() => {
     ref="viewportRef"
     class="relative h-full w-full overflow-hidden"
     data-testid="flows-canvas"
-    :class="{ 'canvas-drop-target': isDragOver }"
+    :class="{ 'canvas-drop-target': isDragOver, 'cursor-grab': !isPanning, 'cursor-grabbing': isPanning }"
     :style="{
       backgroundColor: 'var(--color-canvas)',
       backgroundImage: 'radial-gradient(var(--color-canvas-dot) 1.1px, transparent 1.1px)',
@@ -491,16 +556,18 @@ onBeforeUnmount(() => {
       backgroundPosition: '-1px -1px',
     }"
     @click.self="onSurfaceClick"
+    @pointerdown.self="onSurfacePointerDown"
+    @wheel.prevent="onWheel"
     @dragenter.prevent="onDragEnter"
     @dragover.prevent="onDragOver"
     @dragleave="onDragLeave"
     @drop.prevent="onDrop"
   >
-    <div v-if="flow.nodes.length === 0" class="flex h-full items-center justify-center px-8 text-center text-[13px] text-text-4" data-testid="canvas-empty">
+    <div v-if="flow.nodes.length === 0" class="pointer-events-none flex h-full items-center justify-center px-8 text-center text-[13px] text-text-4" data-testid="canvas-empty">
       Add a node from the palette to get started. Drag from an output port to an input port to wire nodes together.
     </div>
 
-    <div class="absolute left-0 top-0 origin-top-left" :style="{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }">
+    <div class="absolute left-0 top-0 origin-top-left" :style="{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }" data-testid="canvas-content">
       <svg class="pointer-events-none absolute left-0 top-0 h-0 w-0 overflow-visible">
         <g v-for="(wire, i) in flow.wires" :key="i" class="wire-group">
           <path

--- a/desktop/frontend/src/pipeline/components/__tests__/FlowsCanvas.spec.ts
+++ b/desktop/frontend/src/pipeline/components/__tests__/FlowsCanvas.spec.ts
@@ -272,6 +272,58 @@ describe('FlowsCanvas', () => {
     wrapper.unmount()
   })
 
+  it('click-dragging empty canvas space pans the graph with a grabbing cursor', async () => {
+    const wrapper = mountCanvas()
+    const canvas = wrapper.get('[data-testid="flows-canvas"]')
+    const content = wrapper.get('[data-testid="canvas-content"]')
+
+    await canvas.trigger('pointerdown', { button: 0, clientX: 100, clientY: 80 })
+    expect(canvas.classes()).toContain('cursor-grabbing')
+
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 145, clientY: 110 }))
+    await nextTick()
+    expect(content.attributes('style')).toContain('translate(45px, 30px)')
+
+    window.dispatchEvent(new PointerEvent('pointerup', { clientX: 145, clientY: 110 }))
+    await nextTick()
+    expect(canvas.classes()).not.toContain('cursor-grabbing')
+
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 200, clientY: 200 }))
+    await nextTick()
+    expect(content.attributes('style')).toContain('translate(45px, 30px)')
+
+    wrapper.unmount()
+  })
+
+  it('scrolling pans the canvas, with Shift converting a mouse wheel to horizontal pan', async () => {
+    const wrapper = mountCanvas()
+    const canvas = wrapper.get('[data-testid="flows-canvas"]')
+    const content = wrapper.get('[data-testid="canvas-content"]')
+
+    await canvas.trigger('wheel', { deltaX: 20, deltaY: 30 })
+    expect(content.attributes('style')).toContain('translate(-20px, -30px)')
+
+    await canvas.trigger('wheel', { deltaX: 0, deltaY: 25, shiftKey: true })
+    expect(content.attributes('style')).toContain('translate(-45px, -30px)')
+
+    wrapper.unmount()
+  })
+
+  it('Ctrl/Cmd+scroll zooms around the pointer location', async () => {
+    const wrapper = mountCanvas()
+    const canvas = wrapper.get('[data-testid="flows-canvas"]')
+    const content = wrapper.get('[data-testid="canvas-content"]')
+
+    await canvas.trigger('wheel', { clientX: 100, clientY: 80, deltaY: -100, ctrlKey: true })
+
+    expect(wrapper.vm.zoom).toBeCloseTo(Math.exp(0.2))
+    const transform = content.attributes('style') ?? ''
+    expect(transform).toContain('translate(-22.')
+    expect(transform).toContain('scale(1.221')
+
+    wrapper.unmount()
+  })
+
   it('zoomIn/zoomOut adjust the exposed zoom level for the toolbar to display', () => {
     const wrapper = mountCanvas()
 

--- a/desktop/frontend/src/types/feed.ts
+++ b/desktop/frontend/src/types/feed.ts
@@ -14,6 +14,9 @@ export interface FeedItem {
   title: string
   author: string
   age: string
+  // GitHub's last-updated time in unix milliseconds. This is source recency,
+  // not feed_item.updated_at (which changes on every polling snapshot).
+  updatedAt: number
   unread: boolean
   reason?: string
   labels: string[]
@@ -25,6 +28,8 @@ export interface FeedItem {
 
 // FeedSummary is one feed (a flow feed node) in the sidebar: its id is the
 // flow-qualified feed key.
+export type FeedSort = 'newest' | 'oldest' | 'unread'
+
 export interface FeedSummary {
   id: string
   name: string

--- a/internal/desktop/feed/feed.go
+++ b/internal/desktop/feed/feed.go
@@ -9,14 +9,15 @@ package feed
 // It is JSON-encoded as a source node's event_log payload and re-surfaced as
 // a feed_item, so the frontend and the persisted feed both read this shape.
 type Item struct {
-	ID     string `json:"id"`
-	Kind   string `json:"kind"` // "PR" | "Issue"
-	Repo   string `json:"repo"`
-	Num    int    `json:"num"`
-	Title  string `json:"title"`
-	Author string `json:"author"`
-	Age    string `json:"age"`
-	Unread bool   `json:"unread"`
+	ID        string `json:"id"`
+	Kind      string `json:"kind"` // "PR" | "Issue"
+	Repo      string `json:"repo"`
+	Num       int    `json:"num"`
+	Title     string `json:"title"`
+	Author    string `json:"author"`
+	Age       string `json:"age"`
+	UpdatedAt int64  `json:"updatedAt"` // GitHub's last-updated time, unix milliseconds
+	Unread    bool   `json:"unread"`
 	// Reason is the GitHub notification reason (e.g. "review_requested"),
 	// empty for items known only from search.
 	Reason string   `json:"reason,omitempty"`

--- a/internal/desktop/feed/live.go
+++ b/internal/desktop/feed/live.go
@@ -435,19 +435,20 @@ func (p *LiveProvider) searchItems(items []github.SearchItem) []liveItem {
 		}
 		repo := si.Repo
 		item := Item{
-			ID:     itemID(repo, si.Number),
-			Kind:   kind,
-			Repo:   repo,
-			Num:    si.Number,
-			Title:  si.Title,
-			Author: si.Author,
-			Age:    shortAge(p.now().Sub(si.UpdatedAt)),
-			Unread: true, // inbox model: unread until read (feed_item.unread)
-			Labels: labelNames(si.Labels),
-			Branch: suggestedBranch(kind, si.Number, si.Title),
-			Body:   si.Body,
-			Prompt: suggestedPrompt(kind, repo, si.Number, si.Title),
-			URL:    si.URL,
+			ID:        itemID(repo, si.Number),
+			Kind:      kind,
+			Repo:      repo,
+			Num:       si.Number,
+			Title:     si.Title,
+			Author:    si.Author,
+			Age:       shortAge(p.now().Sub(si.UpdatedAt)),
+			UpdatedAt: si.UpdatedAt.UnixMilli(),
+			Unread:    true, // inbox model: unread until read (feed_item.unread)
+			Labels:    labelNames(si.Labels),
+			Branch:    suggestedBranch(kind, si.Number, si.Title),
+			Body:      si.Body,
+			Prompt:    suggestedPrompt(kind, repo, si.Number, si.Title),
+			URL:       si.URL,
 		}
 		out = append(out, liveItem{item: item, updatedAt: si.UpdatedAt})
 	}
@@ -470,18 +471,19 @@ func (p *LiveProvider) notificationItems(notifications []github.Notification) []
 			id = "notif-" + n.ID
 		}
 		item := Item{
-			ID:     id,
-			Kind:   kind,
-			Repo:   repo,
-			Num:    num,
-			Title:  n.Subject.Title,
-			Age:    shortAge(p.now().Sub(n.UpdatedAt)),
-			Unread: n.Unread,
-			Reason: n.Reason,
-			Branch: suggestedBranch(kind, num, n.Subject.Title),
-			Body:   fmt.Sprintf("GitHub notification for %s in %s.", strings.ToLower(kind), repo),
-			Prompt: suggestedPrompt(kind, repo, num, n.Subject.Title),
-			URL:    htmlURLForSubject(repo, kind, num),
+			ID:        id,
+			Kind:      kind,
+			Repo:      repo,
+			Num:       num,
+			Title:     n.Subject.Title,
+			Age:       shortAge(p.now().Sub(n.UpdatedAt)),
+			UpdatedAt: n.UpdatedAt.UnixMilli(),
+			Unread:    n.Unread,
+			Reason:    n.Reason,
+			Branch:    suggestedBranch(kind, num, n.Subject.Title),
+			Body:      fmt.Sprintf("GitHub notification for %s in %s.", strings.ToLower(kind), repo),
+			Prompt:    suggestedPrompt(kind, repo, num, n.Subject.Title),
+			URL:       htmlURLForSubject(repo, kind, num),
 		}
 		out = append(out, liveItem{item: item, updatedAt: n.UpdatedAt})
 	}

--- a/internal/desktop/feed/live_test.go
+++ b/internal/desktop/feed/live_test.go
@@ -101,6 +101,7 @@ func TestPrefetchSearch_OneRequestForManySources(t *testing.T) {
 		items, err := live.SourceItems(t.Context(), def)
 		require.NoError(t, err)
 		require.Len(t, items, 1)
+		assert.Equal(t, time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC).UnixMilli(), items[0].UpdatedAt)
 	}
 	calls, _ = api.snapshot()
 	assert.Equal(t, 1, calls, "prefetched entries should serve every source from cache")

--- a/internal/desktop/pipeline/flow/store.go
+++ b/internal/desktop/pipeline/flow/store.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -135,6 +136,35 @@ func (s *FlowStore) Create(name string) (Flow, error) {
 		return Flow{}, err
 	}
 	if err := SaveUI(s.uiPath(id), layout); err != nil {
+		return Flow{}, err
+	}
+	if err := s.reloadLocked(); err != nil {
+		return Flow{}, err
+	}
+	return s.flows[id], nil
+}
+
+// Rename updates a flow's display name without changing its stable id or any
+// graph content.
+func (s *FlowStore) Rename(id, name string) (Flow, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Flow{}, fmt.Errorf("flow: name cannot be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLoadedLocked()
+
+	f, ok := s.flows[id]
+	if !ok {
+		return Flow{}, fmt.Errorf("flow %q not found", id)
+	}
+	f.Name = name
+	if _, err := validateFlow(&f, s.refs); err != nil {
+		return Flow{}, fmt.Errorf("flow %q: %w", f.ID, err)
+	}
+	if err := SaveFlow(filepath.Join(s.dir, f.ID+".yaml"), f); err != nil {
 		return Flow{}, err
 	}
 	if err := s.reloadLocked(); err != nil {

--- a/internal/desktop/pipeline/flow/store_test.go
+++ b/internal/desktop/pipeline/flow/store_test.go
@@ -160,6 +160,29 @@ func TestFlowStore_Create_SeedsStarterFlowWithUniqueID(t *testing.T) {
 	assert.NotEmpty(t, layout.Nodes)
 }
 
+func TestFlowStore_Rename_UpdatesOnlyDisplayName(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFlowStore(dir, minimalRefs())
+	created, err := store.Create("Frontend Triage")
+	require.NoError(t, err)
+
+	renamed, err := store.Rename(created.ID, "  Team Triage  ")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, renamed.ID)
+	assert.Equal(t, "Team Triage", renamed.Name)
+	assert.Equal(t, created.Nodes, renamed.Nodes)
+	assert.Equal(t, created.Wires, renamed.Wires)
+
+	loaded, ok := store.Get(created.ID)
+	require.True(t, ok)
+	assert.Equal(t, "Team Triage", loaded.Name)
+
+	_, err = store.Rename(created.ID, "   ")
+	require.ErrorContains(t, err, "name cannot be empty")
+	_, err = store.Rename("missing", "Name")
+	require.ErrorContains(t, err, "not found")
+}
+
 func TestFlowStore_Delete_RemovesFlowAndLayout(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFlowStore(dir, minimalRefs())


### PR DESCRIPTION
## Purpose

Tighten the desktop feed workflow and make navigation behavior consistent across the title bar, flow canvas, and mouse controls.

## Proposed Changes

  - Improve detail/canvas navigation and support mouse Back/Forward while suppressing accidental Backspace history navigation
  - Add persisted inbox sorting and consolidate secondary feed controls into a View menu
  - Allow profile renaming from settings

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)