### PR TITLE
Fix desktop entitlements plist

### DIFF
--- a/desktop/build/darwin/entitlements.plist
+++ b/desktop/build/darwin/entitlements.plist
@@ -4,7 +4,7 @@
 <dict>
 	<!-- WKWebView JITs JavaScript; the hardened runtime blocks that unless
 	     these are granted. Required for the app to launch under a Developer ID
-	     signature with --options runtime. -->
+	     signature with hardened runtime enabled. -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>


### PR DESCRIPTION
## Summary
- remove an XML-invalid double hyphen from the entitlements comment
- allow the desktop release workflow to parse the plist during codesigning

## Validation
- `plutil -lint desktop/build/darwin/entitlements.plist`