### PR TITLE
feat(desktop): compact grouped System settings page

### DIFF
--- a/desktop/frontend/src/components/SystemSettingsView.vue
+++ b/desktop/frontend/src/components/SystemSettingsView.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 // System settings: on-disk locations (data dir, config dir, log file,
-// database) with open/reveal actions, and point-only overrides for the data
-// and config directories that take effect after a restart.
+// database) grouped into one card per section with per-row open/reveal
+// actions, point-only overrides for the data and config directories that take
+// effect after a restart, and an About card with the build strip and
+// auto-update controls.
 import { onMounted } from 'vue'
 import IconInfo from '~icons/lucide/info'
 import IconExternalLink from '~icons/lucide/external-link'
 import IconRefreshCw from '~icons/lucide/refresh-cw'
 import SettingsPathRow from './settings/SettingsPathRow.vue'
-import SettingsSection from './settings/SettingsSection.vue'
 import AppSwitch from './AppSwitch.vue'
 import { useSystemSettings } from '../composables/useSystemSettings'
 
@@ -40,10 +41,10 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="mx-auto max-w-[640px]" data-testid="settings-system">
+  <div class="mx-auto flex max-w-[860px] flex-col gap-6" data-testid="settings-system">
     <div
       v-if="restartRequired"
-      class="mb-5 flex items-center gap-3 rounded-lg border border-border bg-severity-info-tint p-3.5"
+      class="flex items-center gap-3 rounded-lg border border-border bg-severity-info-tint p-3.5"
       data-testid="system-restart-banner"
     >
       <IconInfo class="size-4 shrink-0 text-severity-info" />
@@ -58,19 +59,21 @@ onMounted(() => {
 
     <div
       v-if="error"
-      class="mb-4 rounded-md border border-border bg-severity-error-tint px-3 py-2 text-xs text-severity-error"
+      class="rounded-md border border-border bg-severity-error-tint px-3 py-2 text-xs text-severity-error"
       data-testid="system-error"
     >{{ error }}</div>
 
-    <SettingsSection
-      title="Storage locations"
-      description="Point Hive at a different folder — for example an iCloud-synced directory to share configuration across machines. Existing data is not moved, and a new location applies after restarting."
-      class="mb-6 [&>p]:mb-3"
-    >
-      <div v-if="info" class="flex flex-col gap-3">
+    <section class="flex flex-col gap-2.5">
+      <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <h2 class="text-xs font-semibold uppercase tracking-[.1em] text-text-2">Storage locations</h2>
+        <p class="text-xs text-text-3">Point Hive at a different folder. Existing data isn't moved; a new location applies after restart.</p>
+      </div>
+      <div v-if="info" class="divide-y divide-row overflow-hidden rounded-[11px] border border-card bg-raised">
         <SettingsPathRow
           label="Data directory"
           hint="Desktop state, logs, and the databases live here."
+          icon="folder"
+          tone="accent"
           :path="info.dataDir.path"
           :exists="info.dataDir.exists"
           :overridden="info.dataDir.overridden"
@@ -84,6 +87,8 @@ onMounted(() => {
         <SettingsPathRow
           label="Config directory"
           hint="Profiles, flows, and actions.yml."
+          icon="folder"
+          tone="accent"
           :path="info.configDir.path"
           :exists="info.configDir.exists"
           :overridden="info.configDir.overridden"
@@ -95,16 +100,17 @@ onMounted(() => {
           @reset="resetConfigDir"
         />
       </div>
-    </SettingsSection>
+    </section>
 
-    <SettingsSection
-      title="Diagnostics"
-      description="Open or locate the log file and database when troubleshooting."
-      class="[&>p]:mb-3"
-    >
-      <div v-if="info" class="flex flex-col gap-3">
+    <section class="flex flex-col gap-2.5">
+      <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <h2 class="text-xs font-semibold uppercase tracking-[.1em] text-text-2">Diagnostics</h2>
+        <p class="text-xs text-text-3">Open or locate the log file and database when troubleshooting.</p>
+      </div>
+      <div v-if="info" class="divide-y divide-row overflow-hidden rounded-[11px] border border-card bg-raised">
         <SettingsPathRow
           label="Log file"
+          icon="log"
           :path="info.logFile.path"
           :exists="info.logFile.exists"
           testid="system-log-file"
@@ -113,6 +119,7 @@ onMounted(() => {
         />
         <SettingsPathRow
           label="Database"
+          icon="database"
           :path="info.database.path"
           :exists="info.database.exists"
           testid="system-database"
@@ -120,50 +127,74 @@ onMounted(() => {
           @reveal="revealPath(info.database.path)"
         />
       </div>
-    </SettingsSection>
+    </section>
 
-    <SettingsSection
-      title="About"
-      description="The build of Hive you're running. Include this when reporting an issue."
-      class="mt-6 [&>p]:mb-3"
-      data-testid="system-about"
-    >
-      <div v-if="build" class="rounded-lg border border-border">
-        <div class="flex items-center justify-between gap-3 px-3.5 py-2.5">
-          <span class="text-[12.5px] text-text-3">Version</span>
-          <div class="flex items-center gap-2">
-            <span
-              v-if="update?.available"
-              class="rounded-full border border-severity-info-border bg-severity-info-tint px-2 py-0.5 text-[11px] font-medium text-severity-info"
-              data-testid="system-update-available"
-            >Update available: {{ update.latestVersion }}</span>
-            <span
-              v-else-if="checkedOnce"
-              class="text-[11px] text-text-4"
-              data-testid="system-update-uptodate"
-            >Up to date</span>
-            <span class="font-mono text-[12.5px] text-text-2" data-testid="system-build-version">{{ build.version }}</span>
+    <section class="flex flex-col gap-2.5" data-testid="system-about">
+      <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <h2 class="text-xs font-semibold uppercase tracking-[.1em] text-text-2">About</h2>
+        <p class="text-xs text-text-3">The build of Hive you're running — include this when reporting an issue.</p>
+      </div>
+      <div v-if="build" class="overflow-hidden rounded-[11px] border border-card bg-raised">
+        <div class="flex flex-wrap items-center gap-x-6 gap-y-3 px-4 py-3.5">
+          <div class="flex flex-col gap-1">
+            <span class="text-[11px] text-text-3">Version</span>
+            <div class="flex items-center gap-2">
+              <span class="font-mono text-[13px] text-text" data-testid="system-build-version">{{ build.version }}</span>
+              <span
+                v-if="update?.available"
+                class="rounded-full border border-severity-info-border bg-severity-info-tint px-2 py-0.5 text-[11px] font-medium text-severity-info"
+                data-testid="system-update-available"
+              >Update available: {{ update.latestVersion }}</span>
+              <span
+                v-else-if="checkedOnce"
+                class="text-[11px] text-text-4"
+                data-testid="system-update-uptodate"
+              >Up to date</span>
+            </div>
+          </div>
+          <div class="h-[26px] w-px bg-row" />
+          <div class="flex flex-col gap-1">
+            <span class="text-[11px] text-text-3">Commit</span>
+            <span class="font-mono text-[13px] text-text" data-testid="system-build-commit">{{ build.commit }}</span>
+          </div>
+          <div class="h-[26px] w-px bg-row" />
+          <div class="flex flex-col gap-1">
+            <span class="text-[11px] text-text-3">Built</span>
+            <span class="font-mono text-[13px] text-text" data-testid="system-build-date">{{ build.date }}</span>
+          </div>
+          <div class="flex-1" />
+          <div class="flex items-center gap-4 text-[13px]">
+            <button
+              type="button"
+              class="flex cursor-pointer items-center gap-1.5 text-accent hover:underline"
+              title="View project on GitHub"
+              data-testid="system-build-repo"
+              @click="openRepo"
+            ><IconExternalLink class="size-3.5" />Project</button>
+            <button
+              v-if="build.releaseUrl"
+              type="button"
+              class="flex cursor-pointer items-center gap-1.5 text-accent hover:underline"
+              title="View release on GitHub"
+              data-testid="system-build-release"
+              @click="openReleaseNotes"
+            ><IconExternalLink class="size-3.5" />Release</button>
           </div>
         </div>
-        <div class="flex items-center justify-between gap-3 border-t border-border px-3.5 py-2.5">
-          <span class="text-[12.5px] text-text-3">Commit</span>
-          <span class="font-mono text-[12.5px] text-text-2" data-testid="system-build-commit">{{ build.commit }}</span>
-        </div>
-        <div class="flex items-center justify-between gap-3 border-t border-border px-3.5 py-2.5">
-          <span class="text-[12.5px] text-text-3">Built</span>
-          <span class="font-mono text-[12.5px] text-text-2" data-testid="system-build-date">{{ build.date }}</span>
-        </div>
-        <div class="flex items-center justify-between gap-3 border-t border-border px-3.5 py-2.5">
+        <div class="flex items-center gap-3.5 border-t border-row px-4 py-3.5">
           <AppSwitch
             :model-value="autoUpdate"
-            label="Automatic updates"
-            hint="Check for and install new versions from GitHub in the background."
+            aria-label="Automatic updates"
             testid="system-auto-update"
             @update:model-value="setAutoUpdate"
           />
+          <div class="min-w-0 flex-1">
+            <div class="text-[13.5px] font-semibold text-text">Automatic updates</div>
+            <div class="mt-0.5 text-[11.5px] text-text-3">Check for and install new versions from GitHub in the background.</div>
+          </div>
           <button
             type="button"
-            class="flex shrink-0 cursor-pointer items-center gap-1.5 self-start rounded-md border border-border px-2.5 py-1.5 text-[12px] font-medium text-text-2 hover:bg-chip hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+            class="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-[7px] border border-card px-3 py-1.5 text-[12.5px] font-medium text-text-2 hover:border-strong hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="checkingUpdate"
             data-testid="system-check-update"
             @click="checkForUpdates"
@@ -172,28 +203,7 @@ onMounted(() => {
             {{ checkingUpdate ? 'Checking…' : 'Check for updates' }}
           </button>
         </div>
-        <div class="flex flex-col gap-2 border-t border-border px-3.5 py-2.5">
-          <button
-            type="button"
-            class="flex cursor-pointer items-center gap-1.5 text-[12.5px] font-medium text-severity-info hover:underline"
-            data-testid="system-build-repo"
-            @click="openRepo"
-          >
-            <IconExternalLink class="size-3.5" />
-            View project on GitHub
-          </button>
-          <button
-            v-if="build.releaseUrl"
-            type="button"
-            class="flex cursor-pointer items-center gap-1.5 text-[12.5px] font-medium text-severity-info hover:underline"
-            data-testid="system-build-release"
-            @click="openReleaseNotes"
-          >
-            <IconExternalLink class="size-3.5" />
-            View release on GitHub
-          </button>
-        </div>
       </div>
-    </SettingsSection>
+    </section>
   </div>
 </template>

--- a/desktop/frontend/src/components/__tests__/SystemSettingsView.spec.ts
+++ b/desktop/frontend/src/components/__tests__/SystemSettingsView.spec.ts
@@ -119,7 +119,7 @@ describe('SystemSettingsView', () => {
     await wrapper.find('[data-testid="system-data-dir-copy"]').trigger('click')
     await flushPromises()
     expect(mocks.SetText).toHaveBeenCalledWith(DATA)
-    expect(wrapper.find('[data-testid="system-data-dir-copy"]').text()).toContain('Copied')
+    expect(wrapper.find('[data-testid="system-data-dir-copy"]').attributes('aria-label')).toBe('Copied')
   })
 
   it('changes the data directory and surfaces the restart banner and Reset', async () => {

--- a/desktop/frontend/src/components/settings/SettingsPathRow.vue
+++ b/desktop/frontend/src/components/settings/SettingsPathRow.vue
@@ -1,102 +1,131 @@
 <script setup lang="ts">
-// A single on-disk location row for the System settings screen: a label, the
-// path in monospace, and action buttons. Copy is handled locally (no backend);
-// open/reveal/change/reset are emitted for the parent to route through the
-// SystemService. `editable` adds the Change…/Reset controls used by the data
-// and config directories.
+// A single on-disk location row inside a grouped System-settings card: a
+// leading type icon, the label and monospace path on one line, and quiet
+// icon-only actions. Copy is handled locally (no backend); open/reveal/
+// change/reset are emitted for the parent to route through the SystemService.
+// `editable` adds the Change… button and, when overridden, the Reset action
+// used by the data and config directories.
+import { computed } from 'vue'
 import IconCheck from '~icons/lucide/check'
 import IconCopy from '~icons/lucide/copy'
+import IconDatabase from '~icons/lucide/database'
 import IconExternalLink from '~icons/lucide/external-link'
+import IconFileText from '~icons/lucide/file-text'
 import IconFolder from '~icons/lucide/folder'
 import IconFolderOpen from '~icons/lucide/folder-open'
 import IconRotateCcw from '~icons/lucide/rotate-ccw'
 import { useClipboard } from '../../composables/useClipboard'
 import BaseBadge from '../BaseBadge.vue'
+import BaseIconBadge from '../BaseIconBadge.vue'
 
 const props = withDefaults(
   defineProps<{
     label: string
     path: string
     hint?: string
+    icon?: 'folder' | 'log' | 'database'
+    tone?: 'accent' | 'neutral'
     exists?: boolean
     overridden?: boolean
     editable?: boolean
     testid?: string
   }>(),
-  { exists: true, overridden: false, editable: false },
+  { icon: 'folder', tone: 'neutral', exists: true, overridden: false, editable: false },
 )
 const emit = defineEmits<{ open: []; reveal: []; change: []; reset: [] }>()
 
 const { copy, status: copyStatus } = useClipboard()
 
-const btnClass =
-  'flex cursor-pointer items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] font-medium text-text-2 hover:bg-chip hover:text-text'
+const typeIcon = computed(() => ({ folder: IconFolder, log: IconFileText, database: IconDatabase })[props.icon])
+const copyLabel = computed(() =>
+  copyStatus.value === 'success' ? 'Copied' : copyStatus.value === 'error' ? 'Copy failed' : 'Copy path',
+)
+
+const iconBtnClass =
+  'flex size-[30px] cursor-pointer items-center justify-center rounded-[7px] text-text-3 hover:bg-hover hover:text-text'
 </script>
 
 <template>
-  <article class="rounded-lg border border-border bg-raised p-4" :data-testid="props.testid">
-    <div class="flex items-center gap-2">
-      <span class="text-[13.5px] font-semibold text-text">{{ props.label }}</span>
-      <BaseBadge
-        v-if="props.overridden"
-        variant="pill"
-        class="px-2 py-0.5 text-[10.5px] font-semibold"
-        :data-testid="props.testid ? `${props.testid}-overridden` : undefined"
-      >Custom</BaseBadge>
-      <BaseBadge
-        v-if="!props.exists"
-        tone="muted"
-        variant="pill"
-        class="px-2 py-0.5 text-[10.5px] font-medium"
-      >Not created yet</BaseBadge>
+  <article
+    class="flex items-center gap-3.5 px-4 py-3 transition-colors hover:bg-row-hover"
+    :data-testid="props.testid"
+  >
+    <BaseIconBadge
+      :size="32"
+      rounded="rounded-lg"
+      :class="props.tone === 'accent'
+        ? 'border border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.13)] text-accent'
+        : 'border border-card bg-chip text-text-2'"
+    >
+      <component :is="typeIcon" class="size-4" />
+    </BaseIconBadge>
+
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+        <span class="shrink-0 text-[13.5px] font-semibold text-text">{{ props.label }}</span>
+        <BaseBadge
+          v-if="props.overridden"
+          variant="pill"
+          class="shrink-0 px-2 py-0.5 text-[10.5px] font-semibold"
+          :data-testid="props.testid ? `${props.testid}-overridden` : undefined"
+        >Custom</BaseBadge>
+        <BaseBadge
+          v-if="!props.exists"
+          tone="muted"
+          variant="pill"
+          class="shrink-0 px-2 py-0.5 text-[10.5px] font-medium"
+        >Not created yet</BaseBadge>
+        <span
+          class="min-w-0 max-w-full truncate font-mono text-xs text-text-2"
+          :title="props.path"
+          :data-testid="props.testid ? `${props.testid}-path` : undefined"
+        >{{ props.path }}</span>
+      </div>
+      <p v-if="props.hint" class="mt-0.5 text-[11.5px] text-text-3">{{ props.hint }}</p>
     </div>
 
-    <div
-      class="mt-1.5 truncate font-mono text-[12px] text-text-2"
-      :title="props.path"
-      :data-testid="props.testid ? `${props.testid}-path` : undefined"
-    >{{ props.path }}</div>
-
-    <p v-if="props.hint" class="mt-1 text-xs leading-relaxed text-text-4">{{ props.hint }}</p>
-
-    <div class="mt-3 flex flex-wrap items-center gap-2">
+    <div class="flex shrink-0 items-center gap-1">
       <button
         type="button"
-        :class="btnClass"
+        :class="iconBtnClass"
+        :title="copyLabel"
+        :aria-label="copyLabel"
         :data-testid="props.testid ? `${props.testid}-copy` : undefined"
         @click="copy(props.path)"
-      >
-        <component :is="copyStatus === 'success' ? IconCheck : IconCopy" class="size-3.5" />
-        {{ copyStatus === 'success' ? 'Copied' : copyStatus === 'error' ? 'Copy failed' : 'Copy path' }}
-      </button>
+      ><component :is="copyStatus === 'success' ? IconCheck : IconCopy" class="size-[15px]" /></button>
       <button
         type="button"
-        :class="btnClass"
+        :class="iconBtnClass"
+        title="Open"
+        aria-label="Open"
         :data-testid="props.testid ? `${props.testid}-open` : undefined"
         @click="emit('open')"
-      ><IconExternalLink class="size-3.5" />Open</button>
+      ><IconExternalLink class="size-[15px]" /></button>
       <button
         type="button"
-        :class="btnClass"
+        :class="iconBtnClass"
+        title="Reveal"
+        aria-label="Reveal"
         :data-testid="props.testid ? `${props.testid}-reveal` : undefined"
         @click="emit('reveal')"
-      ><IconFolderOpen class="size-3.5" />Reveal</button>
+      ><IconFolderOpen class="size-[15px]" /></button>
 
       <template v-if="props.editable">
-        <div class="flex-1" />
-        <button
-          type="button"
-          :class="btnClass"
-          :data-testid="props.testid ? `${props.testid}-change` : undefined"
-          @click="emit('change')"
-        ><IconFolder class="size-3.5" />Change…</button>
         <button
           v-if="props.overridden"
           type="button"
-          :class="btnClass"
+          :class="iconBtnClass"
+          title="Reset to default"
+          aria-label="Reset to default"
           :data-testid="props.testid ? `${props.testid}-reset` : undefined"
           @click="emit('reset')"
-        ><IconRotateCcw class="size-3.5" />Reset</button>
+        ><IconRotateCcw class="size-[15px]" /></button>
+        <button
+          type="button"
+          class="ml-1 cursor-pointer rounded-[7px] border border-card px-3 py-1.5 text-[12.5px] font-medium text-text-2 hover:border-strong hover:text-text"
+          :data-testid="props.testid ? `${props.testid}-change` : undefined"
+          @click="emit('change')"
+        >Change…</button>
       </template>
     </div>
   </article>


### PR DESCRIPTION
## Purpose

Implement the 11a "grouped rows" settings design from the Hive Desktop design file. The old System page gave every path its own tall card with four full-width buttons, so five short facts filled three screens of scroll; the page now fits without scrolling.

## Proposed Changes

  - Collapse each on-disk location to one row inside a single card per section: leading type icon, label + mono path inline, icon-only copy/open/reveal hover actions, and Change…/Reset for the overridable directories
  - Rebuild About as a build strip (Version / Commit / Built, Project/Release links) with the auto-update toggle and check button on a second row
  - All colors map to existing theme tokens, so non-dark themes inherit the redesign; restart/error banners, update pill, and all data-testids are preserved

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)