### PR TITLE
Desktop QoL improvements

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -23,16 +23,20 @@ Wails' internal window-destroy listener, which otherwise races the callback
 in a separate goroutine. The app keeps running; reopen the window from the
 Dock (`ApplicationShouldHandleReopen` calls `Show`) or from the tray menu.
 
-The tray is a template icon with a menu: **Show Hive** calls `window.Show()`
-and `window.Focus()`, and **Quit** calls `app.Quit()`. In the pinned Wails
+The tray is a template icon with a dynamic menu: **Show Hive** calls
+`window.Show()` and `window.Focus()`, profile checkboxes toggle whether each
+flow polls and runs, and **Quit** calls `app.Quit()`. Invalid flow files remain
+visible as disabled menu items. The menu is rebuilt after flow changes so
+external YAML edits and in-app toggles stay synchronized. In the pinned Wails
 alpha, `SystemTray.SetTemplateIcon` accepts exactly one `[]byte` PNG, so the
 shell embeds only the retina `tray-templateTemplate@2x.png`; the 1x PNG is
 still generated and committed as an asset but not embedded.
 
 Manual native-shell verification remains required: check the Dock icon,
 native traffic lights centered on the 42px titlebar, close-hides-window,
-reopening from the Dock and from the tray menu, template-icon tinting in
-light and dark menu bars, and Quit from the tray menu.
+reopening from the Dock and from the tray menu, profile checkbox toggles and
+live menu refresh, template-icon tinting in light and dark menu bars, and Quit
+from the tray menu.
 
 ## Pinned versions
 

--- a/desktop/flowsservice.go
+++ b/desktop/flowsservice.go
@@ -23,11 +23,12 @@ type FlowSummary struct {
 // injected *flow.FlowStore; this type is wire glue only, matching
 // FeedService/PipelineService's thin-glue style.
 type FlowsService struct {
-	store *flow.FlowStore
+	store     *flow.FlowStore
+	onUpdated func()
 }
 
-func NewFlowsService(store *flow.FlowStore) *FlowsService {
-	return &FlowsService{store: store}
+func NewFlowsService(store *flow.FlowStore, onUpdated func()) *FlowsService {
+	return &FlowsService{store: store, onUpdated: onUpdated}
 }
 
 // ListFlows returns one summary per flow file — valid and invalid alike —
@@ -64,6 +65,19 @@ func (s *FlowsService) RenameFlow(id, name string) (FlowSummary, error) {
 	f, err := s.store.Rename(id, name)
 	if err != nil {
 		return FlowSummary{}, err
+	}
+	return FlowSummary{ID: f.ID, Name: f.Name, Enabled: f.Enabled, Valid: true}, nil
+}
+
+// SetFlowEnabled controls whether a profile participates in polling and flow
+// execution while preserving its existing feed data and graph definition.
+func (s *FlowsService) SetFlowEnabled(id string, enabled bool) (FlowSummary, error) {
+	f, err := s.store.SetEnabled(id, enabled)
+	if err != nil {
+		return FlowSummary{}, err
+	}
+	if s.onUpdated != nil {
+		s.onUpdated()
 	}
 	return FlowSummary{ID: f.ID, Name: f.Name, Enabled: f.Enabled, Valid: true}, nil
 }

--- a/desktop/flowsservice_test.go
+++ b/desktop/flowsservice_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/colonyops/hive/internal/desktop/pipeline/flow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlowsServiceSetFlowEnabled(t *testing.T) {
+	store := flow.NewFlowStore(t.TempDir(), nil)
+	created, err := store.Create("Triage")
+	require.NoError(t, err)
+
+	updates := 0
+	service := NewFlowsService(store, func() { updates++ })
+	summary, err := service.SetFlowEnabled(created.ID, false)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, summary.ID)
+	assert.False(t, summary.Enabled)
+	assert.True(t, summary.Valid)
+	assert.Equal(t, 1, updates)
+
+	stored, ok := store.Get(created.ID)
+	require.True(t, ok)
+	assert.False(t, stored.Enabled)
+}
+
+func TestFlowsServiceSetFlowEnabledDoesNotEmitOnFailure(t *testing.T) {
+	updates := 0
+	service := NewFlowsService(flow.NewFlowStore(t.TempDir(), nil), func() { updates++ })
+
+	_, err := service.SetFlowEnabled("missing", false)
+	require.Error(t, err)
+	assert.Zero(t, updates)
+}

--- a/desktop/frontend/bindings/github.com/colonyops/hive/desktop/flowsservice.ts
+++ b/desktop/frontend/bindings/github.com/colonyops/hive/desktop/flowsservice.ts
@@ -100,3 +100,11 @@ export function SaveLayout(id: string, layout: flow$0.Layout): $CancellablePromi
 export function SaveSidebar(id: string, layout: flow$0.SidebarLayout): $CancellablePromise<void> {
     return $Call.ByID(3551590419, id, layout);
 }
+
+/**
+ * SetFlowEnabled controls whether a profile participates in polling and flow
+ * execution while preserving its existing feed data and graph definition.
+ */
+export function SetFlowEnabled(id: string, enabled: boolean): $CancellablePromise<$models.FlowSummary> {
+    return $Call.ByID(822063213, id, enabled);
+}

--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -51,7 +51,7 @@ const {
 const {
   profiles, profilesLoaded, profilesError, activeProfile, activeProfileId, selection, items, visibleItems, unreadCount, search, loadError,
   selectedId, selectedItem, actions, pendingAction, actionRuns, sessionLaunchAction, sessionLaunchOptions, sessionLaunchBusy, sessionLaunchError, unreadOnly, feedSort, setFeedSort, title, toasts, dismissToast, clearToasts,
-  creatingProfile, createProfileError, renamingProfile, renameProfileError, deletingProfile, loadProfiles, createProfile, renameProfile, deleteProfile,
+  creatingProfile, createProfileError, renamingProfile, renameProfileError, togglingProfileId, toggleProfileError, deletingProfile, loadProfiles, createProfile, renameProfile, setProfileEnabled, deleteProfile,
   reorderFeeds, selectProfile, selectSidebar, selectUnreadView, selectItem, openActionRun, selectNext, selectPrev,
   toggleUnread, refresh, invokeAction, cancelSessionLaunch, submitSessionLaunch, notWired, openUrl, openSelectedInBrowser, hideWindow,
 } = useFeedState()
@@ -345,6 +345,11 @@ async function submitNewProfile(name: string) {
 async function submitProfileRename(name: string) {
   if (!activeProfileId.value) return
   await renameProfile(activeProfileId.value, name)
+}
+
+async function submitProfileEnabled(enabled: boolean) {
+  if (!activeProfileId.value) return
+  await setProfileEnabled(activeProfileId.value, enabled)
 }
 
 const deleteProfileOpen = ref(false)
@@ -654,8 +659,11 @@ onUnmounted(() => {
           :active-section="profileSettingsSection"
           :renaming="renamingProfile"
           :rename-error="renameProfileError"
+          :toggling="togglingProfileId !== null"
+          :toggle-error="toggleProfileError"
           @close="closeSettings"
           @rename="submitProfileRename"
+          @toggle-enabled="submitProfileEnabled"
           @delete="openDeleteProfile"
           @select-section="selectProfileSettingsSection"
         />

--- a/desktop/frontend/src/components/AppSwitch.vue
+++ b/desktop/frontend/src/components/AppSwitch.vue
@@ -3,15 +3,16 @@ const props = withDefaults(defineProps<{
   modelValue: boolean
   label?: string
   hint?: string
+  ariaLabel?: string
   disabled?: boolean
   testid?: string
-}>(), { label: '', hint: '', disabled: false, testid: undefined })
+}>(), { label: '', hint: '', ariaLabel: undefined, disabled: false, testid: undefined })
 const emit = defineEmits<{ 'update:modelValue': [value: boolean] }>()
 </script>
 
 <template>
   <div>
-    <button type="button" role="switch" :aria-checked="modelValue" :disabled="disabled" class="flex items-center gap-2 text-left text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50" :class="disabled ? '' : 'cursor-pointer'" :data-testid="testid" @click="emit('update:modelValue', !modelValue)">
+    <button type="button" role="switch" :aria-checked="modelValue" :aria-label="ariaLabel" :disabled="disabled" class="flex items-center gap-2 text-left text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50" :class="disabled ? '' : 'cursor-pointer'" :data-testid="testid" @click="emit('update:modelValue', !modelValue)">
       <span class="relative h-[17px] w-[30px] shrink-0 rounded-full transition-colors" :class="modelValue ? 'bg-severity-success' : 'bg-chip'">
         <span class="absolute top-[3px] size-[11px] rounded-full bg-pane transition-[left]" :class="modelValue ? 'left-[16px]' : 'left-[3px]'" />
       </span>

--- a/desktop/frontend/src/components/DetailPane.vue
+++ b/desktop/frontend/src/components/DetailPane.vue
@@ -160,6 +160,24 @@ const { size: bodyHeight, startResize: startBodyResize, step: stepBody } = useRe
   margin: 10px 0; padding: 2px 14px; border-left: 3px solid var(--color-border);
   color: var(--color-text-3);
 }
+.markdown-body :deep(details) {
+  margin: 10px 0; padding: 8px 12px; border: 1px solid var(--color-border);
+  border-radius: 7px; background: var(--color-card);
+}
+.markdown-body :deep(summary) {
+  cursor: pointer; color: var(--color-text); font-weight: 650;
+}
+.markdown-body :deep(details[open] summary) { margin-bottom: 8px; }
+.markdown-body :deep(.markdown-alert) {
+  --alert-color: var(--color-accent);
+  margin: 10px 0; padding: 2px 14px; border-left: 3px solid var(--alert-color);
+  color: var(--color-text-2); background: color-mix(in srgb, var(--alert-color) 7%, transparent);
+}
+.markdown-body :deep(.markdown-alert-title) { color: var(--alert-color); font-weight: 650; }
+.markdown-body :deep(.markdown-alert-tip) { --alert-color: var(--color-kind-issue); }
+.markdown-body :deep(.markdown-alert-important) { --alert-color: var(--color-kind-pr); }
+.markdown-body :deep(.markdown-alert-warning),
+.markdown-body :deep(.markdown-alert-caution) { --alert-color: var(--color-warning, #d29922); }
 .markdown-body :deep(hr) { margin: 16px 0; border: 0; border-top: 1px solid var(--color-border); }
 .markdown-body :deep(code) {
   padding: 1.5px 6px; border-radius: 5px; background: var(--color-card);

--- a/desktop/frontend/src/components/ProfileRail.vue
+++ b/desktop/frontend/src/components/ProfileRail.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import IconPause from '~icons/lucide/pause'
 import IconPlus from '~icons/lucide/plus'
 import IconSettings from '~icons/lucide/settings'
 import type { Profile } from '../types/feed'
@@ -12,15 +13,18 @@ const emit = defineEmits<{ select: [profileId: string]; add: []; 'open-settings'
     <button
       v-for="profile in profiles"
       :key="profile.id"
-      :title="profile.name"
+      :title="profile.enabled ? profile.name : `${profile.name} (disabled)`"
+      :aria-label="profile.enabled ? profile.name : `${profile.name}, disabled`"
       :data-id="profile.id"
+      :data-enabled="profile.enabled"
       data-testid="profile-tile"
       class="relative flex size-[38px] cursor-pointer items-center justify-center rounded-[10px] border border-card bg-chip font-mono text-sm font-semibold text-text-2 transition-colors hover:bg-hover hover:text-text"
-      :class="{ 'text-text': profile.id === activeProfileId }"
+      :class="{ 'text-text': profile.id === activeProfileId, 'opacity-55': !profile.enabled }"
       @click="emit('select', profile.id)"
     >
       <span v-if="profile.id === activeProfileId" class="absolute bottom-2 left-[-13px] top-2 w-[3px] rounded-sm bg-accent" />
       {{ profile.letter }}
+      <span v-if="!profile.enabled" class="absolute -bottom-1 -right-1 flex size-4 items-center justify-center rounded-full border border-border bg-raised text-text-3" aria-hidden="true"><IconPause class="size-2.5" /></span>
     </button>
     <button class="flex size-[38px] cursor-pointer items-center justify-center rounded-[10px] border border-dashed border-card text-text-4 hover:border-strong hover:text-text-2" aria-label="Add profile" data-testid="profile-add" @click="emit('add')"><IconPlus class="size-4" /></button>
     <div class="flex-1" />

--- a/desktop/frontend/src/components/ProfileSettingsView.vue
+++ b/desktop/frontend/src/components/ProfileSettingsView.vue
@@ -2,17 +2,33 @@
 import { ref, watch } from 'vue'
 import IconSlidersHorizontal from '~icons/lucide/sliders-horizontal'
 import IconTrash2 from '~icons/lucide/trash-2'
+import AppSwitch from './AppSwitch.vue'
 import BaseButton from './BaseButton.vue'
 import SettingsLayout from './settings/SettingsLayout.vue'
 import SettingsNavItem from './settings/SettingsNavItem.vue'
 import type { Profile } from '../types/feed'
 import type { ProfileSettingsSection } from '../router'
 
-const props = withDefaults(defineProps<{ profile: Profile; activeSection: ProfileSettingsSection; renaming?: boolean; renameError?: string | null }>(), {
+const props = withDefaults(defineProps<{
+  profile: Profile
+  activeSection: ProfileSettingsSection
+  renaming?: boolean
+  renameError?: string | null
+  toggling?: boolean
+  toggleError?: string | null
+}>(), {
   renaming: false,
   renameError: null,
+  toggling: false,
+  toggleError: null,
 })
-const emit = defineEmits<{ close: []; delete: []; rename: [name: string]; 'select-section': [section: ProfileSettingsSection] }>()
+const emit = defineEmits<{
+  close: []
+  delete: []
+  rename: [name: string]
+  'toggle-enabled': [enabled: boolean]
+  'select-section': [section: ProfileSettingsSection]
+}>()
 
 const name = ref(props.profile.name)
 
@@ -77,6 +93,21 @@ function submitRename(): void {
           </div>
           <p v-if="props.renameError" class="mt-2 text-xs text-severity-error" data-testid="profile-settings-rename-error">{{ props.renameError }}</p>
           <div class="mt-3 border-t border-border pt-3 text-xs text-text-3">{{ props.profile.sourceSummary }}</div>
+          <div class="mt-4 flex items-start justify-between gap-5 border-t border-border pt-4">
+            <div>
+              <div class="text-[13px] font-medium text-text">Profile polling</div>
+              <p class="mt-1 text-xs leading-relaxed text-text-3">Disabled profiles keep their existing feed items but stop polling and running their flow.</p>
+            </div>
+            <AppSwitch
+              :model-value="props.profile.enabled"
+              :label="props.profile.enabled ? 'Enabled' : 'Disabled'"
+              aria-label="Profile polling"
+              :disabled="props.toggling"
+              testid="profile-settings-enabled"
+              @update:model-value="emit('toggle-enabled', $event)"
+            />
+          </div>
+          <p v-if="props.toggleError" class="mt-2 text-xs text-severity-error" data-testid="profile-settings-toggle-error">{{ props.toggleError }}</p>
         </form>
 
         <div v-else class="rounded-lg border border-severity-error/35 bg-raised p-4">

--- a/desktop/frontend/src/components/__tests__/ProfileRail.spec.ts
+++ b/desktop/frontend/src/components/__tests__/ProfileRail.spec.ts
@@ -6,6 +6,7 @@ const profiles = [{
   id: 'personal',
   letter: 'P',
   name: 'Personal',
+  enabled: true,
   sourceSummary: 'GitHub · 2 sources',
   totalCount: 3,
   unreadCount: 1,
@@ -13,6 +14,17 @@ const profiles = [{
 }]
 
 describe('ProfileRail', () => {
+  it('marks disabled profiles while keeping them selectable', async () => {
+    const disabled = { ...profiles[0], enabled: false }
+    const wrapper = mount(ProfileRail, { props: { profiles: [disabled], activeProfileId: 'personal' } })
+    const tile = wrapper.get('[data-testid="profile-tile"]')
+
+    expect(tile.attributes('data-enabled')).toBe('false')
+    expect(tile.attributes('aria-label')).toContain('disabled')
+    await tile.trigger('click')
+    expect(wrapper.emitted('select')).toEqual([['personal']])
+  })
+
   it('shows one application settings action at the bottom', async () => {
     const wrapper = mount(ProfileRail, { props: { profiles, activeProfileId: 'personal' } })
 

--- a/desktop/frontend/src/components/__tests__/ProfileSettingsView.spec.ts
+++ b/desktop/frontend/src/components/__tests__/ProfileSettingsView.spec.ts
@@ -6,6 +6,7 @@ const profile = {
   id: 'personal',
   letter: 'P',
   name: 'Personal',
+  enabled: true,
   sourceSummary: 'GitHub · 2 sources',
   totalCount: 3,
   unreadCount: 1,
@@ -38,6 +39,21 @@ describe('ProfileSettingsView', () => {
     await wrapper.get('form').trigger('submit')
 
     expect(wrapper.emitted('rename')).toEqual([['Team Triage']])
+  })
+
+  it('toggles profile polling and shows failures', async () => {
+    const wrapper = mount(ProfileSettingsView, {
+      props: { profile, activeSection: 'general', toggleError: 'Could not update' },
+    })
+
+    const toggle = wrapper.get('[data-testid="profile-settings-enabled"]')
+    expect(toggle.attributes('aria-checked')).toBe('true')
+    await toggle.trigger('click')
+    expect(wrapper.emitted('toggle-enabled')).toEqual([[false]])
+    expect(wrapper.get('[data-testid="profile-settings-toggle-error"]').text()).toBe('Could not update')
+
+    await wrapper.setProps({ toggling: true })
+    expect(toggle.attributes('disabled')).toBeDefined()
   })
 
   it('shows rename progress and errors', async () => {

--- a/desktop/frontend/src/components/__tests__/SideBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SideBar.spec.ts
@@ -10,6 +10,7 @@ const profile: Profile = {
   id: 'personal',
   letter: 'P',
   name: 'Personal',
+  enabled: true,
   sourceSummary: '2 sources',
   totalCount: 3,
   unreadCount: 1,

--- a/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
+++ b/desktop/frontend/src/composables/__tests__/useFeedState.spec.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   GetFlow: vi.fn(),
   CreateFlow: vi.fn(),
   RenameFlow: vi.fn(),
+  SetFlowEnabled: vi.fn(),
   DeleteFlow: vi.fn(),
   GetSidebar: vi.fn(),
   SaveSidebar: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock('../../../bindings/github.com/colonyops/hive/desktop/flowsservice', () =
   GetFlow: mocks.GetFlow,
   CreateFlow: mocks.CreateFlow,
   RenameFlow: mocks.RenameFlow,
+  SetFlowEnabled: mocks.SetFlowEnabled,
   DeleteFlow: mocks.DeleteFlow,
   GetSidebar: mocks.GetSidebar,
   SaveSidebar: mocks.SaveSidebar,
@@ -75,6 +77,7 @@ beforeEach(() => {
   mocks.GetFlow.mockResolvedValue(flow)
   mocks.GetSidebar.mockResolvedValue({ items: [] })
   mocks.SaveSidebar.mockResolvedValue(undefined)
+  mocks.SetFlowEnabled.mockImplementation((id: string, enabled: boolean) => Promise.resolve({ ...flowSummary, id, enabled }))
   mocks.FeedItemCounts.mockResolvedValue([{ feedId: 'triage/my-prs', total: 3, unread: 2 }])
   mocks.FeedItems.mockResolvedValue([])
   mocks.ActionViews.mockResolvedValue([])
@@ -93,6 +96,7 @@ describe('useFeedState', () => {
     const state = get()
     expect(state.profiles.value).toHaveLength(1)
     expect(state.activeProfileId.value).toBe('triage')
+    expect(state.activeProfile.value?.enabled).toBe(true)
     expect(state.activeProfile.value?.feeds).toEqual([
       { id: 'triage/my-prs', name: 'My PRs', count: 3, newCount: 2 },
     ])
@@ -144,6 +148,30 @@ describe('useFeedState', () => {
     await flushPromises()
 
     expect(get().activeProfile.value?.feeds[0]?.name).toBe('Team PRs')
+  })
+
+  it('drops stale profile-list reloads so enablement cannot move backwards', async () => {
+    const handlers: Record<string, () => void> = {}
+    mocks.On.mockImplementation((event: string, cb: () => void) => {
+      handlers[event] = cb
+      return () => {}
+    })
+    const get = mountState()
+    await flushPromises()
+
+    const resolvers: Array<(flows: unknown) => void> = []
+    mocks.ListFlows.mockImplementation(() => new Promise((resolve) => { resolvers.push(resolve) }))
+    handlers['flows:updated']?.()
+    await flushPromises()
+    handlers['flows:updated']?.()
+    await flushPromises()
+
+    resolvers[1]([{ ...flowSummary, enabled: false }])
+    await flushPromises()
+    resolvers[0]([{ ...flowSummary, enabled: true }])
+    await flushPromises()
+
+    expect(get().activeProfile.value?.enabled).toBe(false)
   })
 
   it('reconciles the saved sidebar layout (folders, node-id keyed) into the tree', async () => {
@@ -251,6 +279,31 @@ describe('useFeedState', () => {
     expect(renamed).toBe(false)
     expect(get().renameProfileError.value).toBe('disk is read-only')
     expect(get().activeProfile.value?.name).toBe('Frontend Triage')
+  })
+
+  it('disables a profile while keeping it selected and its feeds visible', async () => {
+    const get = mountState()
+    await flushPromises()
+
+    const changed = await get().setProfileEnabled('triage', false)
+
+    expect(changed).toBe(true)
+    expect(mocks.SetFlowEnabled).toHaveBeenCalledWith('triage', false)
+    expect(get().activeProfileId.value).toBe('triage')
+    expect(get().activeProfile.value?.enabled).toBe(false)
+    expect(get().activeProfile.value?.feeds).toHaveLength(1)
+  })
+
+  it('preserves profile enablement and surfaces an update failure', async () => {
+    mocks.SetFlowEnabled.mockRejectedValue(new Error('disk is read-only'))
+    const get = mountState()
+    await flushPromises()
+
+    const changed = await get().setProfileEnabled('triage', false)
+
+    expect(changed).toBe(false)
+    expect(get().activeProfile.value?.enabled).toBe(true)
+    expect(get().toggleProfileError.value).toBe('disk is read-only')
   })
 
   it('deletes a profile by deleting its flow', async () => {

--- a/desktop/frontend/src/composables/useFeedState.ts
+++ b/desktop/frontend/src/composables/useFeedState.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useStorage } from '@vueuse/core'
 import { Browser, Window } from '@wailsio/runtime'
-import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, RenameFlow, SaveSidebar } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
+import { CreateFlow, DeleteFlow, GetFlow, GetSidebar, ListFlows, RenameFlow, SaveSidebar, SetFlowEnabled } from '../../bindings/github.com/colonyops/hive/desktop/flowsservice'
 import { ActionRun, ActionViews, FeedItemCounts, FeedItems, InvokeAction, MarkFeedItemRead, SessionLaunchOptions } from '../../bindings/github.com/colonyops/hive/desktop/pipelineservice'
 import type { ActionRunView, SessionLaunchOptions as SessionLaunchOptionsView } from '../../bindings/github.com/colonyops/hive/internal/desktop/pipeline/models'
 import { bodySnippet, feedSource, typeLabel } from '../lib/feedPresentation'
@@ -66,6 +66,8 @@ export function useFeedState() {
   const createProfileError = ref<string | null>(null)
   const renamingProfile = ref(false)
   const renameProfileError = ref<string | null>(null)
+  const togglingProfileId = ref<string | null>(null)
+  const toggleProfileError = ref<string | null>(null)
   const deletingProfile = ref(false)
   let nextToastId = 1
   const toastTimers = new Map<number, ReturnType<typeof setTimeout>>()
@@ -73,6 +75,7 @@ export function useFeedState() {
   // Monotonic token: out-of-order loadItems responses must not clobber newer.
   let loadSeq = 0
   let feedsSeq = 0
+  let profilesSeq = 0
   let actionLoadSeq = 0
 
   function actionKey(itemID: string, actionID: string): string { return `${itemID}\u0000${actionID}` }
@@ -200,14 +203,16 @@ export function useFeedState() {
 
   // A flow summary maps to a profile; feeds are filled in by loadFeeds once
   // the profile is selected (the rail only needs the letter/name).
-  function toProfileStub(flow: { id: string; name: string }): Profile {
+  function toProfileStub(flow: { id: string; name: string; enabled: boolean }): Profile {
     const name = flow.name || flow.id
-    return { id: flow.id, letter: letter(name), name, sourceSummary: '', totalCount: 0, unreadCount: 0, feeds: [] }
+    return { id: flow.id, letter: letter(name), name, enabled: flow.enabled, sourceSummary: '', totalCount: 0, unreadCount: 0, feeds: [] }
   }
 
   async function loadProfiles() {
+    const seq = ++profilesSeq
     try {
       const flows = (await ListFlows()) ?? []
+      if (seq !== profilesSeq) return
       profiles.value = flows.map(toProfileStub)
       profilesLoaded.value = true
       profilesError.value = null
@@ -215,6 +220,7 @@ export function useFeedState() {
       if (active) await selectProfile(active.id)
       else clearActive()
     } catch (error) {
+      if (seq !== profilesSeq) return
       console.warn('Unable to load flows', error)
       profilesError.value = 'Could not load your workspaces.'
     }
@@ -228,8 +234,11 @@ export function useFeedState() {
   }
 
   async function reloadProfilesQuietly() {
+    const seq = ++profilesSeq
     try {
-      profiles.value = ((await ListFlows()) ?? []).map(toProfileStub)
+      const flows = (await ListFlows()) ?? []
+      if (seq !== profilesSeq) return
+      profiles.value = flows.map(toProfileStub)
       if (activeProfileId.value) await loadFeeds(activeProfileId.value)
     } catch (error) {
       console.warn('Unable to refresh flows', error)
@@ -339,6 +348,28 @@ export function useFeedState() {
       return false
     } finally {
       renamingProfile.value = false
+    }
+  }
+
+  async function setProfileEnabled(profileID: string, enabled: boolean): Promise<boolean> {
+    if (togglingProfileId.value) return false
+    const current = profiles.value.find((profile) => profile.id === profileID)
+    if (!current || current.enabled === enabled) return true
+
+    togglingProfileId.value = profileID
+    toggleProfileError.value = null
+    try {
+      const updated = await SetFlowEnabled(profileID, enabled)
+      const profile = profiles.value.find((candidate) => candidate.id === profileID)
+      if (profile) profile.enabled = updated.enabled
+      showToast(enabled ? 'Profile enabled' : 'Profile disabled', { severity: 'success' })
+      return true
+    } catch (error) {
+      console.warn('Unable to update flow enablement', error)
+      toggleProfileError.value = error instanceof Error && error.message ? error.message : 'Could not update the profile.'
+      return false
+    } finally {
+      togglingProfileId.value = null
     }
   }
 
@@ -734,10 +765,13 @@ export function useFeedState() {
     createProfileError,
     renamingProfile,
     renameProfileError,
+    togglingProfileId,
+    toggleProfileError,
     deletingProfile,
     loadProfiles,
     createProfile,
     renameProfile,
+    setProfileEnabled,
     deleteProfile,
     reorderFeeds,
     selectProfile,

--- a/desktop/frontend/src/lib/__tests__/githubMarkdown.spec.ts
+++ b/desktop/frontend/src/lib/__tests__/githubMarkdown.spec.ts
@@ -36,6 +36,51 @@ describe('renderGithubMarkdown', () => {
     expect(renderGithubMarkdown('~~gone~~')).toContain('<s>gone</s>')
   })
 
+  it('renders collapsible details with markdown content', () => {
+    const src = '<details>\n<summary>More information</summary>\n\n**Hidden** details\n\n</details>'
+    const html = renderGithubMarkdown(src)
+    expect(html).toContain('<details>')
+    expect(html).toContain('<summary>More information</summary>')
+    expect(html).toContain('<strong>Hidden</strong> details')
+    expect(html).toContain('</details>')
+  })
+
+  it('supports open details but escapes unsupported attributes', () => {
+    expect(renderGithubMarkdown('<details open>\ncontent\n</details>')).toContain('<details open="">')
+
+    const html = renderGithubMarkdown('<details onclick="alert(1)">\ncontent\n</details>')
+    expect(html).not.toContain('<details onclick')
+    expect(html).toContain('&lt;details onclick=')
+  })
+
+  it.each([
+    ['NOTE', 'Note'],
+    ['TIP', 'Tip'],
+    ['IMPORTANT', 'Important'],
+    ['WARNING', 'Warning'],
+    ['CAUTION', 'Caution'],
+  ])('renders a GitHub %s alert', (type, label) => {
+    const html = renderGithubMarkdown(`> [!${type}]\n> Useful **information**`)
+    expect(html).toContain(`class="markdown-alert markdown-alert-${type.toLowerCase()}"`)
+    expect(html).toContain(`<p class="markdown-alert-title">${label}</p>`)
+    expect(html).toContain('Useful <strong>information</strong>')
+    expect(html).not.toContain(`[!${type}]`)
+  })
+
+  it('removes GitHub HTML comments without hiding surrounding content', () => {
+    const src = 'You can ask for more help in #proj-renovate-self-hosted.\n<!--renovate-debug:eyJ2ZXIiOiI0My4yNjYuMCJ9-->'
+    const html = renderGithubMarkdown(src)
+    expect(html).toContain('You can ask for more help in #proj-renovate-self-hosted.')
+    expect(html).not.toContain('renovate-debug')
+    expect(html).not.toContain('&lt;!--')
+  })
+
+  it('preserves comment-like text inside code', () => {
+    const html = renderGithubMarkdown('`<!-- keep me -->`\n\n```html\n<!-- keep me too -->\n```')
+    expect(html).toContain('&lt;!-- keep me --&gt;')
+    expect(html).toContain('&lt;!-- keep me too --&gt;')
+  })
+
   it('renders fenced code blocks', () => {
     const html = renderGithubMarkdown('```\nconst x = 1\n```')
     expect(html).toContain('<pre>')

--- a/desktop/frontend/src/lib/githubMarkdown.ts
+++ b/desktop/frontend/src/lib/githubMarkdown.ts
@@ -1,25 +1,155 @@
 // Renders untrusted GitHub-flavored markdown (issue / PR bodies) to HTML for
 // injection via v-html. markdown-it is a pure string transform (no DOM), and
 // it's safe-by-default for attacker-controllable input:
-//   - html:false escapes any raw HTML embedded in the markdown, so a body
-//     like `<script>…</script>` renders as inert text, never a live element.
-//   - its built-in link validator drops dangerous URL schemes (javascript:,
-//     vbscript:, and non-image data:), so a `[x](javascript:…)` never becomes
-//     a clickable anchor.
-// Because escaping happens during parse, no separate sanitizer pass is needed.
+//   - Raw HTML is tokenized but always escaped by custom renderer rules. The
+//     plugin below recognizes only exact <details>, <summary>, and closing tags,
+//     and emits those tags itself.
+//   - HTML comments are removed from parsed HTML tokens, while comment-like
+//     text in code spans and fences remains visible.
+//   - markdown-it's built-in link validator drops dangerous URL schemes
+//     (javascript:, vbscript:, and non-image data:).
 //
 // GFM coverage comes from markdown-it's defaults (tables, strikethrough) plus
-// linkify (autolink bare URLs) and the task-lists plugin (checkbox items).
+// linkify, task lists, GitHub alerts, and collapsible <details> sections.
 // breaks:true mirrors how GitHub renders a single newline in a comment body
 // as a line break.
 //
 // This is deliberately separate from pipeline/lib/markdown.ts, a tiny
-// hand-rolled renderer for FIRST-PARTY node help.md docs — trusted authors, a
-// fixed subset, no need for a full parser.
+// hand-rolled renderer for FIRST-PARTY node help.md docs.
 import MarkdownIt from 'markdown-it'
+import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs'
+import type Token from 'markdown-it/lib/token.mjs'
 import taskLists from 'markdown-it-task-lists'
 
-const md = new MarkdownIt({ html: false, linkify: true, breaks: true }).use(taskLists)
+const alertTypes = new Map([
+  ['NOTE', 'Note'],
+  ['TIP', 'Tip'],
+  ['IMPORTANT', 'Important'],
+  ['WARNING', 'Warning'],
+  ['CAUTION', 'Caution'],
+])
+
+function lineText(state: StateBlock, line: number): string {
+  return state.src.slice(state.bMarks[line] + state.tShift[line], state.eMarks[line]).trim()
+}
+
+// GitHub permits markdown inside a details element. Raw HTML remains escaped;
+// this rule admits only the exact, attribute-free tags plus GitHub's `open`
+// boolean attribute and lets markdown-it parse all inner content normally.
+function githubDetails(md: MarkdownIt) {
+  md.block.ruler.before('html_block', 'github_details', (state, startLine, endLine, silent) => {
+    const opening = lineText(state, startLine).match(/^<details(?:\s+(open))?\s*>$/i)
+    if (!opening) return false
+
+    let depth = 1
+    let closeLine = startLine + 1
+    for (; closeLine < endLine; closeLine++) {
+      const line = lineText(state, closeLine)
+      if (/^<details(?:\s+open)?\s*>$/i.test(line)) depth++
+      if (/^<\/details\s*>$/i.test(line) && --depth === 0) break
+    }
+    if (closeLine >= endLine) return false
+    if (silent) return true
+
+    const open = state.push('github_details_open', 'details', 1)
+    open.map = [startLine, closeLine + 1]
+    if (opening[1]) open.attrSet('open', '')
+
+    let contentLine = startLine + 1
+    const summary = contentLine < closeLine
+      ? lineText(state, contentLine).match(/^<summary>(.*?)<\/summary\s*>$/i)
+      : null
+    if (summary) {
+      state.push('github_summary_open', 'summary', 1)
+      const inline = state.push('inline', '', 0)
+      inline.content = summary[1]
+      inline.children = []
+      state.push('github_summary_close', 'summary', -1)
+      contentLine++
+    }
+
+    if (contentLine < closeLine) state.md.block.tokenize(state, contentLine, closeLine)
+    state.push('github_details_close', 'details', -1)
+    state.line = closeLine + 1
+    return true
+  }, { alt: ['paragraph', 'reference', 'blockquote', 'list'] })
+}
+
+function removeHtmlComments(tokens: Token[]) {
+  for (let index = tokens.length - 1; index >= 0; index--) {
+    const token = tokens[index]
+    if ((token.type === 'html_block' || token.type === 'html_inline') && /^<!--[\s\S]*-->$/.test(token.content.trim())) {
+      tokens.splice(index, 1)
+      continue
+    }
+    if (token.children) removeHtmlComments(token.children)
+  }
+}
+
+function githubExtensions(md: MarkdownIt) {
+  githubDetails(md)
+
+  // Alert markup is parsed as a blockquote by CommonMark. Promote blockquotes
+  // whose first paragraph starts with [!TYPE] into GitHub-style alert blocks.
+  md.core.ruler.push('github_alerts_and_comments', (state) => {
+    removeHtmlComments(state.tokens)
+
+    for (let index = 0; index < state.tokens.length - 2; index++) {
+      const open = state.tokens[index]
+      const paragraph = state.tokens[index + 1]
+      const inline = state.tokens[index + 2]
+      if (open.type !== 'blockquote_open' || paragraph.type !== 'paragraph_open' || inline.type !== 'inline') continue
+
+      const match = inline.content.match(/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\](?:\n|$)/)
+      if (!match) continue
+
+      const label = alertTypes.get(match[1])!
+      open.tag = 'div'
+      open.attrSet('class', `markdown-alert markdown-alert-${match[1].toLowerCase()}`)
+
+      let depth = 1
+      for (let closeIndex = index + 1; closeIndex < state.tokens.length; closeIndex++) {
+        if (state.tokens[closeIndex].type === 'blockquote_open') depth++
+        if (state.tokens[closeIndex].type === 'blockquote_close' && --depth === 0) {
+          state.tokens[closeIndex].tag = 'div'
+          break
+        }
+      }
+
+      const titleOpen = new state.Token('paragraph_open', 'p', 1)
+      titleOpen.attrSet('class', 'markdown-alert-title')
+      const title = new state.Token('inline', '', 0)
+      title.content = label
+      title.children = []
+      md.inline.parse(label, md, state.env, title.children)
+      const titleClose = new state.Token('paragraph_close', 'p', -1)
+      state.tokens.splice(index + 1, 0, titleOpen, title, titleClose)
+
+      inline.content = inline.content.slice(match[0].length)
+      inline.children = []
+      md.inline.parse(inline.content, md, state.env, inline.children)
+      index += 3
+    }
+  })
+}
+
+const md = new MarkdownIt({ html: true, linkify: true, breaks: true })
+  .use(taskLists)
+  .use(githubExtensions)
+
+// Enabling HTML lets the parser distinguish comments from text. Keep the
+// output safe by escaping every remaining HTML token; whitelisted details
+// elements never pass through these renderer rules because the block plugin
+// emits dedicated token types for them.
+const renderEscapedHtml = (tokens: Token[], index: number) => md.utils.escapeHtml(tokens[index].content)
+md.renderer.rules.html_block = renderEscapedHtml
+md.renderer.rules.html_inline = (tokens: Token[], index: number) => {
+  const content = tokens[index].content
+  // markdown-it-task-lists emits this fixed, disabled checkbox as an HTML
+  // token. It contains no user-controlled values, so preserve it verbatim.
+  if (/^<input class="task-list-item-checkbox"(?: checked="")? disabled="" type="checkbox">$/.test(content)) return content
+  return md.utils.escapeHtml(content)
+}
 
 export function renderGithubMarkdown(src: string): string {
   if (!src.trim()) return ''

--- a/desktop/frontend/src/types/feed.ts
+++ b/desktop/frontend/src/types/feed.ts
@@ -67,6 +67,7 @@ export interface Profile {
   id: string
   letter: string
   name: string
+  enabled: boolean
   sourceSummary: string
   totalCount: number
   unreadCount: number

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -147,7 +147,7 @@ func emitAuthUpdated() {
 // including the app's own SaveFlow/SaveLayout writes. A watcher that fails to
 // start degrades to no hot-reload: the app still works, edits just need a
 // restart to pick up.
-func buildFlowsStore(actionStore *actions.ActionStore, logger zerolog.Logger) (*flow.FlowStore, *flow.FlowsWatcher) {
+func buildFlowsStore(actionStore *actions.ActionStore, onUpdated func(), logger zerolog.Logger) (*flow.FlowStore, *flow.FlowsWatcher) {
 	dir := desktop.FlowsDir()
 	store := flow.NewFlowStore(dir, newActionsRefs(actionStore))
 
@@ -155,7 +155,9 @@ func buildFlowsStore(actionStore *actions.ActionStore, logger zerolog.Logger) (*
 		if err := store.Reload(); err != nil {
 			logger.Warn().Err(err).Msg("flows reload failed")
 		}
-		emitFlowsUpdated()
+		if onUpdated != nil {
+			onUpdated()
+		}
 	}, logger)
 	if err != nil {
 		logger.Warn().Err(err).Msg("flows hot-reload unavailable")
@@ -385,13 +387,18 @@ func main() {
 		actionsWatcher.Start()
 	}
 
+	var refreshProfileTray func()
+	onFlowsUpdated := func() {
+		emitFlowsUpdated()
+		if refreshProfileTray != nil {
+			refreshProfileTray()
+		}
+	}
+
 	// The flows store must exist before the producer and retention maintenance:
 	// both resolve enabled flow IDs live from it.
-	flowsStore, flowsWatcher := buildFlowsStore(actionStore, logger)
+	flowsStore, flowsWatcher := buildFlowsStore(actionStore, onFlowsUpdated, logger)
 	actionStore.SetUsageChecker(actionUsageChecker{flows: flowsStore, db: pipelineDB})
-	if flowsWatcher != nil {
-		flowsWatcher.Start()
-	}
 
 	outputWorker := buildOutputWorker(pipelineDB, actionStore, actionRuntime.launcher, actionRuntime.publisher, activityStore, jobStore, logger)
 	if desktop.MockMode() == "" {
@@ -429,7 +436,7 @@ func main() {
 		Services: []application.Service{
 			application.NewService(auth.NewService(buildAuthBackend(onAuthChange))),
 			application.NewService(NewPipelineService(pipelineDB, actionStore, outputWorker, actionRuntime.launcher)),
-			application.NewService(NewFlowsService(flowsStore)),
+			application.NewService(NewFlowsService(flowsStore, onFlowsUpdated)),
 			application.NewService(NewActionsService(actionStore, emitActionsUpdated)),
 			application.NewService(NewActivityService(activityStore)),
 			application.NewService(NewJobService(jobStore)),
@@ -485,17 +492,31 @@ func main() {
 		window.Show()
 	})
 
-	trayMenu := app.NewMenu()
-	trayMenu.Add("Show Hive").OnClick(func(*application.Context) {
-		window.Show()
-		window.Focus()
+	profilesTray := newProfileTray(
+		app,
+		flowsStore,
+		logger,
+		trayIcon,
+		onFlowsUpdated,
+		func() {
+			window.Show()
+			window.Focus()
+		},
+		app.Quit,
+	)
+	refreshProfileTray = profilesTray.Refresh
+	if flowsWatcher != nil {
+		// Start only after refreshProfileTray is published. The watcher invokes
+		// onFlowsUpdated from its goroutine, so starting earlier would race the
+		// callback assignment above.
+		flowsWatcher.Start()
+	}
+	app.OnShutdown(func() {
+		profilesTray.Close()
+		if flowsWatcher != nil {
+			flowsWatcher.Close()
+		}
 	})
-	trayMenu.AddSeparator()
-	trayMenu.Add("Quit").OnClick(func(*application.Context) {
-		app.Quit()
-	})
-
-	app.SystemTray.New().SetTemplateIcon(trayIcon).SetMenu(trayMenu)
 
 	shutdown := func() {
 		maintenance.Stop()

--- a/desktop/profiletray.go
+++ b/desktop/profiletray.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/colonyops/hive/internal/desktop/pipeline/flow"
+	"github.com/rs/zerolog"
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+type trayProfile struct {
+	ID      string
+	Label   string
+	Enabled bool
+	Valid   bool
+}
+
+func trayProfiles(store *flow.FlowStore) []trayProfile {
+	statuses := store.Statuses()
+	profiles := make([]trayProfile, 0, len(statuses))
+	for _, status := range statuses {
+		if status.Valid {
+			profiles = append(profiles, trayProfile{
+				ID:      status.ID,
+				Label:   status.Flow.Name,
+				Enabled: status.Flow.Enabled,
+				Valid:   true,
+			})
+			continue
+		}
+		profiles = append(profiles, trayProfile{
+			ID:    status.ID,
+			Label: status.ID + " (invalid)",
+		})
+	}
+	return profiles
+}
+
+// profileTray owns the dynamic native tray menu. Profile rows are checkboxes:
+// checked profiles poll and run, while unchecked profiles retain their feed
+// data without executing. Invalid flow files remain visible but non-interactive.
+type profileTray struct {
+	app       *application.App
+	store     *flow.FlowStore
+	logger    zerolog.Logger
+	onUpdated func()
+	show      func()
+	quit      func()
+	tray      *application.SystemTray
+	mu        sync.Mutex
+	active    bool
+}
+
+func newProfileTray(
+	app *application.App,
+	store *flow.FlowStore,
+	logger zerolog.Logger,
+	icon []byte,
+	onUpdated func(),
+	show func(),
+	quit func(),
+) *profileTray {
+	result := &profileTray{
+		app:       app,
+		store:     store,
+		logger:    logger,
+		onUpdated: onUpdated,
+		show:      show,
+		quit:      quit,
+		active:    true,
+	}
+	result.tray = app.SystemTray.New().SetTemplateIcon(icon)
+	result.Refresh()
+	return result
+}
+
+// Refresh replaces the tray menu from the current flow-store snapshot. Wails
+// marshals SetMenu onto the native UI thread after app startup.
+func (t *profileTray) Refresh() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.active {
+		return
+	}
+	t.tray.SetMenu(t.menu())
+}
+
+// Close prevents filesystem watcher callbacks from touching the native tray
+// once Wails begins tearing down its UI loop.
+func (t *profileTray) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.active = false
+}
+
+func (t *profileTray) menu() *application.Menu {
+	menu := t.app.NewMenu()
+	menu.Add("Show Hive").OnClick(func(*application.Context) { t.show() })
+	menu.AddSeparator()
+
+	for _, profile := range trayProfiles(t.store) {
+		item := menu.AddCheckbox(profile.Label, profile.Enabled).SetEnabled(profile.Valid)
+		if !profile.Valid {
+			continue
+		}
+		id := profile.ID
+		enabled := !profile.Enabled
+		item.OnClick(func(*application.Context) {
+			if _, err := t.store.SetEnabled(id, enabled); err != nil {
+				t.logger.Warn().Err(err).Str("profile", id).Msg("tray: updating profile enablement failed")
+				return
+			}
+			if t.onUpdated != nil {
+				t.onUpdated()
+			}
+		})
+	}
+
+	menu.AddSeparator()
+	menu.Add("Quit").OnClick(func(*application.Context) { t.quit() })
+	return menu
+}

--- a/desktop/profiletray_test.go
+++ b/desktop/profiletray_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/colonyops/hive/internal/desktop/pipeline/flow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrayProfilesIncludesValidAndInvalidFlows(t *testing.T) {
+	dir := t.TempDir()
+	store := flow.NewFlowStore(dir, nil)
+	created, err := store.Create("Triage")
+	require.NoError(t, err)
+	_, err = store.SetEnabled(created.ID, false)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.yaml"), []byte("name: [\n"), 0o600))
+	require.NoError(t, store.Reload())
+
+	assert.Equal(t, []trayProfile{
+		{ID: "broken", Label: "broken (invalid)"},
+		{ID: created.ID, Label: "Triage", Enabled: false, Valid: true},
+	}, trayProfiles(store))
+}

--- a/internal/desktop/activity/activity.go
+++ b/internal/desktop/activity/activity.go
@@ -4,17 +4,14 @@
 // records its own via the ActivityService. Events persist in the pipeline
 // SQLite store and surface, newest first, in the Activity view.
 //
-// The ergonomic constructors ([Refresh], [SessionCreated], [AutoAction], …) are
-// the "mixin" surface: an emit site names what happened and passes the few
+// The ergonomic constructors ([RefreshFailed], [SessionCreated], [AutoAction],
+// …) are the "mixin" surface: an emit site names what happened and passes the few
 // facts it has, and the constructor assembles the category, severity, and human
 // copy. New event shapes are added as new constructors, not new call-site
 // formatting.
 package activity
 
-import (
-	"fmt"
-	"time"
-)
+import "fmt"
 
 // Category is the semantic bucket of an event. It drives the Activity view's
 // filter pills and, for non-error events, the row's icon and accent color.
@@ -44,27 +41,6 @@ type Event struct {
 	// ids, counts). No emit site populates it yet; it round-trips through the
 	// reserved metadata column so a future write path needs no schema change.
 	Metadata map[string]string `json:"metadata,omitempty"`
-}
-
-// Refresh records a source/feed refresh that completed, reporting how many
-// items changed and how long it took.
-func Refresh(source string, changed int, took time.Duration) Event {
-	body := "no changes"
-	if changed == 1 {
-		body = "1 item updated"
-	} else if changed > 1 {
-		body = fmt.Sprintf("%d items updated", changed)
-	}
-	if took > 0 {
-		body = fmt.Sprintf("%s · %s", body, took.Round(time.Millisecond))
-	}
-	return Event{
-		Category: CategoryRefresh,
-		Severity: SeverityInfo,
-		Title:    fmt.Sprintf("Refreshed %s", source),
-		Body:     body,
-		Source:   source,
-	}
 }
 
 // RefreshFailed records a source refresh that errored, capturing the reason

--- a/internal/desktop/activity/recorder_test.go
+++ b/internal/desktop/activity/recorder_test.go
@@ -23,13 +23,13 @@ func TestStoreAppendRoundTrip(t *testing.T) {
 	store := newTestStore(t, Options{Emit: func(id int64) { emitted++; lastEmittedID = id }})
 	ctx := context.Background()
 
-	stored, err := store.Append(ctx, Refresh("github:hive/core", 12, 340*time.Millisecond))
+	stored, err := store.Append(ctx, ActionRun("Reproduce & fix", "exit 0"))
 	require.NoError(t, err)
 	require.NotZero(t, stored.ID)
 	require.NotZero(t, stored.CreatedAt)
-	require.Equal(t, CategoryRefresh, stored.Category)
-	require.Equal(t, SeverityInfo, stored.Severity)
-	require.Equal(t, "Refreshed github:hive/core", stored.Title)
+	require.Equal(t, CategoryAction, stored.Category)
+	require.Equal(t, SeveritySuccess, stored.Severity)
+	require.Equal(t, "Ran Reproduce & fix", stored.Title)
 	require.Equal(t, 1, emitted, "emit fires once per successful append")
 	require.Equal(t, stored.ID, lastEmittedID, "emit carries the new event id")
 
@@ -89,7 +89,6 @@ func TestConstructors(t *testing.T) {
 		category Category
 		severity Severity
 	}{
-		{"refresh", Refresh("s", 3, 0), CategoryRefresh, SeverityInfo},
 		{"refresh-failed", RefreshFailed("s", "boom"), CategoryRefresh, SeverityError},
 		{"session", SessionCreated("review-pr-2841", "sonnet", "hive/core"), CategorySession, SeveritySuccess},
 		{"auto-action", AutoAction("Triage", "triage.default", "#4820"), CategoryAutoAction, SeverityAuto},

--- a/internal/desktop/pipeline/flow/store.go
+++ b/internal/desktop/pipeline/flow/store.go
@@ -1,6 +1,7 @@
 package flow
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -165,6 +166,37 @@ func (s *FlowStore) Rename(id, name string) (Flow, error) {
 		return Flow{}, fmt.Errorf("flow %q: %w", f.ID, err)
 	}
 	if err := SaveFlow(filepath.Join(s.dir, f.ID+".yaml"), f); err != nil {
+		return Flow{}, err
+	}
+	if err := s.reloadLocked(); err != nil {
+		return Flow{}, err
+	}
+	return s.flows[id], nil
+}
+
+// SetEnabled updates whether a flow participates in polling and runtime
+// execution without changing its graph or display name.
+func (s *FlowStore) SetEnabled(id string, enabled bool) (Flow, error) {
+	if !validSlug(id) {
+		return Flow{}, fmt.Errorf("flow: id %q is not a valid slug", id)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Read the file directly instead of mutating the cached snapshot. The flow
+	// watcher is debounced, so an external graph edit may already be on disk but
+	// not yet reflected in s.flows; writing that stale snapshot would revert it.
+	path := filepath.Join(s.dir, id+".yaml")
+	f, _, err := LoadFlow(path, s.refs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Flow{}, fmt.Errorf("flow %q not found", id)
+		}
+		return Flow{}, err
+	}
+	f.Enabled = enabled
+	if err := SaveFlow(path, f); err != nil {
 		return Flow{}, err
 	}
 	if err := s.reloadLocked(); err != nil {

--- a/internal/desktop/pipeline/flow/store_test.go
+++ b/internal/desktop/pipeline/flow/store_test.go
@@ -183,6 +183,37 @@ func TestFlowStore_Rename_UpdatesOnlyDisplayName(t *testing.T) {
 	require.ErrorContains(t, err, "not found")
 }
 
+func TestFlowStore_SetEnabled_PreservesFlowAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFlowStore(dir, minimalRefs())
+	created, err := store.Create("Triage")
+	require.NoError(t, err)
+
+	disabled, err := store.SetEnabled(created.ID, false)
+	require.NoError(t, err)
+	assert.False(t, disabled.Enabled)
+	assert.Equal(t, created.Name, disabled.Name)
+	assert.Equal(t, created.Nodes, disabled.Nodes)
+	assert.Equal(t, created.Wires, disabled.Wires)
+
+	loaded, _, err := LoadFlow(filepath.Join(dir, created.ID+".yaml"), minimalRefs())
+	require.NoError(t, err)
+	assert.False(t, loaded.Enabled)
+
+	// A disk edit that has not reached the debounced watcher must survive the
+	// toggle; SetEnabled reads the current file rather than the cached graph.
+	loaded.Name = "Externally edited"
+	require.NoError(t, SaveFlow(filepath.Join(dir, created.ID+".yaml"), loaded))
+
+	enabled, err := store.SetEnabled(created.ID, true)
+	require.NoError(t, err)
+	assert.True(t, enabled.Enabled)
+	assert.Equal(t, "Externally edited", enabled.Name)
+
+	_, err = store.SetEnabled("missing", false)
+	require.ErrorContains(t, err, "not found")
+}
+
 func TestFlowStore_Delete_RemovesFlowAndLayout(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFlowStore(dir, minimalRefs())

--- a/internal/desktop/pipeline/producer.go
+++ b/internal/desktop/pipeline/producer.go
@@ -42,9 +42,9 @@ type Producer struct {
 	stop     chan struct{}
 }
 
-// SetRecorder attaches an activity recorder so refreshes and their failures
-// surface in the Activity view. Optional: a nil recorder (the default) means
-// the producer records nothing. Set once at wiring time, before Start.
+// SetRecorder attaches an activity recorder so refresh failures surface in the
+// Activity view. Successful periodic refreshes are intentionally omitted to
+// avoid flooding the activity log. Set once at wiring time, before Start.
 func (pr *Producer) SetRecorder(r activity.Recorder) { pr.recorder = r }
 
 // SearchPrefetcher batch-fetches all search-kind source definitions before
@@ -165,8 +165,6 @@ func (pr *Producer) Tick(ctx context.Context) {
 	for id, src := range sources {
 		topic := "source:" + id
 		items := make([]pipelinedb.SnapshotItem, 0)
-		started := time.Now()
-		changed := 0
 		err := src.Produce(ctx, func(msg Msg) error {
 			if msg.Topic != topic {
 				return fmt.Errorf("source %q emitted topic %q, expected %q", id, msg.Topic, topic)
@@ -178,7 +176,6 @@ func (pr *Producer) Tick(ctx context.Context) {
 			}
 			if ok {
 				appended++
-				changed++
 				lastOffset = offset
 			}
 			return nil
@@ -197,12 +194,6 @@ func (pr *Producer) Tick(ctx context.Context) {
 		}
 		appended++
 		lastOffset = offset
-
-		// Only surface refreshes that actually changed something: an unchanged
-		// poll every interval would flood the Activity view with noise.
-		if changed > 0 {
-			pr.record(ctx, activity.Refresh(id, changed, time.Since(started)))
-		}
 	}
 
 	if appended > 0 && pr.onAppended != nil {

--- a/internal/desktop/pipeline/producer_test.go
+++ b/internal/desktop/pipeline/producer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/colonyops/hive/internal/desktop/activity"
 	"github.com/colonyops/hive/internal/desktop/pipeline/pipelinedb"
 )
 
@@ -78,6 +79,14 @@ func (a *fakeAppender) callCount() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return len(a.calls)
+}
+
+type activityRecorder struct {
+	events []activity.Event
+}
+
+func (r *activityRecorder) Record(_ context.Context, event activity.Event) {
+	r.events = append(r.events, event)
 }
 
 func openTestPipelineDB(t *testing.T) *pipelinedb.DB {
@@ -158,12 +167,14 @@ func TestProducer_Tick_SourceErrorDoesNotBlockOthers(t *testing.T) {
 	ok := &fakeSource{batches: [][]Msg{{{Topic: "source:ok", Key: "x", Payload: []byte(`{}`)}}}}
 
 	var appendedOffsets []int64
+	recorder := &activityRecorder{}
 	producer := NewProducer(db, listerOf(map[string]Source{
 		"failing": failing,
 		"ok":      ok,
 	}), time.Hour, func(offset int64) {
 		appendedOffsets = append(appendedOffsets, offset)
 	}, zerolog.Nop())
+	producer.SetRecorder(recorder)
 
 	producer.Tick(t.Context())
 
@@ -173,6 +184,10 @@ func TestProducer_Tick_SourceErrorDoesNotBlockOthers(t *testing.T) {
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "x", msgs[0].Key)
 	assert.Len(t, msgs[1].Snapshot, 1)
+	require.Len(t, recorder.events, 1, "successful refreshes must not crowd the activity log")
+	assert.Equal(t, activity.CategoryRefresh, recorder.events[0].Category)
+	assert.Equal(t, activity.SeverityError, recorder.events[0].Severity)
+	assert.Equal(t, "Refresh failed for failing", recorder.events[0].Title)
 }
 
 // TestProducer_DedupesUnchangedPayload verifies durable deduplication: an


### PR DESCRIPTION
## Purpose

Bundle several desktop quality-of-life improvements: profile enable/disable controls, richer GitHub issue markdown rendering, and quieter activity feed refreshes.

## Proposed Changes

  - Add profile enable/disable controls (including a profile tray)
  - Support GitHub issue markdown elements in the feed
  - Omit successful refresh events from the activity feed to reduce noise

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)