### PR TITLE
feat(desktop): collapsible detail preview pane

### DIFF
--- a/desktop/frontend/src/App.vue
+++ b/desktop/frontend/src/App.vue
@@ -438,10 +438,12 @@ watch(() => (authenticated.value ? authStatus.value?.login ?? '' : null), (key) 
 const needsWorkspace = computed(() => authenticated.value && profilesLoaded.value && profiles.value.length === 0)
 
 // ── Layout chrome ─────────────────────────────────────────────────────────────
-// The feed sidebar collapses to reclaim horizontal space (handy in split
-// screens); the choice is persisted. Its toggle only appears in the feed view —
-// the one place a sidebar renders — so it never dangles over settings or flows.
+// The feed sidebar and the detail preview both collapse to reclaim horizontal
+// space (handy in split screens); each choice is persisted. Their toggles only
+// appear in the feed view — the one place those panels render — so they never
+// dangle over settings or flows.
 const sidebarCollapsed = useStorage('hive.panel.sidebar.collapsed', false)
+const previewCollapsed = useStorage('hive.panel.detailpane.collapsed', false)
 const feedViewActive = computed(() =>
   authenticated.value && !needsWorkspace.value &&
   !applicationSettingsActive.value && !profileSettingsActive.value &&
@@ -451,6 +453,10 @@ const feedViewActive = computed(() =>
 
 function toggleSidebar(): void {
   sidebarCollapsed.value = !sidebarCollapsed.value
+}
+
+function togglePreview(): void {
+  previewCollapsed.value = !previewCollapsed.value
 }
 
 // We draw our own hidden-inset title bar, so the native double-click-to-zoom
@@ -477,6 +483,7 @@ const runMap: Record<string, () => void | Promise<void>> = {
   'feed.prev': selectPrev,
   'feed.open-in-browser': openSelectedInBrowser,
   'feed.toggle-unread': navigateUnreadToggle,
+  'feed.toggle-preview': togglePreview,
   'feed.refresh': refresh,
   'feed.toggle-archive': async () => { if (selectedItem.value) await toggleArchive(selectedItem.value) },
   'feed.mark-unread': async () => { if (selectedItem.value) await markItemUnread(selectedItem.value, true) },
@@ -673,6 +680,8 @@ onUnmounted(() => {
         :can-go-forward="canGoForward"
         :sidebar-collapsed="sidebarCollapsed"
         :can-toggle-sidebar="feedViewActive"
+        :preview-collapsed="previewCollapsed"
+        :can-toggle-preview="feedViewActive"
         @back="router.back()"
         @forward="router.forward()"
         @open-error-node="openErrorNode"
@@ -680,6 +689,7 @@ onUnmounted(() => {
         @open-job-run="openJobRun"
         @open-update="openUpdate"
         @toggle-sidebar="toggleSidebar"
+        @toggle-preview="togglePreview"
         @open-palette="togglePalette"
         @toggle-maximise="toggleMaximise"
       />
@@ -763,7 +773,7 @@ onUnmounted(() => {
               @set-unread="navigateUnreadFilter"
               @refresh="refresh"
             />
-            <DetailPane :item="selectedItem" :events="selectedEvents" :actions="actions" :pending-action="pendingAction" :action-runs="actionRuns" @run-action="invokeAction" @open-browser="openSelectedInBrowser" @open-url="openUrl" @set-unread="(value) => selectedItem && markItemUnread(selectedItem, value)" @toggle-archive="selectedItem && toggleArchive(selectedItem)" @toggle-ignored="selectedItem && toggleIgnored(selectedItem)" @edit="requestOpenActionsSettings" />
+            <DetailPane v-if="!previewCollapsed" :item="selectedItem" :events="selectedEvents" :actions="actions" :pending-action="pendingAction" :action-runs="actionRuns" @run-action="invokeAction" @open-browser="openSelectedInBrowser" @open-url="openUrl" @set-unread="(value) => selectedItem && markItemUnread(selectedItem, value)" @toggle-archive="selectedItem && toggleArchive(selectedItem)" @toggle-ignored="selectedItem && toggleIgnored(selectedItem)" @edit="requestOpenActionsSettings" />
           </section>
           <div v-else class="flex flex-1 flex-col items-center justify-center gap-3 font-mono text-xs text-text-4">
             <template v-if="profilesError">

--- a/desktop/frontend/src/__tests__/App.spec.ts
+++ b/desktop/frontend/src/__tests__/App.spec.ts
@@ -256,6 +256,22 @@ describe('App', () => {
     wrapper.unmount()
   })
 
+  it('collapses and restores the detail preview from the title-bar toggle and the p key', async () => {
+    const wrapper = await mountApp()
+    expect(wrapper.find('[data-testid="detail-pane"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="titlebar-toggle-preview"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="detail-pane"]').exists()).toBe(false)
+    expect(localStorage.getItem('hive.panel.detailpane.collapsed')).toBe('true')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }))
+    await flushPromises()
+    expect(wrapper.find('[data-testid="detail-pane"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
   it('opens profile settings from the sidebar gear and application settings from the rail', async () => {
     const wrapper = await mountApp()
 

--- a/desktop/frontend/src/components/TitleBar.vue
+++ b/desktop/frontend/src/components/TitleBar.vue
@@ -6,6 +6,8 @@ import IconArrowLeft from '~icons/lucide/arrow-left'
 import IconArrowRight from '~icons/lucide/arrow-right'
 import IconPanelLeftClose from '~icons/lucide/panel-left-close'
 import IconPanelLeftOpen from '~icons/lucide/panel-left-open'
+import IconPanelRightClose from '~icons/lucide/panel-right-close'
+import IconPanelRightOpen from '~icons/lucide/panel-right-open'
 import IconSearch from '~icons/lucide/search'
 import IconTriangleAlert from '~icons/lucide/triangle-alert'
 import IconLoader from '~icons/lucide/loader'
@@ -26,6 +28,8 @@ import type { Job } from '../../bindings/github.com/colonyops/hive/internal/desk
 // events recorded since the user last opened that page, shown as a pulsing dot.
 // sidebarCollapsed drives the panel-toggle glyph; canToggleSidebar hides the
 // toggle in views that have no feed sidebar (settings, flows, onboarding).
+// previewCollapsed/canTogglePreview are the same pair for the detail preview
+// pane, mirrored at the far right of the bar to match the panel it controls.
 // updateAvailable renders a click-to-install chip (with the latestVersion
 // label) in the right cluster, mirroring the error/activity chip pattern. It
 // is independent of profileName so it can show during onboarding too.
@@ -42,6 +46,8 @@ const props = defineProps<{
   canGoForward?: boolean
   sidebarCollapsed?: boolean
   canToggleSidebar?: boolean
+  previewCollapsed?: boolean
+  canTogglePreview?: boolean
 }>()
 const emit = defineEmits<{
   back: []
@@ -51,6 +57,7 @@ const emit = defineEmits<{
   'open-job-run': [commandId: number]
   'open-update': []
   'toggle-sidebar': []
+  'toggle-preview': []
   'open-palette': []
   'toggle-maximise': []
 }>()
@@ -187,6 +194,16 @@ function onTitlebarDblclick(event: MouseEvent): void {
           data-testid="titlebar-activity-unseen"
         />
       </button>
+      <button
+        v-if="canTogglePreview"
+        type="button"
+        class="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-chip hover:text-text"
+        style="--wails-draggable: no-drag"
+        :aria-label="previewCollapsed ? 'Show preview' : 'Hide preview'"
+        :title="previewCollapsed ? 'Show preview' : 'Hide preview'"
+        data-testid="titlebar-toggle-preview"
+        @click="emit('toggle-preview')"
+      ><component :is="previewCollapsed ? IconPanelRightOpen : IconPanelRightClose" class="size-3.5" /></button>
     </div>
   </header>
 </template>

--- a/desktop/frontend/src/components/__tests__/TitleBar.spec.ts
+++ b/desktop/frontend/src/components/__tests__/TitleBar.spec.ts
@@ -93,6 +93,22 @@ describe('TitleBar', () => {
     expect(collapsed.find('[data-testid="titlebar-toggle-sidebar"]').attributes('aria-label')).toBe('Show sidebar')
   })
 
+  it('shows the preview toggle only when the feed view is active and reflects the collapsed state', async () => {
+    const hidden = mount(TitleBar, { props: { profileName: 'Triage' } })
+    expect(hidden.find('[data-testid="titlebar-toggle-preview"]').exists()).toBe(false)
+
+    const expanded = mount(TitleBar, { props: { profileName: 'Triage', canTogglePreview: true } })
+    const toggle = expanded.find('[data-testid="titlebar-toggle-preview"]')
+    expect(toggle.exists()).toBe(true)
+    expect(toggle.attributes('aria-label')).toBe('Hide preview')
+
+    await toggle.trigger('click')
+    expect(expanded.emitted('toggle-preview')).toHaveLength(1)
+
+    const collapsed = mount(TitleBar, { props: { profileName: 'Triage', canTogglePreview: true, previewCollapsed: true } })
+    expect(collapsed.find('[data-testid="titlebar-toggle-preview"]').attributes('aria-label')).toBe('Show preview')
+  })
+
   it('zooms on a double-click of the bar itself, but not on its controls', async () => {
     const wrapper = mount(TitleBar, { props: { profileName: 'Triage', canToggleSidebar: true } })
 

--- a/desktop/frontend/src/keybindings/catalog.ts
+++ b/desktop/frontend/src/keybindings/catalog.ts
@@ -5,6 +5,7 @@ import IconCommand from '~icons/lucide/command'
 import IconExternalLink from '~icons/lucide/external-link'
 import IconEye from '~icons/lucide/eye'
 import IconMinus from '~icons/lucide/minus'
+import IconPanelRight from '~icons/lucide/panel-right'
 import IconRefreshCw from '~icons/lucide/refresh-cw'
 
 // The single declarative source of truth for *bindable* commands — the stable
@@ -71,6 +72,15 @@ export const commandCatalog: BindableCommand[] = [
     keywords: ['unread', 'filter'],
     icon: IconEye,
     defaultCombos: ['u'],
+    context: 'feed',
+  },
+  {
+    id: 'feed.toggle-preview',
+    title: 'Toggle preview pane',
+    group: 'Feeds',
+    keywords: ['preview', 'detail', 'pane', 'panel', 'reading', 'close'],
+    icon: IconPanelRight,
+    defaultCombos: ['p'],
     context: 'feed',
   },
   { id: 'feed.toggle-archive', title: 'Archive / unarchive item', group: 'Feeds', defaultCombos: ['e'], context: 'feed' },


### PR DESCRIPTION
## Purpose

Allow closing the feed's detail preview pane (Slack/Gmail-style) so the item list can use the full width — useful in split-screen where the window is narrow.

## Proposed Changes

  - Persisted `previewCollapsed` state (`hive.panel.detailpane.collapsed`), mirroring the sidebar-collapse pattern
  - Title-bar toggle at the far right with `panel-right-close/open` icons, shown only in the feed view
  - Bindable `feed.toggle-preview` command (default `p`, feed context) that also seeds the command palette and keybinding settings

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)