### PR TITLE
Expose terminal liveness and stable window IDs

### DIFF
--- a/internal/core/terminal/classifier/classifier.go
+++ b/internal/core/terminal/classifier/classifier.go
@@ -43,6 +43,7 @@ type PaneInput struct {
 	SessionName string
 	PaneID      string
 	PanePID     int64
+	WindowID    string
 	WindowIndex string
 	WindowName  string
 	PaneTitle   string

--- a/internal/core/terminal/terminal.go
+++ b/internal/core/terminal/terminal.go
@@ -16,6 +16,7 @@ const (
 // SessionInfo holds information about a discovered terminal session.
 type SessionInfo struct {
 	Name         string // terminal session name (e.g., tmux session name)
+	WindowID     string // stable tmux window ID in @N format
 	WindowIndex  string // tmux window index (e.g., "0", "1")
 	PaneID       string // tmux pane ID in %N format
 	WindowName   string // window name (for display and template data)

--- a/internal/core/terminal/tmux/commander_test.go
+++ b/internal/core/terminal/tmux/commander_test.go
@@ -22,7 +22,7 @@ func (f *fakeCommander) Output(_ context.Context, args ...string) ([]byte, error
 	f.calls = append(f.calls, slices.Clone(args))
 	switch args[0] {
 	case "list-panes":
-		return []byte("session|||0|||shell|||/work|||100|||%1|||0|||shell|||session\n"), nil
+		return []byte("session|||@1|||0|||shell|||/work|||100|||%1|||0|||shell|||session\n"), nil
 	case "capture-pane":
 		return []byte("## Task\n● Finished\n❯ "), nil
 	default:
@@ -42,6 +42,7 @@ func TestWithCommanderControlsAvailabilityListingAndCapture(t *testing.T) {
 	info, err := integration.DiscoverSession(t.Context(), "session", nil)
 	require.NoError(t, err)
 	require.NotNil(t, info)
+	assert.Equal(t, "@1", info.WindowID)
 
 	status, err := integration.GetStatus(t.Context(), info)
 	require.NoError(t, err)

--- a/internal/core/terminal/tmux/pane_lister.go
+++ b/internal/core/terminal/tmux/pane_lister.go
@@ -22,17 +22,19 @@ type TmuxPaneLister struct {
 // listPanesFormat is the delimited format used for `tmux list-panes -a`.
 // tmux replaces literal tab format separators with underscores, so use a
 // printable delimiter that survives format rendering.
-// Fields: session_name, window_index, window_name, pane_current_path,
-// window_activity, pane_id, pane_pid, pane_title, @hive-session.
+// Fields: session_name, window_id, window_index, window_name,
+// pane_current_path, window_activity, pane_id, pane_pid, pane_title,
+// @hive-session.
 const listPanesDelimiter = "|||"
 
-const listPanesFormat = "#{session_name}" + listPanesDelimiter + "#{window_index}" + listPanesDelimiter + "#{window_name}" + listPanesDelimiter +
+const listPanesFormat = "#{session_name}" + listPanesDelimiter + "#{window_id}" + listPanesDelimiter + "#{window_index}" + listPanesDelimiter + "#{window_name}" + listPanesDelimiter +
 	"#{pane_current_path}" + listPanesDelimiter + "#{window_activity}" + listPanesDelimiter + "#{pane_id}" + listPanesDelimiter +
 	"#{pane_pid}" + listPanesDelimiter + "#{pane_title}" + listPanesDelimiter + "#{@hive-session}"
 
 // paneLine is the parsed form of one line of `tmux list-panes` output.
 type paneLine struct {
 	sessName    string
+	winID       string
 	winIdx      string
 	winName     string
 	workDir     string
@@ -76,6 +78,7 @@ func paneInputFromLine(pl paneLine) classifier.PaneInput {
 		SessionName: pl.sessName,
 		PaneID:      pl.paneID,
 		PanePID:     pl.panePID,
+		WindowID:    pl.winID,
 		WindowIndex: pl.winIdx,
 		WindowName:  pl.winName,
 		PaneTitle:   pl.paneTitle,
@@ -87,26 +90,27 @@ func paneInputFromLine(pl paneLine) classifier.PaneInput {
 
 // parsePaneLine parses one delimited line in listPanesFormat.
 func parsePaneLine(line string) (paneLine, bool) {
-	parts := strings.SplitN(line, listPanesDelimiter, 9)
-	if len(parts) < 6 || line == "" {
+	parts := strings.SplitN(line, listPanesDelimiter, 10)
+	if len(parts) < 7 || line == "" {
 		return paneLine{}, false
 	}
 	pl := paneLine{
 		sessName: parts[0],
-		winIdx:   parts[1],
-		winName:  parts[2],
-		workDir:  parts[3],
-		paneID:   parts[5],
+		winID:    parts[1],
+		winIdx:   parts[2],
+		winName:  parts[3],
+		workDir:  parts[4],
+		paneID:   parts[6],
 	}
-	_, _ = fmt.Sscanf(parts[4], "%d", &pl.activity)
-	if len(parts) >= 7 {
-		_, _ = fmt.Sscanf(parts[6], "%d", &pl.panePID)
-	}
+	_, _ = fmt.Sscanf(parts[5], "%d", &pl.activity)
 	if len(parts) >= 8 {
-		pl.paneTitle = parts[7]
+		_, _ = fmt.Sscanf(parts[7], "%d", &pl.panePID)
 	}
 	if len(parts) >= 9 {
-		pl.hiveSession = strings.TrimSpace(parts[8])
+		pl.paneTitle = parts[8]
+	}
+	if len(parts) >= 10 {
+		pl.hiveSession = strings.TrimSpace(parts[9])
 	}
 	return pl, true
 }

--- a/internal/core/terminal/tmux/parse_test.go
+++ b/internal/core/terminal/tmux/parse_test.go
@@ -14,35 +14,35 @@ func TestParsePaneLine(t *testing.T) {
 		ok   bool
 	}{
 		{
-			name: "9 fields with pane title and hive tag",
-			line: "sess|||1|||wname|||/work|||12345|||%2|||6789|||ptitle|||my-slug",
+			name: "10 fields with pane title and hive tag",
+			line: "sess|||@2|||1|||wname|||/work|||12345|||%2|||6789|||ptitle|||my-slug",
 			want: paneLine{
-				sessName: "sess", winIdx: "1", winName: "wname", workDir: "/work",
+				sessName: "sess", winID: "@2", winIdx: "1", winName: "wname", workDir: "/work",
 				activity: 12345, paneID: "%2", panePID: 6789, paneTitle: "ptitle", hiveSession: "my-slug",
 			},
 			ok: true,
 		},
 		{
-			name: "8 fields with pane title and no hive tag",
-			line: "sess|||0|||bash|||/home|||100|||%0|||1234|||ptitle",
+			name: "9 fields with pane title and no hive tag",
+			line: "sess|||@0|||0|||bash|||/home|||100|||%0|||1234|||ptitle",
 			want: paneLine{
-				sessName: "sess", winIdx: "0", winName: "bash", workDir: "/home",
+				sessName: "sess", winID: "@0", winIdx: "0", winName: "bash", workDir: "/home",
 				activity: 100, paneID: "%0", panePID: 1234, paneTitle: "ptitle",
 			},
 			ok: true,
 		},
 		{
-			name: "6 fields (no panePID, no tag)",
-			line: "sess|||0|||bash|||/home|||100|||%0",
+			name: "7 fields (no panePID, no tag)",
+			line: "sess|||@0|||0|||bash|||/home|||100|||%0",
 			want: paneLine{
-				sessName: "sess", winIdx: "0", winName: "bash", workDir: "/home",
+				sessName: "sess", winID: "@0", winIdx: "0", winName: "bash", workDir: "/home",
 				activity: 100, paneID: "%0",
 			},
 			ok: true,
 		},
 		{
-			name: "5 fields rejected",
-			line: "sess|||0|||bash|||/home|||100",
+			name: "6 fields rejected",
+			line: "sess|||@0|||0|||bash|||/home|||100",
 			ok:   false,
 		},
 		{
@@ -52,18 +52,18 @@ func TestParsePaneLine(t *testing.T) {
 		},
 		{
 			name: "malformed activity treated as zero",
-			line: "sess|||0|||bash|||/home|||notanumber|||%0|||1234",
+			line: "sess|||@0|||0|||bash|||/home|||notanumber|||%0|||1234",
 			want: paneLine{
-				sessName: "sess", winIdx: "0", winName: "bash", workDir: "/home",
+				sessName: "sess", winID: "@0", winIdx: "0", winName: "bash", workDir: "/home",
 				activity: 0, paneID: "%0", panePID: 1234,
 			},
 			ok: true,
 		},
 		{
 			name: "tag with surrounding whitespace trimmed",
-			line: "sess|||1|||wname|||/work|||12345|||%2|||6789|||ptitle|||  my-slug  ",
+			line: "sess|||@2|||1|||wname|||/work|||12345|||%2|||6789|||ptitle|||  my-slug  ",
 			want: paneLine{
-				sessName: "sess", winIdx: "1", winName: "wname", workDir: "/work",
+				sessName: "sess", winID: "@2", winIdx: "1", winName: "wname", workDir: "/work",
 				activity: 12345, paneID: "%2", panePID: 6789, paneTitle: "ptitle", hiveSession: "my-slug",
 			},
 			ok: true,
@@ -83,9 +83,10 @@ func TestParsePaneLine(t *testing.T) {
 }
 
 func TestParsePaneList(t *testing.T) {
-	got := parsePaneList("sess|||0|||claude|||/work|||100|||%1|||123|||ptitle|||my-slug\n")
+	got := parsePaneList("sess|||@1|||0|||claude|||/work|||100|||%1|||123|||ptitle|||my-slug\n")
 	assert.Len(t, got, 1)
 	assert.Equal(t, "sess", got[0].SessionName)
+	assert.Equal(t, "@1", got[0].WindowID)
 	assert.Equal(t, "%1", got[0].PaneID)
 	assert.Equal(t, int64(123), got[0].PanePID)
 	assert.Equal(t, "ptitle", got[0].PaneTitle)

--- a/internal/core/terminal/tmux/tmux.go
+++ b/internal/core/terminal/tmux/tmux.go
@@ -385,6 +385,9 @@ func (t *Integration) DiscoverSession(_ context.Context, slug string, metadata m
 	}
 
 	pane := disambiguatePane(sc, metadata[SessionPathKey], slug)
+	if pane == nil {
+		return &terminal.SessionInfo{Name: sessionName}, nil
+	}
 	return sessionInfoFromPane(sessionName, pane), nil
 }
 
@@ -418,6 +421,7 @@ func sessionInfoFromPane(sessionName string, pane *cachedPane) *terminal.Session
 	}
 	return &terminal.SessionInfo{
 		Name:         sessionName,
+		WindowID:     pane.input.WindowID,
 		WindowIndex:  pane.input.WindowIndex,
 		PaneID:       pane.input.PaneID,
 		WindowName:   pane.input.WindowName,

--- a/internal/core/terminal/tmux/tmux_test.go
+++ b/internal/core/terminal/tmux/tmux_test.go
@@ -273,35 +273,56 @@ func TestRefreshCache_ResetsStateOnPIDChange(t *testing.T) {
 func TestDiscoverSession(t *testing.T) {
 	integ := New(nil, nil)
 	integ.cache = map[string]*sessionCache{"my-session": {panes: []cachedPane{
-		{input: classifier.PaneInput{PaneID: "%1", WindowIndex: "0", WindowName: testToolClaude, WorkDir: "/a", Activity: 100}, result: classifier.Result{IsAgent: true, Tool: testToolClaude}},
-		{input: classifier.PaneInput{PaneID: "%2", WindowIndex: "1", WindowName: testToolCodex, WorkDir: "/b", Activity: 200}, result: classifier.Result{IsAgent: true, Tool: testToolCodex}},
+		{input: classifier.PaneInput{PaneID: "%1", WindowID: "@1", WindowIndex: "0", WindowName: testToolClaude, WorkDir: "/a", Activity: 100}, result: classifier.Result{IsAgent: true, Tool: testToolClaude}},
+		{input: classifier.PaneInput{PaneID: "%2", WindowID: "@2", WindowIndex: "1", WindowName: testToolCodex, WorkDir: "/b", Activity: 200}, result: classifier.Result{IsAgent: true, Tool: testToolCodex}},
 	}}}
 	integ.cacheTime = time.Now()
 
 	info, err := integ.DiscoverSession(context.Background(), "my-session", map[string]string{SessionPathKey: "/b"})
 	require.NoError(t, err)
 	require.NotNil(t, info)
+	assert.Equal(t, "@2", info.WindowID)
 	assert.Equal(t, "%2", info.PaneID)
 
 	info, err = integ.DiscoverSession(context.Background(), "my-session", map[string]string{"tmux_window": "0"})
 	require.NoError(t, err)
 	require.NotNil(t, info)
+	assert.Equal(t, "@1", info.WindowID)
 	assert.Equal(t, "%1", info.PaneID)
+}
+
+func TestDiscoverSessionReportsAnExistingSessionWithoutAnAgentPane(t *testing.T) {
+	integ := New(nil, nil)
+	integ.cache = map[string]*sessionCache{"shell-only": {panes: []cachedPane{{
+		input:  classifier.PaneInput{PaneID: "%1", WindowID: "@1", WindowIndex: "0", WindowName: "shell"},
+		result: classifier.Result{IsAgent: false},
+	}}}}
+	integ.cacheTime = time.Now()
+
+	info, err := integ.DiscoverSession(t.Context(), "shell-only", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "shell-only", info.Name)
+	assert.Empty(t, info.PaneID)
+	assert.Empty(t, info.WindowID)
 }
 
 func TestDiscoverAllPanes(t *testing.T) {
 	integ := New(nil, nil)
 	integ.cache = map[string]*sessionCache{"multi-sess": {panes: []cachedPane{
-		{input: classifier.PaneInput{PaneID: "%1", WindowIndex: "0", WindowName: testToolClaude}, result: classifier.Result{IsAgent: true, Tool: testToolClaude}},
-		{input: classifier.PaneInput{PaneID: "%2", WindowIndex: "0", WindowName: "bash"}, result: classifier.Result{IsAgent: false}},
-		{input: classifier.PaneInput{PaneID: "%3", WindowIndex: "1", WindowName: testToolCodex}, result: classifier.Result{IsAgent: true, Tool: testToolCodex}},
+		{input: classifier.PaneInput{PaneID: "%1", WindowID: "@1", WindowIndex: "0", WindowName: testToolClaude}, result: classifier.Result{IsAgent: true, Tool: testToolClaude}},
+		{input: classifier.PaneInput{PaneID: "%2", WindowID: "@1", WindowIndex: "0", WindowName: "bash"}, result: classifier.Result{IsAgent: false}},
+		{input: classifier.PaneInput{PaneID: "%3", WindowID: "@2", WindowIndex: "1", WindowName: testToolCodex}, result: classifier.Result{IsAgent: true, Tool: testToolCodex}},
 	}}}
 	integ.cacheTime = time.Now()
 
 	infos, err := integ.DiscoverAllPanes(context.Background(), "multi-sess", nil)
 	require.NoError(t, err)
 	require.Len(t, infos, 2)
+	assert.Equal(t, "@1", infos[0].WindowID)
 	assert.Equal(t, "%1", infos[0].PaneID)
+	assert.Equal(t, "@2", infos[1].WindowID)
 	assert.Equal(t, "%3", infos[1].PaneID)
 }
 

--- a/internal/hive/status_service.go
+++ b/internal/hive/status_service.go
@@ -26,6 +26,7 @@ type PaneStatus struct {
 
 // WindowStatus holds per-window terminal status for multi-window sessions.
 type WindowStatus struct {
+	WindowID    string
 	WindowIndex string
 	WindowName  string
 	Status      terminal.Status
@@ -37,7 +38,9 @@ type WindowStatus struct {
 // TerminalStatus holds the terminal integration status for a session.
 type TerminalStatus struct {
 	Status      terminal.Status
+	Running     bool
 	Tool        string
+	WindowID    string
 	WindowName  string
 	PaneContent string
 	IsLoading   bool
@@ -166,6 +169,7 @@ func (s *StatusService) fetchRoot(ctx context.Context, target RootRepoTarget) Te
 	if info == nil || integration == nil {
 		return status
 	}
+	status.Running = true
 
 	termStatus, err := integration.GetStatus(ctx, info)
 	if err != nil {
@@ -176,6 +180,7 @@ func (s *StatusService) fetchRoot(ctx context.Context, target RootRepoTarget) Te
 
 	status.Status = termStatus
 	status.Tool = info.DetectedTool
+	status.WindowID = info.WindowID
 	status.WindowName = info.WindowName
 	status.PaneContent = info.PaneContent
 	return status
@@ -206,6 +211,7 @@ func (s *StatusService) FetchSession(ctx context.Context, sess *session.Session)
 	if info == nil || integration == nil {
 		return status
 	}
+	status.Running = true
 
 	// Get status from integration
 	termStatus, err := integration.GetStatus(ctx, info)
@@ -217,6 +223,7 @@ func (s *StatusService) FetchSession(ctx context.Context, sess *session.Session)
 
 	status.Status = termStatus
 	status.Tool = info.DetectedTool
+	status.WindowID = info.WindowID
 	status.WindowName = info.WindowName
 	status.PaneContent = info.PaneContent
 
@@ -258,13 +265,17 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 			IsAgent:     true,
 		}
 
-		// \x1f is an ASCII Unit Separator, which avoids collisions with printable tmux window names.
-		key := wi.WindowIndex + "\x1f" + wi.WindowName
+		key := wi.WindowID
+		if key == "" {
+			// \x1f is an ASCII Unit Separator, which avoids collisions with printable tmux window names.
+			key = wi.WindowIndex + "\x1f" + wi.WindowName
+		}
 		idx, ok := byWindow[key]
 		if !ok {
 			idx = len(windows)
 			byWindow[key] = idx
 			windows = append(windows, WindowStatus{
+				WindowID:    wi.WindowID,
 				WindowIndex: wi.WindowIndex,
 				WindowName:  wi.WindowName,
 				Status:      paneStatus,

--- a/internal/hive/status_service.go
+++ b/internal/hive/status_service.go
@@ -283,7 +283,12 @@ func groupPaneStatuses(ctx context.Context, integration terminal.Integration, sl
 				PaneContent: wi.PaneContent,
 			})
 		} else {
-			windows[idx].Status = aggregateStatus(windows[idx].Status, paneStatus)
+			aggregated := aggregateStatus(windows[idx].Status, paneStatus)
+			if aggregated != windows[idx].Status {
+				windows[idx].Tool = wi.DetectedTool
+				windows[idx].PaneContent = wi.PaneContent
+			}
+			windows[idx].Status = aggregated
 			if windows[idx].Tool == "" {
 				windows[idx].Tool = wi.DetectedTool
 			}

--- a/internal/hive/status_service_test.go
+++ b/internal/hive/status_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/colonyops/hive/internal/core/session"
 	"github.com/colonyops/hive/internal/core/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,19 +17,42 @@ func TestGroupPaneStatuses(t *testing.T) {
 		"%3": terminal.StatusActive,
 	}}
 	infos := []*terminal.SessionInfo{
-		{WindowIndex: "0", WindowName: "main", PaneID: "%1", DetectedTool: "claude", PaneContent: "ready"},
-		{WindowIndex: "0", WindowName: "main", PaneID: "%2", DetectedTool: "codex", PaneContent: "approval"},
-		{WindowIndex: "1", WindowName: "main", PaneID: "%3", DetectedTool: "aider", PaneContent: "active"},
+		{WindowID: "@1", WindowIndex: "0", WindowName: "main", PaneID: "%1", DetectedTool: "claude", PaneContent: "ready"},
+		{WindowID: "@1", WindowIndex: "0", WindowName: "main", PaneID: "%2", DetectedTool: "codex", PaneContent: "approval"},
+		{WindowID: "@2", WindowIndex: "1", WindowName: "main", PaneID: "%3", DetectedTool: "aider", PaneContent: "active"},
 	}
 
 	got := groupPaneStatuses(context.Background(), integration, "sess", infos)
 
 	require.Len(t, got, 2)
+	assert.Equal(t, "@1", got[0].WindowID)
 	assert.Equal(t, "0", got[0].WindowIndex)
 	assert.Equal(t, terminal.StatusApproval, got[0].Status)
 	assert.Len(t, got[0].Panes, 2)
+	assert.Equal(t, "@2", got[1].WindowID)
 	assert.Equal(t, "1", got[1].WindowIndex)
 	assert.Equal(t, terminal.StatusActive, got[1].Status)
+}
+
+func TestGroupPaneStatusesFallsBackWhenWindowIDIsUnavailable(t *testing.T) {
+	integration := &fakeTerminalIntegration{statuses: map[string]terminal.Status{
+		"%1": terminal.StatusReady,
+		"%2": terminal.StatusApproval,
+		"%3": terminal.StatusActive,
+	}}
+	infos := []*terminal.SessionInfo{
+		{WindowIndex: "0", WindowName: "main", PaneID: "%1"},
+		{WindowIndex: "0", WindowName: "main", PaneID: "%2"},
+		{WindowIndex: "1", WindowName: "main", PaneID: "%3"},
+	}
+
+	got := groupPaneStatuses(t.Context(), integration, "sess", infos)
+
+	require.Len(t, got, 2)
+	assert.Len(t, got[0].Panes, 2)
+	assert.Equal(t, "0", got[0].WindowIndex)
+	assert.Len(t, got[1].Panes, 1)
+	assert.Equal(t, "1", got[1].WindowIndex)
 }
 
 func TestAggregateStatus(t *testing.T) {
@@ -57,7 +81,40 @@ func TestStatusRank(t *testing.T) {
 	assert.Zero(t, statusRank(terminal.Status("unknown")))
 }
 
+func TestFetchSessionReportsLivenessAndWindowIdentity(t *testing.T) {
+	integration := &fakeTerminalIntegration{
+		info:     &terminal.SessionInfo{Name: "sess", WindowID: "@7", WindowIndex: "2", WindowName: "agent", PaneID: "%1", DetectedTool: "claude"},
+		statuses: map[string]terminal.Status{"%1": terminal.StatusReady},
+	}
+	manager := terminal.NewManager([]string{"fake"})
+	manager.Register(integration)
+
+	got := NewStatusService(manager, 1).FetchSession(t.Context(), &session.Session{Slug: "sess"})
+
+	assert.True(t, got.Running)
+	assert.Equal(t, terminal.StatusReady, got.Status)
+	assert.Equal(t, "@7", got.WindowID)
+	assert.Equal(t, "agent", got.WindowName)
+	assert.Equal(t, "claude", got.Tool)
+}
+
+func TestFetchSessionReportsRunningWithoutAnAgentPane(t *testing.T) {
+	integration := &fakeTerminalIntegration{
+		info:     &terminal.SessionInfo{Name: "sess"},
+		statuses: map[string]terminal.Status{"": terminal.StatusMissing},
+	}
+	manager := terminal.NewManager([]string{"fake"})
+	manager.Register(integration)
+
+	got := NewStatusService(manager, 1).FetchSession(t.Context(), &session.Session{Slug: "sess"})
+
+	assert.True(t, got.Running)
+	assert.Equal(t, terminal.StatusMissing, got.Status)
+	assert.Empty(t, got.WindowID)
+}
+
 type fakeTerminalIntegration struct {
+	info     *terminal.SessionInfo
 	statuses map[string]terminal.Status
 }
 
@@ -65,7 +122,7 @@ func (f *fakeTerminalIntegration) Name() string    { return "fake" }
 func (f *fakeTerminalIntegration) Available() bool { return true }
 func (f *fakeTerminalIntegration) RefreshCache()   {}
 func (f *fakeTerminalIntegration) DiscoverSession(context.Context, string, map[string]string) (*terminal.SessionInfo, error) {
-	return nil, nil
+	return f.info, nil
 }
 
 func (f *fakeTerminalIntegration) GetStatus(_ context.Context, info *terminal.SessionInfo) (terminal.Status, error) {

--- a/internal/hive/status_service_test.go
+++ b/internal/hive/status_service_test.go
@@ -28,6 +28,8 @@ func TestGroupPaneStatuses(t *testing.T) {
 	assert.Equal(t, "@1", got[0].WindowID)
 	assert.Equal(t, "0", got[0].WindowIndex)
 	assert.Equal(t, terminal.StatusApproval, got[0].Status)
+	assert.Equal(t, "codex", got[0].Tool)
+	assert.Equal(t, "approval", got[0].PaneContent)
 	assert.Len(t, got[0].Panes, 2)
 	assert.Equal(t, "@2", got[1].WindowID)
 	assert.Equal(t, "1", got[1].WindowIndex)


### PR DESCRIPTION
## Purpose

Embedded status consumers need to distinguish whether a tmux session is running from what an agent inside each window is doing. They also need the stable `@N` identity used by tmux control clients; window indexes can change and names need not be unique.

## Changes

- carry `#{window_id}` from pane enumeration through `SessionInfo`, per-window aggregation, and the top-level terminal status
- report `TerminalStatus.Running` after a tmux session is discovered, including shell-only sessions with no classified agent pane
- preserve the existing status vocabulary and window index/name fields for TUI behavior and compatibility

The tmux integration now returns a session-only `SessionInfo` when the session exists but no pane classifies as an agent. `GetStatus` still returns `missing`, so existing status presentation is unchanged while embedders gain a separate liveness signal.

## Verification

- `mise run check`
- focused terminal and status-service tests

## Checklist

- [x] I have added tests that prove the change is effective
- [x] I have updated the relevant API documentation
