### PR TITLE
Allow embedders to control tmux status commands

### DIFF
--- a/internal/core/terminal/tmux/capture.go
+++ b/internal/core/terminal/tmux/capture.go
@@ -3,15 +3,20 @@ package tmux
 import (
 	"context"
 	"fmt"
-	"os/exec"
 )
 
 // TmuxCapture implements classifier.ContentCapture via tmux capture-pane.
-type TmuxCapture struct{}
+type TmuxCapture struct {
+	commander Commander
+}
 
 // CapturePane captures content from a tmux pane or target address.
-func (TmuxCapture) CapturePane(ctx context.Context, target string) (string, error) {
-	output, err := exec.CommandContext(ctx, "tmux", "capture-pane", "-t", target, "-p", "-J").Output()
+func (c TmuxCapture) CapturePane(ctx context.Context, target string) (string, error) {
+	commander := c.commander
+	if commander == nil {
+		commander = execCommander{}
+	}
+	output, err := commander.Output(ctx, "capture-pane", "-t", target, "-p", "-J")
 	if err != nil {
 		return "", fmt.Errorf("capture-pane failed: %w", err)
 	}

--- a/internal/core/terminal/tmux/commander.go
+++ b/internal/core/terminal/tmux/commander.go
@@ -1,0 +1,25 @@
+package tmux
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Commander runs tmux commands for an Integration. Implementations may select
+// an absolute binary, environment, or server socket for embedded use. Methods
+// may be called concurrently and must be safe for concurrent use.
+type Commander interface {
+	Available() bool
+	Output(ctx context.Context, args ...string) ([]byte, error)
+}
+
+type execCommander struct{}
+
+func (execCommander) Available() bool {
+	_, err := exec.LookPath("tmux")
+	return err == nil
+}
+
+func (execCommander) Output(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "tmux", args...).Output()
+}

--- a/internal/core/terminal/tmux/commander_test.go
+++ b/internal/core/terminal/tmux/commander_test.go
@@ -1,0 +1,54 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/colonyops/hive/internal/core/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCommander struct {
+	available bool
+	calls     [][]string
+}
+
+func (f *fakeCommander) Available() bool { return f.available }
+
+func (f *fakeCommander) Output(_ context.Context, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, slices.Clone(args))
+	switch args[0] {
+	case "list-panes":
+		return []byte("session|||0|||shell|||/work|||100|||%1|||0|||shell|||session\n"), nil
+	case "capture-pane":
+		return []byte("## Task\n● Finished\n❯ "), nil
+	default:
+		return nil, fmt.Errorf("unexpected tmux command %q", args[0])
+	}
+}
+
+func TestWithCommanderControlsAvailabilityListingAndCapture(t *testing.T) {
+	commander := &fakeCommander{}
+	integration := NewFromPreviewMatchers([]string{"claude"}, WithCommander(commander))
+
+	assert.False(t, integration.Available())
+	commander.available = true
+	assert.True(t, integration.Available(), "availability failures must not be cached")
+
+	integration.RefreshCache()
+	info, err := integration.DiscoverSession(t.Context(), "session", nil)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	status, err := integration.GetStatus(t.Context(), info)
+	require.NoError(t, err)
+	assert.Equal(t, terminal.StatusReady, status)
+	assert.Equal(t, "## Task\n● Finished\n❯ ", info.PaneContent)
+	require.Len(t, commander.calls, 3)
+	assert.Equal(t, "list-panes", commander.calls[0][0])
+	assert.Equal(t, []string{"capture-pane", "-t", "%1", "-p", "-J"}, commander.calls[1])
+	assert.Equal(t, []string{"capture-pane", "-t", "%1", "-p", "-J"}, commander.calls[2])
+}

--- a/internal/core/terminal/tmux/pane_lister.go
+++ b/internal/core/terminal/tmux/pane_lister.go
@@ -1,8 +1,8 @@
 package tmux
 
 import (
+	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/colonyops/hive/internal/core/terminal/classifier"
@@ -15,7 +15,9 @@ type PaneLister interface {
 }
 
 // TmuxPaneLister calls tmux list-panes -a and parses the output.
-type TmuxPaneLister struct{}
+type TmuxPaneLister struct {
+	commander Commander
+}
 
 // listPanesFormat is the delimited format used for `tmux list-panes -a`.
 // tmux replaces literal tab format separators with underscores, so use a
@@ -42,8 +44,12 @@ type paneLine struct {
 }
 
 // ListAllPanes returns all tmux panes visible to the current tmux client.
-func (TmuxPaneLister) ListAllPanes() ([]classifier.PaneInput, error) {
-	output, err := exec.Command("tmux", "list-panes", "-a", "-F", listPanesFormat).Output()
+func (l TmuxPaneLister) ListAllPanes() ([]classifier.PaneInput, error) {
+	commander := l.commander
+	if commander == nil {
+		commander = execCommander{}
+	}
+	output, err := commander.Output(context.Background(), "list-panes", "-a", "-F", listPanesFormat)
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes failed: %w", err)
 	}

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -3,7 +3,6 @@ package tmux
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -30,8 +29,7 @@ type Integration struct {
 	trackers        map[string]*terminal.StateTracker
 	limiters        map[string]*terminal.RateLimiter
 	contentLimiters map[string]*terminal.RateLimiter // per-pane Tier 3 rate limiter
-	available       bool
-	availableOnce   sync.Once
+	commander       Commander
 	classifier      *classifier.Classifier
 	classCache      *classifier.Cache
 	processReader   process.ProcessReader
@@ -128,19 +126,33 @@ func WithCaptureRecorder(recorder CaptureRecorder) Option {
 	}
 }
 
+// WithCommander uses commander for tmux discovery, pane listing, and capture.
+// Embedders can supply an absolute binary, environment, or socket selection
+// without changing the process-wide environment.
+func WithCommander(commander Commander) Option {
+	return func(integration *Integration) {
+		if commander != nil {
+			integration.commander = commander
+		}
+	}
+}
+
 // NewFromPreviewMatchers creates the production tmux integration from config
 // matchers. Tool names for process detection are derived automatically from
 // the pattern strings (e.g. "^pi$" → "pi"), so callers only need to pass
 // the single PreviewWindowMatcher slice from config.
 func NewFromPreviewMatchers(previewMatchers []string, options ...Option) *Integration {
-	capture := TmuxCapture{}
 	reader := process.OSReader{}
-	agentNames := classifier.ToolNamesFromPatterns(previewMatchers)
-	cls := classifier.New(classifier.TitlePatternsFromConfig(previewMatchers, agentNames), reader, capture, content.NewScorer())
-	integration := NewWithReader(cls, TmuxPaneLister{}, reader)
+	integration := newIntegration(reader)
 	for _, option := range options {
 		option(integration)
 	}
+
+	capture := TmuxCapture{commander: integration.commander}
+	agentNames := classifier.ToolNamesFromPatterns(previewMatchers)
+	integration.classifier = classifier.New(classifier.TitlePatternsFromConfig(previewMatchers, agentNames), reader, capture, content.NewScorer())
+	integration.lister = TmuxPaneLister{commander: integration.commander}
+	integration.capture = capture
 	return integration
 }
 
@@ -151,26 +163,32 @@ func New(cls *classifier.Classifier, lister PaneLister) *Integration {
 
 // NewWithReader creates a tmux integration with explicit dependencies for tests.
 func NewWithReader(cls *classifier.Classifier, lister PaneLister, reader process.ProcessReader) *Integration {
-	capture := TmuxCapture{}
 	if reader == nil {
 		reader = process.OSReader{}
 	}
+	integration := newIntegration(reader)
+	capture := TmuxCapture{commander: integration.commander}
 	if cls == nil {
 		cls = classifier.New(nil, reader, capture, nil)
 	}
 	if lister == nil {
-		lister = TmuxPaneLister{}
+		lister = TmuxPaneLister{commander: integration.commander}
 	}
+	integration.classifier = cls
+	integration.lister = lister
+	integration.capture = capture
+	return integration
+}
+
+func newIntegration(reader process.ProcessReader) *Integration {
 	return &Integration{
 		cache:           make(map[string]*sessionCache),
 		trackers:        make(map[string]*terminal.StateTracker),
 		limiters:        make(map[string]*terminal.RateLimiter),
 		contentLimiters: make(map[string]*terminal.RateLimiter),
-		classifier:      cls,
+		commander:       execCommander{},
 		classCache:      classifier.NewCache(),
 		processReader:   reader,
-		lister:          lister,
-		capture:         capture,
 	}
 }
 
@@ -182,11 +200,7 @@ func (t *Integration) Name() string { return "tmux" }
 
 // Available returns true if tmux is installed and accessible.
 func (t *Integration) Available() bool {
-	t.availableOnce.Do(func() {
-		_, err := exec.LookPath("tmux")
-		t.available = err == nil
-	})
-	return t.available
+	return t.commander != nil && t.commander.Available()
 }
 
 // RefreshCache updates cached pane classifications. Call once per poll cycle.


### PR DESCRIPTION
## Purpose

Allow embedded hosts to use terminal status detection when tmux is resolved outside the process PATH or requires host-specific environment and socket selection.

## Proposed Changes

- Add an injectable, concurrency-safe tmux commander while preserving the existing exec-based default.
- Route availability, pane discovery, classifier captures, and status captures through the same commander.
- Retry availability after failures so installing or resolving tmux later does not require restarting the host.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)