### PR TITLE
Move agent status detection out of the TUI into hive.StatusService

### DIFF
--- a/internal/commands/cmd_tui.go
+++ b/internal/commands/cmd_tui.go
@@ -11,7 +11,6 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/colonyops/hive/internal/core/config"
-	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/colonyops/hive/internal/hive"
 	"github.com/colonyops/hive/internal/tui"
 	"github.com/colonyops/hive/pkg/profiler"
@@ -79,25 +78,18 @@ func (cmd *TuiCmd) run(ctx context.Context, _ *cli.Command) error {
 
 	source, _ := os.Getwd()
 
-	// Create terminal integration manager (tmux always enabled)
-	termMgr := terminal.NewManager([]string{"tmux"})
-	tmuxIntegration := newTmuxIntegration(cmd.app.Config)
-	if tmuxIntegration.Available() {
-		termMgr.Register(tmuxIntegration)
-	}
-
 	deps := tui.Deps{
-		Config:          cmd.app.Config,
-		Service:         cmd.app.Sessions,
-		MsgStore:        cmd.app.Messages,
-		TodoService:     cmd.app.Todos,
-		Bus:             cmd.app.Bus,
-		TerminalManager: termMgr,
-		PluginManager:   cmd.app.Plugins,
-		CommandSet:      cmd.app.CommandSet,
-		DB:              cmd.app.DB,
-		KVStore:         cmd.app.KV,
-		Renderer:        cmd.app.Renderer,
+		Config:        cmd.app.Config,
+		Service:       cmd.app.Sessions,
+		MsgStore:      cmd.app.Messages,
+		TodoService:   cmd.app.Todos,
+		Bus:           cmd.app.Bus,
+		Status:        cmd.app.Status,
+		PluginManager: cmd.app.Plugins,
+		CommandSet:    cmd.app.CommandSet,
+		DB:            cmd.app.DB,
+		KVStore:       cmd.app.KV,
+		Renderer:      cmd.app.Renderer,
 		BuildInfo: tui.BuildInfo{
 			Version: cmd.app.Build.Version,
 			Commit:  cmd.app.Build.Commit,

--- a/internal/commands/cmd_x_pick.go
+++ b/internal/commands/cmd_x_pick.go
@@ -565,12 +565,7 @@ func (cmd *ExperimentalCmd) pickCmd() *cli.Command {
 				}
 			}
 
-			// Create terminal manager (same as TUI) since cmd.app.Terminal is nil at app level
-			termMgr := terminal.NewManager([]string{"tmux"})
-			tmuxIntegration := newTmuxIntegration(cmd.app.Config)
-			if tmuxIntegration.Available() {
-				termMgr.Register(tmuxIntegration)
-			}
+			termMgr := cmd.app.Terminal
 
 			// Pre-fetch statuses synchronously so the first render has data.
 			// Keep baseItems as the original per-session slice; refreshStatusCmd

--- a/internal/hive/app.go
+++ b/internal/hive/app.go
@@ -32,6 +32,7 @@ type App struct {
 	Doctor    *DoctorService
 	Todos     *TodoService
 	Honeycomb *HoneycombService
+	Status    *StatusService
 
 	Bus        *eventbus.EventBus
 	Terminal   *terminal.Manager
@@ -69,6 +70,7 @@ func NewApp(
 		Doctor:     NewDoctorService(sessions.sessions, cfg, pluginInfos),
 		Todos:      NewTodoService(todoStore, bus, cfg, logger.With().Str("component", "todos").Logger()),
 		Honeycomb:  NewHoneycombService(hcStore, logger.With().Str("component", "honeycomb").Logger()),
+		Status:     NewStatusService(termMgr, cfg.Git.StatusWorkers),
 		Bus:        bus,
 		Terminal:   termMgr,
 		Plugins:    pluginMgr,

--- a/internal/hive/status_service.go
+++ b/internal/hive/status_service.go
@@ -1,0 +1,247 @@
+package hive
+
+import (
+	"context"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/core/terminal"
+	terminaltmux "github.com/colonyops/hive/internal/core/terminal/tmux"
+)
+
+const terminalStatusTimeout = 2 * time.Second
+
+// PaneStatus holds per-pane terminal status for agent panes.
+type PaneStatus struct {
+	PaneID      string
+	Status      terminal.Status
+	Tool        string
+	PaneContent string
+	IsAgent     bool
+}
+
+// WindowStatus holds per-window terminal status for multi-window sessions.
+type WindowStatus struct {
+	WindowIndex string
+	WindowName  string
+	Status      terminal.Status
+	Tool        string
+	PaneContent string
+	Panes       []PaneStatus
+}
+
+// TerminalStatus holds the terminal integration status for a session.
+type TerminalStatus struct {
+	Status      terminal.Status
+	Tool        string
+	WindowName  string
+	PaneContent string
+	IsLoading   bool
+	Error       error
+	Windows     []WindowStatus // per-window statuses (populated only for multi-window sessions)
+}
+
+// StatusService performs agent status detection for sessions via terminal
+// integrations. It is UI-agnostic so embedders can run status checks outside
+// the TUI.
+type StatusService struct {
+	term    *terminal.Manager
+	workers int
+}
+
+// NewStatusService creates a StatusService. workers bounds the number of
+// concurrent per-session status fetches in FetchBatch.
+func NewStatusService(term *terminal.Manager, workers int) *StatusService {
+	if workers < 1 {
+		workers = 1
+	}
+	return &StatusService{term: term, workers: workers}
+}
+
+// Available reports whether any terminal integration is enabled and usable.
+// It is safe to call on a nil service.
+func (s *StatusService) Available() bool {
+	return s != nil && s.term != nil && s.term.HasEnabledIntegrations()
+}
+
+// FetchBatch fetches terminal status for the given sessions concurrently and
+// returns results keyed by session ID. Non-active sessions are skipped. Each
+// per-session fetch is bounded by an internal timeout in addition to ctx.
+func (s *StatusService) FetchBatch(ctx context.Context, sessions []*session.Session) map[string]TerminalStatus {
+	results := make(map[string]TerminalStatus)
+	if len(sessions) == 0 || !s.Available() {
+		return results
+	}
+
+	// Refresh integration caches once before fetching statuses
+	s.term.RefreshAll()
+
+	var mu sync.Mutex
+	sem := make(chan struct{}, s.workers)
+	var wg sync.WaitGroup
+
+	for _, sess := range sessions {
+		if sess.State != session.StateActive {
+			continue
+		}
+
+		wg.Add(1)
+		go func(sess *session.Session) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			fetchCtx, cancel := context.WithTimeout(ctx, terminalStatusTimeout)
+			defer cancel()
+
+			status := s.FetchSession(fetchCtx, sess)
+
+			mu.Lock()
+			results[sess.ID] = status
+			mu.Unlock()
+		}(sess)
+	}
+
+	wg.Wait()
+	return results
+}
+
+// FetchSession fetches terminal status for a single session.
+func (s *StatusService) FetchSession(ctx context.Context, sess *session.Session) TerminalStatus {
+	status := TerminalStatus{
+		Status: terminal.StatusMissing,
+	}
+
+	// Inject session path into metadata for multi-window disambiguation
+	metadata := sess.Metadata
+	if sess.Path != "" {
+		metadata = make(map[string]string, len(sess.Metadata)+1)
+		maps.Copy(metadata, sess.Metadata)
+		metadata[terminaltmux.SessionPathKey] = sess.Path
+	}
+
+	// Try to discover terminal session
+	info, integration, err := s.term.DiscoverSession(ctx, sess.Slug, metadata)
+	if err != nil {
+		log.Debug().Err(err).Str("session", sess.Slug).Msg("terminal session discovery failed")
+		status.Error = err
+		return status
+	}
+
+	if info == nil || integration == nil {
+		return status
+	}
+
+	// Get status from integration
+	termStatus, err := integration.GetStatus(ctx, info)
+	if err != nil {
+		log.Debug().Err(err).Str("session", sess.Slug).Msg("terminal status lookup failed")
+		status.Error = err
+		return status
+	}
+
+	status.Status = termStatus
+	status.Tool = info.DetectedTool
+	status.WindowName = info.WindowName
+	status.PaneContent = info.PaneContent
+
+	// Discover all panes/windows if the integration supports it.
+	var allInfos []*terminal.SessionInfo
+	var discErr error
+	if disc, ok := integration.(terminal.AllPanesDiscoverer); ok {
+		allInfos, discErr = disc.DiscoverAllPanes(ctx, sess.Slug, metadata)
+	}
+	if allInfos != nil || discErr != nil {
+		if discErr != nil {
+			log.Debug().Err(discErr).Str("session", sess.Slug).Msg("multi-window discovery failed, using single-window mode")
+		} else if len(allInfos) > 0 {
+			windows := groupPaneStatuses(ctx, integration, sess.Slug, allInfos)
+			if ShouldExposeWindows(windows) {
+				status.Windows = windows
+			}
+		}
+	}
+
+	return status
+}
+
+func groupPaneStatuses(ctx context.Context, integration terminal.Integration, slug string, infos []*terminal.SessionInfo) []WindowStatus {
+	windows := make([]WindowStatus, 0, len(infos))
+	byWindow := make(map[string]int, len(infos))
+	for _, wi := range infos {
+		paneStatus, wErr := integration.GetStatus(ctx, wi)
+		if wErr != nil {
+			log.Debug().Err(wErr).Str("session", slug).Str("window", wi.WindowIndex).Str("pane", wi.PaneID).Msg("per-pane status failed, marking missing")
+			paneStatus = terminal.StatusMissing
+		}
+
+		pane := PaneStatus{
+			PaneID:      wi.PaneID,
+			Status:      paneStatus,
+			Tool:        wi.DetectedTool,
+			PaneContent: wi.PaneContent,
+			IsAgent:     true,
+		}
+
+		// \x1f is an ASCII Unit Separator, which avoids collisions with printable tmux window names.
+		key := wi.WindowIndex + "\x1f" + wi.WindowName
+		idx, ok := byWindow[key]
+		if !ok {
+			idx = len(windows)
+			byWindow[key] = idx
+			windows = append(windows, WindowStatus{
+				WindowIndex: wi.WindowIndex,
+				WindowName:  wi.WindowName,
+				Status:      paneStatus,
+				Tool:        wi.DetectedTool,
+				PaneContent: wi.PaneContent,
+			})
+		} else {
+			windows[idx].Status = aggregateStatus(windows[idx].Status, paneStatus)
+			if windows[idx].Tool == "" {
+				windows[idx].Tool = wi.DetectedTool
+			}
+			if windows[idx].PaneContent == "" {
+				windows[idx].PaneContent = wi.PaneContent
+			}
+		}
+		windows[idx].Panes = append(windows[idx].Panes, pane)
+	}
+	return windows
+}
+
+// ShouldExposeWindows reports whether a session's windows warrant per-window
+// breakdown: more than one window, or a single window with multiple agent panes.
+func ShouldExposeWindows(windows []WindowStatus) bool {
+	if len(windows) > 1 {
+		return true
+	}
+	return len(windows) == 1 && len(windows[0].Panes) > 1
+}
+
+func aggregateStatus(current, next terminal.Status) terminal.Status {
+	if statusRank(next) > statusRank(current) {
+		return next
+	}
+	return current
+}
+
+func statusRank(status terminal.Status) int {
+	switch status {
+	case terminal.StatusApproval:
+		return 4
+	case terminal.StatusActive:
+		return 3
+	case terminal.StatusMissing:
+		return 2
+	case terminal.StatusReady:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/hive/status_service_test.go
+++ b/internal/hive/status_service_test.go
@@ -1,4 +1,4 @@
-package sessions
+package hive
 
 import (
 	"context"

--- a/internal/hive/terminal.go
+++ b/internal/hive/terminal.go
@@ -1,11 +1,20 @@
-package commands
+package hive
 
 import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/colonyops/hive/internal/core/config"
+	"github.com/colonyops/hive/internal/core/terminal"
 	terminaltmux "github.com/colonyops/hive/internal/core/terminal/tmux"
 )
+
+// NewTerminalManager builds the terminal integration manager from config.
+// tmux is always enabled; availability is checked lazily by the manager.
+func NewTerminalManager(cfg *config.Config) *terminal.Manager {
+	mgr := terminal.NewManager([]string{"tmux"})
+	mgr.Register(newTmuxIntegration(cfg))
+	return mgr
+}
 
 func newTmuxIntegration(cfg *config.Config) *terminaltmux.Integration {
 	if cfg == nil {

--- a/internal/hive/terminal_test.go
+++ b/internal/hive/terminal_test.go
@@ -1,4 +1,4 @@
-package commands
+package hive
 
 import (
 	"os"

--- a/internal/tui/form_factory.go
+++ b/internal/tui/form_factory.go
@@ -7,8 +7,8 @@ import (
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/colonyops/hive/internal/core/workspace"
+	"github.com/colonyops/hive/internal/hive"
 	"github.com/colonyops/hive/internal/tui/components/form"
-	"github.com/colonyops/hive/internal/tui/views/sessions"
 	"github.com/colonyops/hive/pkg/kv"
 )
 
@@ -19,7 +19,7 @@ func newFormDialog(
 	fields []config.FormField,
 	sessions []session.Session,
 	repos []workspace.DiscoveredRepo,
-	termStatuses *kv.Store[string, sessions.TerminalStatus],
+	termStatuses *kv.Store[string, hive.TerminalStatus],
 ) (*form.Dialog, error) {
 	components := make([]form.Field, 0, len(fields))
 	variables := make([]string, 0, len(fields))
@@ -60,7 +60,7 @@ func newFormDialog(
 // filterActiveSessions returns sessions that are active and have a non-missing
 // terminal status. When termStatuses is nil (no terminal integration), falls
 // back to filtering by session state only.
-func filterActiveSessions(sessions []session.Session, termStatuses *kv.Store[string, sessions.TerminalStatus]) []session.Session {
+func filterActiveSessions(sessions []session.Session, termStatuses *kv.Store[string, hive.TerminalStatus]) []session.Session {
 	filtered := make([]session.Session, 0, len(sessions))
 	for _, s := range sessions {
 		if s.State != session.StateActive {

--- a/internal/tui/form_factory_test.go
+++ b/internal/tui/form_factory_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/colonyops/hive/internal/core/workspace"
-	"github.com/colonyops/hive/internal/tui/views/sessions"
+	"github.com/colonyops/hive/internal/hive"
 	"github.com/colonyops/hive/pkg/kv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -163,10 +163,10 @@ func TestNewFormDialog(t *testing.T) {
 			{ID: "s2", Name: "beta", State: session.StateActive},
 			{ID: "s3", Name: "gamma", State: session.StateActive},
 		}
-		ts := kv.New[string, sessions.TerminalStatus]()
-		ts.Set("s1", sessions.TerminalStatus{Status: terminal.StatusActive})
-		ts.Set("s2", sessions.TerminalStatus{Status: terminal.StatusMissing})
-		ts.Set("s3", sessions.TerminalStatus{Status: terminal.StatusReady})
+		ts := kv.New[string, hive.TerminalStatus]()
+		ts.Set("s1", hive.TerminalStatus{Status: terminal.StatusActive})
+		ts.Set("s2", hive.TerminalStatus{Status: terminal.StatusMissing})
+		ts.Set("s3", hive.TerminalStatus{Status: terminal.StatusReady})
 
 		fields := []config.FormField{
 			{Variable: "target", Preset: config.FormPresetSessionSelector, Label: "Target"},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -27,7 +27,6 @@ import (
 	"github.com/colonyops/hive/internal/core/notify"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
-	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/colonyops/hive/internal/sources"
 	"github.com/colonyops/hive/internal/tui/sourcepicker"
 
@@ -76,14 +75,14 @@ const (
 // Deps holds all external dependencies for the TUI Model.
 type Deps struct {
 	// Required; nil causes a panic at construction time.
-	Config          *config.Config
-	Service         *hive.SessionService
-	Renderer        *tmpl.Renderer
-	TerminalManager *terminal.Manager
-	PluginManager   *plugins.Manager
-	CommandSet      *plugins.CommandSet
-	TodoService     *hive.TodoService
-	DB              *db.DB
+	Config        *config.Config
+	Service       *hive.SessionService
+	Renderer      *tmpl.Renderer
+	Status        *hive.StatusService
+	PluginManager *plugins.Manager
+	CommandSet    *plugins.CommandSet
+	TodoService   *hive.TodoService
+	DB            *db.DB
 
 	// Optional; nil disables the corresponding feature.
 	MsgStore      *hive.MessageService
@@ -248,8 +247,8 @@ type todoCreatedMsg struct {
 
 // New creates a new TUI model. Panics if required Deps fields are nil.
 func New(deps Deps, opts Opts) Model {
-	if deps.Config == nil || deps.Service == nil || deps.Renderer == nil || deps.TerminalManager == nil || deps.PluginManager == nil || deps.CommandSet == nil || deps.TodoService == nil || deps.DB == nil {
-		panic("tui.New: Config, Service, Renderer, TerminalManager, PluginManager, CommandSet, TodoService, and DB are required")
+	if deps.Config == nil || deps.Service == nil || deps.Renderer == nil || deps.Status == nil || deps.PluginManager == nil || deps.CommandSet == nil || deps.TodoService == nil || deps.DB == nil {
+		panic("tui.New: Config, Service, Renderer, Status, PluginManager, CommandSet, TodoService, and DB are required")
 	}
 	cfg := deps.Config
 	service := deps.Service
@@ -264,15 +263,15 @@ func New(deps Deps, opts Opts) Model {
 	cmdService := command.NewService(service, service, service, service, service)
 
 	sessionsView := sessions.New(sessions.ViewOpts{
-		Cfg:             cfg,
-		Service:         service,
-		Handler:         handler,
-		TerminalManager: deps.TerminalManager,
-		PluginManager:   deps.PluginManager,
-		LocalRemote:     opts.LocalRemote,
-		Workspaces:      cfg.Workspaces,
-		Renderer:        deps.Renderer,
-		Bus:             deps.Bus,
+		Cfg:           cfg,
+		Service:       service,
+		Handler:       handler,
+		Status:        deps.Status,
+		PluginManager: deps.PluginManager,
+		LocalRemote:   opts.LocalRemote,
+		Workspaces:    cfg.Workspaces,
+		Renderer:      deps.Renderer,
+		Bus:           deps.Bus,
 	})
 
 	// Wire handler lookups through sessions view stores

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -84,14 +84,14 @@ func newMouseTestSessionsView(t *testing.T) *sessions.View {
 	svc := newMouseTestSessionService(t)
 	cfg := &config.Config{}
 	handler := NewKeybindingResolver(nil, plugins.NewCommandSet(nil, nil), testRenderer)
-	mgr := terminal.NewManager(nil)
+	status := hive.NewStatusService(terminal.NewManager(nil), 1)
 	pm := plugins.NewManager(plugins.NewWorkerPool(0), plugins.NewCommandSet(nil, nil))
 	return sessions.New(sessions.ViewOpts{
-		Cfg:             cfg,
-		Service:         svc,
-		Handler:         handler,
-		TerminalManager: mgr,
-		PluginManager:   pm,
+		Cfg:           cfg,
+		Service:       svc,
+		Handler:       handler,
+		Status:        status,
+		PluginManager: pm,
 	})
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -63,15 +63,15 @@ func newKeybindingPrecedenceModel(t *testing.T, mutate func(*config.Config)) Mod
 	)
 
 	m := New(Deps{
-		Config:          cfg,
-		Service:         newMouseTestSessionService(t),
-		Renderer:        testRenderer,
-		TerminalManager: terminal.NewManager(nil),
-		PluginManager:   pluginManager,
-		CommandSet:      commandSet,
-		TodoService:     todoService,
-		DB:              database,
-		Bus:             tb.EventBus,
+		Config:        cfg,
+		Service:       newMouseTestSessionService(t),
+		Renderer:      testRenderer,
+		Status:        hive.NewStatusService(terminal.NewManager(nil), 1),
+		PluginManager: pluginManager,
+		CommandSet:    commandSet,
+		TodoService:   todoService,
+		DB:            database,
+		Bus:           tb.EventBus,
 	}, Opts{})
 
 	return m
@@ -128,15 +128,15 @@ func TestOpenNewSessionFormUsesEnvironmentDefaultAgent(t *testing.T) {
 	)
 
 	m := New(Deps{
-		Config:          cfg,
-		Service:         newMouseTestSessionService(t),
-		Renderer:        testRenderer,
-		TerminalManager: terminal.NewManager(nil),
-		PluginManager:   pluginManager,
-		CommandSet:      commandSet,
-		TodoService:     todoService,
-		DB:              database,
-		Bus:             tb.EventBus,
+		Config:        cfg,
+		Service:       newMouseTestSessionService(t),
+		Renderer:      testRenderer,
+		Status:        hive.NewStatusService(terminal.NewManager(nil), 1),
+		PluginManager: pluginManager,
+		CommandSet:    commandSet,
+		TodoService:   todoService,
+		DB:            database,
+		Bus:           tb.EventBus,
 	}, Opts{})
 
 	model, _ := m.openNewSessionForm()

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -2,233 +2,30 @@ package sessions
 
 import (
 	"context"
-	"maps"
-	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/rs/zerolog/log"
 
 	"github.com/colonyops/hive/internal/core/session"
-	"github.com/colonyops/hive/internal/core/terminal"
-	terminaltmux "github.com/colonyops/hive/internal/core/terminal/tmux"
+	"github.com/colonyops/hive/internal/hive"
 )
-
-const terminalStatusTimeout = 2 * time.Second
-
-// PaneStatus holds per-pane terminal status for agent panes.
-type PaneStatus struct {
-	PaneID      string
-	Status      terminal.Status
-	Tool        string
-	PaneContent string
-	IsAgent     bool
-}
-
-// WindowStatus holds per-window terminal status for multi-window sessions.
-type WindowStatus struct {
-	WindowIndex string
-	WindowName  string
-	Status      terminal.Status
-	Tool        string
-	PaneContent string
-	Panes       []PaneStatus
-}
-
-// TerminalStatus holds the terminal integration status for a session.
-type TerminalStatus struct {
-	Status      terminal.Status
-	Tool        string
-	WindowName  string
-	PaneContent string
-	IsLoading   bool
-	Error       error
-	Windows     []WindowStatus // per-window statuses (populated only for multi-window sessions)
-}
 
 // TerminalStatusBatchCompleteMsg is sent when all terminal status fetches complete.
 type TerminalStatusBatchCompleteMsg struct {
-	Results map[string]TerminalStatus // sessionID -> status
+	Results map[string]hive.TerminalStatus // sessionID -> status
 }
 
 // TerminalPollTickMsg triggers a terminal status poll cycle.
 type TerminalPollTickMsg struct{}
 
 // FetchTerminalStatusBatch returns a command that fetches terminal status for multiple sessions.
-func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int) tea.Cmd {
-	if len(sessions) == 0 || !mgr.HasEnabledIntegrations() {
+func FetchTerminalStatusBatch(status *hive.StatusService, sessions []*session.Session) tea.Cmd {
+	if len(sessions) == 0 || !status.Available() {
 		return nil
 	}
 
 	return func() tea.Msg {
-		// Refresh integration caches once before fetching statuses
-		mgr.RefreshAll()
-
-		results := make(map[string]TerminalStatus)
-		var mu sync.Mutex
-
-		sem := make(chan struct{}, workers)
-		var wg sync.WaitGroup
-
-		for _, sess := range sessions {
-			// Skip non-active sessions
-			if sess.State != session.StateActive {
-				continue
-			}
-
-			wg.Add(1)
-			go func(s *session.Session) {
-				defer wg.Done()
-
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				ctx, cancel := context.WithTimeout(context.Background(), terminalStatusTimeout)
-				defer cancel()
-
-				status := fetchTerminalStatusForSession(ctx, mgr, s)
-
-				mu.Lock()
-				results[s.ID] = status
-				mu.Unlock()
-			}(sess)
-		}
-
-		wg.Wait()
-		return TerminalStatusBatchCompleteMsg{Results: results}
-	}
-}
-
-// fetchTerminalStatusForSession fetches terminal status for a single session.
-func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, sess *session.Session) TerminalStatus {
-	status := TerminalStatus{
-		Status: terminal.StatusMissing,
-	}
-
-	// Inject session path into metadata for multi-window disambiguation
-	metadata := sess.Metadata
-	if sess.Path != "" {
-		metadata = make(map[string]string, len(sess.Metadata)+1)
-		maps.Copy(metadata, sess.Metadata)
-		metadata[terminaltmux.SessionPathKey] = sess.Path
-	}
-
-	// Try to discover terminal session
-	info, integration, err := mgr.DiscoverSession(ctx, sess.Slug, metadata)
-	if err != nil {
-		log.Debug().Err(err).Str("session", sess.Slug).Msg("terminal session discovery failed")
-		status.Error = err
-		return status
-	}
-
-	if info == nil || integration == nil {
-		return status
-	}
-
-	// Get status from integration
-	termStatus, err := integration.GetStatus(ctx, info)
-	if err != nil {
-		log.Debug().Err(err).Str("session", sess.Slug).Msg("terminal status lookup failed")
-		status.Error = err
-		return status
-	}
-
-	status.Status = termStatus
-	status.Tool = info.DetectedTool
-	status.WindowName = info.WindowName
-	status.PaneContent = info.PaneContent
-
-	// Discover all panes/windows if the integration supports it.
-	var allInfos []*terminal.SessionInfo
-	var discErr error
-	if disc, ok := integration.(terminal.AllPanesDiscoverer); ok {
-		allInfos, discErr = disc.DiscoverAllPanes(ctx, sess.Slug, metadata)
-	}
-	if allInfos != nil || discErr != nil {
-		if discErr != nil {
-			log.Debug().Err(discErr).Str("session", sess.Slug).Msg("multi-window discovery failed, using single-window mode")
-		} else if len(allInfos) > 0 {
-			windows := groupPaneStatuses(ctx, integration, sess.Slug, allInfos)
-			if shouldExposeWindows(windows) {
-				status.Windows = windows
-			}
-		}
-	}
-
-	return status
-}
-
-func groupPaneStatuses(ctx context.Context, integration terminal.Integration, slug string, infos []*terminal.SessionInfo) []WindowStatus {
-	windows := make([]WindowStatus, 0, len(infos))
-	byWindow := make(map[string]int, len(infos))
-	for _, wi := range infos {
-		paneStatus, wErr := integration.GetStatus(ctx, wi)
-		if wErr != nil {
-			log.Debug().Err(wErr).Str("session", slug).Str("window", wi.WindowIndex).Str("pane", wi.PaneID).Msg("per-pane status failed, marking missing")
-			paneStatus = terminal.StatusMissing
-		}
-
-		pane := PaneStatus{
-			PaneID:      wi.PaneID,
-			Status:      paneStatus,
-			Tool:        wi.DetectedTool,
-			PaneContent: wi.PaneContent,
-			IsAgent:     true,
-		}
-
-		// \x1f is an ASCII Unit Separator, which avoids collisions with printable tmux window names.
-		key := wi.WindowIndex + "\x1f" + wi.WindowName
-		idx, ok := byWindow[key]
-		if !ok {
-			idx = len(windows)
-			byWindow[key] = idx
-			windows = append(windows, WindowStatus{
-				WindowIndex: wi.WindowIndex,
-				WindowName:  wi.WindowName,
-				Status:      paneStatus,
-				Tool:        wi.DetectedTool,
-				PaneContent: wi.PaneContent,
-			})
-		} else {
-			windows[idx].Status = aggregateStatus(windows[idx].Status, paneStatus)
-			if windows[idx].Tool == "" {
-				windows[idx].Tool = wi.DetectedTool
-			}
-			if windows[idx].PaneContent == "" {
-				windows[idx].PaneContent = wi.PaneContent
-			}
-		}
-		windows[idx].Panes = append(windows[idx].Panes, pane)
-	}
-	return windows
-}
-
-func shouldExposeWindows(windows []WindowStatus) bool {
-	if len(windows) > 1 {
-		return true
-	}
-	return len(windows) == 1 && len(windows[0].Panes) > 1
-}
-
-func aggregateStatus(current, next terminal.Status) terminal.Status {
-	if statusRank(next) > statusRank(current) {
-		return next
-	}
-	return current
-}
-
-func statusRank(status terminal.Status) int {
-	switch status {
-	case terminal.StatusApproval:
-		return 4
-	case terminal.StatusActive:
-		return 3
-	case terminal.StatusMissing:
-		return 2
-	case terminal.StatusReady:
-		return 1
-	default:
-		return 0
+		return TerminalStatusBatchCompleteMsg{Results: status.FetchBatch(context.Background(), sessions)}
 	}
 }
 

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -12,6 +12,7 @@ import (
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/internal/hive"
 	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/internal/tui/components"
 	"github.com/colonyops/hive/pkg/kv"
@@ -58,7 +59,7 @@ const currentRepoIndicator = "◆"
 // For active sessions with terminal integration, it uses terminal status.
 // For recycled sessions or when no terminal status is available, it falls back to session state.
 // The animFrame parameter controls the fade animation for active status (0 to AnimationFrameCount-1).
-func renderStatusIndicator(state session.State, termStatus *TerminalStatus, treeStyles TreeDelegateStyles, animFrame int) string {
+func renderStatusIndicator(state session.State, termStatus *hive.TerminalStatus, treeStyles TreeDelegateStyles, animFrame int) string {
 	// Recycled sessions always show recycled indicator
 	if state == session.StateRecycled {
 		return treeStyles.StatusRecycled.Render(styles.StatusIndicatorRecycled)
@@ -290,7 +291,7 @@ func CalculateColumnWidths(sessions []session.Session, gitBranches map[string]st
 type TreeDelegate struct {
 	Styles           TreeDelegateStyles
 	GitStatuses      *kv.Store[string, GitStatus]
-	TerminalStatuses *kv.Store[string, TerminalStatus]
+	TerminalStatuses *kv.Store[string, hive.TerminalStatus]
 	PluginStatuses   map[string]*kv.Store[string, plugins.Status] // plugin name -> session ID -> status
 	ColumnWidths     *ColumnWidths
 	AnimationFrame   int  // Current frame for status animations
@@ -406,7 +407,7 @@ func (d TreeDelegate) renderSession(item TreeItem, isSelected bool, m list.Model
 	prefixStyled := d.Styles.TreeLine.Render(prefix)
 
 	// Get terminal status if available
-	var termStatus *TerminalStatus
+	var termStatus *hive.TerminalStatus
 	if d.TerminalStatuses != nil {
 		if ts, ok := d.TerminalStatuses.Get(item.Session.ID); ok {
 			termStatus = &ts
@@ -480,7 +481,7 @@ func (d TreeDelegate) renderPane(item TreeItem, isSelected bool) string {
 	}
 	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
 
-	termStatus := &TerminalStatus{Status: item.PaneStatus}
+	termStatus := &hive.TerminalStatus{Status: item.PaneStatus}
 	statusStr := renderStatusIndicator(session.StateActive, termStatus, d.Styles, d.AnimationFrame)
 
 	nameStyle := d.Styles.SessionName
@@ -523,7 +524,7 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
 
 	// Get per-window terminal status from the delegate's store
-	var windowStatus *WindowStatus
+	var windowStatus *hive.WindowStatus
 	if d.TerminalStatuses != nil {
 		if ts, ok := d.TerminalStatuses.Get(item.ParentSession.ID); ok {
 			for i := range ts.Windows {
@@ -538,7 +539,7 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 	// Status indicator
 	var statusStr string
 	if windowStatus != nil {
-		termStatus := &TerminalStatus{Status: windowStatus.Status}
+		termStatus := &hive.TerminalStatus{Status: windowStatus.Status}
 		statusStr = renderStatusIndicator(session.StateActive, termStatus, d.Styles, d.AnimationFrame)
 	} else {
 		statusStr = d.Styles.StatusUnknown.Render(styles.StatusIndicatorMissing)

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -39,11 +39,11 @@ var builderPool = sync.Pool{
 // ViewOpts configures a new sessions View.
 type ViewOpts struct {
 	// Required — nil causes a panic at construction time.
-	Cfg             *config.Config
-	Service         *hive.SessionService
-	Handler         KeyResolver
-	TerminalManager *terminal.Manager
-	PluginManager   *plugins.Manager
+	Cfg           *config.Config
+	Service       *hive.SessionService
+	Handler       KeyResolver
+	Status        *hive.StatusService
+	PluginManager *plugins.Manager
 
 	// Optional — nil disables the corresponding feature.
 	LocalRemote string
@@ -74,8 +74,8 @@ type View struct {
 	gitWorkers  int
 
 	// Terminal integration
-	terminalManager    *terminal.Manager
-	terminalStatuses   *kv.Store[string, TerminalStatus]
+	status             *hive.StatusService
+	terminalStatuses   *kv.Store[string, hive.TerminalStatus]
 	previewEnabled     bool
 	previewTemplates   *PreviewTemplates
 	currentTmuxSession string
@@ -116,13 +116,13 @@ type View struct {
 // initialized here so the parent Model can pass them through ViewOpts without
 // constructing them itself.
 func New(opts ViewOpts) *View {
-	if opts.Cfg == nil || opts.Service == nil || opts.Handler == nil || opts.TerminalManager == nil || opts.PluginManager == nil {
-		panic("sessions.New: Cfg, Service, Handler, TerminalManager, and PluginManager are required")
+	if opts.Cfg == nil || opts.Service == nil || opts.Handler == nil || opts.Status == nil || opts.PluginManager == nil {
+		panic("sessions.New: Cfg, Service, Handler, Status, and PluginManager are required")
 	}
 	cfg := opts.Cfg
 
 	gitStatuses := kv.New[string, GitStatus]()
-	terminalStatuses := kv.New[string, TerminalStatus]()
+	terminalStatuses := kv.New[string, hive.TerminalStatus]()
 	columnWidths := &ColumnWidths{}
 
 	pluginStatuses := make(map[string]*kv.Store[string, plugins.Status])
@@ -188,7 +188,7 @@ func New(opts ViewOpts) *View {
 		gitStatuses: gitStatuses,
 		gitWorkers:  cfg.Git.StatusWorkers,
 
-		terminalManager:    opts.TerminalManager,
+		status:             opts.Status,
 		terminalStatuses:   terminalStatuses,
 		previewEnabled:     cfg.Views.Sessions.PreviewEnabled,
 		previewTemplates:   previewTemplates,
@@ -215,7 +215,7 @@ func (v *View) Init() tea.Cmd {
 		cmds = append(cmds, v.scanRepoDirs())
 	}
 
-	if v.terminalManager.HasEnabledIntegrations() {
+	if v.status.Available() {
 		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
 		cmds = append(cmds, scheduleAnimationTick())
 	}
@@ -286,12 +286,12 @@ func (v *View) handleSessionsLoaded(msg sessionsLoadedMsg) tea.Cmd {
 	}
 	// Immediately fetch terminal status so newly created sessions are detected
 	// without waiting for the next scheduled poll tick (up to 1500ms delay).
-	if v.terminalManager != nil && v.terminalManager.HasEnabledIntegrations() && len(v.allSessions) > 0 {
+	if v.status.Available() && len(v.allSessions) > 0 {
 		sessPtrs := make([]*session.Session, len(v.allSessions))
 		for i := range v.allSessions {
 			sessPtrs[i] = &v.allSessions[i]
 		}
-		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+		cmds = append(cmds, FetchTerminalStatusBatch(v.status, sessPtrs))
 	}
 	return tea.Batch(cmds...)
 }
@@ -344,8 +344,8 @@ func (v *View) handleTerminalPollTick() tea.Cmd {
 	for i := range allSess {
 		sessPtrs[i] = &v.allSessions[i]
 	}
-	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
-	if v.terminalManager.HasEnabledIntegrations() {
+	cmds = append(cmds, FetchTerminalStatusBatch(v.status, sessPtrs))
+	if v.status.Available() {
 		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
 	}
 	return tea.Batch(cmds...)
@@ -750,7 +750,7 @@ func (v *View) rebuildWindowItems() {
 		if !ti.IsSession() {
 			continue
 		}
-		if ts, ok := v.terminalStatuses.Get(ti.Session.ID); ok && shouldExposeWindows(ts.Windows) {
+		if ts, ok := v.terminalStatuses.Get(ti.Session.ID); ok && hive.ShouldExposeWindows(ts.Windows) {
 			for _, w := range ts.Windows {
 				expected["w\x1f"+ti.Session.ID+"\x1f"+w.WindowIndex+"\x1f"+w.WindowName] = struct{}{}
 				if len(w.Panes) > 1 {
@@ -807,7 +807,7 @@ func (v *View) expandWindowItems(items []list.Item) []list.Item {
 		}
 
 		ts, ok := v.terminalStatuses.Get(treeItem.Session.ID)
-		if !ok || !shouldExposeWindows(ts.Windows) {
+		if !ok || !hive.ShouldExposeWindows(ts.Windows) {
 			continue
 		}
 
@@ -1151,7 +1151,7 @@ func (v *View) handleFilterAction(actionType act.Type) bool {
 
 // selectedPaneStatus returns the PaneStatus for the currently selected pane item,
 // or nil if a session/window is selected.
-func (v *View) selectedPaneStatus() *PaneStatus {
+func (v *View) selectedPaneStatus() *hive.PaneStatus {
 	item := v.list.SelectedItem()
 	if item == nil {
 		return nil
@@ -1182,7 +1182,7 @@ func (v *View) selectedPaneStatus() *PaneStatus {
 
 // selectedWindowStatus returns the WindowStatus for the currently selected window item,
 // or nil if a session (not a window) is selected.
-func (v *View) selectedWindowStatus() *WindowStatus {
+func (v *View) selectedWindowStatus() *hive.WindowStatus {
 	item := v.list.SelectedItem()
 	if item == nil {
 		return nil
@@ -1394,7 +1394,7 @@ func (v *View) DiscoveredRepos() []workspace.DiscoveredRepo {
 }
 
 // TerminalStatuses returns the terminal status store.
-func (v *View) TerminalStatuses() *kv.Store[string, TerminalStatus] {
+func (v *View) TerminalStatuses() *kv.Store[string, hive.TerminalStatus] {
 	return v.terminalStatuses
 }
 
@@ -1492,7 +1492,7 @@ func (v *View) ApplyStatusFilter(actionType act.Type) {
 
 // HasTerminalIntegration returns true if a terminal manager is configured with enabled integrations.
 func (v *View) HasTerminalIntegration() bool {
-	return v.terminalManager.HasEnabledIntegrations()
+	return v.status.Available()
 }
 
 // TogglePreview toggles the preview sidebar on/off.

--- a/internal/tui/views/sessions/view_test.go
+++ b/internal/tui/views/sessions/view_test.go
@@ -90,8 +90,8 @@ func TestExpandWindowItems_NilTerminalStatuses(t *testing.T) {
 }
 
 func TestExpandWindowItems_ZeroWindows(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{Status: terminal.StatusActive})
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{Status: terminal.StatusActive})
 	v := &View{terminalStatuses: ts}
 
 	items := []list.Item{TreeItem{Session: session.Session{ID: "s1"}}}
@@ -100,9 +100,9 @@ func TestExpandWindowItems_ZeroWindows(t *testing.T) {
 }
 
 func TestExpandWindowItems_OneWindow(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{
-		Windows: []WindowStatus{{WindowIndex: "0", WindowName: "main"}},
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{
+		Windows: []hive.WindowStatus{{WindowIndex: "0", WindowName: "main"}},
 	})
 	v := &View{terminalStatuses: ts}
 
@@ -112,12 +112,12 @@ func TestExpandWindowItems_OneWindow(t *testing.T) {
 }
 
 func TestExpandWindowItems_OneWindowMultiplePanes(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{
-		Windows: []WindowStatus{{
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{
+		Windows: []hive.WindowStatus{{
 			WindowIndex: "0",
 			WindowName:  "main",
-			Panes: []PaneStatus{
+			Panes: []hive.PaneStatus{
 				{PaneID: "%1", Tool: "claude", Status: terminal.StatusReady},
 				{PaneID: "%2", Tool: "codex", Status: terminal.StatusActive},
 			},
@@ -143,11 +143,11 @@ func TestExpandWindowItems_OneWindowMultiplePanes(t *testing.T) {
 
 func TestRenderPreviewHeader_SelectedPaneUsesDisplayID(t *testing.T) {
 	sess := session.Session{ID: "abcd1234", Name: "my-session"}
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{Windows: []WindowStatus{{
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{Windows: []hive.WindowStatus{{
 		WindowIndex: "0",
 		WindowName:  "main",
-		Panes:       []PaneStatus{{PaneID: "%12", Tool: "claude", Status: terminal.StatusReady}},
+		Panes:       []hive.PaneStatus{{PaneID: "%12", Tool: "claude", Status: terminal.StatusReady}},
 	}}})
 	v := newTestView([]list.Item{TreeItem{
 		IsPaneItem:    true,
@@ -166,9 +166,9 @@ func TestRenderPreviewHeader_SelectedPaneUsesDisplayID(t *testing.T) {
 }
 
 func TestExpandWindowItems_MultipleWindows(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{
-		Windows: []WindowStatus{
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{
+		Windows: []hive.WindowStatus{
 			{WindowIndex: "0", WindowName: "claude"},
 			{WindowIndex: "1", WindowName: "aider"},
 		},
@@ -191,7 +191,7 @@ func TestExpandWindowItems_MultipleWindows(t *testing.T) {
 }
 
 func TestExpandWindowItems_NonSessionPassthrough(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
+	ts := kv.New[string, hive.TerminalStatus]()
 	v := &View{terminalStatuses: ts}
 
 	items := []list.Item{
@@ -204,13 +204,13 @@ func TestExpandWindowItems_NonSessionPassthrough(t *testing.T) {
 
 // --- applyFilter ---
 
-func newFilterTestView(sessions []session.Session, statusFilter terminal.Status, statuses *kv.Store[string, TerminalStatus]) *View {
+func newFilterTestView(sessions []session.Session, statusFilter terminal.Status, statuses *kv.Store[string, hive.TerminalStatus]) *View {
 	delegate := NewTreeDelegate()
 	l := list.New([]list.Item{}, delegate, 80, 24)
 	columnWidths := &ColumnWidths{}
 	ts := statuses
 	if ts == nil {
-		ts = kv.New[string, TerminalStatus]()
+		ts = kv.New[string, hive.TerminalStatus]()
 	}
 	gitStatuses := kv.New[string, GitStatus]()
 	// new(hive.SessionService) gives a zero-valued service whose Git() returns nil.
@@ -253,9 +253,9 @@ func TestApplyFilter_NoStatusFilter(t *testing.T) {
 }
 
 func TestApplyFilter_StatusFilterMatches(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{Status: terminal.StatusActive})
-	ts.Set("s2", TerminalStatus{Status: terminal.StatusReady})
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{Status: terminal.StatusActive})
+	ts.Set("s2", hive.TerminalStatus{Status: terminal.StatusReady})
 
 	sessions := []session.Session{
 		newSess("s1", "active-session"),
@@ -274,8 +274,8 @@ func TestApplyFilter_StatusFilterMatches(t *testing.T) {
 }
 
 func TestApplyFilter_StatusFilterNoMatches(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{Status: terminal.StatusReady})
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{Status: terminal.StatusReady})
 
 	sessions := []session.Session{newSess("s1", "ready-session")}
 	v := newFilterTestView(sessions, terminal.StatusActive, ts)
@@ -291,9 +291,9 @@ func TestApplyFilter_StatusFilterNoMatches(t *testing.T) {
 }
 
 func TestApplyFilter_FilterThenClear(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
-	ts.Set("s1", TerminalStatus{Status: terminal.StatusActive})
-	ts.Set("s2", TerminalStatus{Status: terminal.StatusReady})
+	ts := kv.New[string, hive.TerminalStatus]()
+	ts.Set("s1", hive.TerminalStatus{Status: terminal.StatusActive})
+	ts.Set("s2", hive.TerminalStatus{Status: terminal.StatusReady})
 
 	sessions := []session.Session{
 		newSess("s1", "active"),
@@ -316,7 +316,7 @@ func TestApplyFilter_FilterThenClear(t *testing.T) {
 }
 
 func TestApplyFilter_NoTerminalStatusExcluded(t *testing.T) {
-	ts := kv.New[string, TerminalStatus]()
+	ts := kv.New[string, hive.TerminalStatus]()
 	// neither session has a terminal status entry
 
 	sessions := []session.Session{
@@ -362,11 +362,11 @@ func newViewWithTerminalMgr(sessions []session.Session) *View {
 		list:             l,
 		allSessions:      sessions,
 		groupBy:          config.GroupByRepo,
-		terminalStatuses: kv.New[string, TerminalStatus](),
+		terminalStatuses: kv.New[string, hive.TerminalStatus](),
 		gitStatuses:      kv.New[string, GitStatus](),
 		columnWidths:     &ColumnWidths{},
 		service:          new(hive.SessionService),
-		terminalManager:  mgr,
+		status:           hive.NewStatusService(mgr, 1),
 		gitWorkers:       1,
 		cfg:              &config.Config{},
 	}

--- a/main.go
+++ b/main.go
@@ -286,6 +286,7 @@ Run 'hive new' to create a new session from the current repository.`,
 			)
 
 			sessionSvc := hive.NewSessionService(sessionStore, gitExec, cfg, bus, exec, renderer, svcLogger, os.Stdout, os.Stderr)
+			termMgr := hive.NewTerminalManager(cfg)
 
 			// Create all plugin instances, collect availability info for doctor,
 			// then register with the manager.
@@ -338,7 +339,7 @@ Run 'hive new' to create a new session from the current repository.`,
 				hcStore,
 				cfg,
 				bus,
-				nil, // terminal manager created in TUI command
+				termMgr,
 				pluginMgr,
 				commandSet,
 				database,


### PR DESCRIPTION
## Purpose

Consumers that vendor this repo (hive-desktop) need session status checks without going through the Bubble Tea TUI. The discover → classify → aggregate workflow lived in `internal/tui/views/sessions/terminalstatus.go` wrapped in `tea.Cmd` closures, and the terminal manager was only constructed inside the `tui` and `x pick` commands, so `App.Terminal` was `nil` everywhere else.

## Proposed Changes

- Move the status workflow (batch worker pool, per-session discovery, multi-window pane grouping, status ranking) into `hive.StatusService` with UI-free types; the sessions view keeps a thin `tea.Cmd`/msg adapter and takes a `StatusService` instead of a raw `terminal.Manager`
- Build the terminal manager from config in bootstrap (`hive.NewTerminalManager`), so `App.Terminal` and `App.Status` are always populated; `tui` and `x pick` consume them instead of building their own managers
- Embedders get `app.Sessions.ListSessions(ctx)` + `app.Status.FetchBatch(ctx, sessions)` for status checks outside the TUI

Notes: `StatusService.Available` is nil-receiver safe on purpose (matches the old `terminalManager != nil` guard used by view tests); the tmux integration is now registered unconditionally since the manager filters by `Available()` lazily — same behavior, no eager tmux probe at startup.

Follow-up: extracting the `App` bootstrap from `main.go` into a reusable constructor is tracked in hc-974bl6wg.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)