### PR TITLE
desktop: consolidate shared logic & componentize frontend UI

### DIFF
--- a/.github/workflows/partial-integration-tests.yml
+++ b/.github/workflows/partial-integration-tests.yml
@@ -16,11 +16,14 @@ jobs:
           cache: true
 
       # mise install compiles the pinned wails3 CLI, which needs the
-      # GTK4/WebKitGTK 6.0 dev stack on Linux.
+      # GTK4/WebKitGTK 6.0 dev stack on Linux. Cache the resolved .deb set
+      # (webkitgtk pulls ~69MB of transitive deps) so a cache hit reinstalls
+      # in seconds instead of re-downloading from a throttled mirror.
       - name: Install Linux desktop build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-4-dev libwebkitgtk-6.0-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        with:
+          packages: libgtk-4-dev libwebkitgtk-6.0-dev
+          version: 1
 
       - name: Set up mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/partial-tests.yml
+++ b/.github/workflows/partial-tests.yml
@@ -15,9 +15,13 @@ jobs:
       # The pinned wails alpha defaults to the GTK4/WebKitGTK 6.0 stack on
       # Linux (GTK3 is opt-in via -tags gtk3, which nothing here passes).
       - name: Install Linux desktop build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-4-dev libwebkitgtk-6.0-dev
+        # Cache the resolved .deb set (webkitgtk pulls ~69MB of transitive
+        # deps); a cache hit reinstalls in seconds instead of re-downloading
+        # from the Ubuntu mirror, which has throttled runs to ~7min.
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        with:
+          packages: libgtk-4-dev libwebkitgtk-6.0-dev
+          version: 1
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -34,6 +34,7 @@ import { comboFromEvent, formatCombo, useKeybindings } from './composables/useKe
 import { commandCatalog } from './keybindings/catalog'
 import { setTheme, themeLabels, themes } from './composables/useTheme'
 import { useFlowsSession } from './pipeline/composables/useFlowsSession'
+import { isEditableTarget } from './lib/isEditableTarget'
 import type { ApplicationSettingsSection, ProfileSettingsSection } from './router'
 import type { SidebarSelection } from './types/feed'
 
@@ -518,13 +519,6 @@ useCommands(computed(() => {
 // Resolves a keydown against the configurable keymap and runs the matched
 // command. Bare (modifier-less) keys are ignored while typing; feed commands
 // only fire on the feed; overlays suppress everything but the palette toggle.
-
-function isEditableTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target instanceof HTMLSelectElement ||
-    (target instanceof HTMLElement && target.isContentEditable)
-}
 
 function onGlobalKeydown(e: KeyboardEvent): void {
   // WebKit can treat an unhandled Backspace as browser Back. Suppress that

--- a/desktop/frontend/src/components/ActionEditor.vue
+++ b/desktop/frontend/src/components/ActionEditor.vue
@@ -2,6 +2,7 @@
 import { nextTick, onMounted, onUnmounted, ref } from 'vue'
 import IconPlay from '~icons/lucide/play'
 import IconX from '~icons/lucide/x'
+import BaseButton from './BaseButton.vue'
 import AppCheckbox from './AppCheckbox.vue'
 import AppSelect from './AppSelect.vue'
 import AppliesToField from './AppliesToField.vue'
@@ -68,7 +69,7 @@ onUnmounted(() => {
     </div>
 
     <template #footer>
-      <div class="flex justify-end gap-2.5"><button class="rounded-lg border border-card px-[15px] py-2 text-[13px] text-text-2 hover:text-text disabled:opacity-50" :disabled="busy" @click="cancel">Cancel</button><button class="rounded-lg bg-accent px-[18px] py-2 text-[13px] font-semibold text-accent-contrast disabled:opacity-50" :disabled="busy" data-testid="action-save" @click="save">{{ busy ? 'Saving…' : 'Save' }}</button></div>
+      <div class="flex justify-end gap-2.5"><BaseButton variant="secondary" size="sm" :busy="busy" @click="cancel">Cancel</BaseButton><BaseButton size="sm" :busy="busy" data-testid="action-save" @click="save">{{ busy ? 'Saving…' : 'Save' }}</BaseButton></div>
     </template>
   </DrawerSheet>
 </template>

--- a/desktop/frontend/src/components/ActionEditor.vue
+++ b/desktop/frontend/src/components/ActionEditor.vue
@@ -7,12 +7,13 @@ import AppCheckbox from './AppCheckbox.vue'
 import AppSelect from './AppSelect.vue'
 import AppliesToField from './AppliesToField.vue'
 import DrawerSheet from './DrawerSheet.vue'
+import { TextareaField, TextField } from '../pipeline/fields'
 import type { EditableAction } from '../composables/useActionsSettings'
 
 const props = withDefaults(defineProps<{ action: EditableAction; isNew: boolean; busy?: boolean; error?: string | null; returnFocusTo?: HTMLElement | null; knownTypes?: string[] }>(), { knownTypes: () => [] })
 const emit = defineEmits<{ save: []; cancel: [] }>()
-const idRef = ref<HTMLInputElement | null>(null)
-const labelRef = ref<HTMLInputElement | null>(null)
+const idRef = ref<{ focus: () => void } | null>(null)
+const labelRef = ref<{ focus: () => void } | null>(null)
 const appliesField = ref<{ flush: () => void } | null>(null)
 const closeRef = ref<HTMLButtonElement | null>(null)
 const validationError = ref<string | null>(null)
@@ -29,15 +30,15 @@ function setType(value: string): void {
   else { props.action.launch = undefined; props.action.shell = undefined; props.action.message = { topic: '', messageTemplate: '' } }
 }
 function envText(): string { return Object.entries(props.action.shell?.env ?? {}).sort(([a], [b]) => a.localeCompare(b)).map(([key, value]) => `${key}=${value ?? ''}`).join('\n') }
-function setEnv(event: Event): void { if (!props.action.shell) return; const env: Record<string, string> = {}; for (const line of (event.target as HTMLTextAreaElement).value.split('\n')) { const [key, ...value] = line.split('='); if (key.trim()) env[key.trim()] = value.join('=') }; props.action.shell.env = env }
+function setEnv(text: string): void { if (!props.action.shell) return; const env: Record<string, string> = {}; for (const line of text.split('\n')) { const [key, ...value] = line.split('='); if (key.trim()) env[key.trim()] = value.join('=') }; props.action.shell.env = env }
 function save(): void { appliesField.value?.flush(); if (!props.action.id.trim() || !props.action.label.trim()) { validationError.value = 'ID and label are required.'; return }; validationError.value = null; emit('save') }
 function cancel(): void { if (!props.busy) emit('cancel') }
 let trigger: HTMLElement | null = null
 onMounted(async () => {
   trigger = props.returnFocusTo ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null)
   await nextTick()
-  if (props.isNew && idRef.value && !idRef.value.disabled) idRef.value.focus()
-  else if (labelRef.value && !labelRef.value.disabled) labelRef.value.focus()
+  if (props.isNew && idRef.value) idRef.value.focus()
+  else if (labelRef.value) labelRef.value.focus()
   else closeRef.value?.focus()
 })
 onUnmounted(() => {
@@ -57,14 +58,26 @@ onUnmounted(() => {
     </template>
 
     <div class="grid gap-3">
-      <label class="text-xs text-text-2">ID<input ref="idRef" v-model="action.id" :disabled="!isNew" data-testid="action-id" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent disabled:opacity-60" /></label>
-      <label class="text-xs text-text-2">Label<input ref="labelRef" v-model="action.label" data-testid="action-label" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label>
+      <TextField ref="idRef" v-model="action.id" label="ID" :disabled="!isNew" testid="action-id" />
+      <TextField ref="labelRef" v-model="action.label" label="Label" testid="action-label" />
       <div class="text-xs text-text-2">Type<AppSelect :model-value="action.type" :options="typeOptions" testid="action-type" aria-label="Type" class="mt-1" @update:model-value="setType" /></div>
       <AppCheckbox v-model="action.showInDetail" label="Show manual button in detail pane" testid="action-show-in-detail" />
       <AppliesToField ref="appliesField" :model-value="action.appliesTo" :known-types="knownTypes" @update:model-value="action.appliesTo = $event" />
-      <template v-if="action.launch"><label class="text-xs text-text-2">Prompt template<textarea v-model="action.launch.promptTemplate" data-testid="action-launch-prompt" class="mt-1 min-h-[90px] w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label><label class="text-xs text-text-2">Repository template<input v-model="action.launch.repoTemplate" data-testid="action-launch-repo" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label><label class="text-xs text-text-2">Agent (optional)<input v-model="action.launch.agent" data-testid="action-launch-agent" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label></template>
-      <template v-if="action.shell"><label class="text-xs text-text-2">Command template<textarea v-model="action.shell.commandTemplate" data-testid="action-shell-command" class="mt-1 min-h-[72px] w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label><label class="text-xs text-text-2">Working directory<input v-model="action.shell.cwd" data-testid="action-shell-cwd" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label><label class="text-xs text-text-2">Timeout<input v-model="action.shell.timeout" data-testid="action-shell-timeout" placeholder="e.g. 30s" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label><label class="text-xs text-text-2">Environment (KEY=value per line)<textarea :value="envText()" data-testid="action-shell-env" class="mt-1 min-h-[72px] w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" @input="setEnv" /></label></template>
-      <template v-if="action.message"><label class="text-xs text-text-2">Message template<textarea v-model="action.message.messageTemplate" data-testid="action-message-template" class="mt-1 min-h-[72px] w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label><label class="text-xs text-text-2">Topic<input v-model="action.message.topic" data-testid="action-message-topic" class="mt-1 w-full rounded border border-border bg-app px-2 py-1.5 text-text outline-none focus:border-accent" /></label></template>
+      <template v-if="action.launch">
+        <TextareaField v-model="action.launch.promptTemplate" label="Prompt template" :rows="4" monospace testid="action-launch-prompt" />
+        <TextField v-model="action.launch.repoTemplate" label="Repository template" testid="action-launch-repo" />
+        <TextField v-model="action.launch.agent" label="Agent (optional)" testid="action-launch-agent" />
+      </template>
+      <template v-if="action.shell">
+        <TextareaField v-model="action.shell.commandTemplate" label="Command template" monospace testid="action-shell-command" />
+        <TextField v-model="action.shell.cwd" label="Working directory" testid="action-shell-cwd" />
+        <TextField v-model="action.shell.timeout" label="Timeout" placeholder="e.g. 30s" testid="action-shell-timeout" />
+        <TextareaField :model-value="envText()" label="Environment (KEY=value per line)" monospace testid="action-shell-env" @update:model-value="setEnv" />
+      </template>
+      <template v-if="action.message">
+        <TextareaField v-model="action.message.messageTemplate" label="Message template" monospace testid="action-message-template" />
+        <TextField v-model="action.message.topic" label="Topic" testid="action-message-topic" />
+      </template>
       <p v-if="validationError || error" class="rounded border border-severity-error bg-severity-error-tint px-3 py-2 text-xs text-severity-error" data-testid="action-editor-error">{{ validationError || error }}</p>
     </div>
 

--- a/desktop/frontend/src/components/ActionSettingsView.vue
+++ b/desktop/frontend/src/components/ActionSettingsView.vue
@@ -3,6 +3,8 @@ import { computed, ref } from 'vue'
 import IconPlus from '~icons/lucide/plus'
 import IconTrash2 from '~icons/lucide/trash-2'
 import BaseButton from './BaseButton.vue'
+import BaseCard from './BaseCard.vue'
+import BaseIconBadge from './BaseIconBadge.vue'
 import AppIcon from './AppIcon.vue'
 import ActionEditor from './ActionEditor.vue'
 import ConfirmationDialog from './ConfirmationDialog.vue'
@@ -53,15 +55,18 @@ function requestDelete(action: EditableAction): void { confirmation.request({ ti
     <p v-if="loading" class="text-xs text-text-4">Loading actions…</p>
 
     <div v-else class="flex flex-col gap-3">
-      <article
+      <BaseCard
         v-for="action in actions"
         :key="action.id"
-        class="flex items-center gap-4 rounded-[11px] border border-card bg-raised px-4 py-3.5 transition-colors hover:border-strong"
+        :padded="false"
+        class="gap-4 rounded-[11px] border border-card bg-raised px-4 py-3.5 transition-colors hover:border-strong"
         :data-testid="`action-row-${action.id}`"
       >
-        <span class="flex size-[38px] shrink-0 items-center justify-center rounded-[10px] border border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.13)] text-accent">
-          <AppIcon :name="actionTypeMeta(action.type).icon" class="size-[17px]" />
-        </span>
+        <template #icon>
+          <BaseIconBadge :size="38" rounded="rounded-[10px]" class="border border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.13)] text-accent">
+            <AppIcon :name="actionTypeMeta(action.type).icon" class="size-[17px]" />
+          </BaseIconBadge>
+        </template>
         <div class="min-w-0 flex-1">
           <div class="truncate text-[15px] font-semibold tracking-[-.01em] text-text">{{ action.label }}</div>
           <div class="mt-1.5 flex flex-wrap items-center gap-1.5">
@@ -72,11 +77,13 @@ function requestDelete(action: EditableAction): void { confirmation.request({ ti
             </span>
           </div>
         </div>
-        <div class="flex shrink-0 items-center gap-2">
-          <button class="rounded-[7px] border border-card px-3.5 py-1.5 text-[12.5px] text-text-2 hover:border-strong hover:text-text" @click="edit(action, $event)">Edit</button>
-          <button class="flex size-[34px] items-center justify-center rounded-[7px] border border-card text-text-3 hover:border-severity-error-border hover:text-severity-error" aria-label="Delete" @click="requestDelete(action)"><IconTrash2 class="size-[15px]" /></button>
-        </div>
-      </article>
+        <template #actions>
+          <div class="flex shrink-0 items-center gap-2">
+            <button class="rounded-[7px] border border-card px-3.5 py-1.5 text-[12.5px] text-text-2 hover:border-strong hover:text-text" @click="edit(action, $event)">Edit</button>
+            <button class="flex size-[34px] items-center justify-center rounded-[7px] border border-card text-text-3 hover:border-severity-error-border hover:text-severity-error" aria-label="Delete" @click="requestDelete(action)"><IconTrash2 class="size-[15px]" /></button>
+          </div>
+        </template>
+      </BaseCard>
 
       <p v-if="!actions.length" class="py-8 text-center text-xs text-text-4">No actions configured.</p>
       <div v-else class="mt-1 flex items-center gap-1.5 font-mono text-[11.5px] text-text-4" data-testid="actions-source">Synced from .hive/actions.yml · {{ actions.length }} {{ actions.length === 1 ? 'action' : 'actions' }}</div>

--- a/desktop/frontend/src/components/ActionSettingsView.vue
+++ b/desktop/frontend/src/components/ActionSettingsView.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import IconPlus from '~icons/lucide/plus'
 import IconTrash2 from '~icons/lucide/trash-2'
+import BaseButton from './BaseButton.vue'
 import AppIcon from './AppIcon.vue'
 import ActionEditor from './ActionEditor.vue'
 import ConfirmationDialog from './ConfirmationDialog.vue'
@@ -40,11 +41,12 @@ function requestDelete(action: EditableAction): void { confirmation.request({ ti
         <h2 class="text-[15px] font-semibold text-text">Actions</h2>
         <p class="mt-1 text-xs leading-relaxed text-text-3">Detail visibility controls only manual feed-item buttons. Flow nodes can still target any action.</p>
       </div>
-      <button
-        class="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-accent px-3.5 py-2 text-[13px] font-semibold text-accent-contrast hover:opacity-90"
+      <BaseButton
+        size="sm"
+        class="shrink-0"
         data-testid="action-create"
         @click="createNew"
-      ><IconPlus class="size-3.5" :stroke-width="2.4" />New action</button>
+      ><template #icon><IconPlus class="size-3.5" :stroke-width="2.4" /></template>New action</BaseButton>
     </div>
 
     <p v-if="error && !editing" class="mb-3 rounded border border-severity-error bg-severity-error-tint px-3 py-2 text-xs text-severity-error" data-testid="actions-error">{{ error }}</p>

--- a/desktop/frontend/src/components/ActionSettingsView.vue
+++ b/desktop/frontend/src/components/ActionSettingsView.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import IconPlus from '~icons/lucide/plus'
 import IconTrash2 from '~icons/lucide/trash-2'
+import BaseBadge from './BaseBadge.vue'
 import BaseButton from './BaseButton.vue'
 import BaseCard from './BaseCard.vue'
 import BaseIconBadge from './BaseIconBadge.vue'
@@ -70,11 +71,11 @@ function requestDelete(action: EditableAction): void { confirmation.request({ ti
         <div class="min-w-0 flex-1">
           <div class="truncate text-[15px] font-semibold tracking-[-.01em] text-text">{{ action.label }}</div>
           <div class="mt-1.5 flex flex-wrap items-center gap-1.5">
-            <span class="rounded-[5px] border border-row bg-app px-[7px] py-0.5 font-mono text-[11px] text-text-3">{{ action.id }}</span>
-            <span class="rounded-[5px] bg-chip px-2 py-0.5 text-[11px] text-text-2">{{ actionTypeMeta(action.type).label }}</span>
-            <span class="inline-flex items-center gap-1.5 rounded-[5px] bg-chip px-2 py-0.5 text-[11px] text-text-3">
+            <BaseBadge class="border border-row !bg-app px-[7px] py-0.5 font-mono text-[11px]">{{ action.id }}</BaseBadge>
+            <BaseBadge class="px-2 py-0.5 text-[11px] !text-text-2">{{ actionTypeMeta(action.type).label }}</BaseBadge>
+            <BaseBadge class="px-2 py-0.5 text-[11px]">
               <span class="size-1.5 rounded-full" :class="action.showInDetail ? 'bg-severity-success' : 'bg-text-4'" />{{ action.showInDetail ? 'Shown in detail' : 'Flow-only' }}
-            </span>
+            </BaseBadge>
           </div>
         </div>
         <template #actions>

--- a/desktop/frontend/src/components/ActionSettingsView.vue
+++ b/desktop/frontend/src/components/ActionSettingsView.vue
@@ -9,6 +9,8 @@ import BaseIconBadge from './BaseIconBadge.vue'
 import AppIcon from './AppIcon.vue'
 import ActionEditor from './ActionEditor.vue'
 import ConfirmationDialog from './ConfirmationDialog.vue'
+import EmptyState from './settings/EmptyState.vue'
+import SettingsSection from './settings/SettingsSection.vue'
 import { useConfirmation } from '../composables/useConfirmation'
 import { actionTypeMeta } from '../lib/actionPresentation'
 import { useActionsSettings, type EditableAction } from '../composables/useActionsSettings'
@@ -40,10 +42,11 @@ function requestDelete(action: EditableAction): void { confirmation.request({ ti
 <template>
   <div class="mx-auto max-w-[720px]" data-testid="actions-settings">
     <div class="mb-5 flex items-start gap-4">
-      <div class="flex-1">
-        <h2 class="text-[15px] font-semibold text-text">Actions</h2>
-        <p class="mt-1 text-xs leading-relaxed text-text-3">Detail visibility controls only manual feed-item buttons. Flow nodes can still target any action.</p>
-      </div>
+      <SettingsSection
+        title="Actions"
+        description="Detail visibility controls only manual feed-item buttons. Flow nodes can still target any action."
+        class="flex-1"
+      />
       <BaseButton
         size="sm"
         class="shrink-0"
@@ -86,7 +89,7 @@ function requestDelete(action: EditableAction): void { confirmation.request({ ti
         </template>
       </BaseCard>
 
-      <p v-if="!actions.length" class="py-8 text-center text-xs text-text-4">No actions configured.</p>
+      <EmptyState v-if="!actions.length" message="No actions configured." />
       <div v-else class="mt-1 flex items-center gap-1.5 font-mono text-[11.5px] text-text-4" data-testid="actions-source">Synced from .hive/actions.yml · {{ actions.length }} {{ actions.length === 1 ? 'action' : 'actions' }}</div>
     </div>
 

--- a/desktop/frontend/src/components/ActivityView.vue
+++ b/desktop/frontend/src/components/ActivityView.vue
@@ -5,7 +5,6 @@
 // activity.Recorder and by the frontend via ActivityService.Record; this view
 // only reads and presents them. Reached from the titlebar Activity link.
 import { computed, onMounted, ref, type Component } from 'vue'
-import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconInfo from '~icons/lucide/info'
 import IconPlay from '~icons/lucide/play'
 import IconRefreshCw from '~icons/lucide/refresh-cw'
@@ -16,6 +15,7 @@ import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import IconZap from '~icons/lucide/zap'
 import { useActivity } from '../composables/useActivity'
 import { useEscapeToClose } from '../composables/useEscapeToClose'
+import ViewHeader from './settings/ViewHeader.vue'
 import {
   ACTIVITY_FILTERS,
   eventStyleKey,
@@ -67,17 +67,12 @@ onMounted(() => {
 
 <template>
   <div class="flex h-full min-h-0 flex-1 flex-col" data-testid="activity-view">
-    <header class="flex h-11 shrink-0 items-center gap-2.5 border-b border-row bg-canvas-toolbar px-4">
-      <span class="text-[13px] font-semibold text-text">Activity</span>
-      <span class="font-mono text-[11px] text-text-4">audit log</span>
-      <div class="flex-1" />
-      <button
-        type="button"
-        class="flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12.5px] text-text-2 hover:bg-chip hover:text-text"
-        data-testid="activity-close"
-        @click="emit('close')"
-      ><IconArrowLeft class="size-3.5" />Back to feed</button>
-    </header>
+    <ViewHeader close-testid="activity-close" @close="emit('close')">
+      <template #title>
+        <span class="text-[13px] font-semibold text-text">Activity</span>
+        <span class="font-mono text-[11px] text-text-4">audit log</span>
+      </template>
+    </ViewHeader>
 
     <!-- toolbar: filter pills + search -->
     <div class="flex shrink-0 items-center gap-2 border-b border-row bg-sidebar px-5 py-2.5">

--- a/desktop/frontend/src/components/ActivityView.vue
+++ b/desktop/frontend/src/components/ActivityView.vue
@@ -4,7 +4,7 @@
 // reloads, and errors. Events are recorded by backend subsystems through the
 // activity.Recorder and by the frontend via ActivityService.Record; this view
 // only reads and presents them. Reached from the titlebar Activity link.
-import { computed, onMounted, onUnmounted, ref, type Component } from 'vue'
+import { computed, onMounted, ref, type Component } from 'vue'
 import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconInfo from '~icons/lucide/info'
 import IconPlay from '~icons/lucide/play'
@@ -15,6 +15,7 @@ import IconSquareTerminal from '~icons/lucide/square-terminal'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import IconZap from '~icons/lucide/zap'
 import { useActivity } from '../composables/useActivity'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 import {
   ACTIVITY_FILTERS,
   eventStyleKey,
@@ -57,15 +58,11 @@ function styleFor(styleKey: ActivityStyleKey) {
   return STYLES[styleKey]
 }
 
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') emit('close')
-}
+useEscapeToClose(() => emit('close'))
 
 onMounted(() => {
-  window.addEventListener('keydown', onKeydown)
   void load()
 })
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>

--- a/desktop/frontend/src/components/AppSelect.vue
+++ b/desktop/frontend/src/components/AppSelect.vue
@@ -2,7 +2,8 @@
 // Themed single-select. A native <select> renders its open list with the OS
 // chrome (a light popup that ignores the app theme); this reimplements the
 // listbox so the open state matches the rest of the drawer.
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { onClickOutside } from '@vueuse/core'
+import { computed, ref } from 'vue'
 import IconCheck from '~icons/lucide/check'
 import IconChevronDown from '~icons/lucide/chevron-down'
 
@@ -31,9 +32,7 @@ function onKeydown(event: KeyboardEvent): void {
   else if (event.key === 'End') { event.preventDefault(); active.value = props.options.length - 1 }
   else if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); choose(props.options[active.value].value) }
 }
-function onDocumentPointer(event: PointerEvent): void { if (open.value && root.value && !root.value.contains(event.target as Node)) close() }
-onMounted(() => document.addEventListener('pointerdown', onDocumentPointer))
-onBeforeUnmount(() => document.removeEventListener('pointerdown', onDocumentPointer))
+onClickOutside(root, () => { if (open.value) close() })
 </script>
 
 <template>

--- a/desktop/frontend/src/components/BaseBadge.vue
+++ b/desktop/frontend/src/components/BaseBadge.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<{
+  tone?: 'neutral' | 'success' | 'accent' | 'muted' | 'danger'
+  variant?: 'pill' | 'chip'
+  dot?: boolean
+}>(), {
+  tone: 'neutral',
+  variant: 'chip',
+  dot: false,
+})
+
+const attrs = useAttrs()
+
+const toneClasses = {
+  neutral: 'bg-chip text-text-3',
+  success: 'bg-severity-success-tint text-severity-success',
+  accent: 'bg-accent-tint text-accent',
+  muted: 'bg-chip text-text-4',
+  danger: 'bg-severity-error-tint text-severity-error',
+}
+
+const dotClasses = {
+  neutral: 'bg-text-3',
+  success: 'bg-severity-success',
+  accent: 'bg-accent',
+  muted: 'bg-text-4',
+  danger: 'bg-severity-error',
+}
+
+const classes = computed(() => [
+  'inline-flex items-center gap-1.5',
+  props.variant === 'pill' ? 'rounded-full' : 'rounded-[5px]',
+  toneClasses[props.tone],
+])
+</script>
+
+<template>
+  <span v-bind="attrs" :class="classes">
+    <span v-if="props.dot" aria-hidden="true" class="size-1.5 shrink-0 rounded-full" :class="dotClasses[props.tone]" />
+    <slot />
+  </span>
+</template>

--- a/desktop/frontend/src/components/BaseButton.vue
+++ b/desktop/frontend/src/components/BaseButton.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = withDefaults(defineProps<{
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost'
+  size?: 'sm' | 'md'
+  busy?: boolean
+  disabled?: boolean
+  type?: 'button' | 'submit'
+}>(), {
+  variant: 'primary',
+  size: 'md',
+  busy: false,
+  disabled: false,
+  type: 'button',
+})
+
+const emit = defineEmits<{ click: [event: MouseEvent] }>()
+const buttonRef = ref<HTMLButtonElement | null>(null)
+
+const classes = computed(() => [
+  'inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-lg transition disabled:cursor-default disabled:opacity-50',
+  props.size === 'md'
+    ? 'px-4 py-2.5 text-[13.5px] font-semibold'
+    : 'px-3.5 py-2 text-[13px] font-medium',
+  {
+    primary: 'bg-accent text-accent-contrast hover:brightness-110',
+    secondary: 'border border-card text-text-2 hover:text-text',
+    danger: 'bg-severity-error text-accent-contrast hover:brightness-110',
+    ghost: 'text-text-2 hover:text-text',
+  }[props.variant],
+])
+
+defineExpose({ focus: () => buttonRef.value?.focus() })
+</script>
+
+<template>
+  <button ref="buttonRef" :type="type" :disabled="disabled || busy" :class="classes" @click="emit('click', $event)">
+    <slot name="icon" />
+    <slot />
+  </button>
+</template>

--- a/desktop/frontend/src/components/BaseCard.vue
+++ b/desktop/frontend/src/components/BaseCard.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<{
+  as?: 'article' | 'button'
+  interactive?: boolean
+  padded?: boolean
+}>(), {
+  as: 'article',
+  interactive: false,
+  padded: true,
+})
+
+const attrs = useAttrs()
+const classes = computed(() => [
+  'flex items-center gap-3',
+  props.padded && 'p-4',
+  props.interactive && 'transition-colors hover:border-strong hover:bg-chip',
+])
+</script>
+
+<template>
+  <component :is="props.as" v-bind="attrs" :class="classes">
+    <slot name="icon" />
+    <slot />
+    <slot name="actions" />
+  </component>
+</template>

--- a/desktop/frontend/src/components/BaseIconBadge.vue
+++ b/desktop/frontend/src/components/BaseIconBadge.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<{
+  size?: number
+  rounded?: string
+}>(), {
+  size: 38,
+  rounded: 'rounded-[7px]',
+})
+
+const attrs = useAttrs()
+const classes = computed(() => [
+  'flex shrink-0 items-center justify-center',
+  props.rounded,
+])
+</script>
+
+<template>
+  <span
+    v-bind="attrs"
+    :class="classes"
+    :style="{ width: `${props.size}px`, height: `${props.size}px` }"
+  ><slot /></span>
+</template>

--- a/desktop/frontend/src/components/BaseModal.vue
+++ b/desktop/frontend/src/components/BaseModal.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { computed, type Component } from 'vue'
+import IconX from '~icons/lucide/x'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
+
+const props = withDefaults(defineProps<{
+  title: string
+  icon?: Component
+  tone?: 'accent' | 'danger'
+  width?: number
+  ariaRole?: 'dialog' | 'alertdialog'
+  busy?: boolean
+  closeOnBackdrop?: boolean
+  closeOnEscape?: boolean
+  pt?: string
+  testid?: string
+}>(), {
+  tone: 'accent',
+  width: 420,
+  ariaRole: 'dialog',
+  busy: false,
+  closeOnBackdrop: true,
+  closeOnEscape: true,
+  pt: 'pt-[24vh]',
+})
+
+const emit = defineEmits<{ close: [] }>()
+
+const badgeClasses = computed(() => props.tone === 'danger'
+  ? 'bg-severity-error-tint text-severity-error'
+  : 'bg-accent-tint text-accent')
+
+function close(): void {
+  emit('close')
+}
+
+function onBackdropClick(): void {
+  if (props.closeOnBackdrop && !props.busy) close()
+}
+
+useEscapeToClose(close, { enabled: () => props.closeOnEscape && !props.busy })
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      :class="['fixed inset-0 z-40 flex items-start justify-center bg-backdrop', pt]"
+      :data-testid="testid ? `${testid}-backdrop` : undefined"
+      @click.self="onBackdropClick"
+    >
+      <div
+        class="overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl"
+        :style="{ width: `${width}px` }"
+        :role="ariaRole"
+        :aria-label="title"
+        aria-modal="true"
+        :data-testid="testid"
+      >
+        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
+          <span v-if="icon" :class="['flex size-7 items-center justify-center rounded-[7px]', badgeClasses]"><component :is="icon" class="size-4" /></span>
+          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">{{ title }}</div>
+          <button
+            class="cursor-pointer text-text-3 hover:text-text disabled:cursor-default disabled:opacity-50"
+            aria-label="Close"
+            :data-testid="testid ? `${testid}-close` : undefined"
+            :disabled="busy"
+            @click="close"
+          ><IconX class="size-4" /></button>
+        </header>
+        <slot />
+        <footer v-if="$slots.footer" class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
+          <slot name="footer" />
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/desktop/frontend/src/components/ConfirmationDialog.vue
+++ b/desktop/frontend/src/components/ConfirmationDialog.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import IconAlertTriangle from '~icons/lucide/alert-triangle'
 import IconX from '~icons/lucide/x'
+import BaseButton from './BaseButton.vue'
 import { useAutofocus } from '../composables/useAutofocus'
 import { useEscapeToClose } from '../composables/useEscapeToClose'
 
@@ -16,7 +17,7 @@ const props = withDefaults(defineProps<{
   cancelTestid?: string
 }>(), { confirmLabel: 'Confirm', busy: false, error: null, testid: 'confirmation-dialog', confirmTestid: undefined, cancelTestid: undefined })
 const emit = defineEmits<{ confirm: []; cancel: [] }>()
-const confirmRef = ref<HTMLButtonElement | null>(null)
+const confirmRef = ref<{ focus: () => void } | null>(null)
 
 function cancel(): void { if (!props.busy) emit('cancel') }
 
@@ -35,8 +36,8 @@ useAutofocus(confirmRef)
         </header>
         <div class="flex flex-col gap-3 px-5 py-4"><p class="text-[13px] leading-relaxed text-text-2">{{ description }}</p><p v-if="error" class="rounded border border-severity-error bg-severity-error-tint px-3 py-2 text-xs text-severity-error" :data-testid="`${testid}-error`">{{ error }}</p></div>
         <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
-          <button ref="confirmRef" class="flex-1 cursor-pointer rounded-lg bg-severity-error px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50" :disabled="busy" :data-testid="confirmTestid ?? `${testid}-confirm`" @click="emit('confirm')">{{ busy ? 'Working…' : confirmLabel }}</button>
-          <button class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text disabled:cursor-default disabled:opacity-50" :disabled="busy" :data-testid="cancelTestid ?? `${testid}-cancel`" @click="cancel">Cancel</button>
+          <BaseButton ref="confirmRef" variant="danger" class="flex-1" :busy="busy" :data-testid="confirmTestid ?? `${testid}-confirm`" @click="emit('confirm')">{{ busy ? 'Working…' : confirmLabel }}</BaseButton>
+          <BaseButton variant="secondary" :busy="busy" :data-testid="cancelTestid ?? `${testid}-cancel`" @click="cancel">Cancel</BaseButton>
         </footer>
       </div>
     </div>

--- a/desktop/frontend/src/components/ConfirmationDialog.vue
+++ b/desktop/frontend/src/components/ConfirmationDialog.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import IconAlertTriangle from '~icons/lucide/alert-triangle'
-import IconX from '~icons/lucide/x'
 import BaseButton from './BaseButton.vue'
+import BaseModal from './BaseModal.vue'
 import { useAutofocus } from '../composables/useAutofocus'
-import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = withDefaults(defineProps<{
   title: string
@@ -21,25 +20,26 @@ const confirmRef = ref<{ focus: () => void } | null>(null)
 
 function cancel(): void { if (!props.busy) emit('cancel') }
 
-useEscapeToClose(cancel)
 useAutofocus(confirmRef)
 </script>
 
 <template>
-  <Teleport to="body">
-    <div class="fixed inset-0 z-40 flex items-start justify-center bg-backdrop pt-[24vh]" :data-testid="`${testid}-backdrop`" @click.self="cancel">
-      <div class="w-[420px] overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl" role="alertdialog" :aria-label="title" aria-modal="true" :data-testid="testid">
-        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
-          <span class="flex size-7 items-center justify-center rounded-[7px] bg-severity-error-tint text-severity-error"><IconAlertTriangle class="size-4" /></span>
-          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">{{ title }}</div>
-          <button class="cursor-pointer text-text-3 hover:text-text disabled:cursor-default disabled:opacity-50" aria-label="Close" :disabled="busy" @click="cancel"><IconX class="size-4" /></button>
-        </header>
-        <div class="flex flex-col gap-3 px-5 py-4"><p class="text-[13px] leading-relaxed text-text-2">{{ description }}</p><p v-if="error" class="rounded border border-severity-error bg-severity-error-tint px-3 py-2 text-xs text-severity-error" :data-testid="`${testid}-error`">{{ error }}</p></div>
-        <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
-          <BaseButton ref="confirmRef" variant="danger" class="flex-1" :busy="busy" :data-testid="confirmTestid ?? `${testid}-confirm`" @click="emit('confirm')">{{ busy ? 'Working…' : confirmLabel }}</BaseButton>
-          <BaseButton variant="secondary" :busy="busy" :data-testid="cancelTestid ?? `${testid}-cancel`" @click="cancel">Cancel</BaseButton>
-        </footer>
-      </div>
+  <BaseModal
+    :title="title"
+    :icon="IconAlertTriangle"
+    tone="danger"
+    aria-role="alertdialog"
+    :busy="busy"
+    :testid="testid"
+    @close="cancel"
+  >
+    <div class="flex flex-col gap-3 px-5 py-4">
+      <p class="text-[13px] leading-relaxed text-text-2">{{ description }}</p>
+      <p v-if="error" class="rounded border border-severity-error bg-severity-error-tint px-3 py-2 text-xs text-severity-error" :data-testid="`${testid}-error`">{{ error }}</p>
     </div>
-  </Teleport>
+    <template #footer>
+      <BaseButton ref="confirmRef" variant="danger" class="flex-1" :busy="busy" :data-testid="confirmTestid ?? `${testid}-confirm`" @click="emit('confirm')">{{ busy ? 'Working…' : confirmLabel }}</BaseButton>
+      <BaseButton variant="secondary" :busy="busy" :data-testid="cancelTestid ?? `${testid}-cancel`" @click="cancel">Cancel</BaseButton>
+    </template>
+  </BaseModal>
 </template>

--- a/desktop/frontend/src/components/ConfirmationDialog.vue
+++ b/desktop/frontend/src/components/ConfirmationDialog.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { ref } from 'vue'
 import IconAlertTriangle from '~icons/lucide/alert-triangle'
 import IconX from '~icons/lucide/x'
+import { useAutofocus } from '../composables/useAutofocus'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = withDefaults(defineProps<{
   title: string
@@ -17,9 +19,9 @@ const emit = defineEmits<{ confirm: []; cancel: [] }>()
 const confirmRef = ref<HTMLButtonElement | null>(null)
 
 function cancel(): void { if (!props.busy) emit('cancel') }
-function onKeydown(event: KeyboardEvent): void { if (event.key === 'Escape') cancel() }
-onMounted(async () => { window.addEventListener('keydown', onKeydown); await nextTick(); confirmRef.value?.focus() })
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+useEscapeToClose(cancel)
+useAutofocus(confirmRef)
 </script>
 
 <template>

--- a/desktop/frontend/src/components/CreateSessionDialog.vue
+++ b/desktop/frontend/src/components/CreateSessionDialog.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import IconPlay from '~icons/lucide/play'
 import IconX from '~icons/lucide/x'
 import type { SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
+import { useAutofocus } from '../composables/useAutofocus'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ actionLabel: string; options: SessionLaunchOptions; busy: boolean; error: string | null }>()
 const emit = defineEmits<{ close: []; submit: [input: { name: string; repository: string; agent?: string }] }>()
@@ -38,16 +40,8 @@ function close() {
   if (!props.busy) emit('close')
 }
 
-function onKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') close()
-}
-
-onMounted(async () => {
-  window.addEventListener('keydown', onKeydown)
-  await nextTick()
-  nameInput.value?.focus()
-})
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useEscapeToClose(close)
+useAutofocus(nameInput)
 </script>
 
 <template>

--- a/desktop/frontend/src/components/CreateSessionDialog.vue
+++ b/desktop/frontend/src/components/CreateSessionDialog.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import IconPlay from '~icons/lucide/play'
-import IconX from '~icons/lucide/x'
 import BaseButton from './BaseButton.vue'
+import BaseModal from './BaseModal.vue'
 import type { SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
 import { useAutofocus } from '../composables/useAutofocus'
-import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ actionLabel: string; options: SessionLaunchOptions; busy: boolean; error: string | null }>()
 const emit = defineEmits<{ close: []; submit: [input: { name: string; repository: string; agent?: string }] }>()
@@ -37,41 +36,35 @@ function submit() {
   emit('submit', { name: sessionName, repository: repo, ...(agent.value ? { agent: agent.value } : {}) })
 }
 
-function close() {
-  if (!props.busy) emit('close')
-}
-
-useEscapeToClose(close)
 useAutofocus(nameInput)
 </script>
 
 <template>
-  <Teleport to="body">
-    <div class="fixed inset-0 z-40 flex items-start justify-center bg-backdrop pt-[18vh]" @click.self="close">
-      <div class="w-[460px] overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl" role="dialog" aria-modal="true" aria-label="Create session" data-testid="create-session-dialog">
-        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
-          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconPlay class="size-4" /></span>
-          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">{{ actionLabel }}</div>
-          <button class="cursor-pointer text-text-3 hover:text-text disabled:cursor-default disabled:opacity-50" aria-label="Close" :disabled="busy" @click="close"><IconX class="size-4" /></button>
-        </header>
-        <form class="flex flex-col gap-3 px-5 py-4" @submit.prevent="submit">
-          <label class="flex flex-col gap-1.5 text-xs font-medium text-text-2">Repository
-            <input v-model="repository" list="session-repositories" class="rounded-lg border border-strong bg-app px-3 py-2.5 text-[13px] text-text outline-none focus:border-accent" placeholder="https://github.com/owner/repository.git" data-testid="session-repository">
-            <datalist id="session-repositories"><option v-for="repo in options.repositories" :key="repo.repository" :value="repo.repository">{{ repo.name }}</option></datalist>
-          </label>
-          <label class="flex flex-col gap-1.5 text-xs font-medium text-text-2">Session name
-            <input ref="nameInput" v-model="name" class="rounded-lg border border-strong bg-app px-3 py-2.5 text-[13px] text-text outline-none focus:border-accent" placeholder="review-pr-123" data-testid="session-name">
-          </label>
-          <label class="flex flex-col gap-1.5 text-xs font-medium text-text-2">Agent <span class="font-normal text-text-4">(optional)</span>
-            <select v-model="agent" class="rounded-lg border border-strong bg-app px-3 py-2.5 text-[13px] text-text outline-none focus:border-accent" data-testid="session-agent"><option value="">Use action default</option><option v-for="key in options.agents" :key="key" :value="key">{{ key }}</option></select>
-          </label>
-          <p v-if="validationError || error" class="text-xs text-severity-error" data-testid="create-session-error">{{ validationError || error }}</p>
-        </form>
-        <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
-          <BaseButton class="flex-1" :busy="busy" :disabled="!canSubmit" data-testid="create-session-submit" @click="submit">{{ busy ? 'Creating…' : 'Create session' }}</BaseButton>
-          <BaseButton variant="secondary" :busy="busy" @click="close">Cancel</BaseButton>
-        </footer>
-      </div>
-    </div>
-  </Teleport>
+  <BaseModal
+    :title="actionLabel"
+    :icon="IconPlay"
+    :width="460"
+    pt="pt-[18vh]"
+    :busy="busy"
+    testid="create-session-dialog"
+    @close="emit('close')"
+  >
+    <form class="flex flex-col gap-3 px-5 py-4" @submit.prevent="submit">
+      <label class="flex flex-col gap-1.5 text-xs font-medium text-text-2">Repository
+        <input v-model="repository" list="session-repositories" class="rounded-lg border border-strong bg-app px-3 py-2.5 text-[13px] text-text outline-none focus:border-accent" placeholder="https://github.com/owner/repository.git" data-testid="session-repository">
+        <datalist id="session-repositories"><option v-for="repo in options.repositories" :key="repo.repository" :value="repo.repository">{{ repo.name }}</option></datalist>
+      </label>
+      <label class="flex flex-col gap-1.5 text-xs font-medium text-text-2">Session name
+        <input ref="nameInput" v-model="name" class="rounded-lg border border-strong bg-app px-3 py-2.5 text-[13px] text-text outline-none focus:border-accent" placeholder="review-pr-123" data-testid="session-name">
+      </label>
+      <label class="flex flex-col gap-1.5 text-xs font-medium text-text-2">Agent <span class="font-normal text-text-4">(optional)</span>
+        <select v-model="agent" class="rounded-lg border border-strong bg-app px-3 py-2.5 text-[13px] text-text outline-none focus:border-accent" data-testid="session-agent"><option value="">Use action default</option><option v-for="key in options.agents" :key="key" :value="key">{{ key }}</option></select>
+      </label>
+      <p v-if="validationError || error" class="text-xs text-severity-error" data-testid="create-session-error">{{ validationError || error }}</p>
+    </form>
+    <template #footer>
+      <BaseButton class="flex-1" :busy="busy" :disabled="!canSubmit" data-testid="create-session-submit" @click="submit">{{ busy ? 'Creating…' : 'Create session' }}</BaseButton>
+      <BaseButton variant="secondary" :busy="busy" @click="emit('close')">Cancel</BaseButton>
+    </template>
+  </BaseModal>
 </template>

--- a/desktop/frontend/src/components/CreateSessionDialog.vue
+++ b/desktop/frontend/src/components/CreateSessionDialog.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import IconPlay from '~icons/lucide/play'
 import IconX from '~icons/lucide/x'
+import BaseButton from './BaseButton.vue'
 import type { SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
 import { useAutofocus } from '../composables/useAutofocus'
 import { useEscapeToClose } from '../composables/useEscapeToClose'
@@ -67,8 +68,8 @@ useAutofocus(nameInput)
           <p v-if="validationError || error" class="text-xs text-severity-error" data-testid="create-session-error">{{ validationError || error }}</p>
         </form>
         <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
-          <button class="flex-1 cursor-pointer rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50" :disabled="busy || !canSubmit" data-testid="create-session-submit" @click="submit">{{ busy ? 'Creating…' : 'Create session' }}</button>
-          <button class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text disabled:cursor-default disabled:opacity-50" :disabled="busy" @click="close">Cancel</button>
+          <BaseButton class="flex-1" :busy="busy" :disabled="!canSubmit" data-testid="create-session-submit" @click="submit">{{ busy ? 'Creating…' : 'Create session' }}</BaseButton>
+          <BaseButton variant="secondary" :busy="busy" @click="close">Cancel</BaseButton>
         </footer>
       </div>
     </div>

--- a/desktop/frontend/src/components/DrawerSheet.vue
+++ b/desktop/frontend/src/components/DrawerSheet.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 import { useResizablePanel } from '../composables/useResizablePanel'
 import PanelResizeHandle from './PanelResizeHandle.vue'
 
@@ -48,9 +49,7 @@ function onBackdropClick(): void {
   if (props.closeOnBackdrop) close()
 }
 
-function onKeydown(event: KeyboardEvent): void {
-  if (props.closeOnEscape && event.key === 'Escape') close()
-}
+useEscapeToClose(close, { enabled: () => props.closeOnEscape })
 
 function focusableElements(): HTMLElement[] {
   return Array.from(sheetRef.value?.querySelectorAll<HTMLElement>('button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])') ?? [])
@@ -79,10 +78,6 @@ function stepResize(deltaPx: number): void {
   resizePanel?.step(deltaPx)
 }
 
-onMounted(() => {
-  if (props.closeOnEscape) window.addEventListener('keydown', onKeydown)
-})
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>

--- a/desktop/frontend/src/components/FeedList.vue
+++ b/desktop/frontend/src/components/FeedList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onClickOutside } from '@vueuse/core'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import FeedListItem from './FeedListItem.vue'
 import IconCheck from '~icons/lucide/check'
@@ -44,21 +45,13 @@ const activeViewOptionCount = computed(() => props.sort === 'newest' ? 0 : 1)
 function closeViewMenu(): void { viewMenuOpen.value = false }
 function chooseSort(value: FeedSort): void { emit('set-sort', value); closeViewMenu() }
 function refreshFromMenu(): void { emit('refresh'); closeViewMenu() }
-function onDocumentPointer(event: PointerEvent): void {
-  if (viewMenuOpen.value && viewMenu.value && !viewMenu.value.contains(event.target as Node)) closeViewMenu()
-}
 function onDocumentKeydown(event: KeyboardEvent): void {
   if (viewMenuOpen.value && event.key === 'Escape') closeViewMenu()
 }
 
-onMounted(() => {
-  document.addEventListener('pointerdown', onDocumentPointer)
-  document.addEventListener('keydown', onDocumentKeydown)
-})
-onBeforeUnmount(() => {
-  document.removeEventListener('pointerdown', onDocumentPointer)
-  document.removeEventListener('keydown', onDocumentKeydown)
-})
+onClickOutside(viewMenu, () => { if (viewMenuOpen.value) closeViewMenu() })
+onMounted(() => document.addEventListener('keydown', onDocumentKeydown))
+onBeforeUnmount(() => document.removeEventListener('keydown', onDocumentKeydown))
 
 // Keep the selected row in view when navigation moves the cursor by keyboard
 // (mirrors CommandPalette's scrollIntoView on selection change).

--- a/desktop/frontend/src/components/KeybindingSettingsView.vue
+++ b/desktop/frontend/src/components/KeybindingSettingsView.vue
@@ -10,6 +10,8 @@ import IconRotateCcw from '~icons/lucide/rotate-ccw'
 import IconSearch from '~icons/lucide/search'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import IconX from '~icons/lucide/x'
+import EmptyState from './settings/EmptyState.vue'
+import SettingsSection from './settings/SettingsSection.vue'
 import { commandCatalog } from '../keybindings/catalog'
 import { comboFromEvent, formatCombo, useKeybindings } from '../composables/useKeybindings'
 
@@ -92,12 +94,11 @@ onUnmounted(endCapture)
 
 <template>
   <div class="mx-auto max-w-[640px]" data-testid="settings-keybindings">
-    <div class="mb-4">
-      <h2 class="text-[15px] font-semibold text-text">Keyboard shortcuts</h2>
-      <p class="mt-1 text-xs leading-relaxed text-text-3">
-        Rebind commands to your own keys. Bindings apply across the app; feed navigation keys work while the feed is open.
-      </p>
-    </div>
+    <SettingsSection
+      title="Keyboard shortcuts"
+      description="Rebind commands to your own keys. Bindings apply across the app; feed navigation keys work while the feed is open."
+      class="mb-4"
+    />
 
     <label class="mb-4 flex items-center gap-2 rounded-lg border border-strong bg-app px-3 py-2 focus-within:border-accent">
       <IconSearch class="size-[14px] shrink-0 text-text-3" />
@@ -110,9 +111,9 @@ onUnmounted(endCapture)
       >
     </label>
 
-    <div v-if="empty" class="rounded-lg border border-border bg-raised px-4 py-8 text-center text-xs text-text-3" data-testid="keybinding-empty">
+    <EmptyState v-if="empty" boxed data-testid="keybinding-empty">
       No shortcuts match "{{ filter.trim() }}".
-    </div>
+    </EmptyState>
 
     <div v-for="group in groups" :key="group.group" class="mb-5">
       <div class="mb-1.5 px-1 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-text-3">{{ group.group }}</div>

--- a/desktop/frontend/src/components/NewProfileModal.vue
+++ b/desktop/frontend/src/components/NewProfileModal.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import IconLayoutGrid from '~icons/lucide/layout-grid'
-import IconX from '~icons/lucide/x'
 import BaseButton from './BaseButton.vue'
+import BaseModal from './BaseModal.vue'
 import { useAutofocus } from '../composables/useAutofocus'
-import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ busy: boolean; error: string | null }>()
 const emit = defineEmits<{ close: []; create: [name: string] }>()
@@ -18,52 +17,36 @@ function submit() {
   if (trimmed) emit('create', trimmed)
 }
 
-useEscapeToClose(() => emit('close'))
 useAutofocus(inputRef)
 </script>
 
 <template>
-  <Teleport to="body">
-    <div class="fixed inset-0 z-40 flex items-start justify-center bg-backdrop pt-[24vh]" @click.self="emit('close')">
-      <div
-        class="w-[420px] overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl"
-        role="dialog"
-        aria-label="New profile"
-        aria-modal="true"
-        data-testid="new-profile-modal"
+  <BaseModal title="New profile" :icon="IconLayoutGrid" testid="new-profile-modal" @close="emit('close')">
+    <div class="flex flex-col gap-3 px-5 py-4">
+      <input
+        ref="inputRef"
+        v-model="name"
+        type="text"
+        placeholder="Frontend Triage"
+        class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+        data-testid="new-profile-input"
+        @keydown.enter="submit"
       >
-        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
-          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconLayoutGrid class="size-4" /></span>
-          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">New profile</div>
-          <button class="cursor-pointer text-text-3 hover:text-text" aria-label="Close" @click="emit('close')"><IconX class="size-4" /></button>
-        </header>
-        <div class="flex flex-col gap-3 px-5 py-4">
-          <input
-            ref="inputRef"
-            v-model="name"
-            type="text"
-            placeholder="Frontend Triage"
-            class="w-full rounded-lg border border-strong bg-app px-3.5 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
-            data-testid="new-profile-input"
-            @keydown.enter="submit"
-          >
-          <p class="text-xs leading-relaxed text-text-4">
-            Saved as a flow in <span class="font-mono text-text-3">flows/</span> with the default feeds — your open PRs,
-            the notifications inbox, and cross-repo assignments.
-          </p>
-          <p v-if="error" class="text-xs text-kind-issue" data-testid="new-profile-error">{{ error }}</p>
-        </div>
-        <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
-          <BaseButton
-            class="flex-1"
-            :busy="busy"
-            :disabled="!name.trim()"
-            data-testid="new-profile-submit"
-            @click="submit"
-          >Create profile ↵</BaseButton>
-          <BaseButton variant="secondary" @click="emit('close')">Cancel</BaseButton>
-        </footer>
-      </div>
+      <p class="text-xs leading-relaxed text-text-4">
+        Saved as a flow in <span class="font-mono text-text-3">flows/</span> with the default feeds — your open PRs,
+        the notifications inbox, and cross-repo assignments.
+      </p>
+      <p v-if="error" class="text-xs text-kind-issue" data-testid="new-profile-error">{{ error }}</p>
     </div>
-  </Teleport>
+    <template #footer>
+      <BaseButton
+        class="flex-1"
+        :busy="busy"
+        :disabled="!name.trim()"
+        data-testid="new-profile-submit"
+        @click="submit"
+      >Create profile ↵</BaseButton>
+      <BaseButton variant="secondary" @click="emit('close')">Cancel</BaseButton>
+    </template>
+  </BaseModal>
 </template>

--- a/desktop/frontend/src/components/NewProfileModal.vue
+++ b/desktop/frontend/src/components/NewProfileModal.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import IconLayoutGrid from '~icons/lucide/layout-grid'
 import IconX from '~icons/lucide/x'
+import BaseButton from './BaseButton.vue'
 import { useAutofocus } from '../composables/useAutofocus'
 import { useEscapeToClose } from '../composables/useEscapeToClose'
 
@@ -53,13 +54,14 @@ useAutofocus(inputRef)
           <p v-if="error" class="text-xs text-kind-issue" data-testid="new-profile-error">{{ error }}</p>
         </div>
         <footer class="flex gap-2.5 border-t border-row bg-raised px-5 py-3.5">
-          <button
-            class="flex-1 cursor-pointer rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
-            :disabled="busy || !name.trim()"
+          <BaseButton
+            class="flex-1"
+            :busy="busy"
+            :disabled="!name.trim()"
             data-testid="new-profile-submit"
             @click="submit"
-          >Create profile ↵</button>
-          <button class="cursor-pointer rounded-lg border border-card px-4 py-2.5 text-[13.5px] text-text-2 hover:text-text" @click="emit('close')">Cancel</button>
+          >Create profile ↵</BaseButton>
+          <BaseButton variant="secondary" @click="emit('close')">Cancel</BaseButton>
         </footer>
       </div>
     </div>

--- a/desktop/frontend/src/components/NewProfileModal.vue
+++ b/desktop/frontend/src/components/NewProfileModal.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { ref } from 'vue'
 import IconLayoutGrid from '~icons/lucide/layout-grid'
 import IconX from '~icons/lucide/x'
+import { useAutofocus } from '../composables/useAutofocus'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ busy: boolean; error: string | null }>()
 const emit = defineEmits<{ close: []; create: [name: string] }>()
@@ -15,16 +17,8 @@ function submit() {
   if (trimmed) emit('create', trimmed)
 }
 
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') emit('close')
-}
-
-onMounted(async () => {
-  window.addEventListener('keydown', onKeydown)
-  await nextTick()
-  inputRef.value?.focus()
-})
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useEscapeToClose(() => emit('close'))
+useAutofocus(inputRef)
 </script>
 
 <template>

--- a/desktop/frontend/src/components/ProfileSettingsView.vue
+++ b/desktop/frontend/src/components/ProfileSettingsView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconSlidersHorizontal from '~icons/lucide/sliders-horizontal'
 import IconTrash2 from '~icons/lucide/trash-2'
 import type { Profile } from '../types/feed'
 import type { ProfileSettingsSection } from '../router'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = withDefaults(defineProps<{ profile: Profile; activeSection: ProfileSettingsSection; renaming?: boolean; renameError?: string | null }>(), {
   renaming: false,
@@ -24,12 +25,7 @@ function submitRename(): void {
   emit('rename', trimmed)
 }
 
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') emit('close')
-}
-
-onMounted(() => window.addEventListener('keydown', onKeydown))
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useEscapeToClose(() => emit('close'))
 </script>
 
 <template>

--- a/desktop/frontend/src/components/ProfileSettingsView.vue
+++ b/desktop/frontend/src/components/ProfileSettingsView.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconSlidersHorizontal from '~icons/lucide/sliders-horizontal'
 import IconTrash2 from '~icons/lucide/trash-2'
 import BaseButton from './BaseButton.vue'
+import SettingsLayout from './settings/SettingsLayout.vue'
+import SettingsNavItem from './settings/SettingsNavItem.vue'
 import type { Profile } from '../types/feed'
 import type { ProfileSettingsSection } from '../router'
-import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = withDefaults(defineProps<{ profile: Profile; activeSection: ProfileSettingsSection; renaming?: boolean; renameError?: string | null }>(), {
   renaming: false,
@@ -25,89 +25,74 @@ function submitRename(): void {
   if (!trimmed || trimmed === props.profile.name || props.renaming) return
   emit('rename', trimmed)
 }
-
-useEscapeToClose(() => emit('close'))
 </script>
 
 <template>
-  <div class="flex h-full min-h-0 flex-1" data-testid="profile-settings-view">
-    <aside class="hive-scroll w-[200px] shrink-0 overflow-y-auto border-r border-row bg-sidebar">
-      <div class="border-b border-border px-4 pb-3 pt-4">
-        <div class="text-[15px] font-semibold tracking-[-.01em] text-text">Profile settings</div>
-        <div class="mt-1 truncate text-xs text-text-3">{{ props.profile.name }}</div>
-      </div>
-      <nav class="flex flex-col gap-0.5 px-2.5 py-3">
-        <button
-          type="button"
-          class="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px]"
-          :class="props.activeSection === 'general' ? 'bg-hover font-medium text-accent' : 'text-text-2 hover:bg-chip hover:text-text'"
-          :aria-current="props.activeSection === 'general' ? 'true' : undefined"
-          data-testid="profile-settings-general"
-          @click="emit('select-section', 'general')"
-        ><IconSlidersHorizontal class="size-3.5 shrink-0" />General</button>
-        <button
-          type="button"
-          class="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px]"
-          :class="props.activeSection === 'danger' ? 'bg-hover font-medium text-severity-error' : 'text-text-2 hover:bg-chip hover:text-text'"
-          :aria-current="props.activeSection === 'danger' ? 'true' : undefined"
-          data-testid="profile-settings-danger"
-          @click="emit('select-section', 'danger')"
-        ><IconTrash2 class="size-3.5 shrink-0" />Danger zone</button>
-      </nav>
-    </aside>
+  <SettingsLayout close-testid="profile-settings-close" data-testid="profile-settings-view" @close="emit('close')">
+    <template #sidebar-title>
+      <div class="text-[15px] font-semibold tracking-[-.01em] text-text">Profile settings</div>
+      <div class="mt-1 truncate text-xs text-text-3">{{ props.profile.name }}</div>
+    </template>
+    <template #nav>
+      <SettingsNavItem
+        :active="props.activeSection === 'general'"
+        :icon="IconSlidersHorizontal"
+        label="General"
+        testid="profile-settings-general"
+        @select="emit('select-section', 'general')"
+      />
+      <SettingsNavItem
+        :active="props.activeSection === 'danger'"
+        :icon="IconTrash2"
+        label="Danger zone"
+        testid="profile-settings-danger"
+        tone="danger"
+        @select="emit('select-section', 'danger')"
+      />
+    </template>
+    <template #header-title>
+      <span class="text-[13px] font-semibold text-text">{{ props.activeSection === 'general' ? 'General' : 'Danger zone' }}</span>
+    </template>
 
-    <section class="flex min-w-0 flex-1 flex-col">
-      <header class="flex h-11 shrink-0 items-center gap-2.5 border-b border-row bg-canvas-toolbar px-4">
-        <span class="text-[13px] font-semibold text-text">{{ props.activeSection === 'general' ? 'General' : 'Danger zone' }}</span>
-        <div class="flex-1" />
-        <button
-          type="button"
-          class="flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12.5px] text-text-2 hover:bg-chip hover:text-text"
-          data-testid="profile-settings-close"
-          @click="emit('close')"
-        ><IconArrowLeft class="size-3.5" />Back to feed</button>
-      </header>
-
-      <div class="hive-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6">
-        <div class="mx-auto max-w-[560px]">
-          <form v-if="props.activeSection === 'general'" class="rounded-lg border border-border bg-raised p-4" @submit.prevent="submitRename">
-            <label for="profile-settings-name" class="text-[12.5px] text-text-3">Profile name</label>
-            <div class="mt-2 flex items-center gap-2.5">
-              <input
-                id="profile-settings-name"
-                v-model="name"
-                type="text"
-                class="min-w-0 flex-1 rounded-lg border border-strong bg-app px-3 py-2 text-[13.5px] text-text outline-none focus:border-accent disabled:opacity-60"
-                :disabled="props.renaming"
-                data-testid="profile-settings-name"
-              >
-              <BaseButton
-                type="submit"
-                size="sm"
-                :busy="props.renaming"
-                :disabled="!name.trim() || name.trim() === props.profile.name"
-                data-testid="profile-settings-save-name"
-              >{{ props.renaming ? 'Saving…' : 'Save' }}</BaseButton>
-            </div>
-            <p v-if="props.renameError" class="mt-2 text-xs text-severity-error" data-testid="profile-settings-rename-error">{{ props.renameError }}</p>
-            <div class="mt-3 border-t border-border pt-3 text-xs text-text-3">{{ props.profile.sourceSummary }}</div>
-          </form>
-
-          <div v-else class="rounded-lg border border-severity-error/35 bg-raised p-4">
-            <div class="text-[14px] font-semibold text-text">Delete profile</div>
-            <p class="mt-1.5 text-xs leading-relaxed text-text-3">
-              Permanently remove this profile, its flow file, and its committed feed items.
-            </p>
+    <div class="hive-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6">
+      <div class="mx-auto max-w-[560px]">
+        <form v-if="props.activeSection === 'general'" class="rounded-lg border border-border bg-raised p-4" @submit.prevent="submitRename">
+          <label for="profile-settings-name" class="text-[12.5px] text-text-3">Profile name</label>
+          <div class="mt-2 flex items-center gap-2.5">
+            <input
+              id="profile-settings-name"
+              v-model="name"
+              type="text"
+              class="min-w-0 flex-1 rounded-lg border border-strong bg-app px-3 py-2 text-[13.5px] text-text outline-none focus:border-accent disabled:opacity-60"
+              :disabled="props.renaming"
+              data-testid="profile-settings-name"
+            >
             <BaseButton
-              variant="danger"
+              type="submit"
               size="sm"
-              class="mt-4"
-              data-testid="profile-settings-delete"
-              @click="emit('delete')"
-            ><template #icon><IconTrash2 class="size-3.5" /></template>Delete profile</BaseButton>
+              :busy="props.renaming"
+              :disabled="!name.trim() || name.trim() === props.profile.name"
+              data-testid="profile-settings-save-name"
+            >{{ props.renaming ? 'Saving…' : 'Save' }}</BaseButton>
           </div>
+          <p v-if="props.renameError" class="mt-2 text-xs text-severity-error" data-testid="profile-settings-rename-error">{{ props.renameError }}</p>
+          <div class="mt-3 border-t border-border pt-3 text-xs text-text-3">{{ props.profile.sourceSummary }}</div>
+        </form>
+
+        <div v-else class="rounded-lg border border-severity-error/35 bg-raised p-4">
+          <div class="text-[14px] font-semibold text-text">Delete profile</div>
+          <p class="mt-1.5 text-xs leading-relaxed text-text-3">
+            Permanently remove this profile, its flow file, and its committed feed items.
+          </p>
+          <BaseButton
+            variant="danger"
+            size="sm"
+            class="mt-4"
+            data-testid="profile-settings-delete"
+            @click="emit('delete')"
+          ><template #icon><IconTrash2 class="size-3.5" /></template>Delete profile</BaseButton>
         </div>
       </div>
-    </section>
-  </div>
+    </div>
+  </SettingsLayout>
 </template>

--- a/desktop/frontend/src/components/ProfileSettingsView.vue
+++ b/desktop/frontend/src/components/ProfileSettingsView.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconSlidersHorizontal from '~icons/lucide/sliders-horizontal'
 import IconTrash2 from '~icons/lucide/trash-2'
+import BaseButton from './BaseButton.vue'
 import type { Profile } from '../types/feed'
 import type { ProfileSettingsSection } from '../router'
 import { useEscapeToClose } from '../composables/useEscapeToClose'
@@ -80,12 +81,13 @@ useEscapeToClose(() => emit('close'))
                 :disabled="props.renaming"
                 data-testid="profile-settings-name"
               >
-              <button
+              <BaseButton
                 type="submit"
-                class="cursor-pointer rounded-lg bg-accent px-3.5 py-2 text-[12.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
-                :disabled="props.renaming || !name.trim() || name.trim() === props.profile.name"
+                size="sm"
+                :busy="props.renaming"
+                :disabled="!name.trim() || name.trim() === props.profile.name"
                 data-testid="profile-settings-save-name"
-              >{{ props.renaming ? 'Saving…' : 'Save' }}</button>
+              >{{ props.renaming ? 'Saving…' : 'Save' }}</BaseButton>
             </div>
             <p v-if="props.renameError" class="mt-2 text-xs text-severity-error" data-testid="profile-settings-rename-error">{{ props.renameError }}</p>
             <div class="mt-3 border-t border-border pt-3 text-xs text-text-3">{{ props.profile.sourceSummary }}</div>
@@ -96,12 +98,13 @@ useEscapeToClose(() => emit('close'))
             <p class="mt-1.5 text-xs leading-relaxed text-text-3">
               Permanently remove this profile, its flow file, and its committed feed items.
             </p>
-            <button
-              type="button"
-              class="mt-4 flex cursor-pointer items-center gap-1.5 rounded-md bg-severity-error px-3 py-2 text-[12.5px] font-semibold text-accent-contrast hover:brightness-110"
+            <BaseButton
+              variant="danger"
+              size="sm"
+              class="mt-4"
               data-testid="profile-settings-delete"
               @click="emit('delete')"
-            ><IconTrash2 class="size-3.5" />Delete profile</button>
+            ><template #icon><IconTrash2 class="size-3.5" /></template>Delete profile</BaseButton>
           </div>
         </div>
       </div>

--- a/desktop/frontend/src/components/SettingsView.vue
+++ b/desktop/frontend/src/components/SettingsView.vue
@@ -22,6 +22,7 @@ import slackIcon from '../assets/integrations/slack.svg'
 import GithubIntegrationDrawer from './settings/GithubIntegrationDrawer.vue'
 import SettingsLayout from './settings/SettingsLayout.vue'
 import SettingsNavItem from './settings/SettingsNavItem.vue'
+import SettingsSection from './settings/SettingsSection.vue'
 import SettingsSegmented from './settings/SettingsSegmented.vue'
 import { setTheme, themeLabels, themes, useTheme, type Theme } from '../composables/useTheme'
 import type { ApplicationSettingsSection } from '../router'
@@ -101,12 +102,11 @@ function onThemeChange(value: string): void {
       <SystemSettingsView v-else-if="props.activeCategory === 'system'" />
 
       <div v-else class="mx-auto max-w-[640px]" data-testid="settings-integrations">
-        <div class="mb-5">
-          <h2 class="text-[15px] font-semibold text-text">Data sources</h2>
-          <p class="mt-1 text-xs leading-relaxed text-text-3">
-            Connections bring external events into Hive. More providers will support guided setup here as they become available.
-          </p>
-        </div>
+        <SettingsSection
+          title="Data sources"
+          description="Connections bring external events into Hive. More providers will support guided setup here as they become available."
+          class="mb-5"
+        />
 
         <div class="flex flex-col gap-3">
           <BaseCard class="rounded-lg border border-border bg-raised" data-testid="integration-github">

--- a/desktop/frontend/src/components/SettingsView.vue
+++ b/desktop/frontend/src/components/SettingsView.vue
@@ -3,7 +3,6 @@
 // Only settings backed by real behavior or explicitly marked future
 // integrations belong here.
 import { computed, ref } from 'vue'
-import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconKeyboard from '~icons/lucide/keyboard'
 import IconPalette from '~icons/lucide/palette'
 import IconPlug from '~icons/lucide/plug'
@@ -17,10 +16,11 @@ import githubIcon from '../assets/integrations/github.svg'
 import grafanaIcon from '../assets/integrations/grafana.svg'
 import posthogIcon from '../assets/integrations/posthog.svg'
 import slackIcon from '../assets/integrations/slack.svg'
-import SettingsSegmented from './settings/SettingsSegmented.vue'
 import GithubIntegrationDrawer from './settings/GithubIntegrationDrawer.vue'
+import SettingsLayout from './settings/SettingsLayout.vue'
+import SettingsNavItem from './settings/SettingsNavItem.vue'
+import SettingsSegmented from './settings/SettingsSegmented.vue'
 import { setTheme, themeLabels, themes, useTheme, type Theme } from '../composables/useTheme'
-import { useEscapeToClose } from '../composables/useEscapeToClose'
 import type { ApplicationSettingsSection } from '../router'
 
 const props = withDefaults(defineProps<{
@@ -57,120 +57,105 @@ const futureIntegrations = [
 function onThemeChange(value: string): void {
   setTheme(value as Theme)
 }
-
-useEscapeToClose(() => emit('close'))
 </script>
 
 <template>
-  <div class="flex h-full min-h-0 flex-1" data-testid="settings-view">
-    <aside class="hive-scroll w-[200px] shrink-0 overflow-y-auto border-r border-row bg-sidebar">
-      <div class="border-b border-border px-4 pb-3 pt-4">
-        <div class="text-[15px] font-semibold tracking-[-.01em] text-text">Application settings</div>
+  <SettingsLayout close-testid="settings-close" data-testid="settings-view" @close="emit('close')">
+    <template #sidebar-title>
+      <div class="text-[15px] font-semibold tracking-[-.01em] text-text">Application settings</div>
+    </template>
+    <template #nav>
+      <SettingsNavItem
+        v-for="category in categories"
+        :key="category.id"
+        :active="props.activeCategory === category.id"
+        :icon="category.icon"
+        :label="category.label"
+        :testid="`settings-category-${category.id}`"
+        @select="emit('select-category', category.id)"
+      />
+    </template>
+    <template #header-title>
+      <span class="text-[13px] font-semibold text-text">{{ sectionTitle }}</span>
+    </template>
+
+    <div class="hive-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6">
+      <div v-if="props.activeCategory === 'appearance'" class="mx-auto max-w-[560px]">
+        <SettingsSegmented
+          :model-value="theme"
+          label="Theme"
+          :options="themeOptions"
+          hint="Applies immediately across the whole app."
+          testid="settings-theme-toggle"
+          @update:model-value="onThemeChange"
+        />
       </div>
-      <nav class="flex flex-col gap-0.5 px-2.5 py-3">
-        <button
-          v-for="category in categories"
-          :key="category.id"
-          type="button"
-          class="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px]"
-          :class="props.activeCategory === category.id ? 'bg-hover font-medium text-accent' : 'text-text-2 hover:bg-chip hover:text-text'"
-          :aria-current="props.activeCategory === category.id ? 'true' : undefined"
-          :data-testid="`settings-category-${category.id}`"
-          @click="emit('select-category', category.id)"
-        ><component :is="category.icon" class="size-3.5 shrink-0" />{{ category.label }}</button>
-      </nav>
-    </aside>
 
-    <section class="flex min-w-0 flex-1 flex-col">
-      <header class="flex h-11 shrink-0 items-center gap-2.5 border-b border-row bg-canvas-toolbar px-4">
-        <span class="text-[13px] font-semibold text-text">{{ sectionTitle }}</span>
-        <div class="flex-1" />
-        <button
-          type="button"
-          class="flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12.5px] text-text-2 hover:bg-chip hover:text-text"
-          data-testid="settings-close"
-          @click="emit('close')"
-        ><IconArrowLeft class="size-3.5" />Back to feed</button>
-      </header>
+      <KeybindingSettingsView v-else-if="props.activeCategory === 'keybindings'" />
 
-      <div class="hive-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6">
-        <div v-if="props.activeCategory === 'appearance'" class="mx-auto max-w-[560px]">
-          <SettingsSegmented
-            :model-value="theme"
-            label="Theme"
-            :options="themeOptions"
-            hint="Applies immediately across the whole app."
-            testid="settings-theme-toggle"
-            @update:model-value="onThemeChange"
-          />
+      <ActionSettingsView v-else-if="props.activeCategory === 'actions'" :known-types="props.knownFeedTypes" />
+
+      <SystemSettingsView v-else-if="props.activeCategory === 'system'" />
+
+      <div v-else class="mx-auto max-w-[640px]" data-testid="settings-integrations">
+        <div class="mb-5">
+          <h2 class="text-[15px] font-semibold text-text">Data sources</h2>
+          <p class="mt-1 text-xs leading-relaxed text-text-3">
+            Connections bring external events into Hive. More providers will support guided setup here as they become available.
+          </p>
         </div>
 
-        <KeybindingSettingsView v-else-if="props.activeCategory === 'keybindings'" />
+        <div class="flex flex-col gap-3">
+          <article class="flex items-center gap-3 rounded-lg border border-border bg-raised p-4" data-testid="integration-github">
+            <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white p-2">
+              <img :src="githubIcon" alt="GitHub" class="size-full" />
+            </span>
+            <div class="min-w-0 flex-1">
+              <div class="text-[13.5px] font-semibold text-text">GitHub</div>
+              <div class="mt-0.5 truncate text-xs text-text-3">{{ props.githubLogin ? `Connected as ${props.githubLogin}` : 'Issues, pull requests, and notifications' }}</div>
+            </div>
+            <div class="flex shrink-0 items-center gap-2">
+              <span
+                class="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                :class="props.githubConnected ? 'bg-severity-success-tint text-severity-success' : 'bg-chip text-text-3'"
+                data-testid="integration-github-status"
+              >{{ props.githubConnected ? 'Connected' : 'Not connected' }}</span>
+              <button
+                type="button"
+                class="flex size-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-chip hover:text-text"
+                aria-label="Configure GitHub integration"
+                data-testid="integration-github-configure"
+                @click="githubSettingsOpen = true"
+              ><IconSettings class="size-3.5" /></button>
+            </div>
+          </article>
 
-        <ActionSettingsView v-else-if="props.activeCategory === 'actions'" :known-types="props.knownFeedTypes" />
-
-        <SystemSettingsView v-else-if="props.activeCategory === 'system'" />
-
-        <div v-else class="mx-auto max-w-[640px]" data-testid="settings-integrations">
-          <div class="mb-5">
-            <h2 class="text-[15px] font-semibold text-text">Data sources</h2>
-            <p class="mt-1 text-xs leading-relaxed text-text-3">
-              Connections bring external events into Hive. More providers will support guided setup here as they become available.
-            </p>
-          </div>
-
-          <div class="flex flex-col gap-3">
-            <article class="flex items-center gap-3 rounded-lg border border-border bg-raised p-4" data-testid="integration-github">
-              <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white p-2">
-                <img :src="githubIcon" alt="GitHub" class="size-full" />
-              </span>
-              <div class="min-w-0 flex-1">
-                <div class="text-[13.5px] font-semibold text-text">GitHub</div>
-                <div class="mt-0.5 truncate text-xs text-text-3">{{ props.githubLogin ? `Connected as ${props.githubLogin}` : 'Issues, pull requests, and notifications' }}</div>
-              </div>
-              <div class="flex shrink-0 items-center gap-2">
-                <span
-                  class="rounded-full px-2.5 py-1 text-[11px] font-semibold"
-                  :class="props.githubConnected ? 'bg-severity-success-tint text-severity-success' : 'bg-chip text-text-3'"
-                  data-testid="integration-github-status"
-                >{{ props.githubConnected ? 'Connected' : 'Not connected' }}</span>
-                <button
-                  type="button"
-                  class="flex size-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-chip hover:text-text"
-                  aria-label="Configure GitHub integration"
-                  data-testid="integration-github-configure"
-                  @click="githubSettingsOpen = true"
-                ><IconSettings class="size-3.5" /></button>
-              </div>
-            </article>
-
-            <article
-              v-for="integration in futureIntegrations"
-              :key="integration.id"
-              class="flex items-center gap-3 rounded-lg border border-border bg-raised p-4"
-              :data-testid="`integration-${integration.id}`"
-            >
-              <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white p-2">
-                <img :src="integration.icon" :alt="integration.name" class="size-full object-contain" />
-              </span>
-              <div class="min-w-0 flex-1">
-                <div class="text-[13.5px] font-semibold text-text">{{ integration.name }}</div>
-                <div class="mt-0.5 truncate text-xs text-text-3">{{ integration.description }}</div>
-              </div>
-              <div class="flex shrink-0 items-center gap-2.5">
-                <span class="font-mono text-[10.5px] text-text-4">Coming soon</span>
-                <button
-                  type="button"
-                  disabled
-                  class="cursor-not-allowed rounded-md border border-border px-2.5 py-1.5 text-[11.5px] font-medium text-text-4 opacity-60"
-                  :data-testid="`integration-${integration.id}-add`"
-                >Add connection</button>
-              </div>
-            </article>
-          </div>
-          <GithubIntegrationDrawer v-if="githubSettingsOpen" @close="githubSettingsOpen = false" />
+          <article
+            v-for="integration in futureIntegrations"
+            :key="integration.id"
+            class="flex items-center gap-3 rounded-lg border border-border bg-raised p-4"
+            :data-testid="`integration-${integration.id}`"
+          >
+            <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white p-2">
+              <img :src="integration.icon" :alt="integration.name" class="size-full object-contain" />
+            </span>
+            <div class="min-w-0 flex-1">
+              <div class="text-[13.5px] font-semibold text-text">{{ integration.name }}</div>
+              <div class="mt-0.5 truncate text-xs text-text-3">{{ integration.description }}</div>
+            </div>
+            <div class="flex shrink-0 items-center gap-2.5">
+              <span class="font-mono text-[10.5px] text-text-4">Coming soon</span>
+              <button
+                type="button"
+                disabled
+                class="cursor-not-allowed rounded-md border border-border px-2.5 py-1.5 text-[11.5px] font-medium text-text-4 opacity-60"
+                :data-testid="`integration-${integration.id}-add`"
+              >Add connection</button>
+            </div>
+          </article>
         </div>
+        <GithubIntegrationDrawer v-if="githubSettingsOpen" @close="githubSettingsOpen = false" />
       </div>
-    </section>
-  </div>
+    </div>
+  </SettingsLayout>
 </template>

--- a/desktop/frontend/src/components/SettingsView.vue
+++ b/desktop/frontend/src/components/SettingsView.vue
@@ -2,7 +2,7 @@
 // Application-wide settings, opened from the persistent profile rail.
 // Only settings backed by real behavior or explicitly marked future
 // integrations belong here.
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconKeyboard from '~icons/lucide/keyboard'
 import IconPalette from '~icons/lucide/palette'
@@ -20,6 +20,7 @@ import slackIcon from '../assets/integrations/slack.svg'
 import SettingsSegmented from './settings/SettingsSegmented.vue'
 import GithubIntegrationDrawer from './settings/GithubIntegrationDrawer.vue'
 import { setTheme, themeLabels, themes, useTheme, type Theme } from '../composables/useTheme'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 import type { ApplicationSettingsSection } from '../router'
 
 const props = withDefaults(defineProps<{
@@ -57,12 +58,7 @@ function onThemeChange(value: string): void {
   setTheme(value as Theme)
 }
 
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') emit('close')
-}
-
-onMounted(() => window.addEventListener('keydown', onKeydown))
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useEscapeToClose(() => emit('close'))
 </script>
 
 <template>

--- a/desktop/frontend/src/components/SettingsView.vue
+++ b/desktop/frontend/src/components/SettingsView.vue
@@ -9,6 +9,8 @@ import IconPlug from '~icons/lucide/plug'
 import IconPlay from '~icons/lucide/play'
 import IconHardDrive from '~icons/lucide/hard-drive'
 import IconSettings from '~icons/lucide/settings'
+import BaseCard from './BaseCard.vue'
+import BaseIconBadge from './BaseIconBadge.vue'
 import ActionSettingsView from './ActionSettingsView.vue'
 import KeybindingSettingsView from './KeybindingSettingsView.vue'
 import SystemSettingsView from './SystemSettingsView.vue'
@@ -106,53 +108,61 @@ function onThemeChange(value: string): void {
         </div>
 
         <div class="flex flex-col gap-3">
-          <article class="flex items-center gap-3 rounded-lg border border-border bg-raised p-4" data-testid="integration-github">
-            <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white p-2">
-              <img :src="githubIcon" alt="GitHub" class="size-full" />
-            </span>
+          <BaseCard class="rounded-lg border border-border bg-raised" data-testid="integration-github">
+            <template #icon>
+              <BaseIconBadge :size="40" rounded="rounded-lg" class="bg-white p-2">
+                <img :src="githubIcon" alt="GitHub" class="size-full" />
+              </BaseIconBadge>
+            </template>
             <div class="min-w-0 flex-1">
               <div class="text-[13.5px] font-semibold text-text">GitHub</div>
               <div class="mt-0.5 truncate text-xs text-text-3">{{ props.githubLogin ? `Connected as ${props.githubLogin}` : 'Issues, pull requests, and notifications' }}</div>
             </div>
-            <div class="flex shrink-0 items-center gap-2">
-              <span
-                class="rounded-full px-2.5 py-1 text-[11px] font-semibold"
-                :class="props.githubConnected ? 'bg-severity-success-tint text-severity-success' : 'bg-chip text-text-3'"
-                data-testid="integration-github-status"
-              >{{ props.githubConnected ? 'Connected' : 'Not connected' }}</span>
-              <button
-                type="button"
-                class="flex size-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-chip hover:text-text"
-                aria-label="Configure GitHub integration"
-                data-testid="integration-github-configure"
-                @click="githubSettingsOpen = true"
-              ><IconSettings class="size-3.5" /></button>
-            </div>
-          </article>
+            <template #actions>
+              <div class="flex shrink-0 items-center gap-2">
+                <span
+                  class="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                  :class="props.githubConnected ? 'bg-severity-success-tint text-severity-success' : 'bg-chip text-text-3'"
+                  data-testid="integration-github-status"
+                >{{ props.githubConnected ? 'Connected' : 'Not connected' }}</span>
+                <button
+                  type="button"
+                  class="flex size-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-chip hover:text-text"
+                  aria-label="Configure GitHub integration"
+                  data-testid="integration-github-configure"
+                  @click="githubSettingsOpen = true"
+                ><IconSettings class="size-3.5" /></button>
+              </div>
+            </template>
+          </BaseCard>
 
-          <article
+          <BaseCard
             v-for="integration in futureIntegrations"
             :key="integration.id"
-            class="flex items-center gap-3 rounded-lg border border-border bg-raised p-4"
+            class="rounded-lg border border-border bg-raised"
             :data-testid="`integration-${integration.id}`"
           >
-            <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white p-2">
-              <img :src="integration.icon" :alt="integration.name" class="size-full object-contain" />
-            </span>
+            <template #icon>
+              <BaseIconBadge :size="40" rounded="rounded-lg" class="bg-white p-2">
+                <img :src="integration.icon" :alt="integration.name" class="size-full object-contain" />
+              </BaseIconBadge>
+            </template>
             <div class="min-w-0 flex-1">
               <div class="text-[13.5px] font-semibold text-text">{{ integration.name }}</div>
               <div class="mt-0.5 truncate text-xs text-text-3">{{ integration.description }}</div>
             </div>
-            <div class="flex shrink-0 items-center gap-2.5">
-              <span class="font-mono text-[10.5px] text-text-4">Coming soon</span>
-              <button
-                type="button"
-                disabled
-                class="cursor-not-allowed rounded-md border border-border px-2.5 py-1.5 text-[11.5px] font-medium text-text-4 opacity-60"
-                :data-testid="`integration-${integration.id}-add`"
-              >Add connection</button>
-            </div>
-          </article>
+            <template #actions>
+              <div class="flex shrink-0 items-center gap-2.5">
+                <span class="font-mono text-[10.5px] text-text-4">Coming soon</span>
+                <button
+                  type="button"
+                  disabled
+                  class="cursor-not-allowed rounded-md border border-border px-2.5 py-1.5 text-[11.5px] font-medium text-text-4 opacity-60"
+                  :data-testid="`integration-${integration.id}-add`"
+                >Add connection</button>
+              </div>
+            </template>
+          </BaseCard>
         </div>
         <GithubIntegrationDrawer v-if="githubSettingsOpen" @close="githubSettingsOpen = false" />
       </div>

--- a/desktop/frontend/src/components/SettingsView.vue
+++ b/desktop/frontend/src/components/SettingsView.vue
@@ -9,6 +9,7 @@ import IconPlug from '~icons/lucide/plug'
 import IconPlay from '~icons/lucide/play'
 import IconHardDrive from '~icons/lucide/hard-drive'
 import IconSettings from '~icons/lucide/settings'
+import BaseBadge from './BaseBadge.vue'
 import BaseCard from './BaseCard.vue'
 import BaseIconBadge from './BaseIconBadge.vue'
 import ActionSettingsView from './ActionSettingsView.vue'
@@ -120,11 +121,12 @@ function onThemeChange(value: string): void {
             </div>
             <template #actions>
               <div class="flex shrink-0 items-center gap-2">
-                <span
-                  class="rounded-full px-2.5 py-1 text-[11px] font-semibold"
-                  :class="props.githubConnected ? 'bg-severity-success-tint text-severity-success' : 'bg-chip text-text-3'"
+                <BaseBadge
+                  :tone="props.githubConnected ? 'success' : 'neutral'"
+                  variant="pill"
+                  class="px-2.5 py-1 text-[11px] font-semibold"
                   data-testid="integration-github-status"
-                >{{ props.githubConnected ? 'Connected' : 'Not connected' }}</span>
+                >{{ props.githubConnected ? 'Connected' : 'Not connected' }}</BaseBadge>
                 <button
                   type="button"
                   class="flex size-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-chip hover:text-text"

--- a/desktop/frontend/src/components/SystemSettingsView.vue
+++ b/desktop/frontend/src/components/SystemSettingsView.vue
@@ -6,6 +6,7 @@ import { onMounted } from 'vue'
 import IconInfo from '~icons/lucide/info'
 import IconExternalLink from '~icons/lucide/external-link'
 import SettingsPathRow from './settings/SettingsPathRow.vue'
+import SettingsSection from './settings/SettingsSection.vue'
 import { useSystemSettings } from '../composables/useSystemSettings'
 
 const {
@@ -53,12 +54,11 @@ onMounted(() => {
       data-testid="system-error"
     >{{ error }}</div>
 
-    <section class="mb-6">
-      <h2 class="text-[15px] font-semibold text-text">Storage locations</h2>
-      <p class="mb-3 mt-1 text-xs leading-relaxed text-text-3">
-        Point Hive at a different folder — for example an iCloud-synced directory to share configuration across
-        machines. Existing data is not moved, and a new location applies after restarting.
-      </p>
+    <SettingsSection
+      title="Storage locations"
+      description="Point Hive at a different folder — for example an iCloud-synced directory to share configuration across machines. Existing data is not moved, and a new location applies after restarting."
+      class="mb-6 [&>p]:mb-3"
+    >
       <div v-if="info" class="flex flex-col gap-3">
         <SettingsPathRow
           label="Data directory"
@@ -87,13 +87,13 @@ onMounted(() => {
           @reset="resetConfigDir"
         />
       </div>
-    </section>
+    </SettingsSection>
 
-    <section>
-      <h2 class="text-[15px] font-semibold text-text">Diagnostics</h2>
-      <p class="mb-3 mt-1 text-xs leading-relaxed text-text-3">
-        Open or locate the log file and database when troubleshooting.
-      </p>
+    <SettingsSection
+      title="Diagnostics"
+      description="Open or locate the log file and database when troubleshooting."
+      class="[&>p]:mb-3"
+    >
       <div v-if="info" class="flex flex-col gap-3">
         <SettingsPathRow
           label="Log file"
@@ -112,13 +112,14 @@ onMounted(() => {
           @reveal="revealPath(info.database.path)"
         />
       </div>
-    </section>
+    </SettingsSection>
 
-    <section class="mt-6" data-testid="system-about">
-      <h2 class="text-[15px] font-semibold text-text">About</h2>
-      <p class="mb-3 mt-1 text-xs leading-relaxed text-text-3">
-        The build of Hive you're running. Include this when reporting an issue.
-      </p>
+    <SettingsSection
+      title="About"
+      description="The build of Hive you're running. Include this when reporting an issue."
+      class="mt-6 [&>p]:mb-3"
+      data-testid="system-about"
+    >
       <div v-if="build" class="rounded-lg border border-border">
         <div class="flex items-center justify-between gap-3 px-3.5 py-2.5">
           <span class="text-[12.5px] text-text-3">Version</span>
@@ -154,6 +155,6 @@ onMounted(() => {
           </button>
         </div>
       </div>
-    </section>
+    </SettingsSection>
   </div>
 </template>

--- a/desktop/frontend/src/components/SystemSettingsView.vue
+++ b/desktop/frontend/src/components/SystemSettingsView.vue
@@ -2,7 +2,7 @@
 // System settings: on-disk locations (data dir, config dir, log file,
 // database) with open/reveal actions, and point-only overrides for the data
 // and config directories that take effect after a restart.
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import IconInfo from '~icons/lucide/info'
 import IconExternalLink from '~icons/lucide/external-link'
 import SettingsPathRow from './settings/SettingsPathRow.vue'
@@ -29,6 +29,18 @@ const {
 onMounted(() => {
   void refresh()
 })
+
+// The build-info rows are a flat label/value list; keeping them data-driven
+// avoids three near-identical row blocks.
+const buildRows = computed(() =>
+  build.value
+    ? [
+        { label: 'Version', value: build.value.version, testid: 'system-build-version' },
+        { label: 'Commit', value: build.value.commit, testid: 'system-build-commit' },
+        { label: 'Built', value: build.value.date, testid: 'system-build-date' },
+      ]
+    : [],
+)
 </script>
 
 <template>
@@ -121,17 +133,14 @@ onMounted(() => {
       data-testid="system-about"
     >
       <div v-if="build" class="rounded-lg border border-border">
-        <div class="flex items-center justify-between gap-3 px-3.5 py-2.5">
-          <span class="text-[12.5px] text-text-3">Version</span>
-          <span class="font-mono text-[12.5px] text-text-2" data-testid="system-build-version">{{ build.version }}</span>
-        </div>
-        <div class="flex items-center justify-between gap-3 border-t border-border px-3.5 py-2.5">
-          <span class="text-[12.5px] text-text-3">Commit</span>
-          <span class="font-mono text-[12.5px] text-text-2" data-testid="system-build-commit">{{ build.commit }}</span>
-        </div>
-        <div class="flex items-center justify-between gap-3 border-t border-border px-3.5 py-2.5">
-          <span class="text-[12.5px] text-text-3">Built</span>
-          <span class="font-mono text-[12.5px] text-text-2" data-testid="system-build-date">{{ build.date }}</span>
+        <div
+          v-for="(row, index) in buildRows"
+          :key="row.testid"
+          class="flex items-center justify-between gap-3 px-3.5 py-2.5"
+          :class="{ 'border-t border-border': index > 0 }"
+        >
+          <span class="text-[12.5px] text-text-3">{{ row.label }}</span>
+          <span class="font-mono text-[12.5px] text-text-2" :data-testid="row.testid">{{ row.value }}</span>
         </div>
         <div class="flex flex-col gap-2 border-t border-border px-3.5 py-2.5">
           <button

--- a/desktop/frontend/src/components/UnsavedFlowChangesModal.vue
+++ b/desktop/frontend/src/components/UnsavedFlowChangesModal.vue
@@ -6,25 +6,19 @@
 // draft before proceeding, Discard drops it (App.vue calls
 // session.discardDraft(), which reloads the flow fresh from disk), Cancel
 // aborts the navigation entirely and leaves the draft untouched.
-import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { ref } from 'vue'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import IconX from '~icons/lucide/x'
+import { useAutofocus } from '../composables/useAutofocus'
+import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ busy: boolean; error?: string | null }>()
 const emit = defineEmits<{ close: []; deploy: []; discard: [] }>()
 
 const deployRef = ref<HTMLButtonElement | null>(null)
 
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape' && !props.busy) emit('close')
-}
-
-onMounted(async () => {
-  window.addEventListener('keydown', onKeydown)
-  await nextTick()
-  deployRef.value?.focus()
-})
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useEscapeToClose(() => emit('close'), { enabled: () => !props.busy })
+useAutofocus(deployRef)
 </script>
 
 <template>

--- a/desktop/frontend/src/components/UnsavedFlowChangesModal.vue
+++ b/desktop/frontend/src/components/UnsavedFlowChangesModal.vue
@@ -8,65 +8,57 @@
 // aborts the navigation entirely and leaves the draft untouched.
 import { ref } from 'vue'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
-import IconX from '~icons/lucide/x'
 import BaseButton from './BaseButton.vue'
+import BaseModal from './BaseModal.vue'
 import { useAutofocus } from '../composables/useAutofocus'
-import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ busy: boolean; error?: string | null }>()
 const emit = defineEmits<{ close: []; deploy: []; discard: [] }>()
 
 const deployRef = ref<{ focus: () => void } | null>(null)
 
-useEscapeToClose(() => emit('close'), { enabled: () => !props.busy })
 useAutofocus(deployRef)
 </script>
 
 <template>
-  <Teleport to="body">
-    <div class="fixed inset-0 z-40 flex items-start justify-center bg-backdrop pt-[24vh]" @click.self="!busy && emit('close')">
-      <div
-        class="w-[420px] overflow-hidden rounded-xl border border-strong bg-pane text-text shadow-2xl"
-        role="alertdialog"
-        aria-label="Un-deployed changes"
-        aria-modal="true"
-        data-testid="unsaved-flow-changes-modal"
-      >
-        <header class="flex items-center gap-3 border-b border-row px-5 py-4">
-          <span class="flex size-7 items-center justify-center rounded-[7px] bg-accent-tint text-accent"><IconTriangleAlert class="size-4" /></span>
-          <div class="flex-1 text-[15px] font-semibold tracking-[-.01em]">Un-deployed changes</div>
-          <button class="cursor-pointer text-text-3 hover:text-text disabled:opacity-50" aria-label="Close" :disabled="busy" @click="emit('close')"><IconX class="size-4" /></button>
-        </header>
-        <div class="flex flex-col gap-3 px-5 py-4">
-          <p class="text-[13px] leading-relaxed text-text-2">
-            This profile's flow has un-deployed changes. Deploy them now, or discard the draft to continue without them.
-          </p>
-          <p v-if="error" class="text-xs text-severity-error" data-testid="unsaved-flow-error">{{ error }}</p>
-        </div>
-        <footer class="flex flex-col gap-2 border-t border-row bg-raised px-5 py-3.5">
-          <div class="flex gap-2.5">
-            <BaseButton
-              ref="deployRef"
-              class="flex-1"
-              :busy="busy"
-              data-testid="unsaved-flow-deploy"
-              @click="emit('deploy')"
-            >{{ busy ? 'Deploying…' : 'Deploy' }}</BaseButton>
-            <button
-              class="flex-1 cursor-pointer rounded-lg border border-severity-error/50 px-4 py-2.5 text-[13.5px] font-semibold text-severity-error hover:bg-severity-error-tint disabled:cursor-default disabled:opacity-50"
-              :disabled="busy"
-              data-testid="unsaved-flow-discard"
-              @click="emit('discard')"
-            >Discard changes</button>
-          </div>
-          <BaseButton
-            variant="ghost"
-            :busy="busy"
-            data-testid="unsaved-flow-cancel"
-            @click="emit('close')"
-          >Cancel</BaseButton>
-        </footer>
-      </div>
+  <BaseModal
+    title="Un-deployed changes"
+    :icon="IconTriangleAlert"
+    aria-role="alertdialog"
+    :busy="busy"
+    testid="unsaved-flow-changes-modal"
+    @close="emit('close')"
+  >
+    <div class="flex flex-col gap-3 px-5 py-4">
+      <p class="text-[13px] leading-relaxed text-text-2">
+        This profile's flow has un-deployed changes. Deploy them now, or discard the draft to continue without them.
+      </p>
+      <p v-if="error" class="text-xs text-severity-error" data-testid="unsaved-flow-error">{{ error }}</p>
     </div>
-  </Teleport>
+    <template #footer>
+      <div class="flex w-full flex-col gap-2">
+        <div class="flex gap-2.5">
+          <BaseButton
+            ref="deployRef"
+            class="flex-1"
+            :busy="busy"
+            data-testid="unsaved-flow-deploy"
+            @click="emit('deploy')"
+          >{{ busy ? 'Deploying…' : 'Deploy' }}</BaseButton>
+          <button
+            class="flex-1 cursor-pointer rounded-lg border border-severity-error/50 px-4 py-2.5 text-[13.5px] font-semibold text-severity-error hover:bg-severity-error-tint disabled:cursor-default disabled:opacity-50"
+            :disabled="busy"
+            data-testid="unsaved-flow-discard"
+            @click="emit('discard')"
+          >Discard changes</button>
+        </div>
+        <BaseButton
+          variant="ghost"
+          :busy="busy"
+          data-testid="unsaved-flow-cancel"
+          @click="emit('close')"
+        >Cancel</BaseButton>
+      </div>
+    </template>
+  </BaseModal>
 </template>

--- a/desktop/frontend/src/components/UnsavedFlowChangesModal.vue
+++ b/desktop/frontend/src/components/UnsavedFlowChangesModal.vue
@@ -9,13 +9,14 @@
 import { ref } from 'vue'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import IconX from '~icons/lucide/x'
+import BaseButton from './BaseButton.vue'
 import { useAutofocus } from '../composables/useAutofocus'
 import { useEscapeToClose } from '../composables/useEscapeToClose'
 
 const props = defineProps<{ busy: boolean; error?: string | null }>()
 const emit = defineEmits<{ close: []; deploy: []; discard: [] }>()
 
-const deployRef = ref<HTMLButtonElement | null>(null)
+const deployRef = ref<{ focus: () => void } | null>(null)
 
 useEscapeToClose(() => emit('close'), { enabled: () => !props.busy })
 useAutofocus(deployRef)
@@ -44,13 +45,13 @@ useAutofocus(deployRef)
         </div>
         <footer class="flex flex-col gap-2 border-t border-row bg-raised px-5 py-3.5">
           <div class="flex gap-2.5">
-            <button
+            <BaseButton
               ref="deployRef"
-              class="flex-1 cursor-pointer rounded-lg bg-accent px-4 py-2.5 text-[13.5px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-default disabled:opacity-50"
-              :disabled="busy"
+              class="flex-1"
+              :busy="busy"
               data-testid="unsaved-flow-deploy"
               @click="emit('deploy')"
-            >{{ busy ? 'Deploying…' : 'Deploy' }}</button>
+            >{{ busy ? 'Deploying…' : 'Deploy' }}</BaseButton>
             <button
               class="flex-1 cursor-pointer rounded-lg border border-severity-error/50 px-4 py-2.5 text-[13.5px] font-semibold text-severity-error hover:bg-severity-error-tint disabled:cursor-default disabled:opacity-50"
               :disabled="busy"
@@ -58,12 +59,12 @@ useAutofocus(deployRef)
               @click="emit('discard')"
             >Discard changes</button>
           </div>
-          <button
-            class="cursor-pointer rounded-lg px-4 py-2 text-center text-[12.5px] text-text-2 hover:text-text disabled:cursor-default disabled:opacity-50"
-            :disabled="busy"
+          <BaseButton
+            variant="ghost"
+            :busy="busy"
             data-testid="unsaved-flow-cancel"
             @click="emit('close')"
-          >Cancel</button>
+          >Cancel</BaseButton>
         </footer>
       </div>
     </div>

--- a/desktop/frontend/src/components/__tests__/BaseBadge.spec.ts
+++ b/desktop/frontend/src/components/__tests__/BaseBadge.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BaseBadge from '../BaseBadge.vue'
+
+describe('BaseBadge', () => {
+  it.each([
+    ['neutral', 'bg-chip', 'text-text-3'],
+    ['success', 'bg-severity-success-tint', 'text-severity-success'],
+    ['accent', 'bg-accent-tint', 'text-accent'],
+    ['muted', 'bg-chip', 'text-text-4'],
+    ['danger', 'bg-severity-error-tint', 'text-severity-error'],
+  ] as const)('applies %s tone colors', (tone, background, text) => {
+    const wrapper = mount(BaseBadge, { props: { tone } })
+
+    expect(wrapper.classes()).toEqual(expect.arrayContaining([background, text]))
+  })
+
+  it('uses chip rounding by default and pill rounding when requested', () => {
+    expect(mount(BaseBadge).classes()).toContain('rounded-[5px]')
+    expect(mount(BaseBadge, { props: { variant: 'pill' } }).classes()).toContain('rounded-full')
+  })
+
+  it('renders an optional leading status dot and its label slot', () => {
+    const wrapper = mount(BaseBadge, { props: { tone: 'success', dot: true }, slots: { default: 'Connected' } })
+
+    expect(wrapper.find('[aria-hidden="true"]').classes()).toEqual(expect.arrayContaining(['size-1.5', 'bg-severity-success']))
+    expect(wrapper.text()).toBe('Connected')
+  })
+
+  it('forwards attributes and merges caller classes onto its root', () => {
+    const wrapper = mount(BaseBadge, { attrs: { class: 'px-2 py-0.5 text-[11px]', 'data-testid': 'badge' } })
+
+    expect(wrapper.attributes('data-testid')).toBe('badge')
+    expect(wrapper.classes()).toEqual(expect.arrayContaining(['px-2', 'py-0.5', 'text-[11px]']))
+  })
+})

--- a/desktop/frontend/src/components/__tests__/BaseButton.spec.ts
+++ b/desktop/frontend/src/components/__tests__/BaseButton.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import BaseButton from '../BaseButton.vue'
+
+describe('BaseButton', () => {
+  it.each([
+    ['primary', 'bg-accent'],
+    ['secondary', 'border-card'],
+    ['danger', 'bg-severity-error'],
+    ['ghost', 'text-text-2'],
+  ] as const)('applies %s variant classes', (variant, className) => {
+    const wrapper = mount(BaseButton, { props: { variant } })
+    expect(wrapper.classes()).toContain(className)
+  })
+
+  it('disables while busy and honors submit type', () => {
+    const wrapper = mount(BaseButton, { props: { busy: true, type: 'submit' } })
+    expect(wrapper.attributes('disabled')).toBeDefined()
+    expect(wrapper.attributes('type')).toBe('submit')
+  })
+
+  it('emits clicks and forwards data attributes', async () => {
+    const wrapper = mount(BaseButton, { attrs: { 'data-testid': 'save-button', 'aria-label': 'Save changes' } })
+    await wrapper.trigger('click')
+
+    expect(wrapper.emitted('click')).toHaveLength(1)
+    expect(wrapper.attributes('data-testid')).toBe('save-button')
+    expect(wrapper.attributes('aria-label')).toBe('Save changes')
+  })
+
+  it('renders a leading icon slot before its label', () => {
+    const wrapper = mount(BaseButton, {
+      slots: {
+        icon: () => h('span', { 'data-testid': 'button-icon' }, 'icon'),
+        default: () => 'Save',
+      },
+    })
+
+    expect(wrapper.find('[data-testid="button-icon"]').exists()).toBe(true)
+    expect(wrapper.text()).toBe('iconSave')
+  })
+})

--- a/desktop/frontend/src/components/__tests__/BaseCard.spec.ts
+++ b/desktop/frontend/src/components/__tests__/BaseCard.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import BaseCard from '../BaseCard.vue'
+
+describe('BaseCard', () => {
+  it('renders as an article with its icon, body, and actions slots', () => {
+    const wrapper = mount(BaseCard, {
+      slots: {
+        icon: () => h('span', { 'data-testid': 'card-icon' }, 'icon'),
+        default: () => h('div', { 'data-testid': 'card-body' }, 'body'),
+        actions: () => h('button', { 'data-testid': 'card-actions' }, 'actions'),
+      },
+    })
+
+    expect(wrapper.element.tagName).toBe('ARTICLE')
+    expect(wrapper.classes()).toEqual(expect.arrayContaining(['flex', 'items-center', 'gap-3', 'p-4']))
+    expect(wrapper.find('[data-testid="card-icon"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="card-body"]').text()).toBe('body')
+    expect(wrapper.find('[data-testid="card-actions"]').text()).toBe('actions')
+  })
+
+  it('renders as a button and forwards attributes and clicks to its root', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(BaseCard, {
+      props: { as: 'button', interactive: true, padded: false },
+      attrs: { 'data-testid': 'interactive-card', onClick },
+    })
+
+    expect(wrapper.element.tagName).toBe('BUTTON')
+    expect(wrapper.attributes('data-testid')).toBe('interactive-card')
+    expect(wrapper.classes()).toContain('hover:border-strong')
+    expect(wrapper.classes()).not.toContain('p-4')
+
+    await wrapper.trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/desktop/frontend/src/components/__tests__/BaseIconBadge.spec.ts
+++ b/desktop/frontend/src/components/__tests__/BaseIconBadge.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import BaseIconBadge from '../BaseIconBadge.vue'
+
+describe('BaseIconBadge', () => {
+  it('sizes its square container and renders the default slot', () => {
+    const wrapper = mount(BaseIconBadge, {
+      props: { size: 26 },
+      attrs: { class: 'bg-chip', 'data-testid': 'icon-badge' },
+      slots: { default: () => h('span', { 'data-testid': 'badge-icon' }, 'icon') },
+    })
+
+    expect(wrapper.attributes('data-testid')).toBe('icon-badge')
+    expect(wrapper.attributes('style')).toContain('width: 26px')
+    expect(wrapper.attributes('style')).toContain('height: 26px')
+    expect(wrapper.classes()).toContain('bg-chip')
+    expect(wrapper.find('[data-testid="badge-icon"]').text()).toBe('icon')
+  })
+})

--- a/desktop/frontend/src/components/__tests__/BaseModal.spec.ts
+++ b/desktop/frontend/src/components/__tests__/BaseModal.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import IconPlay from '~icons/lucide/play'
+import BaseModal from '../BaseModal.vue'
+
+function mountModal(props: Record<string, unknown> = {}) {
+  return mount(BaseModal, {
+    props: { title: 'Demo modal', icon: IconPlay, testid: 'demo-modal', ...props },
+    slots: {
+      default: '<p data-testid="modal-body">Body</p>',
+      footer: '<button data-testid="modal-footer">Save</button>',
+    },
+  })
+}
+
+function el<T extends HTMLElement>(testid: string): T {
+  const element = document.querySelector<T>(`[data-testid="${testid}"]`)
+  if (!element) throw new Error(`Missing ${testid}`)
+  return element
+}
+
+describe('BaseModal', () => {
+  it('renders its title, testids, tone, and footer slot', () => {
+    const wrapper = mountModal({ tone: 'danger' })
+
+    expect(el('demo-modal').textContent).toContain('Demo modal')
+    expect(el('demo-modal-backdrop')).toBeTruthy()
+    expect(el('modal-footer').textContent).toBe('Save')
+    const badge = el('demo-modal').querySelector('header span')
+    expect(badge?.className).toContain('bg-severity-error-tint')
+    expect(badge?.className).toContain('text-severity-error')
+
+    wrapper.unmount()
+  })
+
+  it('emits close when its backdrop is clicked', () => {
+    const wrapper = mountModal()
+
+    el('demo-modal-backdrop').click()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it.each([
+    { busy: true },
+    { closeOnBackdrop: false },
+  ])('does not close from the backdrop when %o', (props) => {
+    const wrapper = mountModal(props)
+
+    el('demo-modal-backdrop').click()
+    expect(wrapper.emitted('close')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('emits close on Escape unless busy', () => {
+    const closable = mountModal()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(closable.emitted('close')).toHaveLength(1)
+    closable.unmount()
+
+    const busy = mountModal({ busy: true })
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(busy.emitted('close')).toBeUndefined()
+    busy.unmount()
+  })
+})

--- a/desktop/frontend/src/components/settings/EmptyState.vue
+++ b/desktop/frontend/src/components/settings/EmptyState.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  message?: string
+  boxed?: boolean
+}>(), {
+  boxed: false,
+})
+</script>
+
+<template>
+  <div
+    :class="[
+      'py-8 text-center text-xs',
+      boxed ? 'rounded-lg border border-border bg-raised px-4 text-text-3' : 'text-text-4',
+    ]"
+  >
+    <slot>{{ message }}</slot>
+  </div>
+</template>

--- a/desktop/frontend/src/components/settings/GithubIntegrationDrawer.vue
+++ b/desktop/frontend/src/components/settings/GithubIntegrationDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import IconGithub from '~icons/lucide/github'
+import BaseButton from '../BaseButton.vue'
 import DrawerSheet from '../DrawerSheet.vue'
 import SettingsField from './SettingsField.vue'
 import * as SettingsService from '../../../bindings/github.com/colonyops/hive/desktop/settingsservice'
@@ -88,19 +89,19 @@ onMounted(() => void load())
 
     <template #footer>
       <div class="flex items-center justify-end gap-2.5">
-        <button
-          type="button"
-          class="cursor-pointer rounded-lg border border-card px-[15px] py-2 text-[13px] text-text-2 hover:text-text"
+        <BaseButton
+          variant="secondary"
+          size="sm"
           data-testid="github-settings-cancel"
           @click="emit('close')"
-        >Cancel</button>
-        <button
-          type="button"
-          class="cursor-pointer rounded-lg bg-accent px-[18px] py-2 text-[13px] font-semibold text-accent-contrast hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+        >Cancel</BaseButton>
+        <BaseButton
+          size="sm"
+          :busy="loading || saving"
+          :disabled="!valid"
           data-testid="github-settings-save"
-          :disabled="loading || saving || !valid"
           @click="save"
-        >Save</button>
+        >Save</BaseButton>
       </div>
     </template>
   </DrawerSheet>

--- a/desktop/frontend/src/components/settings/SettingsLayout.vue
+++ b/desktop/frontend/src/components/settings/SettingsLayout.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useEscapeToClose } from '../../composables/useEscapeToClose'
+import ViewHeader from './ViewHeader.vue'
+
+const props = defineProps<{
+  closeTestid?: string
+}>()
+const emit = defineEmits<{ close: [] }>()
+
+function close(): void {
+  emit('close')
+}
+
+useEscapeToClose(close)
+</script>
+
+<template>
+  <div class="flex h-full min-h-0 flex-1">
+    <aside class="hive-scroll w-[200px] shrink-0 overflow-y-auto border-r border-row bg-sidebar">
+      <div class="border-b border-border px-4 pb-3 pt-4">
+        <slot name="sidebar-title" />
+      </div>
+      <nav class="flex flex-col gap-0.5 px-2.5 py-3">
+        <slot name="nav" />
+      </nav>
+    </aside>
+
+    <section class="flex min-w-0 flex-1 flex-col">
+      <ViewHeader :close-testid="props.closeTestid" @close="close">
+        <template #title><slot name="header-title" /></template>
+      </ViewHeader>
+      <slot />
+    </section>
+  </div>
+</template>

--- a/desktop/frontend/src/components/settings/SettingsNavItem.vue
+++ b/desktop/frontend/src/components/settings/SettingsNavItem.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { computed, type Component } from 'vue'
+
+const props = withDefaults(defineProps<{
+  active: boolean
+  icon?: Component
+  label: string
+  tone?: 'default' | 'danger'
+  testid?: string
+}>(), {
+  tone: 'default',
+})
+const emit = defineEmits<{ select: [] }>()
+
+const stateClasses = computed(() => {
+  if (!props.active) return 'text-text-2 hover:bg-chip hover:text-text'
+  return props.tone === 'danger'
+    ? 'bg-hover font-medium text-severity-error'
+    : 'bg-hover font-medium text-accent'
+})
+</script>
+
+<template>
+  <button
+    type="button"
+    class="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px]"
+    :class="stateClasses"
+    :aria-current="props.active ? 'true' : undefined"
+    :data-testid="props.testid"
+    @click="emit('select')"
+  ><component :is="props.icon" v-if="props.icon" class="size-3.5 shrink-0" />{{ props.label }}</button>
+</template>

--- a/desktop/frontend/src/components/settings/SettingsPathRow.vue
+++ b/desktop/frontend/src/components/settings/SettingsPathRow.vue
@@ -11,6 +11,7 @@ import IconFolder from '~icons/lucide/folder'
 import IconFolderOpen from '~icons/lucide/folder-open'
 import IconRotateCcw from '~icons/lucide/rotate-ccw'
 import { useClipboard } from '../../composables/useClipboard'
+import BaseBadge from '../BaseBadge.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -36,15 +37,18 @@ const btnClass =
   <article class="rounded-lg border border-border bg-raised p-4" :data-testid="props.testid">
     <div class="flex items-center gap-2">
       <span class="text-[13.5px] font-semibold text-text">{{ props.label }}</span>
-      <span
+      <BaseBadge
         v-if="props.overridden"
-        class="rounded-full bg-chip px-2 py-0.5 text-[10.5px] font-semibold text-text-3"
+        variant="pill"
+        class="px-2 py-0.5 text-[10.5px] font-semibold"
         :data-testid="props.testid ? `${props.testid}-overridden` : undefined"
-      >Custom</span>
-      <span
+      >Custom</BaseBadge>
+      <BaseBadge
         v-if="!props.exists"
-        class="rounded-full bg-chip px-2 py-0.5 text-[10.5px] font-medium text-text-4"
-      >Not created yet</span>
+        tone="muted"
+        variant="pill"
+        class="px-2 py-0.5 text-[10.5px] font-medium"
+      >Not created yet</BaseBadge>
     </div>
 
     <div

--- a/desktop/frontend/src/components/settings/SettingsSection.vue
+++ b/desktop/frontend/src/components/settings/SettingsSection.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  description?: string
+}>()
+</script>
+
+<template>
+  <section>
+    <h2 class="text-[15px] font-semibold text-text">{{ title }}</h2>
+    <p v-if="description" class="mt-1 text-xs leading-relaxed text-text-3">{{ description }}</p>
+    <slot />
+  </section>
+</template>

--- a/desktop/frontend/src/components/settings/ViewHeader.vue
+++ b/desktop/frontend/src/components/settings/ViewHeader.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import IconArrowLeft from '~icons/lucide/arrow-left'
+
+const props = withDefaults(defineProps<{
+  closeTestid?: string
+  closeLabel?: string
+}>(), {
+  closeLabel: 'Back to feed',
+})
+
+const emit = defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <header class="flex h-11 shrink-0 items-center gap-2.5 border-b border-row bg-canvas-toolbar px-4">
+    <slot name="title" />
+    <div class="flex-1" />
+    <button
+      type="button"
+      class="flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12.5px] text-text-2 hover:bg-chip hover:text-text"
+      :data-testid="props.closeTestid"
+      @click="emit('close')"
+    ><IconArrowLeft class="size-3.5" />{{ props.closeLabel }}</button>
+  </header>
+</template>

--- a/desktop/frontend/src/components/settings/__tests__/EmptyState.spec.ts
+++ b/desktop/frontend/src/components/settings/__tests__/EmptyState.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EmptyState from '../EmptyState.vue'
+
+describe('EmptyState', () => {
+  it('renders a message with plain centered styling', () => {
+    const wrapper = mount(EmptyState, {
+      props: { message: 'No actions configured.' },
+    })
+
+    expect(wrapper.text()).toBe('No actions configured.')
+    expect(wrapper.classes()).toEqual(expect.arrayContaining(['py-8', 'text-center', 'text-xs', 'text-text-4']))
+    expect(wrapper.classes()).not.toContain('rounded-lg')
+  })
+
+  it('renders slot content instead of the message', () => {
+    const wrapper = mount(EmptyState, {
+      props: { message: 'Fallback' },
+      slots: { default: 'No shortcuts match "refresh".' },
+    })
+
+    expect(wrapper.text()).toBe('No shortcuts match "refresh".')
+  })
+
+  it('adds boxed variant classes', () => {
+    const wrapper = mount(EmptyState, {
+      props: { boxed: true, message: 'No matches.' },
+    })
+
+    expect(wrapper.classes()).toEqual(expect.arrayContaining(['rounded-lg', 'border', 'border-border', 'bg-raised', 'px-4', 'text-text-3']))
+    expect(wrapper.classes()).not.toContain('text-text-4')
+  })
+})

--- a/desktop/frontend/src/components/settings/__tests__/SettingsLayout.spec.ts
+++ b/desktop/frontend/src/components/settings/__tests__/SettingsLayout.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import SettingsLayout from '../SettingsLayout.vue'
+
+describe('SettingsLayout', () => {
+  it('renders its slots and emits close from the button and Escape', async () => {
+    const wrapper = mount(SettingsLayout, {
+      props: { closeTestid: 'settings-layout-close' },
+      slots: {
+        'sidebar-title': () => h('span', 'Settings title'),
+        nav: () => h('button', { 'data-testid': 'settings-layout-nav' }, 'General'),
+        'header-title': () => h('span', { 'data-testid': 'settings-layout-header-title' }, 'General'),
+        default: () => h('main', { 'data-testid': 'settings-layout-body' }, 'Body'),
+      },
+    })
+
+    expect(wrapper.text()).toContain('Settings title')
+    expect(wrapper.get('[data-testid="settings-layout-nav"]').text()).toBe('General')
+    expect(wrapper.get('[data-testid="settings-layout-header-title"]').text()).toBe('General')
+    expect(wrapper.get('[data-testid="settings-layout-body"]').text()).toBe('Body')
+
+    await wrapper.get('[data-testid="settings-layout-close"]').trigger('click')
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(wrapper.emitted('close')).toHaveLength(2)
+  })
+})

--- a/desktop/frontend/src/components/settings/__tests__/SettingsNavItem.spec.ts
+++ b/desktop/frontend/src/components/settings/__tests__/SettingsNavItem.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SettingsNavItem from '../SettingsNavItem.vue'
+
+describe('SettingsNavItem', () => {
+  it('applies active and danger styling', async () => {
+    const wrapper = mount(SettingsNavItem, {
+      props: { active: true, label: 'Danger zone' },
+    })
+
+    expect(wrapper.classes()).toContain('bg-hover')
+    expect(wrapper.classes()).toContain('font-medium')
+    expect(wrapper.classes()).toContain('text-accent')
+    expect(wrapper.attributes('aria-current')).toBe('true')
+
+    await wrapper.setProps({ tone: 'danger' })
+
+    expect(wrapper.classes()).toContain('text-severity-error')
+    expect(wrapper.classes()).not.toContain('text-accent')
+
+    await wrapper.setProps({ active: false })
+
+    expect(wrapper.classes()).toContain('text-text-2')
+    expect(wrapper.classes()).not.toContain('text-severity-error')
+    expect(wrapper.attributes('aria-current')).toBeUndefined()
+  })
+
+  it('emits select and preserves its test id', async () => {
+    const wrapper = mount(SettingsNavItem, {
+      props: { active: false, label: 'General', testid: 'settings-nav-general' },
+    })
+
+    expect(wrapper.attributes('data-testid')).toBe('settings-nav-general')
+    await wrapper.trigger('click')
+
+    expect(wrapper.emitted('select')).toHaveLength(1)
+  })
+})

--- a/desktop/frontend/src/components/settings/__tests__/SettingsSection.spec.ts
+++ b/desktop/frontend/src/components/settings/__tests__/SettingsSection.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SettingsSection from '../SettingsSection.vue'
+
+describe('SettingsSection', () => {
+  it('renders the title and description', () => {
+    const wrapper = mount(SettingsSection, {
+      props: { title: 'Actions', description: 'Configure actions.' },
+    })
+
+    expect(wrapper.get('h2').text()).toBe('Actions')
+    expect(wrapper.get('h2').classes()).toEqual(expect.arrayContaining(['text-[15px]', 'font-semibold', 'text-text']))
+    expect(wrapper.get('p').text()).toBe('Configure actions.')
+    expect(wrapper.get('p').classes()).toEqual(expect.arrayContaining(['mt-1', 'text-xs', 'leading-relaxed', 'text-text-3']))
+  })
+
+  it('renders slot content after the header', () => {
+    const wrapper = mount(SettingsSection, {
+      props: { title: 'Diagnostics' },
+      slots: { default: '<div data-testid="section-body">Body</div>' },
+    })
+
+    expect(wrapper.get('[data-testid="section-body"]').text()).toBe('Body')
+  })
+
+  it('omits the description when not provided', () => {
+    const wrapper = mount(SettingsSection, {
+      props: { title: 'Storage locations' },
+    })
+
+    expect(wrapper.find('p').exists()).toBe(false)
+  })
+})

--- a/desktop/frontend/src/composables/__tests__/useAutofocus.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useAutofocus.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { useAutofocus } from '../useAutofocus'
+
+describe('useAutofocus', () => {
+  it('focuses its target after mounting', async () => {
+    const FocusTarget = defineComponent({
+      setup() {
+        const target = ref<HTMLInputElement | null>(null)
+        useAutofocus(target)
+        return () => h('input', { ref: target, 'data-testid': 'focus-target' })
+      },
+    })
+    const wrapper = mount(FocusTarget, { attachTo: document.body })
+
+    await flushPromises()
+    expect(document.activeElement).toBe(wrapper.get('[data-testid="focus-target"]').element)
+
+    wrapper.unmount()
+  })
+})

--- a/desktop/frontend/src/composables/__tests__/useDragGesture.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useDragGesture.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { startDrag } from '../useDragGesture'
+
+function pointerEvent(type: string, clientX: number): PointerEvent {
+  return new PointerEvent(type, { pointerId: 7, clientX, bubbles: true, cancelable: true })
+}
+
+describe('startDrag', () => {
+  it('tracks moves through pointerup, then removes its listeners and releases pointer capture', () => {
+    const target = document.createElement('div')
+    const onMove = vi.fn()
+    const onEnd = vi.fn()
+    const setPointerCapture = vi.fn()
+    const releasePointerCapture = vi.fn()
+    Object.defineProperties(target, {
+      setPointerCapture: { value: setPointerCapture },
+      releasePointerCapture: { value: releasePointerCapture },
+    })
+    target.addEventListener('pointerdown', (event) => {
+      startDrag(event as PointerEvent, { onMove, onEnd, pointerCapture: true })
+    })
+
+    target.dispatchEvent(pointerEvent('pointerdown', 10))
+    expect(setPointerCapture).toHaveBeenCalledWith(7)
+
+    const move = pointerEvent('pointermove', 20)
+    window.dispatchEvent(move)
+    expect(onMove).toHaveBeenCalledWith(move)
+
+    const up = pointerEvent('pointerup', 20)
+    window.dispatchEvent(up)
+    expect(onEnd).toHaveBeenCalledWith(up)
+    expect(releasePointerCapture).toHaveBeenCalledWith(7)
+
+    window.dispatchEvent(pointerEvent('pointermove', 30))
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a stop function for ending a drag before pointerup', () => {
+    const onMove = vi.fn()
+    const stop = startDrag(pointerEvent('pointerdown', 0), { onMove })
+
+    stop()
+    window.dispatchEvent(pointerEvent('pointermove', 10))
+
+    expect(onMove).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/frontend/src/composables/__tests__/useEscapeToClose.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useEscapeToClose.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { effectScope, ref } from 'vue'
+import { useEscapeToClose } from '../useEscapeToClose'
+
+function pressEscape(): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+}
+
+describe('useEscapeToClose', () => {
+  it('calls the callback for Escape and removes its listener when the scope stops', () => {
+    const onEscape = vi.fn()
+    const scope = effectScope()
+
+    scope.run(() => useEscapeToClose(onEscape))
+    pressEscape()
+    expect(onEscape).toHaveBeenCalledOnce()
+
+    scope.stop()
+    pressEscape()
+    expect(onEscape).toHaveBeenCalledOnce()
+  })
+
+  it('respects a reactive enabled guard', () => {
+    const onEscape = vi.fn()
+    const enabled = ref(false)
+    const scope = effectScope()
+
+    scope.run(() => useEscapeToClose(onEscape, { enabled }))
+    pressEscape()
+    expect(onEscape).not.toHaveBeenCalled()
+
+    enabled.value = true
+    pressEscape()
+    expect(onEscape).toHaveBeenCalledOnce()
+    scope.stop()
+  })
+})

--- a/desktop/frontend/src/composables/__tests__/useWailsEvent.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useWailsEvent.spec.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  On: vi.fn(),
+}))
+
+vi.mock('@wailsio/runtime', () => ({
+  Events: { On: mocks.On },
+}))
+
+import { useWailsEvent } from '../useWailsEvent'
+
+describe('useWailsEvent', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('registers the handler and unsubscribes when its scope stops', () => {
+    const unsubscribe = vi.fn()
+    const handler = vi.fn()
+    mocks.On.mockReturnValue(unsubscribe)
+    const scope = effectScope()
+
+    scope.run(() => useWailsEvent('test:event', handler))
+
+    expect(mocks.On).toHaveBeenCalledWith('test:event', handler)
+    scope.stop()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+})

--- a/desktop/frontend/src/composables/useActionsSettings.ts
+++ b/desktop/frontend/src/composables/useActionsSettings.ts
@@ -1,7 +1,7 @@
-import { Events } from '@wailsio/runtime'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { CreateAction, DeleteAction, ListActions, UpdateAction } from '../../bindings/github.com/colonyops/hive/desktop/actionsservice'
 import type { EditableAction } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/actions/models'
+import { useWailsEvent } from './useWailsEvent'
 
 export type { EditableAction }
 export type ActionType = EditableAction['type']
@@ -20,7 +20,6 @@ export function useActionsSettings() {
   let generation = 0
   let queued = false
   let running = false
-  let unsubscribe: (() => void) | undefined
 
   async function reload(): Promise<void> {
     if (running) { generation++; queued = true; return }
@@ -59,7 +58,6 @@ export function useActionsSettings() {
   async function remove(id: string): Promise<boolean> {
     try { await DeleteAction(id); await reload(); return true } catch (err) { error.value = message(err, 'Could not delete action.'); return false }
   }
-  onMounted(() => { void reload(); unsubscribe = Events.On('actions:updated', wake) })
-  onUnmounted(() => unsubscribe?.())
+  onMounted(() => { void reload(); useWailsEvent('actions:updated', wake) })
   return { actions, loading, error, reload, create, update, remove }
 }

--- a/desktop/frontend/src/composables/useAuth.ts
+++ b/desktop/frontend/src/composables/useAuth.ts
@@ -1,8 +1,8 @@
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { Events } from '@wailsio/runtime'
+import { computed, onMounted, ref } from 'vue'
 import { SetToken, SignOut, StartDeviceFlow, Status } from '../../bindings/github.com/colonyops/hive/internal/desktop/auth/service'
 import { CancelDeviceFlow } from '../../bindings/github.com/colonyops/hive/internal/desktop/auth/service'
 import type { AuthStatus, DeviceFlowInfo } from '../types/auth'
+import { useWailsEvent } from './useWailsEvent'
 
 export type OnboardingCard = 'idle' | 'device' | 'token'
 
@@ -23,8 +23,6 @@ export function useAuth() {
     return null
   })
   const busy = ref(false)
-  let unsubscribe: (() => void) | undefined
-
   const authenticated = computed(() => status.value?.state === 'authenticated')
 
   async function reload() {
@@ -116,12 +114,8 @@ export function useAuth() {
   onMounted(async () => {
     // auth:updated is a wake-up signal: the device-flow grant lands in a Go
     // goroutine, so state changes arrive here rather than as call results.
-    unsubscribe = Events.On('auth:updated', () => { void reload() })
+    useWailsEvent('auth:updated', () => { void reload() })
     await reload()
-  })
-
-  onUnmounted(() => {
-    unsubscribe?.()
   })
 
   return {

--- a/desktop/frontend/src/composables/useAutofocus.ts
+++ b/desktop/frontend/src/composables/useAutofocus.ts
@@ -1,0 +1,10 @@
+import { nextTick, onMounted, type Ref } from 'vue'
+
+type Focusable = HTMLElement | { focus: () => void }
+
+export function useAutofocus(target: Ref<Focusable | null>): void {
+  onMounted(async () => {
+    await nextTick()
+    target.value?.focus()
+  })
+}

--- a/desktop/frontend/src/composables/useDragGesture.ts
+++ b/desktop/frontend/src/composables/useDragGesture.ts
@@ -1,0 +1,32 @@
+export interface DragGestureOptions {
+  onMove: (event: PointerEvent) => void
+  onEnd?: (event: PointerEvent) => void
+  pointerCapture?: boolean
+}
+
+/** Starts a window-tracked pointer drag and returns a function that stops it early. */
+export function startDrag(event: PointerEvent, options: DragGestureOptions): () => void {
+  const target = options.pointerCapture ? event.target as Element | null : null
+  const pointerId = event.pointerId
+  target?.setPointerCapture?.(pointerId)
+
+  let stopped = false
+
+  function stop(): void {
+    if (stopped) return
+    stopped = true
+    window.removeEventListener('pointermove', options.onMove)
+    window.removeEventListener('pointerup', onUp)
+    target?.releasePointerCapture?.(pointerId)
+  }
+
+  function onUp(upEvent: PointerEvent): void {
+    stop()
+    options.onEnd?.(upEvent)
+  }
+
+  window.addEventListener('pointermove', options.onMove)
+  window.addEventListener('pointerup', onUp)
+
+  return stop
+}

--- a/desktop/frontend/src/composables/useEscapeToClose.ts
+++ b/desktop/frontend/src/composables/useEscapeToClose.ts
@@ -1,0 +1,11 @@
+import { onKeyStroke } from '@vueuse/core'
+import { toValue, type MaybeRefOrGetter } from 'vue'
+
+export function useEscapeToClose(
+  onEscape: () => void,
+  options: { enabled?: MaybeRefOrGetter<boolean> } = {},
+): void {
+  onKeyStroke('Escape', () => {
+    if (toValue(options.enabled ?? true)) onEscape()
+  })
+}

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,11 +1,12 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useStorage } from '@vueuse/core'
-import { Browser, Events, Window } from '@wailsio/runtime'
+import { Browser, Window } from '@wailsio/runtime'
 import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, RenameFlow, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
 import { ActionRun, ActionViews, FeedItemCounts, FeedItems, InvokeAction, MarkFeedItemRead, SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/desktop/pipelineservice'
 import type { ActionRunView, SessionLaunchOptions as SessionLaunchOptionsView } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
 import { bodySnippet, feedSource, typeLabel } from '../lib/feedPresentation'
 import { useActivity } from './useActivity'
+import { useWailsEvent } from './useWailsEvent'
 import { buildFeedTree, treeToLayout } from '../lib/feedTree'
 import type { ActionView } from '../types/action'
 import type { FeedItem, FeedSort, FeedSummary, FeedTree, Profile, SidebarSelection } from '../types/feed'
@@ -672,19 +673,14 @@ export function useFeedState() {
   // it back. Subscribing here too would race that commit and could read
   // stale feed_item rows.
 
-  let unsubscribeFlows: (() => void) | undefined
-  let unsubscribeActions: (() => void) | undefined
-
   onMounted(() => {
     // A flows/*.yaml change (create/delete/edit) reshapes the profiles list.
-    unsubscribeFlows = Events.On('flows:updated', () => { void reloadProfilesQuietly() })
-    unsubscribeActions = Events.On('actions:updated', () => { void loadActions(selectedItem.value) })
+    useWailsEvent('flows:updated', () => { void reloadProfilesQuietly() })
+    useWailsEvent('actions:updated', () => { void loadActions(selectedItem.value) })
     void loadProfiles()
   })
 
   onUnmounted(() => {
-    unsubscribeFlows?.()
-    unsubscribeActions?.()
     clearToasts()
   })
 

--- a/desktop/frontend/src/composables/useResizablePanel.ts
+++ b/desktop/frontend/src/composables/useResizablePanel.ts
@@ -1,5 +1,6 @@
 import { useStorage } from '@vueuse/core'
 import type { Ref } from 'vue'
+import { startDrag } from './useDragGesture'
 
 /** Which edge of the panel the drag handle sits on. This picks both the drag
  * axis and the sign of the delta:
@@ -51,10 +52,6 @@ export function useResizablePanel(options: UseResizablePanelOptions): UseResizab
   const sign = edge === 'left' || edge === 'top' ? -1 : 1
 
   function startResize(event: PointerEvent): void {
-    const target = event.target as Element | null
-    const pointerId = event.pointerId
-    target?.setPointerCapture?.(pointerId)
-
     const start = vertical ? event.clientY : event.clientX
     const startSize = size.value
 
@@ -63,14 +60,7 @@ export function useResizablePanel(options: UseResizablePanelOptions): UseResizab
       size.value = clamp(startSize + sign * (pos - start), min, max)
     }
 
-    function onUp(): void {
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-      target?.releasePointerCapture?.(pointerId)
-    }
-
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
+    startDrag(event, { onMove, pointerCapture: true })
   }
 
   function step(deltaPx: number): void {

--- a/desktop/frontend/src/composables/useWailsEvent.ts
+++ b/desktop/frontend/src/composables/useWailsEvent.ts
@@ -1,0 +1,10 @@
+import { Events } from '@wailsio/runtime'
+import { onScopeDispose } from 'vue'
+
+/**
+ * Subscribes to a Wails event for the lifetime of the calling effect scope.
+ */
+export function useWailsEvent(name: string, handler: Events.WailsEventCallback): void {
+  const unsubscribe = Events.On(name, handler)
+  onScopeDispose(unsubscribe)
+}

--- a/desktop/frontend/src/lib/__tests__/isEditableTarget.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/isEditableTarget.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { isEditableTarget } from '../isEditableTarget'
+
+describe('isEditableTarget', () => {
+  it('returns true for input elements', () => {
+    expect(isEditableTarget(document.createElement('input'))).toBe(true)
+  })
+
+  it('returns true for textarea elements', () => {
+    expect(isEditableTarget(document.createElement('textarea'))).toBe(true)
+  })
+
+  it('returns true for select elements', () => {
+    expect(isEditableTarget(document.createElement('select'))).toBe(true)
+  })
+
+  it('returns true for contentEditable elements', () => {
+    const el = document.createElement('div')
+    el.contentEditable = 'true'
+
+    expect(isEditableTarget(el)).toBe(true)
+  })
+
+  it('returns false for plain div elements', () => {
+    expect(isEditableTarget(document.createElement('div'))).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isEditableTarget(null)).toBe(false)
+  })
+})

--- a/desktop/frontend/src/lib/isEditableTarget.ts
+++ b/desktop/frontend/src/lib/isEditableTarget.ts
@@ -1,0 +1,6 @@
+export function isEditableTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+}

--- a/desktop/frontend/src/pipeline/components/FlowsCanvas.vue
+++ b/desktop/frontend/src/pipeline/components/FlowsCanvas.vue
@@ -45,6 +45,7 @@ import { NODE_TYPE_MIME } from '../lib/dragTypes'
 import { canConnect, hasInputPort, outputPortCount } from '../lib/ports'
 import { classify, statusColor, statusLabel, statusPulses } from '../lib/runStatus'
 import { gridPosition, type EditorFlow, type NodePosition, type NodeRunRecord, type WireLayout } from '../lib/wireFlow'
+import { isEditableTarget } from '../../lib/isEditableTarget'
 import type { FlowNode, Wire } from '../types'
 import NodeEditorDrawer from './NodeEditorDrawer.vue'
 
@@ -516,12 +517,6 @@ function onDrawerDelete(id: string) {
 // and while focus is in a text input/textarea/contentEditable (e.g. the
 // palette search or a drawer field), so typing "delete" as text never
 // deletes the node.
-
-function isEditableTarget(el: Element | null): boolean {
-  if (!el) return false
-  const tag = el.tagName
-  return tag === 'INPUT' || tag === 'TEXTAREA' || (el as HTMLElement).isContentEditable
-}
 
 function onKeyDown(e: KeyboardEvent) {
   if (e.key !== 'Backspace' && e.key !== 'Delete') return

--- a/desktop/frontend/src/pipeline/components/FlowsCanvas.vue
+++ b/desktop/frontend/src/pipeline/components/FlowsCanvas.vue
@@ -46,6 +46,7 @@ import { canConnect, hasInputPort, outputPortCount } from '../lib/ports'
 import { classify, statusColor, statusLabel, statusPulses } from '../lib/runStatus'
 import { gridPosition, type EditorFlow, type NodePosition, type NodeRunRecord, type WireLayout } from '../lib/wireFlow'
 import { isEditableTarget } from '../../lib/isEditableTarget'
+import { startDrag } from '../../composables/useDragGesture'
 import type { FlowNode, Wire } from '../types'
 import NodeEditorDrawer from './NodeEditorDrawer.vue'
 
@@ -234,13 +235,13 @@ function onNodePointerDown(e: PointerEvent, node: FlowNode) {
     }
     emit('move', node.id, Math.round(origin.x + dx), Math.round(origin.y + dy))
   }
-  function onUp() {
-    window.removeEventListener('pointermove', onMove)
-    window.removeEventListener('pointerup', onUp)
-    if (!moved) selectedNodeId.value = node.id
-  }
-  window.addEventListener('pointermove', onMove)
-  window.addEventListener('pointerup', onUp)
+
+  startDrag(e, {
+    onMove,
+    onEnd: () => {
+      if (!moved) selectedNodeId.value = node.id
+    },
+  })
 }
 
 function onNodeDblClick(node: FlowNode) {
@@ -309,16 +310,16 @@ function onOutputPortPointerDown(e: PointerEvent, node: FlowNode, portIndex: num
     wireDraft.value = { fromNodeId: node.id, fromPort: portIndex, toX: world.x, toY: world.y }
     hoverTargetId.value = targetAt(ev.clientX, ev.clientY)?.id ?? null
   }
-  function onUp(ev: PointerEvent) {
-    window.removeEventListener('pointermove', onMove)
-    window.removeEventListener('pointerup', onUp)
-    const target = targetAt(ev.clientX, ev.clientY)
-    if (target) emit('add-wire', { from: node.id, out: portIndex, to: target.id })
-    wireDraft.value = null
-    hoverTargetId.value = null
-  }
-  window.addEventListener('pointermove', onMove)
-  window.addEventListener('pointerup', onUp)
+
+  startDrag(e, {
+    onMove,
+    onEnd: (ev) => {
+      const target = targetAt(ev.clientX, ev.clientY)
+      if (target) emit('add-wire', { from: node.id, out: portIndex, to: target.id })
+      wireDraft.value = null
+      hoverTargetId.value = null
+    },
+  })
 }
 
 const draftPath = computed<string>(() => {
@@ -382,19 +383,19 @@ function onSurfacePointerDown(e: PointerEvent) {
       y: origin.y + ev.clientY - startClientY,
     }
   }
+
+  const stop = startDrag(e, {
+    onMove,
+    onEnd: cleanup,
+  })
+
   function cleanup() {
-    window.removeEventListener('pointermove', onMove)
-    window.removeEventListener('pointerup', onUp)
+    stop()
     isPanning.value = false
     stopPanTracking = null
   }
-  function onUp() {
-    cleanup()
-  }
 
   stopPanTracking = cleanup
-  window.addEventListener('pointermove', onMove)
-  window.addEventListener('pointerup', onUp)
 }
 
 function onWheel(e: WheelEvent) {

--- a/desktop/frontend/src/pipeline/components/NodeEditorDrawer.vue
+++ b/desktop/frontend/src/pipeline/components/NodeEditorDrawer.vue
@@ -10,6 +10,7 @@ import IconChevronRight from '~icons/lucide/chevron-right'
 import { hasInputPort, outputPortCount } from '../lib/ports'
 import { renderMarkdown, summarize } from '../lib/markdown'
 import AppSwitch from '../../components/AppSwitch.vue'
+import BaseButton from '../../components/BaseButton.vue'
 import DrawerSheet from '../../components/DrawerSheet.vue'
 import { useAutofocus } from '../../composables/useAutofocus'
 import { useEscapeToClose } from '../../composables/useEscapeToClose'
@@ -91,7 +92,7 @@ function submit() {
 
 const deleteConfirming = ref(false)
 const deleteTriggerRef = ref<HTMLButtonElement | null>(null)
-const deleteCancelRef = ref<HTMLButtonElement | null>(null)
+const deleteCancelRef = ref<{ focus: () => void } | null>(null)
 
 function requestDelete() {
   deleteConfirming.value = true
@@ -225,33 +226,38 @@ useAutofocus(nameRef)
           >
             <div class="whitespace-nowrap text-[12px] text-text-2">Delete this node?</div>
             <div class="flex items-center gap-2">
-              <button
+              <BaseButton
                 ref="deleteCancelRef"
-                type="button"
-                class="cursor-pointer whitespace-nowrap rounded-md border border-card px-2.5 py-1.5 text-[12px] text-text-2 hover:text-text"
+                variant="secondary"
+                size="sm"
+                class="whitespace-nowrap"
                 data-testid="node-editor-delete-cancel"
                 @click="cancelDelete"
-              >Cancel</button>
-              <button
-                type="button"
-                class="cursor-pointer whitespace-nowrap rounded-md bg-severity-error px-2.5 py-1.5 text-[12px] font-semibold text-accent-contrast hover:brightness-110"
+              >Cancel</BaseButton>
+              <BaseButton
+                variant="danger"
+                size="sm"
+                class="whitespace-nowrap"
                 data-testid="node-editor-delete-confirm"
                 @click="confirmDelete"
-              >Delete node</button>
+              >Delete node</BaseButton>
             </div>
           </div>
         </div>
         <div class="flex-1" />
-        <button
-          class="cursor-pointer whitespace-nowrap rounded-lg border border-card px-[15px] py-2 text-[13px] text-text-2 hover:text-text"
+        <BaseButton
+          variant="secondary"
+          size="sm"
+          class="whitespace-nowrap"
           data-testid="node-editor-cancel"
           @click="emit('close')"
-        >Cancel</button>
-        <button
-          class="cursor-pointer whitespace-nowrap rounded-lg bg-accent px-[18px] py-2 text-[13px] font-semibold text-accent-contrast hover:brightness-110"
+        >Cancel</BaseButton>
+        <BaseButton
+          size="sm"
+          class="whitespace-nowrap"
           data-testid="node-editor-save"
           @click="submit"
-        >Done</button>
+        >Done</BaseButton>
       </div>
     </template>
   </DrawerSheet>

--- a/desktop/frontend/src/pipeline/components/NodeEditorDrawer.vue
+++ b/desktop/frontend/src/pipeline/components/NodeEditorDrawer.vue
@@ -3,7 +3,7 @@
 // receive the draft, while save() emits a whole new FlowNode without mutating
 // `node`. The Delete confirmation remains a popover so the footer actions do
 // not shift while confirming.
-import { computed, nextTick, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
+import { computed, nextTick, ref, toRaw, watch } from 'vue'
 import IconAlertTriangle from '~icons/lucide/alert-triangle'
 import IconChevronDown from '~icons/lucide/chevron-down'
 import IconChevronRight from '~icons/lucide/chevron-right'
@@ -11,6 +11,8 @@ import { hasInputPort, outputPortCount } from '../lib/ports'
 import { renderMarkdown, summarize } from '../lib/markdown'
 import AppSwitch from '../../components/AppSwitch.vue'
 import DrawerSheet from '../../components/DrawerSheet.vue'
+import { useAutofocus } from '../../composables/useAutofocus'
+import { useEscapeToClose } from '../../composables/useEscapeToClose'
 import type { NodeTypeDefinition } from '../nodeType'
 import type { FlowNode } from '../types'
 
@@ -119,8 +121,7 @@ const helpSummary = computed(() => summarize(props.def.help))
 
 const nameRef = ref<HTMLInputElement | null>(null)
 
-function onKeydown(e: KeyboardEvent) {
-  if (e.key !== 'Escape') return
+function onEscape() {
   // The delete popover takes precedence: Esc cancels the pending confirm
   // first, and only closes the whole drawer on a second Esc once the
   // popover is dismissed.
@@ -131,12 +132,8 @@ function onKeydown(e: KeyboardEvent) {
   emit('close')
 }
 
-onMounted(async () => {
-  window.addEventListener('keydown', onKeydown)
-  await nextTick()
-  nameRef.value?.focus()
-})
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useEscapeToClose(onEscape)
+useAutofocus(nameRef)
 </script>
 
 <template>

--- a/desktop/frontend/src/pipeline/composables/usePipelineEditor.ts
+++ b/desktop/frontend/src/pipeline/composables/usePipelineEditor.ts
@@ -7,7 +7,8 @@
 // PipelineEditorClient and is also the one place that subscribes to the
 // "flows:updated" Wails event (calling refreshFlows/refreshNodeRuns here in
 // response), keeping this file trivially unit-testable with a fake client.
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useIntervalFn } from '@vueuse/core'
+import { computed, onMounted, ref } from 'vue'
 import { instantiate } from '../registry'
 import type { FlowNode, Wire } from '../types'
 import {
@@ -233,15 +234,10 @@ export function usePipelineEditor(client: PipelineEditorClient, options: Pipelin
     }
   }
 
-  let pollTimer: ReturnType<typeof setInterval> | undefined
+  useIntervalFn(() => void refreshNodeRuns(), pollIntervalMs)
 
   onMounted(() => {
     void refreshFlows()
-    pollTimer = setInterval(() => { void refreshNodeRuns() }, pollIntervalMs)
-  })
-
-  onUnmounted(() => {
-    if (pollTimer !== undefined) clearInterval(pollTimer)
   })
 
   return {

--- a/desktop/frontend/src/pipeline/fields/TextField.vue
+++ b/desktop/frontend/src/pipeline/fields/TextField.vue
@@ -1,31 +1,42 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import FieldRow from './FieldRow.vue'
 
 const props = defineProps<{
   label?: string
-  modelValue: string
+  modelValue?: string
   placeholder?: string
   hint?: string
   error?: string
   testid?: string
+  disabled?: boolean
   /** font-mono styling for ids/refs/globs, per the design system convention. */
   monospace?: boolean
 }>()
 
 const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+const inputRef = ref<HTMLInputElement | null>(null)
 
 function onInput(e: Event) {
   emit('update:modelValue', (e.target as HTMLInputElement).value)
 }
+
+function focus() {
+  inputRef.value?.focus()
+}
+
+defineExpose({ focus })
 </script>
 
 <template>
   <FieldRow :label="label" :hint="hint" :error="error" :testid="testid">
     <input
+      ref="inputRef"
       type="text"
       :value="modelValue"
       :placeholder="placeholder"
-      class="w-full rounded-lg border border-strong bg-app px-3 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+      :disabled="disabled"
+      class="w-full rounded-lg border border-strong bg-app px-3 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent disabled:opacity-60"
       :class="{ 'font-mono': monospace }"
       :data-testid="testid"
       @input="onInput"

--- a/desktop/frontend/src/pipeline/fields/TextareaField.vue
+++ b/desktop/frontend/src/pipeline/fields/TextareaField.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import FieldRow from './FieldRow.vue'
+
+const props = withDefaults(defineProps<{
+  label?: string
+  modelValue: string
+  placeholder?: string
+  hint?: string
+  error?: string
+  testid?: string
+  rows?: number
+  /** font-mono styling for template and structured text fields. */
+  monospace?: boolean
+}>(), {
+  rows: 3,
+})
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+function onInput(e: Event) {
+  emit('update:modelValue', (e.target as HTMLTextAreaElement).value)
+}
+</script>
+
+<template>
+  <FieldRow :label="label" :hint="hint" :error="error" :testid="testid">
+    <textarea
+      :value="modelValue"
+      :rows="rows"
+      :placeholder="placeholder"
+      class="w-full resize-y rounded-lg border border-strong bg-app px-3 py-2.5 text-[13.5px] text-text outline-none placeholder:text-text-4 focus:border-accent"
+      :class="{ 'font-mono': monospace }"
+      :data-testid="testid"
+      @input="onInput"
+    />
+  </FieldRow>
+</template>

--- a/desktop/frontend/src/pipeline/fields/__tests__/fields.spec.ts
+++ b/desktop/frontend/src/pipeline/fields/__tests__/fields.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import TextField from '../TextField.vue'
+import TextareaField from '../TextareaField.vue'
 import SelectField from '../SelectField.vue'
 import NumberField from '../NumberField.vue'
 import ToggleField from '../ToggleField.vue'
@@ -41,6 +42,28 @@ describe('TextField', () => {
 
     const mono = mount(TextField, { props: { modelValue: '', monospace: true } })
     expect(mono.get('input').classes()).toContain('font-mono')
+  })
+})
+
+describe('TextareaField', () => {
+  it('renders its label and forwards testid, rows, and monospace styling to the textarea', () => {
+    const wrapper = mount(TextareaField, { props: { modelValue: 'hello', label: 'Template', testid: 'ta', rows: 5, monospace: true } })
+    const textarea = wrapper.get('[data-testid="ta"]').element as HTMLTextAreaElement
+
+    expect(wrapper.text()).toContain('Template')
+    expect(textarea.value).toBe('hello')
+    expect(textarea.getAttribute('rows')).toBe('5')
+    expect(textarea.classList).toContain('font-mono')
+  })
+
+  it('emits update:modelValue on input', async () => {
+    const wrapper = mount(TextareaField, { props: { modelValue: '', testid: 'ta' } })
+    const textarea = wrapper.get('textarea').element as HTMLTextAreaElement
+    textarea.value = 'updated'
+    fire(textarea, 'input')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['updated']])
   })
 })
 

--- a/desktop/frontend/src/pipeline/fields/index.ts
+++ b/desktop/frontend/src/pipeline/fields/index.ts
@@ -1,5 +1,6 @@
 export { default as FieldRow } from './FieldRow.vue'
 export { default as TextField } from './TextField.vue'
+export { default as TextareaField } from './TextareaField.vue'
 export { default as SelectField } from './SelectField.vue'
 export type { SelectOption } from './SelectField.vue'
 export { default as SearchableSelectField } from './SearchableSelectField.vue'


### PR DESCRIPTION
## Purpose

Reduce duplication in the desktop frontend (`desktop/frontend`) by consolidating hand-rolled logic into shared composables/VueUse and extracting reusable UI components. Groundwork identified in a review of the codebase; each change is behavior-preserving and independently reviewable per commit.

## Proposed Changes

- **Shared logic / VueUse:** `onClickOutside` for popovers, `useIntervalFn` polling, `useWailsEvent` for `Events.On` subscriptions, `useEscapeToClose` + `useAutofocus` across 9 overlays, `useDragGesture` for the 4 pointer-drag loops (canvas math kept verbatim), and a shared `isEditableTarget` util.
- **Components (`Base*` for multi-instance, per Vue convention):** `BaseButton`, `BaseModal` (collapses 4 dialogs), `BaseCard`/`BaseIconBadge`, `BaseBadge`; plus `SettingsLayout`/`SettingsNavItem`/`ViewHeader`, `SettingsSection`/`EmptyState`, and a `TextareaField` so `ActionEditor` routes through the field kit.
- Componentized the System settings **About** block introduced in #405 (routed through `SettingsSection`, build-info rows collapsed into a `v-for`).

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
