### PR TITLE
Surface root repository checkouts in the sessions tree

### DIFF
--- a/internal/tui/model_handlers.go
+++ b/internal/tui/model_handlers.go
@@ -241,7 +241,7 @@ func (m Model) viewTasksForSelectedSession() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleSessionOpenRepo(msg sessions.OpenRepoRequestMsg) (tea.Model, tea.Cmd) {
-	return m.openRepoHeaderByRemote(msg.Name, msg.Remote)
+	return m.openRepoHeader(msg.Name, msg.Remote, msg.Path)
 }
 
 // --- Outbound messages from tasks view ---
@@ -1566,12 +1566,13 @@ func (m Model) handleTabClick(x int) (tea.Model, tea.Cmd) {
 
 // --- Helper for repo header opening ---
 
-func (m Model) openRepoHeaderByRemote(name, remote string) (tea.Model, tea.Cmd) {
-	var repoPath string
-	for _, repo := range m.sessionsView.DiscoveredRepos() {
-		if repo.Remote == remote {
-			repoPath = repo.Path
-			break
+func (m Model) openRepoHeader(name, remote, repoPath string) (tea.Model, tea.Cmd) {
+	if repoPath == "" {
+		for _, repo := range m.sessionsView.DiscoveredRepos() {
+			if git.EquivalentRemote(repo.Remote, remote) {
+				repoPath = repo.Path
+				break
+			}
 		}
 	}
 	if repoPath == "" {

--- a/internal/tui/views/sessions/messages.go
+++ b/internal/tui/views/sessions/messages.go
@@ -48,6 +48,7 @@ type RecycledDeleteRequestMsg struct {
 type OpenRepoRequestMsg struct {
 	Name   string
 	Remote string
+	Path   string // workspace checkout path when already resolved by the sender
 }
 
 // RefreshSessionsMsg requests a session list refresh.

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -54,9 +54,27 @@ type TerminalStatusBatchCompleteMsg struct {
 // TerminalPollTickMsg triggers a terminal status poll cycle.
 type TerminalPollTickMsg struct{}
 
-// FetchTerminalStatusBatch returns a command that fetches terminal status for multiple sessions.
-func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, workers int) tea.Cmd {
-	if len(sessions) == 0 || !mgr.HasEnabledIntegrations() {
+// RootRepoTarget identifies a workspace checkout to poll for agent status.
+// Name doubles as the tmux session slug because opening a repo header names
+// the root repo's tmux session after the repo name (see openRepoHeader).
+type RootRepoTarget struct {
+	Name string
+	Path string
+}
+
+// RootStatusKey returns the terminalStatuses store key for a root checkout.
+// Prefixed so it can never collide with session IDs, which key the same store.
+func RootStatusKey(path string) string {
+	return "root:" + path
+}
+
+// FetchTerminalStatusBatch returns a command that fetches terminal status for
+// sessions and workspace root checkouts in a single batch. Roots must share
+// the batch (not a separate command): the tmux integration only serves
+// discovery from a cache younger than 2s, so a separate command would race
+// the RefreshAll here and see a stale cache, silently missing statuses.
+func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session, roots []RootRepoTarget, workers int) tea.Cmd {
+	if (len(sessions) == 0 && len(roots) == 0) || !mgr.HasEnabledIntegrations() {
 		return nil
 	}
 
@@ -94,41 +112,7 @@ func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session
 			}(sess)
 		}
 
-		wg.Wait()
-		return TerminalStatusBatchCompleteMsg{Results: results}
-	}
-}
-
-// RootRepoTarget identifies a workspace checkout to poll for agent status.
-// Name doubles as the tmux session slug because opening a repo header names
-// the root repo's tmux session after the repo name (see openRepoHeader).
-type RootRepoTarget struct {
-	Name string
-	Path string
-}
-
-// RootStatusKey returns the terminalStatuses store key for a root checkout.
-// Prefixed so it can never collide with session IDs, which key the same store.
-func RootStatusKey(path string) string {
-	return "root:" + path
-}
-
-// FetchRootRepoStatusBatch returns a command that fetches terminal status for
-// workspace root checkouts. Results share TerminalStatusBatchCompleteMsg with
-// session statuses, keyed by RootStatusKey.
-func FetchRootRepoStatusBatch(mgr *terminal.Manager, targets []RootRepoTarget, workers int) tea.Cmd {
-	if len(targets) == 0 || !mgr.HasEnabledIntegrations() {
-		return nil
-	}
-
-	return func() tea.Msg {
-		results := make(map[string]TerminalStatus)
-		var mu sync.Mutex
-
-		sem := make(chan struct{}, workers)
-		var wg sync.WaitGroup
-
-		for _, target := range targets {
+		for _, target := range roots {
 			wg.Add(1)
 			go func(rt RootRepoTarget) {
 				defer wg.Done()

--- a/internal/tui/views/sessions/terminalstatus.go
+++ b/internal/tui/views/sessions/terminalstatus.go
@@ -99,6 +99,90 @@ func FetchTerminalStatusBatch(mgr *terminal.Manager, sessions []*session.Session
 	}
 }
 
+// RootRepoTarget identifies a workspace checkout to poll for agent status.
+// Name doubles as the tmux session slug because opening a repo header names
+// the root repo's tmux session after the repo name (see openRepoHeader).
+type RootRepoTarget struct {
+	Name string
+	Path string
+}
+
+// RootStatusKey returns the terminalStatuses store key for a root checkout.
+// Prefixed so it can never collide with session IDs, which key the same store.
+func RootStatusKey(path string) string {
+	return "root:" + path
+}
+
+// FetchRootRepoStatusBatch returns a command that fetches terminal status for
+// workspace root checkouts. Results share TerminalStatusBatchCompleteMsg with
+// session statuses, keyed by RootStatusKey.
+func FetchRootRepoStatusBatch(mgr *terminal.Manager, targets []RootRepoTarget, workers int) tea.Cmd {
+	if len(targets) == 0 || !mgr.HasEnabledIntegrations() {
+		return nil
+	}
+
+	return func() tea.Msg {
+		results := make(map[string]TerminalStatus)
+		var mu sync.Mutex
+
+		sem := make(chan struct{}, workers)
+		var wg sync.WaitGroup
+
+		for _, target := range targets {
+			wg.Add(1)
+			go func(rt RootRepoTarget) {
+				defer wg.Done()
+
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				ctx, cancel := context.WithTimeout(context.Background(), terminalStatusTimeout)
+				defer cancel()
+
+				status := fetchRootRepoStatus(ctx, mgr, rt)
+
+				mu.Lock()
+				results[RootStatusKey(rt.Path)] = status
+				mu.Unlock()
+			}(target)
+		}
+
+		wg.Wait()
+		return TerminalStatusBatchCompleteMsg{Results: results}
+	}
+}
+
+// fetchRootRepoStatus fetches terminal status for a workspace root checkout.
+// Unlike sessions, root repos don't expand window sub-items, so multi-window
+// discovery is skipped.
+func fetchRootRepoStatus(ctx context.Context, mgr *terminal.Manager, target RootRepoTarget) TerminalStatus {
+	status := TerminalStatus{Status: terminal.StatusMissing}
+
+	metadata := map[string]string{terminaltmux.SessionPathKey: target.Path}
+	info, integration, err := mgr.DiscoverSession(ctx, target.Name, metadata)
+	if err != nil {
+		log.Debug().Err(err).Str("repo", target.Name).Msg("root repo terminal discovery failed")
+		status.Error = err
+		return status
+	}
+	if info == nil || integration == nil {
+		return status
+	}
+
+	termStatus, err := integration.GetStatus(ctx, info)
+	if err != nil {
+		log.Debug().Err(err).Str("repo", target.Name).Msg("root repo terminal status lookup failed")
+		status.Error = err
+		return status
+	}
+
+	status.Status = termStatus
+	status.Tool = info.DetectedTool
+	status.WindowName = info.WindowName
+	status.PaneContent = info.PaneContent
+	return status
+}
+
 // fetchTerminalStatusForSession fetches terminal status for a single session.
 func fetchTerminalStatusForSession(ctx context.Context, mgr *terminal.Manager, sess *session.Session) TerminalStatus {
 	status := TerminalStatus{

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -358,12 +358,13 @@ func (d TreeDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 		line = d.renderSession(treeItem, isSelected, m, index)
 	}
 
-	// Selection indicator
+	// Selection indicator: a single-cell gutter keeps rows close to the left
+	// edge; the bar sits directly against the item content.
 	var prefix string
 	if isSelected {
-		prefix = d.Styles.SelectedBorder.Render("┃") + " "
+		prefix = d.Styles.SelectedBorder.Render("┃")
 	} else {
-		prefix = "  "
+		prefix = " "
 	}
 
 	_, _ = fmt.Fprintf(w, "%s%s", prefix, line)

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -410,9 +410,9 @@ func (d TreeDelegate) renderRecycledPlaceholder(item TreeItem, isSelected bool) 
 	// Tree prefix
 	var prefix string
 	if item.IsLastInRepo {
-		prefix = treeLast
+		prefix = " " + treeLast
 	} else {
-		prefix = treeBranch
+		prefix = " " + treeBranch
 	}
 	prefixStyled := d.Styles.TreeLine.Render(prefix)
 
@@ -431,9 +431,9 @@ func (d TreeDelegate) renderSession(item TreeItem, isSelected bool, m list.Model
 	// Tree prefix
 	var prefix string
 	if item.IsLastInRepo {
-		prefix = treeLast
+		prefix = " " + treeLast
 	} else {
-		prefix = treeBranch
+		prefix = " " + treeBranch
 	}
 	prefixStyled := d.Styles.TreeLine.Render(prefix)
 
@@ -506,9 +506,9 @@ func (d TreeDelegate) renderPane(item TreeItem, isSelected bool) string {
 
 	var parentLine string
 	if item.IsLastInRepo {
-		parentLine = "        "
+		parentLine = "         "
 	} else {
-		parentLine = "│       "
+		parentLine = " │       "
 	}
 	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
 
@@ -548,9 +548,9 @@ func (d TreeDelegate) renderWindow(item TreeItem, isSelected bool) string {
 	// The parent session's tree line continues vertically
 	var parentLine string
 	if item.IsLastInRepo {
-		parentLine = "    " // parent was └─, no continuing line
+		parentLine = "     " // parent was └─, no continuing line
 	} else {
-		parentLine = "│   " // parent was ├─, line continues
+		parentLine = " │   " // parent was ├─, line continues
 	}
 	prefixStyled := d.Styles.TreeLine.Render(parentLine + connector)
 

--- a/internal/tui/views/sessions/tree_view.go
+++ b/internal/tui/views/sessions/tree_view.go
@@ -9,9 +9,11 @@ import (
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
+	"github.com/colonyops/hive/internal/core/git"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/colonyops/hive/internal/core/workspace"
 	"github.com/colonyops/hive/internal/hive/plugins"
 	"github.com/colonyops/hive/internal/tui/components"
 	"github.com/colonyops/hive/pkg/kv"
@@ -112,6 +114,7 @@ type TreeItem struct {
 	// Header fields (only used when IsHeader is true)
 	RepoName      string
 	RepoRemote    string // Git remote URL for the repo group
+	RootPath      string // Path to the workspace checkout this repo was sourced from (empty if none discovered)
 	IsCurrentRepo bool
 
 	// Session fields (only used when IsHeader is false and IsRecycledPlaceholder is false)
@@ -167,9 +170,18 @@ func (i TreeItem) FilterValue() string {
 }
 
 // BuildTreeItems converts repo groups into tree items for the list.
-func BuildTreeItems(groups []RepoGroup, localRemote string) []list.Item {
+// Workspace repos are matched to groups by remote identity so headers can
+// surface the root checkout's path (git status, open-repo target).
+func BuildTreeItems(groups []RepoGroup, localRemote string, workspaceRepos []workspace.DiscoveredRepo) []list.Item {
 	if len(groups) == 0 {
 		return nil
+	}
+
+	rootPaths := make(map[string]string, len(workspaceRepos))
+	for _, repo := range workspaceRepos {
+		if identity := git.RemoteIdentity(repo.Remote); identity != "" {
+			rootPaths[identity] = repo.Path
+		}
 	}
 
 	items := make([]list.Item, 0)
@@ -184,6 +196,7 @@ func BuildTreeItems(groups []RepoGroup, localRemote string) []list.Item {
 			IsHeader:      true,
 			RepoName:      group.Name,
 			RepoRemote:    group.Remote,
+			RootPath:      rootPaths[git.RemoteIdentity(group.Remote)],
 			IsCurrentRepo: group.Remote == localRemote,
 		}
 		items = append(items, header)
@@ -356,7 +369,9 @@ func (d TreeDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 	_, _ = fmt.Fprintf(w, "%s%s", prefix, line)
 }
 
-// renderHeader renders a repository header.
+// renderHeader renders a repository header. When the repo has a discovered
+// workspace checkout (RootPath), the header also surfaces that checkout's
+// agent status dot and git status, making the root repo visible in the tree.
 func (d TreeDelegate) renderHeader(item TreeItem, isSelected bool, _ list.Model, _ int) string {
 	// Repo name
 	nameStyle := d.Styles.HeaderNormal
@@ -368,6 +383,22 @@ func (d TreeDelegate) renderHeader(item TreeItem, isSelected bool, _ list.Model,
 	// Append indicator for current repo
 	if item.IsCurrentRepo {
 		result += " " + d.Styles.HeaderStar.Render(currentRepoIndicator)
+	}
+
+	if item.RootPath == "" {
+		return result
+	}
+
+	// Status dot only when an agent is actually running in the root checkout;
+	// StatusMissing is the common case and would just add noise to every header.
+	if d.TerminalStatuses != nil {
+		if ts, ok := d.TerminalStatuses.Get(RootStatusKey(item.RootPath)); ok && ts.Status != terminal.StatusMissing {
+			result = renderStatusIndicator(session.StateActive, &ts, d.Styles, d.AnimationFrame) + " " + result
+		}
+	}
+
+	if !d.PreviewMode {
+		result += d.renderGitStatus(item.RootPath)
 	}
 
 	return result

--- a/internal/tui/views/sessions/tree_view_test.go
+++ b/internal/tui/views/sessions/tree_view_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/colonyops/hive/internal/core/session"
+	"github.com/colonyops/hive/internal/core/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +59,7 @@ func TestBuildTreeItems(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			items := BuildTreeItems(tt.groups, tt.localRemote)
+			items := BuildTreeItems(tt.groups, tt.localRemote, nil)
 
 			if tt.wantItems == 0 {
 				assert.Empty(t, items)
@@ -93,13 +94,46 @@ func TestBuildTreeItems_HeaderFields(t *testing.T) {
 		},
 	}
 
-	items := BuildTreeItems(groups, "git@github.com:user/local.git")
+	items := BuildTreeItems(groups, "git@github.com:user/local.git", nil)
 	require.Len(t, items, 3) // 1 header + 2 active sessions
 
 	header := items[0].(TreeItem)
 	assert.True(t, header.IsHeader)
 	assert.Equal(t, "local", header.RepoName)
 	assert.True(t, header.IsCurrentRepo)
+	assert.Empty(t, header.RootPath)
+}
+
+func TestBuildTreeItems_RootPathFromWorkspaceRepos(t *testing.T) {
+	groups := []RepoGroup{
+		{
+			Remote:   "git@github.com:user/alpha.git",
+			Name:     "alpha",
+			Sessions: []session.Session{{ID: "abc1", Name: "s1", State: session.StateActive}},
+		},
+		{
+			Remote:   "git@github.com:user/beta.git",
+			Name:     "beta",
+			Sessions: []session.Session{{ID: "abc2", Name: "s2", State: session.StateActive}},
+		},
+	}
+
+	repos := []workspace.DiscoveredRepo{
+		// HTTPS spelling must match the group's SSH remote (same GitHub repo).
+		{Name: "alpha", Path: "/code/alpha", Remote: "https://github.com/user/alpha.git"},
+		{Name: "unrelated", Path: "/code/unrelated", Remote: "git@github.com:user/unrelated.git"},
+	}
+
+	items := BuildTreeItems(groups, "", repos)
+	require.Len(t, items, 4)
+
+	alphaHeader := items[0].(TreeItem)
+	require.True(t, alphaHeader.IsHeader)
+	assert.Equal(t, "/code/alpha", alphaHeader.RootPath)
+
+	betaHeader := items[2].(TreeItem)
+	require.True(t, betaHeader.IsHeader)
+	assert.Empty(t, betaHeader.RootPath)
 }
 
 func TestBuildTreeItems_SessionFields(t *testing.T) {
@@ -115,7 +149,7 @@ func TestBuildTreeItems_SessionFields(t *testing.T) {
 		},
 	}
 
-	items := BuildTreeItems(groups, "")
+	items := BuildTreeItems(groups, "", nil)
 	require.Len(t, items, 3) // 1 header + 2 sessions
 
 	// First session

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -17,6 +17,7 @@ import (
 	act "github.com/colonyops/hive/internal/core/action"
 	"github.com/colonyops/hive/internal/core/config"
 	"github.com/colonyops/hive/internal/core/eventbus"
+	"github.com/colonyops/hive/internal/core/git"
 	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/styles"
 	"github.com/colonyops/hive/internal/core/terminal"
@@ -345,10 +346,22 @@ func (v *View) handleTerminalPollTick() tea.Cmd {
 		sessPtrs[i] = &v.allSessions[i]
 	}
 	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+	cmds = append(cmds, FetchRootRepoStatusBatch(v.terminalManager, v.rootRepoTargets(), v.gitWorkers))
 	if v.terminalManager.HasEnabledIntegrations() {
 		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
 	}
 	return tea.Batch(cmds...)
+}
+
+// rootRepoTargets collects workspace checkouts currently shown as repo headers.
+func (v *View) rootRepoTargets() []RootRepoTarget {
+	var targets []RootRepoTarget
+	for _, ti := range TreeItemsAll(v.list.Items()) {
+		if ti.IsHeader && ti.RootPath != "" {
+			targets = append(targets, RootRepoTarget{Name: ti.RepoName, Path: ti.RootPath})
+		}
+	}
+	return targets
 }
 
 func (v *View) handlePluginWorkerStarted(msg pluginWorkerStartedMsg) tea.Cmd {
@@ -382,7 +395,9 @@ func (v *View) handleReposDiscovered(msg reposDiscoveredMsg) tea.Cmd {
 	if msg.err != nil {
 		return ErrorCmd(fmt.Errorf("repo scan error: %w", msg.err))
 	}
-	return nil
+	// Rebuild the tree so headers pick up root checkout paths; the scan
+	// usually completes after the initial session load has built items.
+	return v.applyFilter()
 }
 
 func (v *View) handleSessionRefreshTick() tea.Cmd {
@@ -564,12 +579,14 @@ func (v *View) handleRecycledPlaceholderKey(keyStr string, treeItem *TreeItem) (
 }
 
 func (v *View) handleRepoHeaderKey(header *TreeItem) (*View, tea.Cmd) {
-	// Find the original repo path from discovered repos
-	var repoPath string
-	for _, repo := range v.discoveredRepos {
-		if repo.Remote == header.RepoRemote {
-			repoPath = repo.Path
-			break
+	repoPath := header.RootPath
+	if repoPath == "" {
+		// Headers built before the workspace scan finished lack RootPath.
+		for _, repo := range v.discoveredRepos {
+			if git.EquivalentRemote(repo.Remote, header.RepoRemote) {
+				repoPath = repo.Path
+				break
+			}
 		}
 	}
 	if repoPath == "" {
@@ -580,6 +597,7 @@ func (v *View) handleRepoHeaderKey(header *TreeItem) (*View, tea.Cmd) {
 		return OpenRepoRequestMsg{
 			Name:   header.RepoName,
 			Remote: header.RepoRemote,
+			Path:   repoPath,
 		}
 	}
 }
@@ -704,7 +722,7 @@ func (v *View) applyFilter() tea.Cmd {
 	} else {
 		groups = GroupSessionsByRepo(filteredSess, localRemote)
 	}
-	items := BuildTreeItems(groups, localRemote)
+	items := BuildTreeItems(groups, localRemote, v.discoveredRepos)
 	items = v.expandWindowItems(items)
 	*v.columnWidths = CalculateColumnWidths(filteredSess, nil)
 
@@ -715,6 +733,14 @@ func (v *View) applyFilter() tea.Cmd {
 		paths = append(paths, s.Path)
 		if !v.refreshing {
 			v.gitStatuses.Set(s.Path, GitStatus{IsLoading: true})
+		}
+	}
+	for _, ti := range TreeItemsAll(items) {
+		if ti.IsHeader && ti.RootPath != "" {
+			paths = append(paths, ti.RootPath)
+			if !v.refreshing {
+				v.gitStatuses.Set(ti.RootPath, GitStatus{IsLoading: true})
+			}
 		}
 	}
 
@@ -1240,9 +1266,15 @@ func (v *View) RefreshGitStatuses() tea.Cmd {
 	items := v.list.Items()
 	paths := make([]string, 0, len(items))
 
-	for _, ti := range TreeItemsSessions(items) {
-		paths = append(paths, ti.Session.Path)
-		v.gitStatuses.Set(ti.Session.Path, GitStatus{IsLoading: true})
+	for _, ti := range TreeItemsAll(items) {
+		switch {
+		case ti.IsSession():
+			paths = append(paths, ti.Session.Path)
+			v.gitStatuses.Set(ti.Session.Path, GitStatus{IsLoading: true})
+		case ti.IsHeader && ti.RootPath != "":
+			paths = append(paths, ti.RootPath)
+			v.gitStatuses.Set(ti.RootPath, GitStatus{IsLoading: true})
+		}
 	}
 
 	if len(paths) == 0 {

--- a/internal/tui/views/sessions/view.go
+++ b/internal/tui/views/sessions/view.go
@@ -292,7 +292,7 @@ func (v *View) handleSessionsLoaded(msg sessionsLoadedMsg) tea.Cmd {
 		for i := range v.allSessions {
 			sessPtrs[i] = &v.allSessions[i]
 		}
-		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
+		cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.rootRepoTargets(), v.gitWorkers))
 	}
 	return tea.Batch(cmds...)
 }
@@ -345,8 +345,7 @@ func (v *View) handleTerminalPollTick() tea.Cmd {
 	for i := range allSess {
 		sessPtrs[i] = &v.allSessions[i]
 	}
-	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.gitWorkers))
-	cmds = append(cmds, FetchRootRepoStatusBatch(v.terminalManager, v.rootRepoTargets(), v.gitWorkers))
+	cmds = append(cmds, FetchTerminalStatusBatch(v.terminalManager, sessPtrs, v.rootRepoTargets(), v.gitWorkers))
 	if v.terminalManager.HasEnabledIntegrations() {
 		cmds = append(cmds, StartTerminalPollTicker(v.cfg.Tmux.PollInterval))
 	}
@@ -397,7 +396,12 @@ func (v *View) handleReposDiscovered(msg reposDiscoveredMsg) tea.Cmd {
 	}
 	// Rebuild the tree so headers pick up root checkout paths; the scan
 	// usually completes after the initial session load has built items.
-	return v.applyFilter()
+	// Fetch root statuses immediately rather than waiting for the next poll
+	// tick — this is the first moment root targets exist.
+	return tea.Batch(
+		v.applyFilter(),
+		FetchTerminalStatusBatch(v.terminalManager, nil, v.rootRepoTargets(), v.gitWorkers),
+	)
 }
 
 func (v *View) handleSessionRefreshTick() tea.Cmd {
@@ -975,7 +979,11 @@ func (v *View) renderDualColumnLayout(contentHeight int) string {
 	selected := v.SelectedSession()
 	var previewContent string
 
-	if selected != nil {
+	if selected == nil {
+		previewContent = v.renderRootRepoPreview(contentHeight, previewWidth)
+	}
+
+	if selected != nil { //nolint:nestif
 		// Check if this is the current session (would cause recursive preview)
 		isSelf := v.isCurrentTmuxSession(selected)
 
@@ -1008,7 +1016,7 @@ func (v *View) renderDualColumnLayout(contentHeight int) string {
 		default:
 			previewContent = v.renderPreviewHeader(selected, previewWidth-4) + "\n\nNo pane content available"
 		}
-	} else {
+	} else if previewContent == "" {
 		previewContent = "No session selected"
 	}
 
@@ -1051,10 +1059,6 @@ func (v *View) renderPreviewHeader(sess *session.Session, maxWidth int) string {
 	nameStyle := styles.PreviewHeaderNameStyle
 	separatorStyle := styles.TextMutedStyle
 	idStyle := styles.TextSecondaryStyle
-	branchStyle := styles.TextSecondaryStyle
-	addStyle := styles.TextSuccessStyle
-	delStyle := styles.TextErrorStyle
-	dirtyStyle := styles.TextWarningStyle
 	dividerStyle := styles.TextMutedStyle
 
 	divider := strings.Repeat("─", maxWidth)
@@ -1077,20 +1081,8 @@ func (v *View) renderPreviewHeader(sess *session.Session, maxWidth int) string {
 	var statusParts []string
 
 	// Git status
-	if v.gitStatuses != nil {
-		if status, ok := v.gitStatuses.Get(sess.Path); ok && !status.IsLoading && status.Error == nil {
-			gitPart := branchStyle.Render("(")
-			if iconsEnabled {
-				gitPart += branchStyle.Render(styles.IconGitBranch + " ")
-			}
-			gitPart += branchStyle.Render(status.Branch + ")")
-			gitPart += " " + addStyle.Render("+"+fmt.Sprintf("%d", status.Additions))
-			gitPart += " " + delStyle.Render("-"+fmt.Sprintf("%d", status.Deletions))
-			if status.HasChanges && iconsEnabled {
-				gitPart += " " + dirtyStyle.Render(styles.IconGit)
-			}
-			statusParts = append(statusParts, gitPart)
-		}
+	if gitPart := v.previewGitStatusPart(sess.Path, iconsEnabled); gitPart != "" {
+		statusParts = append(statusParts, gitPart)
 	}
 
 	// Plugin statuses (neutral color)
@@ -1125,6 +1117,86 @@ func (v *View) renderPreviewHeader(sess *session.Session, maxWidth int) string {
 	if status != "" {
 		parts = append(parts, status)
 	}
+	parts = append(parts, "")
+	parts = append(parts, styles.TextMutedStyle.Render("Output"))
+	parts = append(parts, dividerStyle.Render(divider))
+
+	return strings.Join(parts, "\n")
+}
+
+// previewGitStatusPart formats the git status fragment for a preview header,
+// or returns "" when no loaded status exists for the path.
+func (v *View) previewGitStatusPart(path string, iconsEnabled bool) string {
+	if v.gitStatuses == nil {
+		return ""
+	}
+	status, ok := v.gitStatuses.Get(path)
+	if !ok || status.IsLoading || status.Error != nil {
+		return ""
+	}
+
+	branchStyle := styles.TextSecondaryStyle
+	gitPart := branchStyle.Render("(")
+	if iconsEnabled {
+		gitPart += branchStyle.Render(styles.IconGitBranch + " ")
+	}
+	gitPart += branchStyle.Render(status.Branch + ")")
+	gitPart += " " + styles.TextSuccessStyle.Render("+"+fmt.Sprintf("%d", status.Additions))
+	gitPart += " " + styles.TextErrorStyle.Render("-"+fmt.Sprintf("%d", status.Deletions))
+	if status.HasChanges && iconsEnabled {
+		gitPart += " " + styles.TextWarningStyle.Render(styles.IconGit)
+	}
+	return gitPart
+}
+
+// renderRootRepoPreview renders the preview pane for a selected repo header's
+// root checkout, or returns "" when the selection isn't a header with a
+// discovered workspace checkout.
+func (v *View) renderRootRepoPreview(contentHeight, previewWidth int) string {
+	ti := v.SelectedTreeItem()
+	if ti == nil || !ti.IsHeader || ti.RootPath == "" {
+		return ""
+	}
+
+	usableWidth := previewWidth - 4
+	header := v.renderRootPreviewHeader(ti, usableWidth)
+
+	// The root repo's tmux session is named after the repo; previewing it
+	// while hive runs inside it would capture hive's own pane recursively.
+	if v.currentTmuxSession != "" && v.currentTmuxSession == ti.RepoName {
+		return header + "\n\n(current session, preventing recursive view)"
+	}
+
+	status, ok := v.terminalStatuses.Get(RootStatusKey(ti.RootPath))
+	if !ok || status.PaneContent == "" {
+		return header + "\n\nNo pane content available"
+	}
+
+	headerHeight := strings.Count(header, "\n") + 1
+	outputHeight := max(contentHeight-headerHeight, 1)
+	content := tailLines(status.PaneContent, outputHeight)
+	content = truncateLines(content, usableWidth)
+	return header + "\n" + content
+}
+
+// renderRootPreviewHeader renders the preview header for a root checkout:
+// repo name, git status, and the checkout path in place of a session ID.
+func (v *View) renderRootPreviewHeader(ti *TreeItem, maxWidth int) string {
+	separatorStyle := styles.TextMutedStyle
+	dividerStyle := styles.TextMutedStyle
+	divider := strings.Repeat("─", max(maxWidth, 1))
+
+	title := styles.PreviewHeaderNameStyle.Render(ti.RepoName) +
+		separatorStyle.Render(" • root")
+
+	var parts []string
+	parts = append(parts, title)
+	parts = append(parts, dividerStyle.Render(divider))
+	status := v.previewGitStatusPart(ti.RootPath, v.cfg.TUI.IconsEnabled())
+	if status != "" {
+		parts = append(parts, status)
+	}
+	parts = append(parts, styles.TextMutedStyle.Render(ti.RootPath))
 	parts = append(parts, "")
 	parts = append(parts, styles.TextMutedStyle.Render("Output"))
 	parts = append(parts, dividerStyle.Render(divider))


### PR DESCRIPTION
## Purpose

Working in the root repository (the workspace checkout sessions are cloned from) was supported but invisible: `enter` on a repo header opened a tmux session there, yet nothing indicated the checkout existed, its branch/dirty state, or that an agent was running in it. This makes the root checkout a first-class citizen of the sessions sidebar.

## Proposed Changes

- Repo headers show the root checkout's git status and, when an agent is running in its tmux session, the same status indicator sessions get (suffix-positioned so header names stay left-anchored)
- Selecting a header in preview mode shows the root checkout like a session: name + `root` marker, git status, path, and live agent pane output
- Root checkouts are matched to repo groups by remote identity (`git.RemoteIdentity`) instead of exact remote strings, so ssh/https spellings of the same GitHub repo now match — the open-repo path previously failed silently on spelling mismatches
- Root statuses are fetched in the same batch as session statuses (a separate command raced the tmux cache refresh and missed statuses), and immediately on session load / workspace scan completion rather than waiting for a poll tick
- Tree layout tightened: single-cell gutter, child rows indented one cell under headers

Deliberately kept as header enrichment rather than a "root" child row: the primary checkout must never look like a sibling of disposable worktree sessions or gain their lifecycle actions (recycle/delete). Headers without a discovered workspace checkout — including group-by-tag mode — render exactly as before.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
